### PR TITLE
Fix tests in non-headless mode

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -501,7 +501,7 @@ describe('Page', function() {
     it('should fail when main resources failed to load', SX(async function() {
       let error = null;
       try {
-        await page.navigate('chrome-devtools://devtools/bundled/inspector.html');
+        await page.navigate('chrome-devtools://non-existing.html');
       } catch (e) {
         error = e;
       }


### PR DESCRIPTION
The chrome-devtools://devtools/bundled/inspector.html is a perfectly
valid url in headful chromium, so we should pick another one for test
to work (and for the navigation inside the test to fail).