### PR TITLE
Roll chromium to r493985

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -103,8 +103,8 @@ class Browser {
    */
   async version() {
     await this._ensureChromeIsRunning();
-    let version = await Connection.version(this._remoteDebuggingPort);
-    return version.Browser;
+    let version = await this._connection.send('Browser.getVersion');
+    return version.product;
   }
 
   /**

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -18,8 +18,6 @@ const debugSession = require('debug')('puppeteer:session');
 
 const EventEmitter = require('events');
 const WebSocket = require('ws');
-const http = require('http');
-const COMMAND_TIMEOUT = 10000;
 
 class Connection extends EventEmitter {
   /**
@@ -129,14 +127,6 @@ class Connection extends EventEmitter {
       ws.on('error', reject);
     });
   }
-
-  /**
-   * @param {number} port
-   * @return {!Promise<!Object>}
-   */
-  static version(port) {
-    return runJsonCommand(port, 'version');
-  }
 }
 
 class Session extends EventEmitter {
@@ -214,49 +204,6 @@ class Session extends EventEmitter {
     for (let callback of this._callbacks.values())
       callback.reject(new Error(`Protocol error (${callback.method}): Target closed.`));
     this._callbacks.clear();
-  }
-}
-
-/**
- * @param {number} port
- * @param {string} command
- * @return {!Promise<!Object>}
- */
-function runJsonCommand(port, command) {
-  let request = http.get({
-    hostname: 'localhost',
-    port: port,
-    path: '/json/' + command
-  }, onResponse);
-  request.setTimeout(COMMAND_TIMEOUT, onTimeout);
-  let resolve, reject;
-  return new Promise((res, rej) => { resolve = res; reject = rej; });
-
-  function onResponse(response) {
-    let data = '';
-    response.on('data', chunk => data += chunk);
-    response.on('end', () => {
-      if (response.statusCode !== 200) {
-        reject(new Error(`Protocol JSON API error (${command}), status: ${response.statusCode}`));
-        return;
-      }
-      // In the case of 'close' & 'activate' Chromium returns a string rather than JSON: goo.gl/7v27xD
-      if (data === 'Target is closing' || data === 'Target activated') {
-        resolve({message: data});
-        return;
-      }
-      try {
-        resolve(JSON.parse(data));
-      } catch (e) {
-        reject(e);
-      }
-    });
-  }
-
-  function onTimeout() {
-    request.abort();
-    // Reject on error with code specifically indicating timeout in connection setup.
-    reject(new Error('Timeout waiting for initial Debugger Protocol connection.'));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "493673"
+    "chromium_revision": "493985"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",


### PR DESCRIPTION
This patch:
- rolls chromium to r493985
- migrates Browser.version() puppeteer method to use newly added
  Browser.getVersion() protocol method