### PR TITLE
Add delay option to input methods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,7 @@
     + [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
     + [page.setViewport(viewport)](#pagesetviewportviewport)
     + [page.title()](#pagetitle)
-    + [page.type(text)](#pagetypetext)
+    + [page.type(text, options)](#pagetypetext-options)
     + [page.uploadFile(selector, ...filePaths)](#pageuploadfileselector-filepaths)
     + [page.url()](#pageurl)
     + [page.viewport()](#pageviewport)
@@ -358,6 +358,7 @@ Shortcut for [page.mainFrame().addScriptTag(url)](#frameaddscripttagurl).
 - `options` <[Object]>
   - `button` <[string]> `left`, `right`, or `middle`, defaults to `left`.
   - `clickCount` <[number]> defaults to 1
+  - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
 - returns: <[Promise]> Promise which resolves when the element matching `selector` is successfully clicked. Promise gets rejected if there's no element matching `selector`.
 <!-- gen:stop -->
 
@@ -547,6 +548,7 @@ The `format` options are:
 - `key` <[string]> Name of key to press, such as `ArrowLeft`. See [KeyboardEvent.key](https://www.w3.org/TR/uievents-key/)
 - `options` <[Object]>
   - `text` <[string]> If specified, generates an input event with this text.
+  - `delay` <[number]> Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 - returns: <[Promise]>
 
 Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#keyboardupkey).
@@ -659,8 +661,10 @@ In case of multiple pages in one browser, each page can have its own viewport si
 
 Shortcut for [page.mainFrame().title()](#frametitle).
 
-#### page.type(text)
+#### page.type(text, options)
 - `text` <[string]> A text to type into a focused element.
+- `options` <[Object]>
+  - `delay` <[number]> Time to wait between key presses in milliseconds. Defaults to 0.
 - returns: <[Promise]> Promise which resolves when the text has been successfully typed.
 
 Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.
@@ -826,6 +830,7 @@ Dispatches a `keyup` event.
 - `options` <[Object]>
   - `button` <[string]> `left`, `right`, or `middle`, defaults to `left`.
   - `clickCount` <[number]> defaults to 1
+  - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
 - returns: <[Promise]>
 
 Shortcut for [`mouse.move`](#mousemovexy), [`mouse.down`](#mousedownkey) and [`mouse.up`](#mouseupkey).
@@ -960,6 +965,7 @@ Adds a `<script>` tag to the frame with the desired url. Alternatively, JavaScri
 - `options` <[Object]>
   - `button` <[string]> `left`, `right`, or `middle`, defaults to `left`.
   - `clickCount` <[number]> defaults to 1
+  - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
 - returns: <[Promise]> Promise which resolves when the element matching `selector` is successfully clicked. Promise gets rejected if there's no element matching `selector`.
 <!-- gen:stop -->
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -671,6 +671,11 @@ Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in t
 
 To press a special key, use [`page.press`](#pagepresskey-options).
 
+```js
+page.type('Hello'); // Types instantly
+page.type('World', {delay: 100}); // Types slower, like a user
+```
+
 #### page.uploadFile(selector, ...filePaths)
 <!-- gen:paste('frame.uploadFile') -->
 <!-- Text below is automatically copied from "gen:copy('frame.uploadFile')" -->

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -126,6 +126,8 @@ class Mouse {
   async click(x, y, options) {
     this.move(x, y);
     this.down(options);
+    if (options && options.delay)
+      await new Promise(f => setTimeout(f, options.delay));
     await this.up(options);
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -532,12 +532,19 @@ class Page extends EventEmitter {
 
   /**
    * @param {string} text
+   * @param {{delay: (number|undefined)}=} options
    * @return {!Promise}
    */
-  async type(text) {
+  async type(text, options) {
+    let delay = 0;
+    if (options && options.delay)
+      delay = options.delay;
     let last;
-    for (let char of text)
-      last = this.press(char, {text: char});
+    for (let char of text) {
+      last = this.press(char, {text: char, delay});
+      if (delay)
+        await new Promise(f => setTimeout(f, delay));
+    }
     await last;
   }
 
@@ -548,6 +555,8 @@ class Page extends EventEmitter {
    */
   async press(key, options) {
     this._keyboard.down(key, options);
+    if (options && options.delay)
+      await new Promise(f => setTimeout(f, options.delay));
     await this._keyboard.up(key);
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1098,6 +1098,12 @@ describe('Puppeteer', function() {
           fail(modifiers[modifier] + ' should be false');
       }
     }));
+    it('should type with a delay', SX(async function(){
+      await page.navigate(PREFIX + '/input/textarea.html');
+      await page.focus('textarea');
+      await page.type('Hello World!', {delay: 50});
+      expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('Hello World!');
+    }));
     function dimensions() {
       let rect = document.querySelector('textarea').getBoundingClientRect();
       return {

--- a/test/test.js
+++ b/test/test.js
@@ -1098,19 +1098,6 @@ describe('Puppeteer', function() {
           fail(modifiers[modifier] + ' should be false');
       }
     }));
-    it('should type with a delay', SX(async function(){
-      await page.navigate(PREFIX + '/input/textarea.html');
-      await page.focus('textarea');
-      // This doesn't actually test delay, it just makes sure that setting delay doesn't break type
-      await page.type('Hello World!', {delay: 1});
-      expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('Hello World!');
-    }));
-    it('should click with a delay', SX(async function(){
-      await page.navigate(PREFIX + '/input/button.html');
-      // This doesn't actually test delay, it just makes sure that setting delay doesn't break click
-      await page.click('button', {delay: 1});
-      expect(await page.evaluate(() => result)).toBe('Clicked');
-    }));
     function dimensions() {
       let rect = document.querySelector('textarea').getBoundingClientRect();
       return {

--- a/test/test.js
+++ b/test/test.js
@@ -1104,6 +1104,11 @@ describe('Puppeteer', function() {
       await page.type('Hello World!', {delay: 50});
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('Hello World!');
     }));
+    it('should click with a delay', SX(async function(){
+      await page.navigate(PREFIX + '/input/button.html');
+      await page.click('button', {delay: 100});
+      expect(await page.evaluate(() => result)).toBe('Clicked');
+    }));
     function dimensions() {
       let rect = document.querySelector('textarea').getBoundingClientRect();
       return {

--- a/test/test.js
+++ b/test/test.js
@@ -1101,12 +1101,14 @@ describe('Puppeteer', function() {
     it('should type with a delay', SX(async function(){
       await page.navigate(PREFIX + '/input/textarea.html');
       await page.focus('textarea');
-      await page.type('Hello World!', {delay: 50});
+      // This doesn't actually test delay, it just makes sure that setting delay doesn't break type
+      await page.type('Hello World!', {delay: 1});
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('Hello World!');
     }));
     it('should click with a delay', SX(async function(){
       await page.navigate(PREFIX + '/input/button.html');
-      await page.click('button', {delay: 100});
+      // This doesn't actually test delay, it just makes sure that setting delay doesn't break click
+      await page.click('button', {delay: 1});
       expect(await page.evaluate(() => result)).toBe('Clicked');
     }));
     function dimensions() {


### PR DESCRIPTION
Closes #156 

This lets you easily simulate a long press of a key or mouse press, or a user typing at a normal speed.