### PR TITLE
docs: fix typo in `event: 'load'` section

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -257,7 +257,7 @@ Emitted when a frame is navigated to a new url.
 
 #### event: 'load'
 
-Emitted when the JavaScriot [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
+Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
 
 #### event: 'pageerror'
 - <[string]> The exception message


### PR DESCRIPTION
fix `JavaScriot` to `JavaScript`.