### PR TITLE
Roll chromium to r486981

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -35,13 +35,11 @@ class Page extends EventEmitter {
       client.send('Runtime.enable', {}),
       client.send('Security.enable', {}),
     ]);
-    let screenDPIExpression = helper.evaluationString(() => window.devicePixelRatio);
-    let {result:{value: screenDPI}} = await client.send('Runtime.evaluate', { expression: screenDPIExpression, returnByValue: true });
     let userAgentExpression = helper.evaluationString(() => window.navigator.userAgent);
     let {result:{value: userAgent}} = await client.send('Runtime.evaluate', { expression: userAgentExpression, returnByValue: true });
     let frameManager = await FrameManager.create(client);
     let networkManager = new NetworkManager(client, userAgent);
-    let page = new Page(client, frameManager, networkManager, screenDPI);
+    let page = new Page(client, frameManager, networkManager);
     // Initialize default page size.
     await page.setViewportSize({width: 400, height: 300});
     return page;
@@ -51,14 +49,12 @@ class Page extends EventEmitter {
    * @param {!Connection} client
    * @param {!FrameManager} frameManager
    * @param {!NetworkManager} networkManager
-   * @param {number} screenDPI
    */
-  constructor(client, frameManager, networkManager, screenDPI) {
+  constructor(client, frameManager, networkManager) {
     super();
     this._client = client;
     this._frameManager = frameManager;
     this._networkManager = networkManager;
-    this._screenDPI = screenDPI;
     /** @type {!Map<string, function>} */
     this._inPageCallbacks = new Map();
 
@@ -285,23 +281,12 @@ class Page extends EventEmitter {
    */
   async setViewportSize(size) {
     this._viewportSize = size;
-    let width = size.width;
-    let height = size.height;
-    let zoom = this._screenDPI;
-    return Promise.all([
-      this._client.send('Emulation.setDeviceMetricsOverride', {
-        width,
-        height,
-        deviceScaleFactor: 1,
-        scale: 1 / zoom,
-        mobile: false,
-        fitWindow: false
-      }),
-      this._client.send('Emulation.setVisibleSize', {
-        width: Math.floor(width / zoom),
-        height: Math.floor(height / zoom),
-      })
-    ]);
+    await this._client.send('Emulation.setDeviceMetricsOverride', {
+      mobile: false,
+      width: size.width,
+      height: size.height,
+      deviceScaleFactor: 1,
+    });
   }
 
   /**
@@ -371,48 +356,30 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {string} screenshotType
+   * @param {string} format
    * @param {!Object=} options
    * @return {!Promise<!Buffer>}
    */
-  async _screenshotTask(screenshotType, options) {
-    if (options.clip) {
-      await Promise.all([
-        this._client.send('Emulation.setVisibleSize', {
-          width: Math.ceil(options.clip.width / this._screenDPI),
-          height: Math.ceil(options.clip.height / this._screenDPI),
-        }),
-        this._client.send('Emulation.forceViewport', {
-          x: options.clip.x / this._screenDPI,
-          y: options.clip.y / this._screenDPI,
-          scale: 1,
-        })
-      ]);
-    } else if (options.fullPage) {
-      let response = await this._client.send('Page.getLayoutMetrics');
-      await Promise.all([
-        this._client.send('Emulation.setVisibleSize', {
-          width: Math.ceil(response.contentSize.width / this._screenDPI),
-          height: Math.ceil(response.contentSize.height / this._screenDPI),
-        }),
-        this._client.send('Emulation.forceViewport', {
-          x: 0,
-          y: 0,
-          scale: 1,
-        })
-      ]);
+  async _screenshotTask(format, options) {
+    if (options.fullPage) {
+      let metrics = await this._client.send('Page.getLayoutMetrics');
+      await this._client.send('Emulation.setDeviceMetricsOverride', {
+        mobile: false,
+        width: Math.ceil(metrics.contentSize.width),
+        height: Math.ceil(metrics.contentSize.height),
+        deviceScaleFactor: 1,
+      });
     }
-    let result = await this._client.send('Page.captureScreenshot', {
-      fromSurface: true,
-      format: screenshotType,
-      quality: options.quality
-    });
-    if (options.clip || options.fullPage) {
-      await Promise.all([
-        this.setViewportSize(this.viewportSize()),
-        this._client.send('Emulation.resetViewport')
-      ]);
+    let clip = options['clip'];
+    if (clip) {
+      // Copy clip to avoid mutating passed-in object.
+      clip = Object.assign({}, clip);
+      clip.scale = 1;
     }
+    const result = await this._client.send('Page.captureScreenshot', { format, quality: options.quality, clip });
+    if (options.fullPage)
+      await this.setViewportSize(this.viewportSize());
+
     let buffer = new Buffer(result.data, 'base64');
     if (options.path)
       fs.writeFileSync(options.path, buffer);
@@ -521,8 +488,7 @@ class Page extends EventEmitter {
     }, selector);
     if (!center)
       throw new Error('No node found for selector: ' + selector);
-    let x = Math.round(center.x / this._screenDPI);
-    let y = Math.round(center.y / this._screenDPI);
+    let {x, y} = center;
     this._client.send('Input.dispatchMouseEvent', {
       type: 'mouseMoved',
       x, y

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "485143"
+    "chromium_revision": "486981"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",

--- a/test/test.js
+++ b/test/test.js
@@ -221,7 +221,7 @@ describe('Puppeteer', function() {
         await page.waitFor('*');
         fail('Failed waitFor did not throw.');
       } catch (e) {
-        expect(e.message).toBe('Evaluation failed: document.querySelector is not a function');
+        expect(e.message).toContain('Evaluation failed: document.querySelector is not a function');
       }
     }));
   });


### PR DESCRIPTION
This patch rolls chromium to r486981 and starts using the new screenshots functionality.

The new chromium takes emulated devicePixelRatio into account when making screenshots.
This allows us to implement a beautiful device emulation.