### PR TITLE
Stricter eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,6 +107,6 @@ module.exports = {
         "indent": [2, 2, { "SwitchCase": 1, "CallExpression": {"arguments": 2}, "MemberExpression": 2 }],
         "key-spacing": [2, {
             "beforeColon": false
-        }],
+        }]
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,11 +43,13 @@ module.exports = {
             "getWithoutSet": false,
             "setWithoutGet": false
         }],
+        "brace-style": [2, "1tbs", {"allowSingleLine": true}],
         "curly": [2, "multi-or-nest", "consistent"],
         "new-parens": 2,
         "func-call-spacing": 2,
         "arrow-parens": [2, "as-needed"],
         "prefer-const": 2,
+        "quote-props": [2, "consistent"],
 
         // anti-patterns
         "no-var": 2,
@@ -70,6 +72,7 @@ module.exports = {
         "radix": 2,
         "valid-typeof": 2,
         "no-unused-vars": [2, { "args": "none", "vars": "local" }],
+        "no-implicit-globals": [2],
 
         // es2015 features
         "require-yield": 2,
@@ -102,23 +105,8 @@ module.exports = {
         "no-trailing-spaces": 2,
         "linebreak-style": [ 2, "unix" ],
         "indent": [2, 2, { "SwitchCase": 1, "CallExpression": {"arguments": 2}, "MemberExpression": 2 }],
-
-        /**
-         * Disabled, aspirational rules
-         */
-        // brace-style is disabled, as eslint cannot enforce 1tbs as default, but allman for functions
-        "brace-style": [0, "allman", { "allowSingleLine": true }],
-
-        // key-spacing is disabled, as some objects use value-aligned spacing, some not.
-        "key-spacing": [0, {
-            "beforeColon": false,
-            "afterColon": true,
-            "align": "value"
+        "key-spacing": [2, {
+            "beforeColon": false
         }],
-        // quote-props is diabled, as property quoting styles are too varied to enforce.
-        "quote-props": [0, "as-needed"],
-
-        // no-implicit-globals will prevent accidental globals
-        "no-implicit-globals": [0]
     }
 };

--- a/test/assets/injectedfile.js
+++ b/test/assets/injectedfile.js
@@ -1,2 +1,2 @@
-__injected = 42;
-__injectedError = new Error('hi');
+window.__injected = 42;
+window.__injectedError = new Error('hi');

--- a/test/test.js
+++ b/test/test.js
@@ -1849,7 +1849,7 @@ describe('Page', function() {
     it('should allow transparency', SX(async function() {
       await page.setViewport({ width: 100, height: 100 });
       await page.goto(EMPTY_PAGE);
-      const screenshot = await page.screenshot({omitBackground:true});
+      const screenshot = await page.screenshot({omitBackground: true});
       expect(screenshot).toBeGolden('transparent.png');
     }));
   });

--- a/utils/doclint/preprocessor/index.js
+++ b/utils/doclint/preprocessor/index.js
@@ -55,7 +55,7 @@ module.exports = function(sources) {
     if (command.source.setText(newText))
       changedSources.add(command.source);
   }
-  for (source of changedSources)
+  for (const source of changedSources)
     messages.push(Message.warning(`GEN: updated ${source.projectPath()}`));
   return messages;
 };


### PR DESCRIPTION
This enforces brace style, implicit globals, quotes in object literals, and spaces around colons.