### PR TITLE
Update default viewport size to be 800px by 600px

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A few notes:
 
 1. By default, Puppeteer bundles chromium browser with which it works best. However, you can point Puppeteer to a different executable ([example](https://github.com/GoogleChrome/puppeteer/blob/master/examples/custom-chromium-revision.js))
 2. Puppeteer creates its own Chromium user profile which it cleans up on every run.
-3. Puppeteer sets an initial page size to 400px x 300px, which defines the screenshot size. The page size can be changed with `Page.setViewportSize()` method
+3. Puppeteer sets an initial page size to 800px x 600px, which defines the screenshot size. The page size can be changed with `Page.setViewportSize()` method
 4. By default, browser is launched in a headless mode. This could be changed via ['headless' browser option](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#new-browseroptions)
 
 ## API Documentation

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -45,7 +45,7 @@ class Page extends EventEmitter {
     const page = new Page(client, ignoreHTTPSErrors, screenshotTaskQueue);
     await page.navigate('about:blank');
     // Initialize default page size.
-    await page.setViewport({width: 400, height: 300});
+    await page.setViewport({width: 800, height: 600});
     return page;
   }
 

--- a/phantom_shim/WebPage.js
+++ b/phantom_shim/WebPage.js
@@ -38,6 +38,8 @@ class WebPage {
       this.settings.userAgent = options.settings.userAgent;
     if (options.viewportSize)
       await(this._page.setViewport(options.viewportSize));
+    else
+      await(this._page.setViewport({width: 400, height: 300}));
 
     this.loading = false;
     this.loadingProgress = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -1320,13 +1320,13 @@ describe('Page', function() {
 
   describe('Page.viewport', function() {
     it('should get the proper viewport size', SX(async function() {
-      expect(page.viewport()).toEqual({width: 400, height: 300});
+      expect(page.viewport()).toEqual({width: 800, height: 600});
       await page.setViewport({width: 123, height: 456});
       expect(page.viewport()).toEqual({width: 123, height: 456});
     }));
     it('should support mobile emulation', SX(async function() {
       await page.navigate(PREFIX + '/mobile.html');
-      expect(await page.evaluate(() => window.innerWidth)).toBe(400);
+      expect(await page.evaluate(() => window.innerWidth)).toBe(800);
       await page.setViewport(iPhone.viewport);
       expect(await page.evaluate(() => window.innerWidth)).toBe(375);
       await page.setViewport({width: 400, height: 300});


### PR DESCRIPTION
This patch updates default viewport size to be 800px by 600px.
This comes handy when observing scripts running in non-headless mode.