### PR TITLE
Add support for request interception patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 
 ### Installation
 
-*Puppeteer requires Node version 6.4.0 or greater*
+> *Note: Puppeteer requires at least Node v6.4.0, but the examples below use async/await which is only supported in Node v7.6.0 or greater*
 
 To use Puppeteer in your project, run:
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,7 +60,7 @@
     + [page.setCookie(...cookies)](#pagesetcookiecookies)
     + [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
     + [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
-    + [page.setRequestInterceptionEnabled(value)](#pagesetrequestinterceptionenabledvalue)
+    + [page.setRequestInterceptionEnabled(value[, patterns])](#pagesetrequestinterceptionenabledvalue-patterns)
     + [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
     + [page.setViewport(viewport)](#pagesetviewportviewport)
     + [page.title()](#pagetitle)
@@ -706,8 +706,9 @@ The extra HTTP headers will be sent with every request the page initiates.
 
 > **NOTE** changing this value won't affect scripts that have already been run. It will take full effect on the next [navigation](#pagegotourl-options).
 
-#### page.setRequestInterceptionEnabled(value)
+#### page.setRequestInterceptionEnabled(value[, patterns])
 - `value` <[boolean]> Whether to enable request interception.
+- `patterns` <[Array]> Array of string patterns. Only requests matching any one of these URL patterns are intercepted. Wildcards ('\*' -> zero or more, '?' -> exactly one) are allowed. Escape character is backslash. Defaults to ['*'] (intercept all).
 - returns: <[Promise]>
 
 Activating request interception enables `request.abort` and `request.continue`.

--- a/lib/Multimap.js
+++ b/lib/Multimap.js
@@ -122,6 +122,13 @@ class Multimap {
     return result;
   }
 
+  /**
+   * @return {!Array<!K>}
+   */
+  keysArray() {
+    return Array.from(this._map.keys());
+  }
+
   clear() {
     this._map.clear();
   }

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -340,7 +340,8 @@ helper.tracePublicAPI(Response);
  */
 function generateRequestHash(request) {
   const hash = {
-    url: request.url,
+    // Decoding is necessary to normalize URLs. @see crbug.com/759388
+    url: decodeURI(request.url),
     method: request.method,
     postData: request.postData,
     headers: {},

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -124,7 +124,7 @@ class Page extends EventEmitter {
    * @param {!Array<string>} patterns
    */
   async setRequestInterceptionEnabled(value, patterns) {
-    return this._networkManager.setRequestInterceptionEnabled(value, patterns);
+    return this._networkManager.setRequestInterceptionEnabled(value, patterns || ['*']);
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -121,9 +121,10 @@ class Page extends EventEmitter {
 
   /**
    * @param {boolean} value
+   * @param {!Array<string>} patterns
    */
-  async setRequestInterceptionEnabled(value) {
-    return this._networkManager.setRequestInterceptionEnabled(value);
+  async setRequestInterceptionEnabled(value, patterns) {
+    return this._networkManager.setRequestInterceptionEnabled(value, patterns);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -949,6 +949,28 @@ describe('Page', function() {
       expect(requests.length).toBe(1);
       expect(requests[0].url).toBe(EMPTY_PAGE);
     }));
+    it('should work with encoded URLs', SX(async function() {
+      // The requestWillBeSent will report encoded URL, whereas interception will
+      // report URL as-is. @see crbug.com/759388
+      await page.setRequestInterceptionEnabled(true);
+      page.on('request', request => request.continue());
+      const response = await page.goto(PREFIX + '/some nonexisting page');
+      expect(response.status).toBe(404);
+    }));
+    it('should work with encoded URLs - 2', SX(async function() {
+      // The requestWillBeSent will report URL as-is, whereas interception will
+      // report encoded URL for stylesheet. @see crbug.com/759388
+      await page.setRequestInterceptionEnabled(true);
+      const requests = [];
+      page.on('request', request => {
+        request.continue();
+        requests.push(request);
+      });
+      const response = await page.goto(`data:text/html,<link rel="stylesheet" href="${PREFIX}/fonts?helvetica|arial"/>`);
+      expect(response.status).toBe(200);
+      expect(requests.length).toBe(2);
+      expect(requests[1].response().status).toBe(404);
+    }));
   });
 
   describe('Page.Events.Dialog', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -810,6 +810,17 @@ describe('Page', function() {
       const response = await page.goto(EMPTY_PAGE);
       expect(response.ok).toBe(true);
     }));
+    it('should block patterns', SX(async function() {
+      await page.setRequestInterceptionEnabled(true, ['*.css']);
+      page.on('request', request => {
+        request.continue();
+      });
+      let failedRequests = 0;
+      page.on('requestfailed', event => ++failedRequests);
+      const response = await page.goto(PREFIX + '/one-style.html');
+      expect(response.ok).toBe(true);
+      expect(failedRequests).toBe(1);
+    }));
     it('should show custom HTTP headers', SX(async function() {
       await page.setExtraHTTPHeaders(new Map(Object.entries({
         foo: 'bar'

--- a/test/test.js
+++ b/test/test.js
@@ -813,7 +813,7 @@ describe('Page', function() {
     it('should block patterns', SX(async function() {
       await page.setRequestInterceptionEnabled(true, ['*.css']);
       page.on('request', request => {
-        request.continue();
+        request.abort();
       });
       let failedRequests = 0;
       page.on('requestfailed', event => ++failedRequests);


### PR DESCRIPTION
This PR introduces support for request interception patterns, freshly introduced in https://chromium-review.googlesource.com/c/chromium/src/+/602483

I'm not sure which release this commit landed in, as I can't find it yet on https://omahaproxy.appspot.com/

The new test fails for now, but rolling Chromium to the version that includes the commit should make it pass.