### PR TITLE
Teach browser to dispatch 'stderr' event to report its stderr stream

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -161,9 +161,15 @@ function waitForChromeResponsive(remoteDebuggingPort, shouldWaitCallback) {
 }
 
 class ProxyStream extends Duplex {
-  _read(size) { }
+  _read() { }
 
+  /**
+   * @param {?} chunk
+   * @param {string} encoding
+   * @param {function()} callback
+   */
   _write(chunk, encoding, callback) {
-    this.push(chunk);
+    this.push(chunk, encoding);
+    callback();
   }
 }

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+let {Duplex} = require('stream');
 let http = require('http');
 let path = require('path');
 let removeRecursive = require('rimraf').sync;
@@ -64,6 +65,9 @@ class Browser {
     this._terminated = false;
     this._chromeProcess = null;
     this._launchPromise = null;
+
+    this.stderr = new ProxyStream();
+    this.stdout = new ProxyStream();
   }
 
   /**
@@ -112,6 +116,8 @@ class Browser {
       this._terminated = true;
       removeRecursive(this._userDataDir);
     });
+    this._chromeProcess.stderr.pipe(this.stderr);
+    this._chromeProcess.stdout.pipe(this.stdout);
 
     await waitForChromeResponsive(this._remoteDebuggingPort, () => !this._terminated);
     if (this._terminated)
@@ -151,5 +157,13 @@ function waitForChromeResponsive(remoteDebuggingPort, shouldWaitCallback) {
         fulfill();
     });
     req.end();
+  }
+}
+
+class ProxyStream extends Duplex {
+  _read(size) { }
+
+  _write(chunk, encoding, callback) {
+    this.push(chunk);
   }
 }


### PR DESCRIPTION
I usually debug chromium with `fprintf` statements. This patch makes it convenient:

```js
let Browser = require('./lib/Browser');
let browser = new Browser({
  // Point to my local chromium build
  executablePath: '/usr/local/home/lushnikov/chromium/out/Release/chrome'
});
// Output chromium stderr and stdout to console
browser.on('stdout', console.log);
browser.on('stderr', console.log);

browser.newPage().then(async page => {
   ...
});
```