### PR TITLE
readme: remove version from docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# Puppeteer API (master)
+# Puppeteer API v<!-- GEN:version -->0.9.1-alpha<!-- GEN:stop-->
 
 ##### Table of Contents
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# Puppeteer API v<!-- GEN:version -->0.9.0<!-- GEN:stop-->
+# Puppeteer API (<!-- GEN:version -->master<!-- GEN:stop-->)
 
 ##### Table of Contents
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# Puppeteer API (<!-- GEN:version -->master<!-- GEN:stop-->)
+# Puppeteer API (master)
 
 ##### Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer",
-  "version": "0.9.0",
+  "version": "0.9.1-alpha",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol",
   "main": "index.js",
   "repository": "github:GoogleChrome/puppeteer",


### PR DESCRIPTION
The version in the docs is confusing users b/c it reflects master and not the latest release.

https://github.com/GoogleChrome/puppeteer/issues/492
https://github.com/GoogleChrome/puppeteer/issues/480