### PR TITLE
Fix Request Interception

### DIFF
--- a/lib/Multimap.js
+++ b/lib/Multimap.js
@@ -122,6 +122,13 @@ class Multimap {
     return result;
   }
 
+  /**
+   * @return {!Array<!K>}
+   */
+  keysArray() {
+    return Array.from(this._map.keys());
+  }
+
   clear() {
     this._map.clear();
   }

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -340,7 +340,8 @@ helper.tracePublicAPI(Response);
  */
 function generateRequestHash(request) {
   const hash = {
-    url: request.url,
+    // Decoding is necessary to normalize URLs. @see crbug.com/759388
+    url: decodeURI(request.url),
     method: request.method,
     postData: request.postData,
     headers: {},

--- a/test/test.js
+++ b/test/test.js
@@ -938,6 +938,28 @@ describe('Page', function() {
       expect(requests.length).toBe(1);
       expect(requests[0].url).toBe(EMPTY_PAGE);
     }));
+    it('should work with encoded URLs', SX(async function() {
+      // The requestWillBeSent will report encoded URL, whereas interception will
+      // report URL as-is. @see crbug.com/759388
+      await page.setRequestInterceptionEnabled(true);
+      page.on('request', request => request.continue());
+      const response = await page.goto(PREFIX + '/some nonexisting page');
+      expect(response.status).toBe(404);
+    }));
+    it('should work with encoded URLs - 2', SX(async function() {
+      // The requestWillBeSent will report URL as-is, whereas interception will
+      // report encoded URL for stylesheet. @see crbug.com/759388
+      await page.setRequestInterceptionEnabled(true);
+      const requests = [];
+      page.on('request', request => {
+        request.continue();
+        requests.push(request);
+      });
+      const response = await page.goto(`data:text/html,<link rel="stylesheet" href="${PREFIX}/fonts?helvetica|arial"/>`);
+      expect(response.status).toBe(200);
+      expect(requests.length).toBe(2);
+      expect(requests[1].response().status).toBe(404);
+    }));
   });
 
   describe('Page.Events.Dialog', function() {


### PR DESCRIPTION
It turned out that either `Network.requestIntercepted` or
`Network.requestWillBeSent` occasionally report encoded URL.
Upstream bug: https://crbug.com/759388

As a workaround, this patch starts decoding URL's when generating request hash.

Fixes #558.