### PR TITLE
Initial post install check

### DIFF
--- a/install.js
+++ b/install.js
@@ -17,6 +17,15 @@
 const Downloader = require('./utils/ChromiumDownloader');
 const revision = require('./package').puppeteer.chromium_revision;
 const ProgressBar = require('progress');
+const os = require('os');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+if (os.platform() === 'linux') {
+  let scriptPath = path.join(path.dirname(fs.realpathSync(__filename)), 'utils', 'linux', 'postinstall.sh');
+  process.stdout.write(execSync(scriptPath));
+}
 
 // Do nothing if the revision is already downloaded.
 if (Downloader.revisionInfo(Downloader.currentPlatform(), revision))

--- a/utils/linux/debian-check.sh
+++ b/utils/linux/debian-check.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+packages="gconf-service
+libasound2
+libatk1.0-0
+libc6
+libcairo2
+libcups2
+libdbus-1-3
+libexpat1
+libfontconfig1
+libgcc1
+libgconf-2-4
+libgdk-pixbuf2.0-0
+libglib2.0-0
+libgtk-3-0
+libnspr4
+libpango-1.0-0
+libpangocairo-1.0-0
+libstdc++6
+libx11-6
+libx11-xcb1
+libxcb1
+libxcomposite1
+libxcursor1
+libxdamage1
+libxext6
+libxfixes3
+libxi6
+libxrandr2
+libxrender1
+libxss1
+libxtst6
+ca-certificates
+fonts-liberation
+libappindicator1
+libnss3
+lsb-release
+xdg-utils
+wget"
+
+declare -a neededPackages
+
+for packageName in $packages; do
+  if ! dpkg-query -l "$packageName" > /dev/null 2>&1; then
+    neededPackages[${#neededPackages[@]}]="$packageName"
+  fi
+done
+
+
+neededCount=${#neededPackages[@]}
+
+if [[ $neededCount -gt 0 ]]; then
+  echo "-----------------------------------------------------"
+  echo "Run the following to get all of the required packages"
+  echo "-----------------------------------------------------"
+  echo "sudo apt install \\"
+  for i in "${neededPackages[@]}"; do
+    output="$i"
+
+     if [[ ${neededPackages[@]: -1 } != "$i" ]]; then
+        output+=" \\"
+     fi
+
+    echo "$output"
+  done
+  echo "-----------------------------------------------------"
+fi
+
+exit 0

--- a/utils/linux/namespace-check.sh
+++ b/utils/linux/namespace-check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+VALUE=$(cat /boot/config-$(uname -r) | grep CONFIG_USER_NS)
+
+if [[ -z "$VALUE" ]]
+then
+  echo 'You do not have namespacing in the kernel. You will need to enable the SUID sandbox or upgrade your kernel.'
+  echo 'See https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md'
+  exit 1
+fi
+
+USER_NS_AVAILABLE="${VALUE: -1}"
+
+if [[ "$USER_NS_AVAILABLE" == "y" ]]
+then
+  exit 0
+else
+  echo 'You do not have namespacing in the kernel. You will need to enable the SUID sandbox or upgrade your kernel.'
+  echo 'See https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md'
+  exit 1
+fi

--- a/utils/linux/postinstall.sh
+++ b/utils/linux/postinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+"$DIR"/namespace-check.sh
+
+if [ -f "/etc/debian_version" ]; then
+  echo "Checking Debian requirements"
+  "$DIR"/debian-check.sh
+fi


### PR DESCRIPTION
This adds a post install script section for linux systems. Attempt to cover the issues from #290 on a more interactive level. Starting with just Debian-based distributions to hone the output and requirements. We can expand later to cover other package managers and distributions. Post install now does the following:

* Checks for linux OS
* If found, execute the main `postinstall` script.
* This script checks for sandbox availability then determines the OS-level script to run to look for dependencies
* The OS scripts have the list of required packages, then loops over them and looks for anything missing. All missing packages are then shown within a script to use to install them easily. So all a developer needs to do is copy and paste the command.
* Chromium is then downloaded if required

<details>
<summary>Example output</summary>

```
~/C/puppeteer (debian-post-install|●4✚2) $ yarn install
yarn install v0.27.5
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning "worker-loader@0.8.1" has unmet peer dependency "webpack@>=0.9 <2 || ^2.1.0-beta || ^2.2.0".
[4/4] Building fresh packages...
$ node install.js
Checking Debian requirements
-----------------------------------------------------
Run the following to get all of the required packages
-----------------------------------------------------
sudo apt install \
gconf-service \
libasound2 \
libatk1.0-0 \
libc6 \
libcairo2 \
libcups2 \
libdbus-1-3 \
libexpat1 \
libfontconfig1 \
libgcc1 \
libgconf-2-4 \
libgdk-pixbuf2.0-0 \
libglib2.0-0 \
libgtk-3-0 \
libnspr4 \
libpango-1.0-0 \
libpangocairo-1.0-0 \
libstdc++6 \
libx11-6 \
libx11-xcb1 \
libxcb1 \
libxcomposite1 \
libxcursor1 \
libxdamage1 \
libxext6 \
libxfixes3 \
libxi6 \
libxrandr2 \
libxrender1 \
libxss1 \
libxtst6 \
ca-certificates \
fonts-liberation \
libappindicator1 \
libnss3 \
lsb-release \
xdg-utils \
wget
-----------------------------------------------------
Downloading Chromium r494755 - 92.1 Mb [====================] 100% 0.0s 
Done in 41.51s.
~/C/puppeteer (debian-post-install|●4) $ 
```

</details>

