### PR TITLE
Add test which reproduces the hanging mouse.click() behavior

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1159,6 +1159,11 @@ describe('Page', function() {
       await page.press('a');
       expect(await page.evaluate(() => window.lastEvent.repeat)).toBe(true);
     }));
+    xit('should click links which cause navigation', SX(async function() {
+      await page.setContent(`<a href="${EMPTY_PAGE}">empty.html</a>`);
+      // This await should not hang.
+      await page.click('a');
+    }));
     function dimensions() {
       let rect = document.querySelector('textarea').getBoundingClientRect();
       return {


### PR DESCRIPTION
This patch adds a disabled test to reproduce the mouse.click() hanging
bug.

References #206.