### PR TITLE
Respect CHROME_PATH env variable to launch chromium

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ HEADLESS=false npm run unit
 ```
 - To run tests with custom chromium executable:
 ```
-CHROME=<path-to-executable> npm run unit
+CHROM_PATH=<path-to-executable> npm run unit
 ```
 - To run tests in slow-mode:
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,9 +179,8 @@ browser.newPage().then(async page => {
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
   - `headless` <[boolean]> Whether to run chromium in [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome). Defaults to `true`.
-  - `executablePath` <[string]> Path to a chromium executable to run instead of bundled chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
-  - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful
-so that you can see what is going on.
+  - `chromePath` <[string]> Path to a chromium executable to run instead of bundled chromium. If `chromePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If `CHROME_PATH` env variable is set, it would be used. If both `CHROME_PATH` env variable and `chromePath` options are specified, `chromePath` option will be used.
+  - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
   - `args` <[Array]<[string]>> Additional arguments to pass to the chromium instance. List of chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
 
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -64,13 +64,15 @@ class Browser {
           `--hide-scrollbars`
       );
     }
-    if (typeof options.executablePath === 'string') {
-      this._chromeExecutable = options.executablePath;
+    if (typeof options.chromePath === 'string') {
+      this._chromeExecutable = options.chromePath;
+    } else if (process.env.CHROME_PATH) {
+      this._chromeExecutable = process.env.CHROME_PATH;
     } else {
       let chromiumRevision = require('../package.json').puppeteer.chromium_revision;
       let revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), chromiumRevision);
       console.assert(revisionInfo, 'Chromium revision is not downloaded. Run npm install');
-      this._chromeExecutable = revisionInfo.executablePath;
+      this._chromeExecutable = revisionInfo.chromePath;
     }
     this._ignoreHTTPSErrors = !!options.ignoreHTTPSErrors;
     if (Array.isArray(options.args))

--- a/test/test.js
+++ b/test/test.js
@@ -38,12 +38,10 @@ const HTTPS_PREFIX = 'https://localhost:' + HTTPS_PORT;
 
 const headless = (process.env.HEADLESS || 'true').trim().toLowerCase() === 'true';
 const slowMo = parseInt((process.env.SLOW_MO || '0').trim(), 10);
-const executablePath = process.env.CHROME;
-if (executablePath)
-  console.warn(`${YELLOW_COLOR}WARN: running tests with ${executablePath}${RESET_COLOR}`);
+if (process.env.CHROME_PATH)
+  console.warn(`${YELLOW_COLOR}WARN: running tests with ${process.env.CHROME_PATH}${RESET_COLOR}`);
 
 const defaultBrowserOptions = {
-  executablePath,
   slowMo,
   headless,
   args: ['--no-sandbox']

--- a/utils/ChromiumDownloader.js
+++ b/utils/ChromiumDownloader.js
@@ -129,24 +129,24 @@ module.exports = {
   /**
    * @param {string} platform
    * @param {string} revision
-   * @return {?{executablePath: string}}
+   * @return {?{chromePath: string}}
    */
   revisionInfo: function(platform, revision) {
     console.assert(downloadURLs[platform], `Unsupported platform: ${platform}`);
     let folderPath = getFolderPath(platform, revision);
     if (!fs.existsSync(folderPath))
       return null;
-    let executablePath = '';
+    let chromePath = '';
     if (platform === 'mac')
-      executablePath = path.join(folderPath, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
+      chromePath = path.join(folderPath, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
     else if (platform === 'linux')
-      executablePath = path.join(folderPath, 'chrome-linux', 'chrome');
+      chromePath = path.join(folderPath, 'chrome-linux', 'chrome');
     else if (platform === 'win32' || platform === 'win64')
-      executablePath = path.join(folderPath, 'chrome-win32', 'chrome.exe');
+      chromePath = path.join(folderPath, 'chrome-win32', 'chrome.exe');
     else
       throw 'Unsupported platfrom: ' + platfrom;
     return {
-      executablePath: executablePath
+      chromePath: chromePath
     };
   },
 };


### PR DESCRIPTION
This patch:
- renames Browser.Options.executablePath into Browser.Options.chromePath
- removes the test-related CHROME env variable
- teaches puppeteer to respect CHROME_PATH env variable

The motivation behind this patch:
- we already had the ability to run tests against custom-built chromium
  with CHROME env variable. It turned out, this would come handy for any
  puppeteer scripts
- this aligns puppeteer with [chrome launcher](https://github.com/GoogleChrome/lighthouse/tree/master/chrome-launcher), which uses CHROME_PATH for the same purpose