### PR TITLE
README: add --save-dev to npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 To use Puppeteer in your project, run:
 ```
 yarn add puppeteer
-# or "npm i puppeteer"
+# or "npm i --save-dev puppeteer"
 ```
 
 > **Note**: When you install Puppeteer, it downloads a recent version of Chromium (~71Mb Mac, ~90Mb Linux, ~110Mb Win) that is guaranteed to work with the API. 


### PR DESCRIPTION
The equivalent of `yarn add puppeteer` would probably be `npm i --save puppeteer` or  `npm i --save-dev puppeteer` as yarn will also [add](https://yarnpkg.com/lang/en/docs/cli/add/#toc-adding-dependencies) an entry for the package to your package.json file.