### PR TITLE
Specify repeat property on repeated keypresses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -802,6 +802,8 @@ This will not send input events unless `text` is specified.
 
 If `key` is a modifier key, `Shift`, `Meta`, `Control`, or `Alt`, subsequent key presses will be sent with that modifier active. To release the modifier key, use [`keyboard.up`](#keyboardupkey).
 
+After the key is pressed once, subsequent calls to [`keyboard.down`](#keyboarddownkey-options) will have [repeat](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat) set to true. To release the key, use [`keyboard.up`](#keyboardupkey).
+
 #### keyboard.sendCharacter(char)
 - `char` <[string]> Character to send into the page.
 - returns: <[Promise]>

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -23,15 +23,18 @@ class Keyboard {
   constructor(client) {
     this._client = client;
     this._modifiers = 0;
+    this._pressedKeys = new Set();
   }
 
   /**
    * @param {string} key
-   * @param {{text: (string|undefined)}=} options
+   * @param {{text: (string|undefined)}} options
    * @return {!Promise}
    */
   async down(key, options) {
-    let { text } = options || {};
+    let {text} = options || {};
+    let autoRepeat = this._pressedKeys.has(key);
+    this._pressedKeys.add(key);
     this._modifiers |= this._modifierBit(key);
     await this._client.send('Input.dispatchKeyEvent', {
       type: text ? 'keyDown' : 'rawKeyDown',
@@ -39,7 +42,8 @@ class Keyboard {
       windowsVirtualKeyCode: codeForKey(key),
       key: key,
       text: text,
-      unmodifiedText: text
+      unmodifiedText: text,
+      autoRepeat
     });
   }
 
@@ -65,6 +69,7 @@ class Keyboard {
    */
   async up(key) {
     this._modifiers &= ~this._modifierBit(key);
+    this._pressedKeys.delete(key);
     await this._client.send('Input.dispatchKeyEvent', {
       type: 'keyUp',
       modifiers: this._modifiers,

--- a/test/test.js
+++ b/test/test.js
@@ -1098,6 +1098,15 @@ describe('Puppeteer', function() {
           fail(modifiers[modifier] + ' should be false');
       }
     }));
+    it('should specify repeat property', SX(async function(){
+      await page.navigate(PREFIX + '/input/textarea.html');
+      await page.focus('textarea');
+      await page.$('textarea', textarea => textarea.addEventListener('keydown', e => window.lastEvent = e, true));
+      await page.keyboard.down('a', {text: 'a'});
+      expect(await page.evaluate(() => window.lastEvent.repeat)).toBe(false);
+      await page.press('a');
+      expect(await page.evaluate(() => window.lastEvent.repeat)).toBe(true);
+    }));
     function dimensions() {
       let rect = document.querySelector('textarea').getBoundingClientRect();
       return {


### PR DESCRIPTION
[Repeat](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat) works a little bit different than I thought it did. When you hold down a key, it sends multiple `keydown` and `input` events, but no `keyup`. This patch automatically sets repeat to the right value.

Closes #157