### PR TITLE
Aborted network requests should use protocol's "Failed" status

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -243,7 +243,7 @@ class InterceptedRequest {
     this._handled = true;
     this._client.send('Network.continueInterceptedRequest', {
       interceptionId: this._interceptionId,
-      errorReason: 'Aborted'
+      errorReason: 'Failed'
     });
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -770,6 +770,16 @@ describe('Page', function() {
       ]);
       expect(request.headers['foo']).toBe('bar');
     }));
+    it('should fail navigation when aborting main resource', SX(async function() {
+      page.setRequestInterceptor(request => request.abort());
+      let error = null;
+      try {
+        await page.navigate(EMPTY_PAGE);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+    }));
   });
 
   describe('Page.Events.Dialog', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -779,6 +779,7 @@ describe('Page', function() {
         error = e;
       }
       expect(error).toBeTruthy();
+      expect(error.message).toContain('Failed to navigate');
     }));
   });
 


### PR DESCRIPTION
The "Aborted" status also has a side-effect of aborting navigation
(there will be no error page).