### PR TITLE
Bump tip-of-tree version to 0.10.1-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 
 ### Installation
 
-*Puppeteer requires Node version 7.10 or greater*
+*Puppeteer requires Node version 6.4.0 or greater*
 
 To use Puppeteer in your project, run:
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
-##### Released API: [v0.9.0](https://github.com/GoogleChrome/puppeteer/blob/v0.9.0/docs/api.md)
+##### Released API: [v0.9.0](https://github.com/GoogleChrome/puppeteer/blob/v0.9.0/docs/api.md) [v0.10.0](https://github.com/GoogleChrome/puppeteer/blob/v0.10.0/docs/api.md)
 
-# Puppeteer API v<!-- GEN:version -->0.10.0<!-- GEN:stop-->
+# Puppeteer API v<!-- GEN:version -->0.10.1-alpha<!-- GEN:stop-->
 
 ##### Table of Contents
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-##### Released API: [v0.9.0](https://github.com/GoogleChrome/puppeteer/blob/v0.9.0/docs/api.md) [v0.10.0](https://github.com/GoogleChrome/puppeteer/blob/v0.10.0/docs/api.md)
+##### Released API: [v0.10.0](https://github.com/GoogleChrome/puppeteer/blob/v0.10.0/docs/api.md) [v0.9.0](https://github.com/GoogleChrome/puppeteer/blob/v0.9.0/docs/api.md) 
 
 # Puppeteer API v<!-- GEN:version -->0.10.1-alpha<!-- GEN:stop-->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer",
-  "version": "0.10.0",
+  "version": "0.10.1-alpha",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol",
   "main": "index.js",
   "repository": "github:GoogleChrome/puppeteer",


### PR DESCRIPTION
This patch:
- bumps tip-of-tree version to 0.10.1-alpha
- updates api.md to refer to released API and fix a nit in README.md