### PR TITLE
Add .content() method. Fixes #406.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
+    + [page.content()](#pagecontent)
     + [page.emulate(options)](#pageemulateoptions)
     + [page.emulateMedia(mediaType)](#pageemulatemediamediatype)
     + [page.evaluate(pageFunction, ...args)](#pageevaluatepagefunction-args)
@@ -314,6 +315,11 @@ Shortcut for [page.mainFrame().click(selector[, options])](#frameclickselector-o
 
 #### page.close()
 - returns: <[Promise]>
+
+#### page.content()
+- returns: <[Promise]<[String]>>
+
+Gets the full HTML contents of the page, including the doctype.
 
 #### page.emulate(options)
 - `options` <[Object]>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -261,6 +261,20 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @return {!Promise<String>}
+   */
+  async content() {
+    return await this.evaluate(() => {
+      let retVal = '';
+      if (document.doctype)
+        retVal = new XMLSerializer().serializeToString(document.doctype);
+      if (document.documentElement)
+        retVal += document.documentElement.outerHTML;
+      return retVal;
+    });
+  }
+
+  /**
    * @param {string} html
    * @return {!Promise}
    */

--- a/test/test.js
+++ b/test/test.js
@@ -1437,10 +1437,24 @@ describe('Page', function() {
     }));
   });
   describe('Page.setContent', function() {
+    const expectedOutput = '<html><head></head><body><div>hello</div></body></html>';
     it('should work', SX(async function() {
       await page.setContent('<div>hello</div>');
-      let result = await page.evaluate(() => document.body.innerHTML);
-      expect(result).toBe('<div>hello</div>');
+      let result = await page.content();
+      expect(result).toBe(expectedOutput);
+    }));
+    it('should work with doctype', SX(async function() {
+      const doctype = '<!DOCTYPE html>';
+      await page.setContent(`${doctype}<div>hello</div>`);
+      let result = await page.content();
+      expect(result).toBe(`${doctype}${expectedOutput}`);
+    }));
+    it('should work with HTML 4 doctype', SX(async function() {
+      const doctype = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" ' +
+        '"http://www.w3.org/TR/html4/strict.dtd">';
+      await page.setContent(`${doctype}<div>hello</div>`);
+      let result = await page.content();
+      expect(result).toBe(`${doctype}${expectedOutput}`);
     }));
   });
   describe('Network Events', function() {


### PR DESCRIPTION
This adds a new method: `.content()` which is the counterpart of `.setContent()`, retrieving the HTML contents of the page, including the doctype (if there is one).