### PR TITLE
Rename 'remoteDebuggingURL' into 'protocolWSEndpoint'

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@
   * [class: Browser](#class-browser)
     + [browser.close()](#browserclose)
     + [browser.newPage()](#browsernewpage)
-    + [browser.remoteDebuggingURL()](#browserremotedebuggingurl)
+    + [browser.protocolWSEndpoint()](#browserprotocolwsendpoint)
     + [browser.version()](#browserversion)
   * [class: Page](#class-page)
     + [event: 'console'](#event-console)

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,8 +11,8 @@
   * [class: Browser](#class-browser)
     + [browser.close()](#browserclose)
     + [browser.newPage()](#browsernewpage)
-    + [browser.protocolWSEndpoint()](#browserprotocolwsendpoint)
     + [browser.version()](#browserversion)
+    + [browser.wsEndpoint()](#browserwsendpoint)
   * [class: Page](#class-page)
     + [event: 'console'](#event-console)
     + [event: 'dialog'](#event-dialog)
@@ -143,7 +143,7 @@ puppeteer.launch().then(async browser => {
 
 #### puppeteer.connect(options)
 - `options` <[Object]>
-  - `remoteDebuggingURL` <[string]> a [remote debugging URL](#browserremotedebuggingurl) to connect to.
+  - `browserWSEndpoint` <[string]> a [browser websocket endpoint](#browserwsendpoint) to connect to.
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
 - returns: <[Promise]<[Browser]>>
 
@@ -185,15 +185,16 @@ Closes browser with all the pages (if any were opened). The browser object itsel
 #### browser.newPage()
 - returns: <[Promise]<[Page]>> Promise which resolves to a new [Page] object.
 
-#### browser.remoteDebuggingURL()
-- returns: <[string]> A URL for debugging this browser instance.
-
-Remote debugging url is as an argument to the [puppeteer.connect](#puppeteerconnect).
-
 #### browser.version()
 - returns: <[Promise]<[string]>> For headless Chromium, this is similar to `HeadlessChrome/61.0.3153.0`. For non-headless, this is similar to `Chrome/61.0.3153.0`.
 
 > **NOTE** the format of browser.version() might change with future releases of Chromium.
+
+#### browser.wsEndpoint()
+- returns: <[string]> Browser websocket url.
+
+Browser websocket endpoint which could be used as an argument to
+[puppeteer.connect](#puppeteerconnect).
 
 ### class: Page
 

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -18,7 +18,9 @@ const puppeteer = require('puppeteer');
 
 (async() => {
 
-const browser = await puppeteer.launch();
+const browser = await puppeteer.launch({
+  executablePath: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'
+});
 const page = await browser.newPage();
 await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -18,9 +18,7 @@ const puppeteer = require('puppeteer');
 
 (async() => {
 
-const browser = await puppeteer.launch({
-  executablePath: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'
-});
+const browser = await puppeteer.launch();
 const page = await browser.newPage();
 await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -33,7 +33,7 @@ class Browser {
   /**
    * @return {string}
    */
-  protocolWSEndpoint() {
+  wsEndpoint() {
     return this._connection.url();
   }
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -33,7 +33,7 @@ class Browser {
   /**
    * @return {string}
    */
-  remoteDebuggingURL() {
+  protocolWSEndpoint() {
     return this._connection.url();
   }
 

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -87,17 +87,17 @@ class Launcher {
       removeRecursive(userDataDir);
     });
 
-    let remoteDebuggingURL = await waitForRemoteDebuggingURL(chromeProcess);
+    let protocolWSEndpoint = await waitForProtocolEndpoint(chromeProcess);
     if (terminated)
       throw new Error('Failed to launch chrome! ' + stderr);
     // Failed to connect to browser.
-    if (!remoteDebuggingURL) {
+    if (!protocolWSEndpoint) {
       chromeProcess.kill();
       throw new Error('Failed to connect to chrome!');
     }
 
     let connectionDelay = options.slowMo || 0;
-    let connection = await Connection.create(remoteDebuggingURL, connectionDelay);
+    let connection = await Connection.create(protocolWSEndpoint, connectionDelay);
     return new Browser(connection, !!options.ignoreHTTPSErrors, () => chromeProcess.kill());
   }
 
@@ -105,8 +105,8 @@ class Launcher {
    * @param {string} options
    * @return {!Promise<!Browser>}
    */
-  static async connect({remoteDebuggingURL, ignoreHTTPSErrors = false}) {
-    let connection = await Connection.create(remoteDebuggingURL);
+  static async connect({protocolWSEndpoint, ignoreHTTPSErrors = false}) {
+    let connection = await Connection.create(protocolWSEndpoint);
     return new Browser(connection, !!ignoreHTTPSErrors);
   }
 }
@@ -115,7 +115,7 @@ class Launcher {
  * @param {!ChildProcess} chromeProcess
  * @return {!Promise<string>}
  */
-function waitForRemoteDebuggingURL(chromeProcess) {
+function waitForProtocolEndpoint(chromeProcess) {
   return new Promise(fulfill => {
     const rl = readline.createInterface({ input: chromeProcess.stderr });
     rl.on('line', onLine);

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -87,17 +87,17 @@ class Launcher {
       removeRecursive(userDataDir);
     });
 
-    let protocolWSEndpoint = await waitForProtocolEndpoint(chromeProcess);
+    let browserWSEndpoint = await waitForWSEndpoint(chromeProcess);
     if (terminated)
       throw new Error('Failed to launch chrome! ' + stderr);
     // Failed to connect to browser.
-    if (!protocolWSEndpoint) {
+    if (!browserWSEndpoint) {
       chromeProcess.kill();
       throw new Error('Failed to connect to chrome!');
     }
 
     let connectionDelay = options.slowMo || 0;
-    let connection = await Connection.create(protocolWSEndpoint, connectionDelay);
+    let connection = await Connection.create(browserWSEndpoint, connectionDelay);
     return new Browser(connection, !!options.ignoreHTTPSErrors, () => chromeProcess.kill());
   }
 
@@ -105,8 +105,8 @@ class Launcher {
    * @param {string} options
    * @return {!Promise<!Browser>}
    */
-  static async connect({protocolWSEndpoint, ignoreHTTPSErrors = false}) {
-    let connection = await Connection.create(protocolWSEndpoint);
+  static async connect({browserWSEndpoint, ignoreHTTPSErrors = false}) {
+    let connection = await Connection.create(browserWSEndpoint);
     return new Browser(connection, !!ignoreHTTPSErrors);
   }
 }
@@ -115,7 +115,7 @@ class Launcher {
  * @param {!ChildProcess} chromeProcess
  * @return {!Promise<string>}
  */
-function waitForProtocolEndpoint(chromeProcess) {
+function waitForWSEndpoint(chromeProcess) {
   return new Promise(fulfill => {
     const rl = readline.createInterface({ input: chromeProcess.stderr });
     rl.on('line', onLine);

--- a/test/test.js
+++ b/test/test.js
@@ -107,7 +107,7 @@ describe('Browser', function() {
   it('Puppeteer.connect', SX(async function() {
     let originalBrowser = await puppeteer.launch(defaultBrowserOptions);
     let browser = await puppeteer.connect({
-      remoteDebuggingURL: originalBrowser.remoteDebuggingURL()
+      protocolWSEndpoint: originalBrowser.protocolWSEndpoint()
     });
     let page = await browser.newPage();
     expect(await page.evaluate(() => 7 * 8)).toBe(56);

--- a/test/test.js
+++ b/test/test.js
@@ -107,7 +107,7 @@ describe('Browser', function() {
   it('Puppeteer.connect', SX(async function() {
     let originalBrowser = await puppeteer.launch(defaultBrowserOptions);
     let browser = await puppeteer.connect({
-      protocolWSEndpoint: originalBrowser.protocolWSEndpoint()
+      browserWSEndpoint: originalBrowser.wsEndpoint()
     });
     let page = await browser.newPage();
     expect(await page.evaluate(() => 7 * 8)).toBe(56);


### PR DESCRIPTION
This patch renames remoteDebuggingURL into protocolWSEndpoint