### PR TITLE
Use randomized folder names for user profile directories

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -20,6 +20,7 @@ const Downloader = require('../utils/ChromiumDownloader');
 const Connection = require('./Connection');
 const Browser = require('./Browser');
 const readline = require('readline');
+const crypto = require('crypto');
 
 const CHROME_PROFILE_PATH = path.resolve(__dirname, '..', '.dev_profile');
 let browserId = 0;
@@ -49,8 +50,13 @@ class Launcher {
    */
   static async launch(options) {
     options = options || {};
-    ++browserId;
-    let userDataDir = CHROME_PROFILE_PATH + browserId;
+    let userDataDir = [
+      CHROME_PROFILE_PATH,
+      process.pid,
+      ++browserId,
+      crypto.randomBytes(8 / 2).toString('hex') // add random salt 8 characters long.
+    ].join('-');
+
     let chromeArguments = DEFAULT_ARGS.concat([
       `--user-data-dir=${userDataDir}`,
     ]);


### PR DESCRIPTION
This will make it much harder for puppeteer browsers to collide
on profile directories.

Fixes #360