### PR TITLE
Roll chromium to r496140

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -35,6 +35,7 @@ const DEFAULT_ARGS = [
   '--disable-prompt-on-repost',
   '--disable-sync',
   '--enable-automation',
+  '--enable-devtools-experiments',
   '--metrics-recording-only',
   '--no-first-run',
   '--password-store=basic',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "494755"
+    "chromium_revision": "496140"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",

--- a/test/test.js
+++ b/test/test.js
@@ -562,7 +562,7 @@ describe('Page', function() {
     it('should fail when main resources failed to load', SX(async function() {
       let error = null;
       try {
-        await page.goto('chrome-devtools://non-existing.html');
+        await page.goto('http://localhost:44123/non-existing-url');
       } catch (e) {
         error = e;
       }


### PR DESCRIPTION
This patch rolls chromium to r496140. This includes the r496130 that
introduces multiple sessions for single target.

With this patch, it is possible to run puppeteer in headful mode
and open devtools over the automated pages without puppeteer losing
connection to the page.