### PR TITLE
Enable MutationObserver attributes

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -497,7 +497,8 @@ async function waitForPredicatePageFunction(predicateBody, polling, timeout) {
     });
     observer.observe(document, {
       childList: true,
-      subtree: true
+      subtree: true,
+      attributes: true
     });
     return result;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -451,6 +451,15 @@ describe('Page', function() {
       expect(error).toBeTruthy();
       expect(error.message).toContain('waiting failed: timeout');
     }));
+
+    it('should respond to node attribute mutation', SX(async function() {
+      let divFound = false;
+      const waitForSelector = page.waitForSelector('.zombo').then(() => divFound = true);
+      await page.setContent(`<div class='notZombo'></div>`);
+      expect(divFound).toBe(false);
+      await page.evaluate(() => document.querySelector('div').className = 'zombo');
+      expect(await waitForSelector).toBe(true);
+    }));
   });
 
   describe('Page.waitFor', function() {


### PR DESCRIPTION
Resolves #474

When modifying a nodes `className`, MutationObserver isn't firing.