### PR TITLE
Use getBoundingClientRect instead of DOM.BoxModel

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -509,31 +509,36 @@ class Page extends EventEmitter {
    * @param {!Promise}
    */
   async click(selector) {
-    try {
-      const nodeId = await this._querySelector(selector);
-      let boxModel = (await this._client.send('DOM.getBoxModel', { nodeId })).model.content;
-      let x = Math.round((boxModel[0] + boxModel[4]) / (2 * this._screenDPI));
-      let y = Math.round((boxModel[1] + boxModel[5]) / (2 * this._screenDPI));
-
-      this._client.send('Input.dispatchMouseEvent', {
-        type: 'mouseMoved',
-        x, y
-      });
-      this._client.send('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        button: 'left',
-        x, y,
-        clickCount: 1
-      });
-      await this._client.send('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        button: 'left',
-        x, y,
-        clickCount: 1
-      });
-    } finally {
-      await this._client.send('DOM.disable');
-    }
+    let center = await this.evaluate(selector => {
+      let node = document.querySelector(selector);
+      if (!node)
+        return null;
+      let rect = node.getBoundingClientRect();
+      return {
+        x: (rect.left + rect.right) / 2,
+        y: (rect.top + rect.bottom) / 2
+      };
+    }, selector);
+    if (!center)
+      throw new Error('No node found for selector: ' + selector);
+    let x = Math.round(center.x / this._screenDPI);
+    let y = Math.round(center.y / this._screenDPI);
+    this._client.send('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x, y
+    });
+    this._client.send('Input.dispatchMouseEvent', {
+      type: 'mousePressed',
+      button: 'left',
+      x, y,
+      clickCount: 1
+    });
+    await this._client.send('Input.dispatchMouseEvent', {
+      type: 'mouseReleased',
+      button: 'left',
+      x, y,
+      clickCount: 1
+    });
   }
 
   /**
@@ -541,12 +546,15 @@ class Page extends EventEmitter {
    * @param {!Promise}
    */
   async focus(selector) {
-    try {
-      const nodeId = await this._querySelector(selector);
-      await this._client.send('DOM.focus', { nodeId });
-    } finally {
-      await this._client.send('DOM.disable');
-    }
+    let success = await this.evaluate(selector => {
+      let node = document.querySelector(selector);
+      if (!node)
+        return false;
+      node.focus();
+      return true;
+    }, selector);
+    if (!success)
+      throw new Error('No node found for selector: ' + selector);
   }
 
   /**


### PR DESCRIPTION
This moves away from page._querySelector and uses JavaScript instead for clicking and focusing.