### PR TITLE
Fix node6 support for Object.entries and URL object

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -16,7 +16,7 @@
 const EventEmitter = require('events');
 const helper = require('./helper');
 const Multimap = require('./Multimap');
-const {URL} = require('url');
+const url = require('url');
 
 class NetworkManager extends EventEmitter {
   /**
@@ -356,13 +356,13 @@ function generateRequestHash(request) {
 }
 
 /**
- * @param {string} url
+ * @param {string} urlString
  * @return {string}
  */
-function removeURLHash(url) {
-  const urlObject = new URL(url);
+function removeURLHash(urlString) {
+  const urlObject = url.parse(urlString);
   urlObject.hash = '';
-  return urlObject.toString();
+  return url.format(urlObject);
 }
 
 NetworkManager.Events = {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -218,4 +218,9 @@ class Helper {
   }
 }
 
+// Polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+if (!Object.entries)
+  Object.entries = obj => Object.keys(obj).map(key => [key, obj[key]]);
+
+
 module.exports = Helper;

--- a/utils/ESTreeWalker.js
+++ b/utils/ESTreeWalker.js
@@ -76,7 +76,7 @@ ESTreeWalker.SkipSubtree = {};
 
 /** @enum {!Array.<string>} */
 ESTreeWalker._walkOrder = {
-  'AwaitExpression': ['arguments'],
+  'AwaitExpression': ['argument'],
   'ArrayExpression': ['elements'],
   'ArrowFunctionExpression': ['params', 'body'],
   'AssignmentExpression': ['left', 'right'],

--- a/utils/node6-transform/TransformAsyncFunctions.js
+++ b/utils/node6-transform/TransformAsyncFunctions.js
@@ -53,7 +53,7 @@ const asyncToGenerator = fn => {
 function transformAsyncFunctions(text) {
   const edits = [];
 
-  const ast = esprima.parseScript(text, {range: true});
+  const ast = esprima.parseScript(text, {range: true, tolerant: true});
   const walker = new ESTreeWalker(node => {
     if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration' || node.type === 'ArrowFunctionExpression')
       onFunction(node);

--- a/utils/node6-transform/test/test.js
+++ b/utils/node6-transform/test/test.js
@@ -64,7 +64,7 @@ describe('TransformAsyncFunctions', function() {
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  fit('should work with double await', function(done) {
+  it('should work with double await', function(done) {
     const input = `async function f(){ return 23 + await Promise.resolve(50 + await Promise.resolve(50)); } f();`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);

--- a/utils/node6-transform/test/test.js
+++ b/utils/node6-transform/test/test.js
@@ -64,4 +64,10 @@ describe('TransformAsyncFunctions', function() {
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
+  fit('should work with double await', function(done) {
+    const input = `async function f(){ return 23 + await Promise.resolve(50 + await Promise.resolve(50)); } f();`;
+    const output = eval(transformAsyncFunctions(input));
+    expect(output instanceof Promise).toBe(true);
+    output.then(result => expect(result).toBe(123)).then(done);
+  });
 });


### PR DESCRIPTION
`Object.entries` is missing from node6
`url.URL` is missing from node6
The ESTreeWalker was failing on nested awaits
Esprima was failing on return statements outside of functions