### PR TITLE
Fix watchdog timer cleanup

### DIFF
--- a/lib/Navigator.js
+++ b/lib/Navigator.js
@@ -41,7 +41,7 @@ class Navigator {
     let certificateError = new Promise(fulfill => this._client.once('Security.certificateError', fulfill)).then(() => false);
     let networkIdle = new Promise(fulfill => this._networkIdleCallback = fulfill).then(() => true);
     let loadEventFired = new Promise(fulfill => this._client.once('Page.loadEventFired', fulfill)).then(() => true);
-    let watchdog = new Promise(fulfill => setTimeout(fulfill, this._maxTime)).then(() => false);
+    let watchdog = new Promise(fulfill => this._maximumTimer = setTimeout(fulfill, this._maxTime)).then(() => false);
 
     // Await for the command to throw exception in case of illegal arguments.
     try {


### PR DESCRIPTION
Fix a bug in f7cd0048af54d44e0c9b2a4f66eb5136785d57a5 which prevents the cleanup of the watchdog timer, thus keeping the Node.js process alive for `this._maxTime` msec no matter what.