### PR TITLE
run phantom tests on windows

### DIFF
--- a/third_party/phantomjs/test/run-tests.py
+++ b/third_party/phantomjs/test/run-tests.py
@@ -768,13 +768,13 @@ class TestRunner(object):
 
     def get_base_command(self, debugger):
         if debugger is None:
-            return [self.phantomjs_exe]
+            return ["node", self.phantomjs_exe]
         elif debugger == "gdb":
-            return ["gdb", "--args", self.phantomjs_exe]
+            return ["gdb", "--args", "node", self.phantomjs_exe]
         elif debugger == "lldb":
-            return ["lldb", "--", self.phantomjs_exe]
+            return ["lldb", "--", "node", self.phantomjs_exe]
         elif debugger == "valgrind":
-            return ["valgrind", self.phantomjs_exe]
+            return ["valgrind", "node", self.phantomjs_exe]
         else:
             raise RuntimeError("Don't know how to invoke " + self.debugger)
 


### PR DESCRIPTION
Allow running phantom tests on Windows. These were relying on `#!/usr/bin/env node` at the top of runner.js, which doesn't work outside of a unix environment.