### PR TITLE
Improve Phantom_Shim to handle more scenarios.

### DIFF
--- a/third_party/phantomjs/test/module/webpage/change-request-encoded-url.js
+++ b/third_party/phantomjs/test/module/webpage/change-request-encoded-url.js
@@ -1,4 +1,3 @@
-//! unsupported
 var webpage = require('webpage');
 
 async_test(function () {

--- a/third_party/phantomjs/test/module/webpage/loading.js
+++ b/third_party/phantomjs/test/module/webpage/loading.js
@@ -1,4 +1,3 @@
-//! unsupported
 async_test(function () {
     var webpage = require('webpage');
     var page = webpage.create();

--- a/third_party/phantomjs/test/module/webpage/long-running-javascript.js
+++ b/third_party/phantomjs/test/module/webpage/long-running-javascript.js
@@ -1,4 +1,3 @@
-//! unsupported
 async_test(function () {
     var page = require('webpage').create();
 

--- a/third_party/phantomjs/test/module/webpage/modify-header.js
+++ b/third_party/phantomjs/test/module/webpage/modify-header.js
@@ -1,4 +1,3 @@
-//! unsupported
 async_test(function () {
     var webpage = require('webpage');
 

--- a/third_party/phantomjs/test/module/webpage/on-initialized.js
+++ b/third_party/phantomjs/test/module/webpage/on-initialized.js
@@ -1,4 +1,3 @@
-//! unsupported
 test(function () {
     var page = require('webpage').create();
 

--- a/third_party/phantomjs/test/module/webpage/remove-header.js
+++ b/third_party/phantomjs/test/module/webpage/remove-header.js
@@ -1,4 +1,3 @@
-//! unsupported
 var webpage = require('webpage');
 
 // NOTE: HTTP header names are case-insensitive. Our test server


### PR DESCRIPTION
This patch improves phantom_shim:
- introduce WebPage.loading/WebPage.loadingProgress
- improve compatibility of WebPage.onInitialized. This allows to
  pass phantomjs tests, even though the implementation is hacky.
- teach PhantomResponse about "stage" state which could be either
  "start" or "end"
- unskip a bunch of phantom webpage tests:
  - webpage/change-request-encoded-url
  - webpage/loading.js
  - webpage/long-running-javascript.js
  - webpage/modify-header.js
  - webpage/on-initialized.js
  - webpage/remove-header.js