### PR TITLE
Trace only string method names

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -106,7 +106,7 @@ class Helper {
       return;
     for (let methodName of Reflect.ownKeys(classType.prototype)) {
       const method = Reflect.get(classType.prototype, methodName);
-      if (methodName === 'constructor' || methodName.startsWith('_') || typeof method !== 'function')
+      if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function')
         continue;
       Reflect.set(classType.prototype, methodName, function(...args) {
         let argsText = args.map(stringifyArgument).join(', ');


### PR DESCRIPTION
Method names could be symbol or number, and then startsWith would throw.