### PR TITLE
Allow custom function in $ selector

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@
     + [event: 'requestfailed'](#event-requestfailed)
     + [event: 'requestfinished'](#event-requestfinished)
     + [event: 'response'](#event-response)
-    + [page.$(selector)](#pageselector)
+    + [page.$(selector, ...args)](#pageselector-args)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
@@ -83,7 +83,7 @@
     + [dialog.message()](#dialogmessage)
     + [dialog.type](#dialogtype)
   * [class: Frame](#class-frame)
-    + [frame.$(selector)](#frameselector)
+    + [frame.$(selector, ...args)](#frameselector-args)
     + [frame.addScriptTag(url)](#frameaddscripttagurl)
     + [frame.childFrames()](#framechildframes)
     + [frame.evaluate(pageFunction, ...args)](#frameevaluatepagefunction-args)
@@ -285,11 +285,12 @@ Emitted when a request finishes successfully.
 
 Emitted when a [response] is received.
 
-#### page.$(selector)
-- `selector` <[string]> Selector to query page for
+#### page.$(selector, ...args)
+- `selector` <[string]|[function]> Selector to query page for, or a function to be evaluated in the page context
+- `...args` <...[Serializable]> Arguments to pass to `selector` function
 - returns: <[Promise]<[ElementHandle]>>
 
-The method runs `document.querySelector` within the page. If no element matches the selector, the return value resolve to `null`.
+The method runs `document.querySelector` by default within the page. You can pass in custom function to perform more complex selecting. If no element matches the selector, the return value resolve to `null`.
 
 Shortcut for [page.mainFrame().$(selector)](#frameselector).
 
@@ -958,8 +959,9 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
-#### frame.$(selector)
-- `selector` <[string]> Selector to query page for
+#### frame.$(selector, ...args)
+- `selector` <[string]|[function]> Selector to query page for, or a function to be evaluated in the page context
+- `...args` <...[Serializable]> Arguments to pass to `selector` function
 - returns: <[Promise]<[ElementHandle]>> Promise which resolves to ElementHandle pointing to the page element.
 
 The method queries page for the selector. If there's no such element within the page, the method will resolve to `null`.

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -184,11 +184,21 @@ class Frame {
   }
 
   /**
-   * @param {string} selector
+   * @param {string|function()} selector
+   * @param {!Array<*>} args
    * @return {!Promise<?ElementHandle>}
    */
-  async $(selector) {
-    let remoteObject = await this._rawEvaluate(selector => document.querySelector(selector), selector);
+  async $(selector, ...args) {
+    let func = selector;
+    let argv = args;
+
+    // default css selector with querySelector
+    if (typeof selector === 'string' && !args.length) {
+      func = selector => document.querySelector(selector);
+      argv = [selector];
+    }
+
+    let remoteObject = await this._rawEvaluate(func, ...argv);
     if (remoteObject.subtype === 'node')
       return new ElementHandle(this._client, remoteObject, this._mouse);
     helper.releaseObject(this._client, remoteObject);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -139,11 +139,12 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {string} selector
+   * @param {string|function()} selector
+   * @param {!Array<*>} args
    * @return {!Promise<?ElementHandle>}
    */
-  async $(selector) {
-    return this.mainFrame().$(selector);
+  async $(selector, ...args) {
+    return this.mainFrame().$(selector, ...args);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1072,6 +1072,19 @@ describe('Page', function() {
       let element = await page.$('non-existing-element');
       expect(element).toBe(null);
     }));
+    it('should query by custom function', SX(async function() {
+      await page.setContent('<section><span>1</span><div>2</div></section>');
+      const selectSecondItem = selector => document.querySelectorAll(selector)[1];
+      let element = await page.$(selectSecondItem, 'section > *');
+      expect(element).toBeTruthy();
+      expect(element._remoteObject.description).toBe('div');
+    }));
+    it('should return null for non-existing query by custom function', SX(async function() {
+      await page.setContent('<section><span>1</span><span>2</span></section>');
+      const selectSecondItem = selector => document.querySelectorAll(selector)[1];
+      let element = await page.$(selectSecondItem, 'section > div');
+      expect(element).toBe(null);
+    }));
   });
 
   describe('ElementHandle.evaluate', function() {


### PR DESCRIPTION
#### Feature Request

I am working on introducing `puppeteer` to our team recently. The problem is that currently the `page.$()` selector only support css selector, but our stack includes `react` and `css-in-js` which make css selecting next to impossible to perform. I think it will be nice to allow custom function in `page.$()` selector and open up the gate of integrating with multiple frameworks and use cases.

Lets say we have a HTML page looks like
```html
<ul>
  <li>1</li>
  <li>2</li>
</ul>
```

We can select the second `<li>` element with a custom function called `selectSecond`
```js
const selectSecond = selector => document.querySelectorAll(selector)[1];
const secondElement = await page.$(selectSecond, 'ul > li'); // <li>2</li>
```

_The simple example use case above doesn't need custom function at all and can be done with simple css selector, it's just to demonstrate the API._

The implementation is backward-compatible and the API style is similar to `evaluate`, but it still only allows selecting one element since I don't want to over-complicate this PR.

Thanks for the great work! I really enjoy `puppeteer` and definitely will work on it more in the future.