### PR TITLE
Introduce new interception API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -617,9 +617,9 @@ The extra HTTP headers will be sent with every request the page initiates.
 - `value` <[boolean]> Whether to enable request interception.
 - returns: <[Promise]> Promise which resolves when request interception change is applied.
 
-As the request interception is enabled, it is allowed to call `request.abort` and `request.continue` methods on [Request] class.
+Activating request interception enables  `request.abort` and `request.continue`.
 
-En example of a naive request interception which aborts all image requests:
+An example of a naïve request interceptor which aborts all image requests:
 ```js
 const {Browser} = require('puppeteer');
 const browser = new Browser();
@@ -1101,8 +1101,8 @@ If request gets a 'redirect' response, the request is successfully finished with
 
 #### request.abort()
 
-Aborts request if the interception is enabled with `page.setRequestInterceptionEnabled`.
-Will throw if called with disabled request interception.
+Aborts request. To use this, request interception should be enabled with `page.setRequestInterceptionEnabled`.
+Exception is immediately thrown if the request interception is not enabled.
 
 #### request.continue([overrides])
 - `overrides` <[Object]> Optional request overwrites, which could be one of the following:
@@ -1111,10 +1111,8 @@ Will throw if called with disabled request interception.
   - `postData` <[string]> If set changes the post data of request
   - `headers` <[Map]> If set changes the request HTTP headers
 
-Continues request with optional request overrides if the interception is enabled with
-`page.setRequestInterceptionEnabled`.
-Will throw if called with disabled request interception.
-
+Continues request with optional request overrides. To use this, request interception should be enabled with `page.setRequestInterceptionEnabled`.
+Exception is immediately thrown if the request interception is not enabled.
 
 #### request.headers
 - <[Map]> A map of HTTP headers associated with the request.

--- a/lib/Multimap.js
+++ b/lib/Multimap.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @template K, V
+ */
+class Multimap {
+  constructor() {
+    /** @type {!Map<K, !Set<!V>>} */
+    this._map = new Map();
+  }
+
+  /**
+   * @param {K} key
+   * @param {V} value
+   */
+  set(key, value) {
+    let set = this._map.get(key);
+    if (!set) {
+      set = new Set();
+      this._map.set(key, set);
+    }
+    set.add(value);
+  }
+
+  /**
+   * @param {K} key
+   * @return {!Set<!V>}
+   */
+  get(key) {
+    let result = this._map.get(key);
+    if (!result)
+      result = new Set();
+    return result;
+  }
+
+  /**
+   * @param {K} key
+   * @return {boolean}
+   */
+  has(key) {
+    return this._map.has(key);
+  }
+
+  /**
+   * @param {K} key
+   * @param {V} value
+   * @return {boolean}
+   */
+  hasValue(key, value) {
+    let set = this._map.get(key);
+    if (!set)
+      return false;
+    return set.has(value);
+  }
+
+  /**
+   * @return {number}
+   */
+  get size() {
+    return this._map.size;
+  }
+
+  /**
+   * @param {K} key
+   * @param {V} value
+   * @return {boolean}
+   */
+  delete(key, value) {
+    let values = this.get(key);
+    let result = values.delete(value);
+    if (!values.size)
+      this._map.delete(key);
+    return result;
+  }
+
+  /**
+   * @param {K} key
+   */
+  deleteAll(key) {
+    this._map.delete(key);
+  }
+
+  /**
+   * @return {!Array<K>}
+   */
+  keysArray() {
+    return this._map.keysArray();
+  }
+
+  /**
+   * @param {K} key
+   * @return {?V} value
+   */
+  firstValue(key) {
+    let set = this._map.get(key);
+    if (!set)
+      return null;
+    return set.values().next().value;
+  }
+
+  /**
+   * @return {K}
+   */
+  firstKey() {
+    return this._map.keys().next().value;
+  }
+
+  /**
+   * @return {!Array<!V>}
+   */
+  valuesArray() {
+    let result = [];
+    let keys = this.keysArray();
+    for (let i = 0; i < keys.length; ++i)
+      result.pushAll(this.get(keys[i]).valuesArray());
+    return result;
+  }
+
+  clear() {
+    this._map.clear();
+  }
+}
+
+module.exports = Multimap;

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -23,11 +23,18 @@ class NetworkManager extends EventEmitter {
   constructor(client) {
     super();
     this._client = client;
-    this._requestInterceptor = null;
     /** @type {!Map<string, !Request>} */
-    this._idToRequest = new Map();
+    this._requestIdToRequest = new Map();
+    /** @type {!Map<string, string>} */
+    this._interceptionIdToRequestId = new Map();
     /** @type {!Map<string, string>} */
     this._extraHTTPHeaders = new Map();
+
+    this._requestInterceptionEnabled = false;
+    /** @type {!Map<string, string>} */
+    this._requestHashToRequestId = new Map();
+    /** @type {!Map<string, !Object>} */
+    this._requestHashToInterception = new Map();
 
     this._client.on('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this));
     this._client.on('Network.requestIntercepted', this._onRequestIntercepted.bind(this));
@@ -64,47 +71,99 @@ class NetworkManager extends EventEmitter {
   }
 
   /**
-   * @param {?function(!InterceptedRequest)} interceptor
+   * @param {boolean} value
    * @return {!Promise}
    */
-  async setRequestInterceptor(interceptor) {
-    this._requestInterceptor = interceptor;
-    await this._client.send('Network.setRequestInterceptionEnabled', {enabled: !!interceptor});
+  async setRequestInterceptionEnabled(value) {
+    await this._client.send('Network.setRequestInterceptionEnabled', {enabled: !!value});
+    this._requestInterceptionEnabled = value;
   }
 
   /**
    * @param {!Object} event
    */
   _onRequestIntercepted(event) {
-    let request = new InterceptedRequest(this._client, event.interceptionId, event.request);
-    this._requestInterceptor(request);
+    if (event.redirectStatusCode) {
+      let requestId = this._interceptionIdToRequestId.get(event.interceptionId);
+      console.assert(requestId, 'INTERNAL ERROR: failed to find requestId for interception.');
+      let request = this._requestIdToRequest.get(requestId);
+      this._handleRequestRedirect(request, event.redirectStatusCode, event.redirectHeaders);
+      this._emitRequestEvent(requestId, event.interceptionId, event.redirectUrl, event.request);
+      return;
+    }
+    let requestHash = generateRequestHash(event.request);
+    this._requestHashToInterception.set(requestHash, event);
+    this._maybeResolveInterception(requestHash);
   }
 
   /**
-   * @param {!Object} event
+   * @param {!Request} request
+   * @param {number} redirectStatus
+   * @param {!Object} redirectHeaders
    */
-  _onRequestWillBeSent(event) {
-    if (event.redirectResponse) {
-      let request = this._idToRequest.get(event.requestId);
-      let response = new Response(this._client, request, event.redirectResponse);
-      request._response = response;
-      this.emit(NetworkManager.Events.Response, response);
-      this.emit(NetworkManager.Events.RequestFinished, request);
-    }
-    let request = new Request(event.requestId, event.request);
-    this._idToRequest.set(event.requestId, request);
+  _handleRequestRedirect(request, redirectStatus, redirectHeaders) {
+    let response = new Response(this._client, request, redirectStatus, redirectHeaders);
+    request._response = response;
+    this.emit(NetworkManager.Events.Response, response);
+    this.emit(NetworkManager.Events.RequestFinished, request);
+  }
+
+  /**
+   * @param {string} requestId
+   * @param {string} interceptionId
+   * @param {string} url
+   * @param {!Object} requestPayload
+   */
+  _emitRequestEvent(requestId, interceptionId, url, requestPayload) {
+    let request = new Request(this._client, requestId, interceptionId, url, requestPayload);
+    this._requestIdToRequest.set(requestId, request);
+    this._interceptionIdToRequestId.set(interceptionId, requestId);
     this.emit(NetworkManager.Events.Request, request);
   }
 
   /**
    * @param {!Object} event
    */
+  _onRequestWillBeSent(event) {
+    if (this._requestInterceptionEnabled) {
+      // All redirects are handled in requestIntercepted.
+      if (event.redirectResponse)
+        return;
+      let requestHash = generateRequestHash(event.request);
+      this._requestHashToRequestId.set(requestHash, event.requestId);
+      this._maybeResolveInterception(requestHash);
+      return;
+    }
+    if (event.redirectResponse) {
+      let request = this._requestIdToRequest.get(event.requestId);
+      this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
+    }
+    this._emitRequestEvent(event.requestId, null, event.request.url, event.request);
+  }
+
+  /**
+   * @param {string} requestHash
+   * @param {!{requestEvent: ?Object, interceptionEvent: ?Object}} interception
+   */
+  _maybeResolveInterception(requestHash) {
+    const requestId = this._requestHashToRequestId.get(requestHash);
+    const interception = this._requestHashToInterception.get(requestHash);
+    if (!requestId || !interception)
+      return;
+    this._requestHashToRequestId.delete(requestHash);
+    this._requestHashToInterception.delete(requestHash);
+    this._emitRequestEvent(requestId, interception.interceptionId, interception.request.url, interception.request);
+  }
+
+  /**
+   * @param {!Object} event
+   */
   _onResponseReceived(event) {
-    let request = this._idToRequest.get(event.requestId);
+    let request = this._requestIdToRequest.get(event.requestId);
     // FileUpload sends a response without a matching request.
     if (!request)
       return;
-    let response = new Response(this._client, request, event.response);
+    let response = new Response(this._client, request, event.response.status, event.response.headers);
     request._response = response;
     this.emit(NetworkManager.Events.Response, response);
   }
@@ -113,13 +172,14 @@ class NetworkManager extends EventEmitter {
    * @param {!Object} event
    */
   _onLoadingFinished(event) {
-    let request = this._idToRequest.get(event.requestId);
+    let request = this._requestIdToRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
     // @see https://crbug.com/750469
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
-    this._idToRequest.delete(event.requestId);
+    this._requestIdToRequest.delete(event.requestId);
+    this._interceptionIdToRequestId.delete(event.interceptionId);
     this.emit(NetworkManager.Events.RequestFinished, request);
   }
 
@@ -127,28 +187,37 @@ class NetworkManager extends EventEmitter {
    * @param {!Object} event
    */
   _onLoadingFailed(event) {
-    let request = this._idToRequest.get(event.requestId);
+    let request = this._requestIdToRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
     // @see https://crbug.com/750469
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
-    this._idToRequest.delete(event.requestId);
+    this._requestIdToRequest.delete(event.requestId);
+    this._interceptionIdToRequestId.delete(event.interceptionId);
     this.emit(NetworkManager.Events.RequestFailed, request);
   }
 }
 
 class Request {
   /**
+   * @param {!Connection} client
+   * @param {string} requestId
+   * @param {string} interceptionId
+   * @param {string} url
    * @param {!Object} payload
    */
-  constructor(requestId, payload) {
+  constructor(client, requestId, interceptionId, url, payload) {
+    this._client = client;
     this._requestId = requestId;
+    this._interceptionId = interceptionId;
+    this._interceptionHandled = false;
     this._response = null;
     this._completePromise = new Promise(fulfill => {
       this._completePromiseFulfill = fulfill;
     });
-    this.url = payload.url;
+
+    this.url = url;
     this.method = payload.method;
     this.postData = payload.postData;
     this.headers = new Map(Object.entries(payload.headers));
@@ -160,25 +229,57 @@ class Request {
   response() {
     return this._response;
   }
+
+  /**
+   * @param {!Object=} overrides
+   */
+  continue(overrides = {}) {
+    console.assert(this._interceptionId, 'Request Interception is not enabled!');
+    console.assert(!this._interceptionHandled, 'Request is already handled!');
+    this._interceptionHandled = true;
+    let headers = undefined;
+    if (overrides.headers) {
+      headers = {};
+      for (let entry of overrides.headers)
+        headers[entry[0]] = entry[1];
+    }
+    this._client.send('Network.continueInterceptedRequest', {
+      interceptionId: this._interceptionId,
+      url: overrides.url,
+      method: overrides.method,
+      postData: overrides.postData,
+      headers: headers
+    });
+  }
+
+  abort() {
+    console.assert(this._interceptionId, 'Request Interception is not enabled!');
+    console.assert(!this._interceptionHandled, 'Request is already handled!');
+    this._interceptionHandled = true;
+    this._client.send('Network.continueInterceptedRequest', {
+      interceptionId: this._interceptionId,
+      errorReason: 'Failed'
+    });
+  }
 }
 helper.tracePublicAPI(Request);
 
 class Response {
   /**
    * @param {!Session} client
-   * @param {?Request} request
-   * @param {!Object} payload
+   * @param {!Request} request
+   * @param {integer} status
+   * @param {!Object} headers
    */
-  constructor(client, request, payload) {
+  constructor(client, request, status, headers) {
     this._client = client;
     this._request = request;
     this._contentPromise = null;
 
-    this.headers = new Map(Object.entries(payload.headers));
-    this.ok = payload.status >= 200 && payload.status <= 299;
-    this.status = payload.status;
-    this.statusText = payload.statusText;
-    this.url = payload.url;
+    this.headers = new Map(Object.entries(headers));
+    this.status = status;
+    this.ok = status >= 200 && status <= 299;
+    this.url = request.url;
   }
 
   /**
@@ -213,7 +314,7 @@ class Response {
   }
 
   /**
-   * @return {?Response}
+   * @return {!Response}
    */
   request() {
     return this._request;
@@ -221,52 +322,25 @@ class Response {
 }
 helper.tracePublicAPI(Response);
 
-class InterceptedRequest {
-  /**
-   * @param {!Session} client
-   * @param {string} interceptionId
-   * @param {!Object} payload
-   */
-  constructor(client, interceptionId, payload) {
-    this._client = client;
-    this._interceptionId = interceptionId;
-    this._handled = false;
-
-    this.url = payload.url;
-    this.method = payload.method;
-    this.headers = new Map(Object.entries(payload.headers));
-    this.postData = payload.postData;
+/**
+ * @param {!Object} request
+ * @return {string}
+ */
+function generateRequestHash(request) {
+  let hash = {
+    url: request.url,
+    method: request.method,
+    postData: request.postData,
+    headers: {},
+  };
+  let headers = Object.keys(request.headers);
+  headers.sort();
+  for (let header of headers) {
+    if (header === 'Accept' || header === 'Referer')
+      continue;
+    hash.headers[header] = request.headers[header];
   }
-
-  abort() {
-    console.assert(!this._handled, 'This request is already handled!');
-    this._handled = true;
-    this._client.send('Network.continueInterceptedRequest', {
-      interceptionId: this._interceptionId,
-      errorReason: 'Failed'
-    });
-  }
-
-  /**
-   * @param {!Object} overrides
-   */
-  continue(overrides = {}) {
-    console.assert(!this._handled, 'This request is already handled!');
-    this._handled = true;
-    let headers = undefined;
-    if (overrides.headers) {
-      headers = {};
-      for (let entry of overrides.headers.entries())
-        headers[entry[0]] = entry[1];
-    }
-    this._client.send('Network.continueInterceptedRequest', {
-      interceptionId: this._interceptionId,
-      url: overrides.url,
-      method: overrides.method,
-      postData: overrides.postData,
-      headers: headers
-    });
-  }
+  return JSON.stringify(hash);
 }
 
 NetworkManager.Events = {

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -15,6 +15,7 @@
  */
 const EventEmitter = require('events');
 const helper = require('./helper');
+const Multimap = require('./Multimap');
 
 class NetworkManager extends EventEmitter {
   /**
@@ -31,10 +32,10 @@ class NetworkManager extends EventEmitter {
     this._extraHTTPHeaders = new Map();
 
     this._requestInterceptionEnabled = false;
-    /** @type {!Map<string, string>} */
-    this._requestHashToRequestId = new Map();
-    /** @type {!Map<string, !Object>} */
-    this._requestHashToInterception = new Map();
+    /** @type {!Multimap<string, string>} */
+    this._requestHashToRequestIds = new Multimap();
+    /** @type {!Multimap<string, !Object>} */
+    this._requestHashToInterceptions = new Multimap();
 
     this._client.on('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this));
     this._client.on('Network.requestIntercepted', this._onRequestIntercepted.bind(this));
@@ -91,7 +92,7 @@ class NetworkManager extends EventEmitter {
       return;
     }
     let requestHash = generateRequestHash(event.request);
-    this._requestHashToInterception.set(requestHash, event);
+    this._requestHashToInterceptions.set(requestHash, event);
     this._maybeResolveInterception(requestHash);
   }
 
@@ -131,7 +132,7 @@ class NetworkManager extends EventEmitter {
       if (event.redirectResponse)
         return;
       let requestHash = generateRequestHash(event.request);
-      this._requestHashToRequestId.set(requestHash, event.requestId);
+      this._requestHashToRequestIds.set(requestHash, event.requestId);
       this._maybeResolveInterception(requestHash);
       return;
     }
@@ -147,12 +148,12 @@ class NetworkManager extends EventEmitter {
    * @param {!{requestEvent: ?Object, interceptionEvent: ?Object}} interception
    */
   _maybeResolveInterception(requestHash) {
-    const requestId = this._requestHashToRequestId.get(requestHash);
-    const interception = this._requestHashToInterception.get(requestHash);
+    const requestId = this._requestHashToRequestIds.firstValue(requestHash);
+    const interception = this._requestHashToInterceptions.firstValue(requestHash);
     if (!requestId || !interception)
       return;
-    this._requestHashToRequestId.delete(requestHash);
-    this._requestHashToInterception.delete(requestHash);
+    this._requestHashToRequestIds.delete(requestHash, requestId);
+    this._requestHashToInterceptions.delete(requestHash, interception);
     this._handleRequestStart(requestId, interception.interceptionId, interception.request.url, interception.request);
   }
 

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -25,8 +25,8 @@ class NetworkManager extends EventEmitter {
     this._client = client;
     /** @type {!Map<string, !Request>} */
     this._requestIdToRequest = new Map();
-    /** @type {!Map<string, string>} */
-    this._interceptionIdToRequestId = new Map();
+    /** @type {!Map<string, !Request>} */
+    this._interceptionIdToRequest = new Map();
     /** @type {!Map<string, string>} */
     this._extraHTTPHeaders = new Map();
 
@@ -84,11 +84,10 @@ class NetworkManager extends EventEmitter {
    */
   _onRequestIntercepted(event) {
     if (event.redirectStatusCode) {
-      let requestId = this._interceptionIdToRequestId.get(event.interceptionId);
-      console.assert(requestId, 'INTERNAL ERROR: failed to find requestId for interception.');
-      let request = this._requestIdToRequest.get(requestId);
+      let request = this._interceptionIdToRequest.get(event.interceptionId);
+      console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
       this._handleRequestRedirect(request, event.redirectStatusCode, event.redirectHeaders);
-      this._emitRequestEvent(requestId, event.interceptionId, event.redirectUrl, event.request);
+      this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.request);
       return;
     }
     let requestHash = generateRequestHash(event.request);
@@ -104,6 +103,8 @@ class NetworkManager extends EventEmitter {
   _handleRequestRedirect(request, redirectStatus, redirectHeaders) {
     let response = new Response(this._client, request, redirectStatus, redirectHeaders);
     request._response = response;
+    this._requestIdToRequest.delete(request._requestId);
+    this._interceptionIdToRequest.delete(request._interceptionId);
     this.emit(NetworkManager.Events.Response, response);
     this.emit(NetworkManager.Events.RequestFinished, request);
   }
@@ -114,10 +115,10 @@ class NetworkManager extends EventEmitter {
    * @param {string} url
    * @param {!Object} requestPayload
    */
-  _emitRequestEvent(requestId, interceptionId, url, requestPayload) {
+  _handleRequestStart(requestId, interceptionId, url, requestPayload) {
     let request = new Request(this._client, requestId, interceptionId, url, requestPayload);
     this._requestIdToRequest.set(requestId, request);
-    this._interceptionIdToRequestId.set(interceptionId, requestId);
+    this._interceptionIdToRequest.set(interceptionId, request);
     this.emit(NetworkManager.Events.Request, request);
   }
 
@@ -138,7 +139,7 @@ class NetworkManager extends EventEmitter {
       let request = this._requestIdToRequest.get(event.requestId);
       this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
     }
-    this._emitRequestEvent(event.requestId, null, event.request.url, event.request);
+    this._handleRequestStart(event.requestId, null, event.request.url, event.request);
   }
 
   /**
@@ -152,7 +153,7 @@ class NetworkManager extends EventEmitter {
       return;
     this._requestHashToRequestId.delete(requestHash);
     this._requestHashToInterception.delete(requestHash);
-    this._emitRequestEvent(requestId, interception.interceptionId, interception.request.url, interception.request);
+    this._handleRequestStart(requestId, interception.interceptionId, interception.request.url, interception.request);
   }
 
   /**
@@ -179,7 +180,7 @@ class NetworkManager extends EventEmitter {
       return;
     request._completePromiseFulfill.call(null);
     this._requestIdToRequest.delete(event.requestId);
-    this._interceptionIdToRequestId.delete(event.interceptionId);
+    this._interceptionIdToRequest.delete(event.interceptionId);
     this.emit(NetworkManager.Events.RequestFinished, request);
   }
 
@@ -194,7 +195,7 @@ class NetworkManager extends EventEmitter {
       return;
     request._completePromiseFulfill.call(null);
     this._requestIdToRequest.delete(event.requestId);
-    this._interceptionIdToRequestId.delete(event.interceptionId);
+    this._interceptionIdToRequest.delete(event.interceptionId);
     this.emit(NetworkManager.Events.RequestFailed, request);
   }
 }

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -116,10 +116,10 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {?function(!InterceptedRequest)} interceptor
+   * @param {boolean} value
    */
-  async setRequestInterceptor(interceptor) {
-    return this._networkManager.setRequestInterceptor(interceptor);
+  async setRequestInterceptionEnabled(value) {
+    return this._networkManager.setRequestInterceptionEnabled(value);
   }
 
   /**

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -38,7 +38,6 @@ const EXCLUDE_METHODS = new Set([
   'Frame.constructor',
   'Headers.constructor',
   'Headers.fromPayload',
-  'InterceptedRequest.constructor',
   'Keyboard.constructor',
   'Mouse.constructor',
   'Tracing.constructor',

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -24,6 +24,7 @@ const EXCLUDE_CLASSES = new Set([
   'EmulationManager',
   'FrameManager',
   'Helper',
+  'Multimap',
   'NavigatorWatcher',
   'NetworkManager',
   'ProxyStream',


### PR DESCRIPTION
This patch removes InterceptedRequest and adds Request.abort() and Request.continue()
instead.

Fixes #121.