### PR TITLE
Fail gracefully when chromium failed to download

### DIFF
--- a/install.js
+++ b/install.js
@@ -35,9 +35,7 @@ function onError(error) {
 - Download chromium manually:
     ${revisionInfo.url}
 - Extract chromium into ${revisionInfo.folderPath}
-  * Chromium executable should be at ${revisionInfo.executablePath}
-- Alternatively, point puppeteer to the downloaded chromium with the 'executablePath' option:
-    https://goo.gl/E8yQua`);
+  * Chromium executable should be at ${revisionInfo.executablePath}`);
 }
 
 let progressBar = null;

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -72,7 +72,7 @@ class Launcher {
     if (typeof chromeExecutable !== 'string') {
       let chromiumRevision = require('../package.json').puppeteer.chromium_revision;
       let revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), chromiumRevision);
-      console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "npm install", or download manually from ${revisionInfo.url} and extract into ${revisionInfo.folderPath}.`);
+      console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "npm install"`);
       chromeExecutable = revisionInfo.executablePath;
     }
     if (Array.isArray(options.args))

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -72,7 +72,7 @@ class Launcher {
     if (typeof chromeExecutable !== 'string') {
       let chromiumRevision = require('../package.json').puppeteer.chromium_revision;
       let revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), chromiumRevision);
-      console.assert(revisionInfo, 'Chromium revision is not downloaded. Run npm install');
+      console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "npm install", or download manually from ${revisionInfo.url} and extract into ${revisionInfo.folderPath}.`);
       chromeExecutable = revisionInfo.executablePath;
     }
     if (Array.isArray(options.args))

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,7 @@ else
   const Downloader = require('../utils/ChromiumDownloader');
   const chromiumRevision = require('../package.json').puppeteer.chromium_revision;
   const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), chromiumRevision);
-  console.assert(revisionInfo, `Chromium r${chromiumRevision} is not downloaded. Run 'npm install' and try to re-run tests.`);
+  console.assert(revisionInfo.downloaded, `Chromium r${chromiumRevision} is not downloaded. Run 'npm install' and try to re-run tests.`);
 }
 
 let server;

--- a/utils/ChromiumDownloader.js
+++ b/utils/ChromiumDownloader.js
@@ -129,13 +129,11 @@ module.exports = {
   /**
    * @param {string} platform
    * @param {string} revision
-   * @return {?{executablePath: string}}
+   * @return {!{folderPath: string, executablePath: string, downloaded: boolean, url: string}}
    */
   revisionInfo: function(platform, revision) {
     console.assert(downloadURLs[platform], `Unsupported platform: ${platform}`);
     let folderPath = getFolderPath(platform, revision);
-    if (!fs.existsSync(folderPath))
-      return null;
     let executablePath = '';
     if (platform === 'mac')
       executablePath = path.join(folderPath, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
@@ -146,7 +144,10 @@ module.exports = {
     else
       throw 'Unsupported platfrom: ' + platfrom;
     return {
-      executablePath: executablePath
+      executablePath,
+      folderPath,
+      downloaded: fs.existsSync(folderPath),
+      url: util.format(downloadURLs[platform], revision)
     };
   },
 };


### PR DESCRIPTION
This patch changes both install.js and Launcher.js to inform how
chromium could be downloaded manually if puppeteer fails to download it.