### PR TITLE
Emit 'error' event when page crashes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,7 @@
   * [class: Page](#class-page)
     + [event: 'console'](#event-console)
     + [event: 'dialog'](#event-dialog)
+    + [event: 'error'](#event-error)
     + [event: 'frameattached'](#event-frameattached)
     + [event: 'framedetached'](#event-framedetached)
     + [event: 'framenavigated'](#event-framenavigated)
@@ -215,6 +216,13 @@ page.evaluate(() => console.log(5, 'hello', {foo: 'bar'}));
 - <[Dialog]>
 
 Emitted when a JavaScript dialog, such as `alert`, `prompt`, `confirm` or `beforeunload`, gets opened on the page. Puppeteer can take action to the dialog via dialog's [accept](#dialogacceptprompttext) or [dismiss](#dialogdismiss) methods.
+
+#### event: 'error'
+- <[Error]>
+
+Emitted when the page crashes.
+
+> **Note** `error` event has a special meaning in Node, see [error events](https://nodejs.org/api/events.html#events_error_events) for details.
 
 #### event: 'frameattached'
 - <[Frame]>
@@ -1153,6 +1161,7 @@ Contains the URL of the response.
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type "String"
 [stream.Readable]: https://nodejs.org/api/stream.html#stream_class_stream_readable "stream.Readable"
+[Error]: https://nodejs.org/api/errors.html#errors_class_error "Error"
 [Frame]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-frame "Frame"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [Response]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-response  "Response"

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -80,11 +80,15 @@ class Page extends EventEmitter {
     this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(Page.Events.RequestFinished, event));
 
     client.on('Page.loadEventFired', event => this.emit(Page.Events.Load));
-
     client.on('Runtime.consoleAPICalled', event => this._onConsoleAPI(event));
     client.on('Page.javascriptDialogOpening', event => this._onDialog(event));
     client.on('Runtime.exceptionThrown', exception => this._handleException(exception.exceptionDetails));
     client.on('Security.certificateError', event => this._onCertificateError(event));
+    client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
+  }
+
+  _onTargetCrashed() {
+    this.emit('error', new Error('Page crashed!'));
   }
 
   /**
@@ -694,6 +698,7 @@ function convertPrintParameterToInches(parameter) {
 Page.Events = {
   Console: 'console',
   Dialog: 'dialog',
+  Error: 'error',
   // Can'e use just 'error' due to node.js special treatment of error events.
   // @see https://nodejs.org/api/events.html#events_error_events
   PageError: 'pageerror',

--- a/test/test.js
+++ b/test/test.js
@@ -155,6 +155,16 @@ describe('Page', function() {
     }));
   });
 
+  describe('Page.Events.error', function() {
+    it('should throw when page crashes', SX(async function() {
+      let error = null;
+      page.on('error', err => error = err);
+      page.goto('chrome://crash').catch(e => {});
+      await waitForEvents(page, 'error');
+      expect(error.message).toBe('Page crashed!');
+    }));
+  });
+
   describe('Page.evaluate', function() {
     it('should work', SX(async function() {
       let result = await page.evaluate(() => 7 * 3);


### PR DESCRIPTION
This patch starts emitting 'error' event when page crashes.
'error' events have special treatment in node, so page crashes
become observable for users.

Fixes #262.