### PR TITLE
Determine failed navigation based on Frame.unreachedURL

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -130,6 +130,14 @@ class FrameManager extends EventEmitter {
     this._frames.delete(frame._id);
     this.emit(FrameManager.Events.FrameDetached, frame);
   }
+
+  /**
+   * @param {!Frame} frame
+   * @return {boolean}
+   */
+  isMainFrameLoadingFailed() {
+    return !!this._mainFrame._loadingFailed;
+  }
 }
 
 /** @enum {string} */
@@ -337,6 +345,7 @@ class Frame {
   _navigated(framePayload) {
     this._name = framePayload.name;
     this._url = framePayload.url;
+    this._loadingFailed = !!framePayload.unreachableUrl;
   }
 
   _detach() {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -293,12 +293,9 @@ class Page extends EventEmitter {
     }
     await result;
     helper.removeEventListeners([listener]);
-    if (url === 'about:blank')
-      return null;
-    let response = responses.get(this.mainFrame().url());
-    if (!response)
+    if (this._frameManager.isMainFrameLoadingFailed())
       throw new Error('Failed to navigate: ' + url);
-    return response;
+    return responses.get(this.mainFrame().url()) || null;
   }
 
   /**


### PR DESCRIPTION
This patch starts using frame.unreachedURL property from
frameNavigated event to determine if the page navigation
was successful.