### PR TITLE
Support anchor navigation

### DIFF
--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -68,7 +68,18 @@ class NavigatorWatcher {
       navigationPromises.push(networkIdle);
     }
 
-    const error = await Promise.race(navigationPromises);
+    let expression = helper.evaluationString(() => {
+      return new Promise(resolve => {
+        window.addEventListener('popstate', () => {
+          window.removeEventListener('popstate', resolve);
+          resolve();
+        });
+      });
+    });
+    let error = null;
+    let isAnchorNavigation = await this._client.send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise: true}).then(() => true).catch(e => false);
+    if (!isAnchorNavigation)
+      error = await Promise.race(navigationPromises);
     this._cleanup();
     if (error)
       throw new Error(error);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -339,6 +339,7 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {number} delta
    * @param {!Object=} options
    * @return {!Promise<?Response>}
    */

--- a/test/test.js
+++ b/test/test.js
@@ -535,6 +535,14 @@ describe('Page', function() {
       let response = await page.goto('about:blank');
       expect(response).toBe(null);
     }));
+    it('should navigate to anchor URL', SX(async function() {
+      let sectionName = '';
+      page.on('console', arg => sectionName = arg);
+      await page.goto(PREFIX + '/anchor-routing.html');
+      let response = await page.goto(page.url() + '#section3');
+      expect(response).toBe(null);
+      expect(sectionName).toBe('#section3');
+    }));
     it('should fail when navigating to bad url', SX(async function() {
       let error = null;
       try {
@@ -725,13 +733,23 @@ describe('Page', function() {
   describe('Page.waitForNavigation', function() {
     it('should work', SX(async function() {
       await page.goto(EMPTY_PAGE);
-      const [result] = await Promise.all([
+      const [response] = await Promise.all([
         page.waitForNavigation(),
         page.evaluate(url => window.location.href = url, PREFIX + '/grid.html')
       ]);
-      const response = await result;
       expect(response.ok).toBe(true);
       expect(response.url).toContain('grid.html');
+    }));
+    it('should work with anchor navigation', SX(async function() {
+      let sectionName = '';
+      page.on('console', arg => sectionName = arg);
+      await page.goto(PREFIX + '/anchor-routing.html');
+      const [response] = await Promise.all([
+        page.waitForNavigation(),
+        page.evaluate(() => window.location.hash = 'section2')
+      ]);
+      expect(response).toBe(null);
+      expect(sectionName).toBe('#section2');
     }));
   });
 
@@ -750,6 +768,21 @@ describe('Page', function() {
 
       response = await page.goForward();
       expect(response).toBe(null);
+    }));
+    it('should navigate between anchor urls', SX(async function() {
+      await page.goto(PREFIX + '/anchor-routing.html');
+      await page.goto(PREFIX + '/anchor-routing.html#section2');
+      await page.goto(PREFIX + '/anchor-routing.html#section4');
+
+      let sectionName = '';
+      page.on('console', arg => sectionName = arg);
+      let response = await page.goBack();
+      expect(response).toBe(null);
+      expect(sectionName).toBe('#section2');
+
+      response = await page.goForward();
+      expect(response).toBe(null);
+      expect(sectionName).toBe('#section4');
     }));
   });
 


### PR DESCRIPTION
This patch adds support for anchor navigation for the following methods:
- `page.goto`
- `page.waitForNavigation`
- `page.goForward` / `page.goBack`

Fixes #257 