### PR TITLE
example 'block images' - make extension check case insensitive

### DIFF
--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -22,7 +22,7 @@ const browser = await puppeteer.launch();
 const page = await browser.newPage();
 await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {
-  if (/\.(png|jpg|jpeg|gif|webp)$/.test(request.url))
+  if (/\.(png|jpg|jpeg|gif|webp)$/i.test(request.url))
     request.abort();
   else
     request.continue();


### PR DESCRIPTION
Just because images may also have uppercase file extensions.