### PR TITLE
Speculative: implement chainable API (aka 'nightmare')

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -88,13 +88,17 @@ class Browser {
   /**
    * @return {!Promise<!Page>}
    */
-  async newPage() {
+  async _newPage() {
     await this._ensureChromeIsRunning();
     if (!this._chromeProcess || this._terminated)
       throw new Error('ERROR: this chrome instance is not alive any more!');
     let client = await Connection.create(this._remoteDebuggingPort, this._connectionDelay);
     let page = await Page.create(client, this._ignoreHTTPSErrors, this._screenshotTaskQueue);
     return page;
+  }
+
+  newPage() {
+    return helper.chain(Page, this._newPage());
   }
 
   /**

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -138,11 +138,18 @@ class Mouse {
 
   async _doubleRaf() {
     // This is a hack for now, to make clicking less race-prone. See crbug.com/747647
-    await this._client.send('Runtime.evaluate', {
-      expression: 'new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f)))',
-      awaitPromise: true,
-      returnByValue: true
-    });
+    try { 
+      await Promise.race([
+        this._client.send('Runtime.evaluate', {
+          expression: 'new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f)))',
+          awaitPromise: true,
+          returnByValue: true
+        }),
+        new Promise(x => setTimeout(x, 100))
+      ]);
+    } catch (e) {
+      // Ignore
+    }
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -86,6 +86,10 @@ class Page extends EventEmitter {
     client.on('Security.certificateError', event => this._onCertificateError(event));
   }
 
+  chain() {
+    return helper.chain(Page, Promise.resolve(this));
+  }
+
   /**
    * @return {!Frame}
    */

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -224,6 +224,43 @@ class Helper {
   static isNumber(obj) {
     return typeof obj === 'number' || obj instanceof Number;
   }
+
+  static chain(classType, instancePromise) {
+    return new Chain(classType, instancePromise, Promise.resolve());
+  }
 }
+
+class Chain {
+  constructor(classType, instancePromise, actionsChain) {
+    this._instancePromise = instancePromise;
+    this._actionsChain = actionsChain;
+    return new Proxy(this, {
+      get: function(target, property, receiver) {
+        if (property === 'then' || property === 'result' || property === '_instancePromise' || property === '_actionsChain')
+          return Reflect.get(target, property, receiver);
+        let classMethod = Reflect.get(classType.prototype, property);
+        console.assert(classMethod, `FAILED: Class "${classType.prototype.constructor.name}" does not have method "${property}"`);
+        console.assert(typeof classMethod === 'function', `FAILED: ${classType.prototype.constructor.name}.{property} is not a function!`);
+        return function(...args) {
+          let next = target._actionsChain.then(async () => {
+            let instance = await target._instancePromise;
+            return instance[property].call(instance, ...args);
+          });
+          return new Chain(classType, instancePromise, next);
+        }
+      }
+    });
+  }
+
+  async result() {
+    return this._actionsChain;
+  }
+
+  async then(resolve, reject) {
+    await this._actionsChain;
+    return this._instancePromise.then(resolve, reject);
+  }
+}
+
 
 module.exports = Helper;


### PR DESCRIPTION
This is a speculative implementation of chaining. It turns out to be simple: the implementation is generic and is ~20 lines of code.

With this patch, the 'scape google results' script feels light (and it actually works):

```js
(async () => {

const {Browser} = require('puppeteer');
const browser = new Browser({headless: false});

// 1. Navigate to google.com
let page = await browser.newPage()
                        .setViewport({width: 800, height: 800})
                        .navigate('https://google.com');

// 2. Type 'godfather' and trigger search.
await page.chain()
          .waitFor('input[title=Search]', {visible: true})
          .type('godfather')
          .click('input[type=submit]');

// 3. Navigate to each result one-by-one and
//    take full page screenshot of each.
for (let i = 0; i < 4; ++i) {
  // Wait for search result link to appear and click it
  const selector = `div.g:nth-child(${i+1}) h3 a`;
  await page.chain()
            .waitFor(selector)
            .click(selector)
            .waitForNavigation({waitUntil: 'networkidle'})
            .screenshot({
              fullPage: true,
              path: `screenshot-${i + 1}.png`
            })
            .goBack();
}

browser.close();

})();
```

For comparison, the current version of the script is:
```js
(async () => {

const {Browser} = require('puppeteer');
const browser = new Browser();

let page = await browser.newPage();
// 1. Navigate to google.com
await page.navigate('https://google.com');
await page.setViewport({width: 800, height: 800});
const searchField = 'input[title=Search]';
await page.waitFor(searchField, {visible: true});

// 2. Type 'godfather' and trigger search.
await page.focus(searchField);
await page.type('godfather');
await page.click('input[type=submit]');

// 3. Navigate to each result one-by-one and
//    take full page screenshot of each.
for (let i = 0; i < 5; ++i) {
  // Wait for search result link and click it
  const searchResult = `div.g:nth-child(${i+1}) h3 a`;
  await page.waitFor(searchResult);
  await page.click(searchResult);
  // Wait for page to navigate to the search result
  await page.waitForNavigation({waitUntil: 'networkidle'});
  await page.screenshot({
    fullPage: true,
    path: `screenshot-${i + 1}.png`
  });
  // Go back to search results page.
  await page.goBack();
}

browser.close();

})();

```