### PR TITLE
readme: tone of logo surface from light source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Puppeteer [![Build Status](https://travis-ci.org/GoogleChrome/puppeteer.svg?branch=master)](https://travis-ci.org/GoogleChrome/puppeteer) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
 
-<img src="https://user-images.githubusercontent.com/39191/29330067-dfc2be5a-81ac-11e7-9cc2-c569dd5f078c.png" height="200" align="right">
+<img src="https://user-images.githubusercontent.com/10379601/29446482-04f7036a-841f-11e7-9872-91d1fc2ea683.png" height="200" align="right">
 
 ###### [API](docs/api.md) | [FAQ](#faq) | [Contributing](https://github.com/GoogleChrome/puppeteer/blob/master/CONTRIBUTING.md)
 


### PR DESCRIPTION
This is a minor cosmetic update on Puppeteer's logo. The rectangle surface at lower left corner seems to have the wrong shade, base on the scene's light source. Below are the original and the updated ones. Of course, if the designer intentionally wants to make the design asymmetric then this is irrelevant.