### PR TITLE
Put chrome profiles into a temporary directory

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -24,7 +24,7 @@ const crypto = require('crypto');
 const helper = require('./helper');
 const ChromiumRevision = require('../package.json').puppeteer.chromium_revision;
 
-const CHROME_PROFILE_PATH = path.resolve(__dirname, '..', '.dev_profile');
+const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile');
 let browserId = 0;
 
 const DEFAULT_ARGS = [

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const os = require('os');
 const path = require('path');
 const removeSync = require('rimraf').sync;
 const childProcess = require('child_process');
@@ -20,12 +21,11 @@ const Downloader = require('../utils/ChromiumDownloader');
 const Connection = require('./Connection');
 const Browser = require('./Browser');
 const readline = require('readline');
-const crypto = require('crypto');
+const fs = require('fs');
 const helper = require('./helper');
 const ChromiumRevision = require('../package.json').puppeteer.chromium_revision;
 
-const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile');
-let browserId = 0;
+const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile-');
 
 const DEFAULT_ARGS = [
   '--disable-background-networking',
@@ -50,13 +50,9 @@ class Launcher {
    * @param {!Object=} options
    * @return {!Promise<!Browser>}
    */
-  static async launch(options = {}) {
-    const userDataDir = [
-      CHROME_PROFILE_PATH,
-      process.pid,
-      ++browserId,
-      crypto.randomBytes(8 / 2).toString('hex') // add random salt 8 characters long.
-    ].join('-');
+  static async launch(options) {
+    options = options || {};
+    const userDataDir = fs.mkdtempSync(CHROME_PROFILE_PATH);
 
     const chromeArguments = DEFAULT_ARGS.concat([
       `--user-data-dir=${userDataDir}`,


### PR DESCRIPTION
I noticed I had a lot of old .dev-profile folders from when I used Ctrl+C to end Puppeteer. I thought about cleaning up on SIGINT, but that would break if users have their own SIGINT handler. So maybe putting the profiles into a temp directory will at least stop them from piling up forever.