### PR TITLE
Kill page.$ and page.$$ functions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,8 +25,6 @@
     + [event: 'requestfailed'](#event-requestfailed)
     + [event: 'requestfinished'](#event-requestfinished)
     + [event: 'response'](#event-response)
-    + [page.$(selector, pageFunction, ...args)](#pageselector-pagefunction-args)
-    + [page.$$(selector, pageFunction, ...args)](#pageselector-pagefunction-args)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
@@ -81,8 +79,6 @@
     + [dialog.message()](#dialogmessage)
     + [dialog.type](#dialogtype)
   * [class: Frame](#class-frame)
-    + [frame.$(selector, pageFunction, ...args)](#frameselector-pagefunction-args)
-    + [frame.$$(selector, pageFunction, ...args)](#frameselector-pagefunction-args)
     + [frame.addScriptTag(url)](#frameaddscripttagurl)
     + [frame.childFrames()](#framechildframes)
     + [frame.click(selector[, options])](#frameclickselector-options)
@@ -315,30 +311,6 @@ Emitted when a request is successfully finished.
 - <[Response]>
 
 Emitted when a [response] is received.
-
-#### page.$(selector, pageFunction, ...args)
-- `selector` <[string]> A [selector] to be matched in the page
-- `pageFunction` <[function]\([Element]\)> Function to be evaluated with first element matching `selector`
-- `...args` <...[string]> Arguments to pass to `pageFunction`
-- returns: <[Promise]<[Object]>> Promise which resolves to function return value.
-Example:
-```js
-const outerhtml = await page.$('#box', e => e.outerHTML);
-```
-Shortcut for [page.mainFrame().$(selector, pageFunction, ...args)](#frameselector-pagefunction-args).
-
-#### page.$$(selector, pageFunction, ...args)
-- `selector` <[string]> A [selector] to be matched in the page
-- `pageFunction` <[function]\([Element]\)> Function to be evaluted for every element matching `selector`.
-- `...args` <...[string]> Arguments to pass to `pageFunction`
-- returns: <[Promise]<[Array]<[Object]>>> Promise which resolves to array of function return values.
-Example:
-```js
-const headings = await page.$$('h1,h2,h3,h4', el => el.textContent);
-for (const heading of headings) console.log(heading);
-```
-
-Shortcut for [page.mainFrame().$$(selector, pageFunction, ...args)](#frameselector-pagefunction-args-1).
 
 #### page.addScriptTag(url)
 - `url` <[string]> Url of a script to be added
@@ -914,28 +886,6 @@ browser.newPage().then(async page => {
       dumpFrameTree(child, indent + '  ');
   }
 });
-```
-
-#### frame.$(selector, pageFunction, ...args)
-- `selector` <[string]> A [selector] to be matched in the page
-- `pageFunction` <[function]\([Element]\)> Function to be evaluated with first element matching `selector`
-- `...args` <...[string]> Arguments to pass to `pageFunction`
-- returns: <[Promise]<[Object]>> Promise which resolves to function return value.
-Example:
-```js
-const outerhtml = await page.$('#box', e => e.outerHTML);
-```
-
-
-#### frame.$$(selector, pageFunction, ...args)
-- `selector` <[string]> A [selector] to be matched in the page
-- `pageFunction` <[function]\([Element]\)> Function to be evaluted for every element matching `selector`.
-- `...args` <...[string]> Arguments to pass to `pageFunction`
-- returns: <[Promise]<[Array]<[Object]>>> Promise which resolves to array of function return values.
-Example:
-```js
-const headings = await page.$$('h1,h2,h3,h4', el => el.textContent);
-for (const heading of headings) console.log(heading);
 ```
 
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -318,40 +318,6 @@ class Frame {
   }
 
   /**
-   * @template T
-   * @param {string} selector
-   * @param {function(!Element):T} pageFunction
-   * @param {!Array<*>} args
-   * @return {!Promise<?T>}
-   */
-  async $(selector, pageFunction, ...args) {
-    let argsString = ['node'].concat(args.map(x => JSON.stringify(x))).join(',');
-    let expression = `(()=>{
-      let node = document.querySelector(${JSON.stringify(selector)});
-      if (!node)
-        return null;
-      return (${pageFunction})(${argsString});
-    })()`;
-    return this.evaluate(expression);
-  }
-
-  /**
-   * @template T
-   * @param {string} selector
-   * @param {function(!Element):T} pageFunction
-   * @param {!Array<*>} args
-   * @return {!Promise<!Array<T>>}
-   */
-  async $$(selector, pageFunction, ...args) {
-    let argsString = ['node, index'].concat(args.map(x => JSON.stringify(x))).join(',');
-    let expression = `(()=>{
-      let nodes = document.querySelectorAll(${JSON.stringify(selector)});
-      return Array.prototype.map.call(nodes, (node, index) => (${pageFunction})(${argsString}));
-    })()`;
-    return this.evaluate(expression);
-  }
-
-  /**
    * @return {!Promise<string>}
    */
   async title() {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -623,28 +623,6 @@ class Page extends EventEmitter {
   async uploadFile(selector, ...filePaths) {
     return this.mainFrame().uploadFile(selector, ...filePaths);
   }
-
-  /**
-   * @template T
-   * @param {string} selector
-   * @param {function(!Element):T} pageFunction
-   * @param {!Array<*>} args
-   * @return {!Promise<?T>}
-   */
-  async $(selector, pageFunction, ...args) {
-    return this.mainFrame().$(selector, pageFunction, ...args);
-  }
-
-  /**
-   * @template T
-   * @param {string} selector
-   * @param {function(!Element):T} pageFunction
-   * @param {!Array<*>} args
-   * @return {!Promise<!Array<T>>}
-   */
-  async $$(selector, pageFunction, ...args) {
-    return this.mainFrame().$$(selector, pageFunction, ...args);
-  }
 }
 
 /** @enum {string} */

--- a/test/test.js
+++ b/test/test.js
@@ -311,7 +311,7 @@ describe('Page', function() {
 
     it('should work when node is added through innerHTML', SX(async function() {
       await page.navigate(EMPTY_PAGE);
-      let watchdog = page.waitForSelector('h3 div').then(() => added = true);
+      let watchdog = page.waitForSelector('h3 div');
       await page.evaluate(addElement, 'span');
       await page.evaluate(() => document.querySelector('span').innerHTML = '<h3><div></div></h3>');
       await watchdog;


### PR DESCRIPTION
The current implementation of page.$ and page.$$ conflicts with
the elemnts handle implementation.

This patch removes functions in favor of future implementation.

References #111.