### PR TITLE
Clarify that examples need Node v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 
 ### Installation
 
-*Puppeteer requires Node version 6.4.0 or greater*
+> *Note: Puppeteer requires at least Node v6.4.0, but the examples below use async/await which is only supported in Node v8+*
 
 To use Puppeteer in your project, run:
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 
 ### Installation
 
-> *Note: Puppeteer requires at least Node v6.4.0, but the examples below use async/await which is only supported in Node v8+*
+> *Note: Puppeteer requires at least Node v6.4.0, but the examples below use async/await which is only supported in Node v7.6.0 or greater*
 
 To use Puppeteer in your project, run:
 ```


### PR DESCRIPTION
The examples use async/await, but Node v6 doesn't support them, so to use these examples you either need Node 8 or a transpiler (like Babel) or to use promises.