### PR TITLE
Kill Chrome quickly on Windows

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -83,25 +83,31 @@ class Launcher {
 
     // Cleanup as processes exit.
     const listeners = [
-      helper.addEventListener(process, 'exit', killChromeAndCleanup),
-      helper.addEventListener(chromeProcess, 'exit', killChromeAndCleanup),
+      helper.addEventListener(process, 'exit', killChrome),
+      helper.addEventListener(chromeProcess, 'close', cleanupChrome),
     ];
     if (options.handleSIGINT !== false)
-      listeners.push(helper.addEventListener(process, 'SIGINT', killChromeAndCleanup));
+      listeners.push(helper.addEventListener(process, 'SIGINT', killChrome));
     try {
       const connectionDelay = options.slowMo || 0;
       const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, options.timeout || 30 * 1000);
       const connection = await Connection.create(browserWSEndpoint, connectionDelay);
-      return new Browser(connection, !!options.ignoreHTTPSErrors, killChromeAndCleanup);
+      return new Browser(connection, !!options.ignoreHTTPSErrors, killChrome);
     } catch (e) {
-      killChromeAndCleanup();
+      killChrome();
       throw e;
     }
 
-    function killChromeAndCleanup() {
+    function cleanupChrome() {
       helper.removeEventListeners(listeners);
-      chromeProcess.kill('SIGKILL');
       removeSync(userDataDir);
+    }
+
+    function killChrome() {
+      if (process.platform === 'win32')
+        childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
+      else
+        chromeProcess.kill('SIGKILL');
     }
   }
 

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -82,12 +82,13 @@ class Launcher {
     }
 
     // Cleanup as processes exit.
-    const listeners = [
-      helper.addEventListener(process, 'exit', killChrome),
-      helper.addEventListener(chromeProcess, 'close', cleanupChrome),
-    ];
+    let killed = false;
+    process.once('exit', killChrome);
+    chromeProcess.once('close', () => removeSync(userDataDir));
+
     if (options.handleSIGINT !== false)
-      listeners.push(helper.addEventListener(process, 'SIGINT', killChrome));
+      process.once('SIGINT', killChrome);
+
     try {
       const connectionDelay = options.slowMo || 0;
       const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, options.timeout || 30 * 1000);
@@ -98,12 +99,10 @@ class Launcher {
       throw e;
     }
 
-    function cleanupChrome() {
-      helper.removeEventListeners(listeners);
-      removeSync(userDataDir);
-    }
-
     function killChrome() {
+      if (killed)
+        return;
+      killed = true;
       if (process.platform === 'win32')
         childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
       else


### PR DESCRIPTION
This fixed the issues of profiles being left behind and errors deleting profiles still in use on Windows. Tested on Windows 10 in `cmd` and `cygwin`.

#298