### PR TITLE
Fix media keys to use new key strings and codes

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -31,7 +31,7 @@ class Keyboard {
    * @return {!Promise}
    */
   async down(key, options) {
-    let {text} = options || {};
+    let { text } = options || {};
     this._modifiers |= this._modifierBit(key);
     await this._client.send('Input.dispatchKeyEvent', {
       type: text ? 'keyDown' : 'rawKeyDown',
@@ -244,9 +244,13 @@ let keys = {
   'F24': 135,
   'NumLock': 144,
   'ScrollLock': 145,
-  'VolumeMute': 181,
-  'VolumeDown': 182,
-  'VolumeUp': 183,
+  'AudioVolumeMute': 173,
+  'AudioVolumeDown': 174,
+  'AudioVolumeUp': 175,
+  'MediaTrackNext': 176,
+  'MediaTrackPrevious': 177,
+  'MediaStop': 178,
+  'MediaPlayPause': 179,
   ';': 186,
   ':': 186,
   '=': 187,
@@ -290,6 +294,6 @@ function codeForKey(key) {
   return 0;
 }
 
-module.exports = {Keyboard, Mouse};
+module.exports = { Keyboard, Mouse };
 helper.tracePublicAPI(Keyboard);
 helper.tracePublicAPI(Mouse);


### PR DESCRIPTION
`VolumeUp`, `VolumeDown`, and `VolumeMute` were changed to `AudioVolumeUp`, `AudioVolumeDown`, and `AudioVolumeMute`

The media keys like `MediaTrackNext` were also missing, so I added them.