### PR TITLE
Refer to the upstream bug

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -115,7 +115,7 @@ class NetworkManager extends EventEmitter {
   _onLoadingFinished(event) {
     let request = this._idToRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
-    // @see https://github.com/GoogleChrome/puppeteer/issues/168
+    // @see https://crbug.com/750469
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
@@ -129,7 +129,7 @@ class NetworkManager extends EventEmitter {
   _onLoadingFailed(event) {
     let request = this._idToRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
-    // @see https://github.com/GoogleChrome/puppeteer/issues/168
+    // @see https://crbug.com/750469
     if (!request)
       return;
     request._completePromiseFulfill.call(null);

--- a/test/test.js
+++ b/test/test.js
@@ -524,7 +524,7 @@ describe('Page', function() {
     }));
     it('should fail when navigating to bad SSL', SX(async function() {
       // Make sure that network events do not emit 'undefind'.
-      // @see https://github.com/GoogleChrome/puppeteer/issues/168
+      // @see https://crbug.com/750469
       page.on('request', request => expect(request).toBeTruthy());
       page.on('requestfinished', request => expect(request).toBeTruthy());
       page.on('requestfailed', request => expect(request).toBeTruthy());


### PR DESCRIPTION
The issue #168 is a protocol inconsistency which happens only
in case of HTTPS error. This patch starts refering to the
upstream bug instead of puppeteer issue.

Closes #168.