### PR TITLE
Rename ElementHandle.release into ElementHandle.dispose

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -99,9 +99,9 @@
     + [frame.waitForSelector(selector[, options])](#framewaitforselectorselector-options)
   * [class: ElementHandle](#class-elementhandle)
     + [elementHandle.click([options])](#elementhandleclickoptions)
+    + [elementHandle.dispose()](#elementhandledispose)
     + [elementHandle.evaluate(pageFunction, ...args)](#elementhandleevaluatepagefunction-args)
     + [elementHandle.hover()](#elementhandlehover)
-    + [elementHandle.release()](#elementhandlerelease)
   * [class: Request](#class-request)
     + [request.abort()](#requestabort)
     + [request.continue([overrides])](#requestcontinueoverrides)
@@ -1098,7 +1098,7 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
-ElementHandle prevents DOM element from garbage collection unless the handle is [released](#elementhandlerelease). ElementHandles are auto-released when their origin frame gets navigated.
+ElementHandle prevents DOM element from garbage collection unless the handle is [disposed](#elementhandledispose). ElementHandles are auto-disposed when their origin frame gets navigated.
 
 #### elementHandle.click([options])
 - `options` <[Object]>
@@ -1109,6 +1109,11 @@ ElementHandle prevents DOM element from garbage collection unless the handle is 
 
 This method scrolls element into view if needed, and then uses [page.mouse](#pagemouse) to click in the center of the element.
 If the element is detached from DOM, the method throws an error.
+
+#### elementHandle.dispose()
+- returns: <[Promise]> Promise which resolves when the element handle is successfully disposed.
+
+The `elementHandle.dispose` method stops referencing the element handle.
 
 #### elementHandle.evaluate(pageFunction, ...args)
 - `pageFunction` <[function]> Function to be evaluated in browser context
@@ -1123,25 +1128,6 @@ The function will be passed in the element ifself as a first argument.
 
 This method scrolls element into view if needed, and then uses [page.mouse](#pagemouse) to hover over the center of the element.
 If the element is detached from DOM, the method throws an error.
-
-
-#### elementHandle.release()
-- returns: <[Promise]> Promise which resolves when the element handle is successfully released.
-
-The `elementHandle.release` method stops referencing the element handle.
-
-```js
-const {Browser} = require('puppeteer');
-const browser = new Browser();
-browser.newPage().then(async page =>
-  await page.setContent('<div>hello</div>');
-  let element = await page.$('div');
-  let text = element.evaluate((e, suffix) => e.textContent + ' ' + suffix, 'world!');
-  console.log(text); // "hello world!"
-  browser.close();
-});
-```
-
 
 ### class: Request
 

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -25,16 +25,16 @@ class ElementHandle {
     this._client = client;
     this._remoteObject = remoteObject;
     this._mouse = mouse;
-    this._released = false;
+    this._disposed = false;
   }
 
   /**
    * @return {!Promise}
    */
-  async release() {
-    if (this._released)
+  async dispose() {
+    if (this._disposed)
       return;
-    this._released = true;
+    this._disposed = true;
     await helper.releaseObject(this._client, this._remoteObject);
   }
 
@@ -44,7 +44,7 @@ class ElementHandle {
    * @return {!Promise<(!Object|undefined)>}
    */
   async evaluate(pageFunction, ...args) {
-    console.assert(!this._released, 'ElementHandle is released!');
+    console.assert(!this._disposed, 'ElementHandle is disposed!');
     console.assert(typeof pageFunction === 'function', 'First argument to ElementHandle.evaluate must be a function!');
 
     let stringifiedArgs = ['this'];

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -566,7 +566,7 @@ class Page extends EventEmitter {
     let handle = await this.$(selector);
     console.assert(handle, 'No node found for selector: ' + selector);
     await handle.click(options);
-    await handle.release();
+    await handle.dispose();
   }
 
   /**
@@ -577,7 +577,7 @@ class Page extends EventEmitter {
     let handle = await this.$(selector);
     console.assert(handle, 'No node found for selector: ' + selector);
     await handle.hover();
-    await handle.release();
+    await handle.dispose();
   }
 
   /**
@@ -588,7 +588,7 @@ class Page extends EventEmitter {
     let handle = await this.$(selector);
     console.assert(handle, 'No node found for selector: ' + selector);
     await handle.evaluate(element => element.focus());
-    await handle.release();
+    await handle.dispose();
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1100,18 +1100,18 @@ describe('Page', function() {
       }
       expect(error.message).toContain('Session closed');
     }));
-    it('should throw if underlying element was released', SX(async function() {
+    it('should throw if underlying element was disposed', SX(async function() {
       await page.setContent('<section>39</section>');
       let element = await page.$('section');
       expect(element).toBeTruthy();
-      await element.release();
+      await element.dispose();
       let error = null;
       try {
         await element.evaluate(e => e.textContent);
       } catch (e) {
         error = e;
       }
-      expect(error.message).toContain('ElementHandle is released');
+      expect(error.message).toContain('ElementHandle is disposed');
     }));
   });
 


### PR DESCRIPTION
The ElementHandle.release feels related to ElementHandle.click.
The dispose is a more clear name.