### PR TITLE
Mark options objects as optional

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -47,7 +47,7 @@ let DEFAULT_ARGS = [
 
 class Browser {
   /**
-   * @param {(!Object|undefined)} options
+   * @param {!Object=} options
    */
   constructor(options) {
     options = options || {};

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -48,7 +48,7 @@ class Connection extends EventEmitter {
 
   /**
    * @param {string} method
-   * @param {(!Object|undefined)} params
+   * @param {!Object=} params
    * @return {!Promise<?Object>}
    */
   send(method, params = {}) {

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -27,7 +27,7 @@ class Keyboard {
 
   /**
    * @param {string} key
-   * @param {{text: (string|undefined)}} options
+   * @param {{text: (string|undefined)}=} options
    * @return {!Promise}
    */
   async down(key, options) {


### PR DESCRIPTION
Typescript appears to treat `undefined` different from optional. This fixes my autocomplete in vscode.