### PR TITLE
Roll chromium to r494365

### DIFF
--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -51,7 +51,7 @@ class ElementHandle {
     stringifiedArgs.push(...args.map(x => JSON.stringify(x)));
     let functionDeclaration = `function() { return (${pageFunction})(${stringifiedArgs.join(',')}) }`;
     const objectId = this._remoteObject.objectId;
-    let { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.callFunctionOn', { objectId, functionDeclaration, returnByValue: false});
+    let { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.callFunctionOn', { objectId, functionDeclaration, returnByValue: false, awaitPromise: true});
     if (exceptionDetails)
       throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
     return await helper.serializeRemoteObject(this._client, remoteObject);

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -196,7 +196,7 @@ class Frame {
   async _rawEvaluate(pageFunction, ...args) {
     let expression = helper.evaluationString(pageFunction, ...args);
     const contextId = this._defaultContextId;
-    let { exceptionDetails, result: remoteObject }  = await this._client.send('Runtime.evaluate', { expression, contextId, returnByValue: false});
+    let { exceptionDetails, result: remoteObject }  = await this._client.send('Runtime.evaluate', { expression, contextId, returnByValue: false, awaitPromise: true});
     if (exceptionDetails)
       throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
     return remoteObject;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -54,16 +54,6 @@ class Helper {
    * @return {!Promise<!Object>}
    */
   static async serializeRemoteObject(client, remoteObject) {
-    if (remoteObject.subtype === 'promise') {
-      let response = (await client.send('Runtime.awaitPromise', {
-        promiseObjectId: remoteObject.objectId,
-        returnByValue: false
-      }));
-      Helper.releaseObject(client, remoteObject);
-      if (response.exceptionDetails)
-        throw new Error('Evaluation failed: ' + Helper.getExceptionMessage(response.exceptionDetails));
-      remoteObject = response.result;
-    }
     if (remoteObject.unserializableValue) {
       switch (remoteObject.unserializableValue) {
         case '-0':
@@ -80,6 +70,8 @@ class Helper {
     }
     if (!remoteObject.objectId)
       return remoteObject.value;
+    if (remoteObject.subtype === 'promise')
+      return remoteObject.description;
     try {
       let response = await client.send('Runtime.callFunctionOn', {
         objectId: remoteObject.objectId,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "493985"
+    "chromium_revision": "494365"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",

--- a/test/test.js
+++ b/test/test.js
@@ -504,6 +504,7 @@ describe('Page', function() {
           console.dir('calling console.dir');
           console.warn('calling console.warn');
           console.error('calling console.error');
+          console.log(Promise.resolve('should not wait until resolved!'));
         }),
         // Wait for 5 events to hit.
         waitForEvents(page, 'console', 5)
@@ -514,6 +515,7 @@ describe('Page', function() {
         'calling console.dir',
         'calling console.warn',
         'calling console.error',
+        'Promise',
       ]);
     }));
     it('should not fail for window object', SX(async function() {


### PR DESCRIPTION
This patch:
- rolls chromium to r494365
- starts using Runtime.evaluate(awaitPromise: true), with new semantic
  we can avoid additional Runtime.awaitPromise call
- stops resolving promises for Console event