### PR TITLE
add 'use strict'; to examples

### DIFF
--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
      */
     "rules": {
         "indent": [2, 2, { "SwitchCase": 1, "CallExpression": {"arguments": 2}, "MemberExpression": 2, "outerIIFEBody": 0 }],
+        "strict": [2, "global"],
     }
 };

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 
 (async() => {

--- a/examples/detect-sniff.js
+++ b/examples/detect-sniff.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 
 function sniffDetector() {

--- a/examples/pdf.js
+++ b/examples/pdf.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 
 (async() => {

--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 
 (async() => {

--- a/examples/screenshot-fullpage.js
+++ b/examples/screenshot-fullpage.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
 

--- a/examples/screenshot.js
+++ b/examples/screenshot.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 
 (async() => {

--- a/examples/search.js
+++ b/examples/search.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 const puppeteer = require('puppeteer');
 
 (async() => {


### PR DESCRIPTION
I am not sure what else non-module scripts should be addressed. If any, let me know to add them in another commit.