### PR TITLE
Upgrade chromium to r493673

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -456,7 +456,7 @@ class WaitTask {
 
     // When the page is navigated, the promise is rejected.
     // We will try again in the new execution context.
-    if (error && error.message.startsWith('Protocol error (Runtime.awaitPromise): Execution context was destroyed'))
+    if (error && error.message.includes('Execution context was destroyed'))
       return;
 
     if (error)

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -454,6 +454,11 @@ class WaitTask {
     if (!success && !error)
       return;
 
+    // When the page is navigated, the promise is rejected.
+    // We will try again in the new execution context.
+    if (error && error.message.startsWith('Protocol error (Runtime.awaitPromise): Execution context was destroyed'))
+      return;
+
     if (error)
       this._reject(error);
     else

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -120,7 +120,6 @@ class Mouse {
       x, y,
       modifiers: this._keyboard._modifiers
     });
-    await this._doubleRaf();
   }
 
   /**
@@ -134,15 +133,6 @@ class Mouse {
     if (options && options.delay)
       await new Promise(f => setTimeout(f, options.delay));
     await this.up(options);
-  }
-
-  async _doubleRaf() {
-    // This is a hack for now, to make clicking less race-prone. See crbug.com/747647
-    await this._client.send('Runtime.evaluate', {
-      expression: 'new Promise(f => requestAnimationFrame(() => requestAnimationFrame(f)))',
-      awaitPromise: true,
-      returnByValue: true
-    });
   }
 
   /**
@@ -160,7 +150,6 @@ class Mouse {
       modifiers: this._keyboard._modifiers,
       clickCount: (options.clickCount || 1)
     });
-    await this._doubleRaf();
   }
 
   /**
@@ -178,7 +167,6 @@ class Mouse {
       modifiers: this._keyboard._modifiers,
       clickCount: (options.clickCount || 1)
     });
-    await this._doubleRaf();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "493596"
+    "chromium_revision": "493673"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "492629"
+    "chromium_revision": "493596"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",

--- a/test/test.js
+++ b/test/test.js
@@ -961,7 +961,7 @@ describe('Page', function() {
       }
     }));
     // @see https://github.com/GoogleChrome/puppeteer/issues/161
-    xit('should not hang with touch-enabled viewports', SX(async function() {
+    it('should not hang with touch-enabled viewports', SX(async function() {
       await page.setViewport(iPhone.viewport);
       await page.mouse.down();
       await page.mouse.move(100, 10);
@@ -1209,7 +1209,7 @@ describe('Page', function() {
       expect(await page.evaluate(() => window.lastEvent.repeat)).toBe(true);
     }));
     // @see https://github.com/GoogleChrome/puppeteer/issues/206
-    xit('should click links which cause navigation', SX(async function() {
+    it('should click links which cause navigation', SX(async function() {
       await page.setContent(`<a href="${EMPTY_PAGE}">empty.html</a>`);
       // This await should not hang.
       await page.click('a');


### PR DESCRIPTION
Mouse events are no longer racy. Enabling touch no longer converts all mouse events into touches. Promises in destroyed execution contexts are rejected immediately.