### PR TITLE
fix typo and add extensions to example 'block images'

### DIFF
--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -33,3 +33,4 @@ await page.screenshot({path: 'news.png', fullPage: true});
 browser.close();
 
 })();
+

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -22,7 +22,7 @@ const browser = await puppeteer.launch();
 const page = await browser.newPage();
 await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {
-  if (/\.(png|jpg|jpeg$)/.test(request.url))
+  if (/\.(png|jpg|jpeg|gif|webp)$/.test(request.url))
     request.abort();
   else
     request.continue();
@@ -33,4 +33,3 @@ await page.screenshot({path: 'news.png', fullPage: true});
 browser.close();
 
 })();
-


### PR DESCRIPTION
* fix position of `$`
* add extensions `.gif`, `.webp`

before)

```
/\.(png|jpg|jpeg$)/.test(request.url)
```

after)

```
/\.(png|jpg|jpeg|gif|webp)$/.test(request.url)
```

