### PR TITLE
Fix full page screenshot example

### DIFF
--- a/examples/screenshot-fullpage.js
+++ b/examples/screenshot-fullpage.js
@@ -18,7 +18,7 @@ const {Browser} = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
 const browser = new Browser();
 
-(async () => {
+(async() => {
 
 let page = await browser.newPage();
 await page.emulate(devices['iPhone 6']);

--- a/examples/screenshot-fullpage.js
+++ b/examples/screenshot-fullpage.js
@@ -18,9 +18,12 @@ const {Browser} = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
 const browser = new Browser();
 
-browser.newPage().then(async page => {
-  await page.emulate(devices['iPhone 6']);
-  await page.navigate('https://www.nytimes.com/');
-  await page.screenshot({path: 'fp_page.png', fullPage: true});
-  browser.close();
-});
+(async () => {
+
+let page = await browser.newPage();
+await page.emulate(devices['iPhone 6']);
+await page.goto('https://www.nytimes.com/');
+await page.screenshot({path: 'full.png', fullPage: true});
+browser.close();
+
+})();


### PR DESCRIPTION
This patch aligns the example with our style in `examples/` folder, and also starts to use `page.goto` instead of `page.navigate`