### PR TITLE
[DEBUG] Trace only those events which have listeners.

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -145,7 +145,7 @@ class Helper {
       const method = Reflect.get(classType.prototype, 'emit');
       Reflect.set(classType.prototype, 'emit', function(event, ...args) {
         let argsText = [JSON.stringify(event)].concat(args.map(stringifyArgument)).join(', ');
-        if (debug.enabled)
+        if (debug.enabled && this.listenerCount(event))
           debug(`${className}.emit(${argsText})`);
         if (apiCoverage && this.listenerCount(event))
           apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, true);


### PR DESCRIPTION
The `DEBUG=*page npm run unit` is too verbose due to events spamming
the console.

This patch starts tracing emitted events only if there are any
listeners.