### PR TITLE
Remove userAgent getter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,7 +58,6 @@
     + [page.type(text)](#pagetypetext)
     + [page.uploadFile(selector, ...filePaths)](#pageuploadfileselector-filepaths)
     + [page.url()](#pageurl)
-    + [page.userAgent()](#pageuseragent)
     + [page.viewport()](#pageviewport)
     + [page.waitFor(target[, options])](#pagewaitfortarget-options)
     + [page.waitForNavigation(options)](#pagewaitfornavigationoptions)
@@ -607,9 +606,6 @@ To press a special key, use [`page.press`](#pagepresskey-options).
 - returns: <[string]> Current page url.
 
 This is a shortcut for [page.mainFrame().url()](#frameurl)
-
-#### page.userAgent()
-- returns: <[string]> Returns user agent.
 
 #### page.viewport()
 - returns: <[Object]>  An object with the save fields as described in [page.setViewport](#pagesetviewportviewport)

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -19,16 +19,14 @@ const helper = require('./helper');
 class NetworkManager extends EventEmitter {
   /**
    * @param {!Connection} client
-   * @param {string} userAgent
    */
-  constructor(client, userAgent) {
+  constructor(client) {
     super();
     this._client = client;
     this._requestInterceptor = null;
     /* @type {!Map<string, !Request>} */
     this._idToRequest = new Map();
     this._httpHeaders = {};
-    this._userAgent = userAgent;
 
     this._client.on('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this));
     this._client.on('Network.requestIntercepted', this._onRequestIntercepted.bind(this));
@@ -61,15 +59,7 @@ class NetworkManager extends EventEmitter {
    * @return {!Promise}
    */
   async setUserAgent(userAgent) {
-    this._userAgent = userAgent;
     return this._client.send('Network.setUserAgentOverride', { userAgent });
-  }
-
-  /**
-   * @return {string}
-   */
-  userAgent() {
-    return this._userAgent;
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -39,12 +39,10 @@ class Page extends EventEmitter {
       client.send('Runtime.enable', {}),
       client.send('Security.enable', {}),
     ]);
-    let userAgentExpression = helper.evaluationString(() => window.navigator.userAgent);
-    let {result:{value: userAgent}} = await client.send('Runtime.evaluate', { expression: userAgentExpression, returnByValue: true });
     let keyboard = new Keyboard(client);
     let mouse = new Mouse(client, keyboard);
     let frameManager = await FrameManager.create(client, mouse);
-    let networkManager = new NetworkManager(client, userAgent);
+    let networkManager = new NetworkManager(client);
     let page = new Page(client, frameManager, networkManager, screenshotTaskQueue, mouse, keyboard);
     // Initialize default page size.
     await page.setViewport({width: 400, height: 300});
@@ -195,13 +193,6 @@ class Page extends EventEmitter {
    */
   async setUserAgent(userAgent) {
     return this._networkManager.setUserAgent(userAgent);
-  }
-
-  /**
-   * @return {string}
-   */
-  userAgent() {
-    return this._networkManager.userAgent();
   }
 
   /**

--- a/phantom_shim/WebPage.js
+++ b/phantom_shim/WebPage.js
@@ -597,7 +597,7 @@ class WebPageSettings {
    * @return {string}
    */
   get userAgent() {
-    return this._page.userAgent();
+    return await(this._page.evaluate(() => window.navigator.userAgent));
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -988,7 +988,7 @@ describe('Puppeteer', function() {
 
   describe('Page.setUserAgent', function() {
     it('should work', SX(async function() {
-      expect(page.userAgent()).toContain('Mozilla');
+      expect(await page.evaluate(() => navigator.userAgent)).toContain('Mozilla');
       page.setUserAgent('foobar');
       page.navigate(EMPTY_PAGE);
       let request = await server.waitForRequest('/empty.html');


### PR DESCRIPTION
Closes #110 

Users can just use `navigator.userAgent` instead.