### PR TITLE
Use objects instead of maps to describe headers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -693,7 +693,7 @@ Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#ke
 - returns: <[Promise]>
 
 #### page.setExtraHTTPHeaders(headers)
-- `headers` <[Map]> A map of additional http headers to be sent with every request.
+- `headers` <[Object]> An object containing additional http headers to be sent with every request.
 - returns: <[Promise]>
 
 The extra HTTP headers will be sent with every request the page initiates.
@@ -1244,13 +1244,13 @@ Exception is immediately thrown if the request interception is not enabled.
   - `url` <[string]> If set, the request url will be changed
   - `method` <[string]> If set changes the request method (e.g. `GET` or `POST`)
   - `postData` <[string]> If set changes the post data of request
-  - `headers` <[Map]> If set changes the request HTTP headers
+  - `headers` <[Object]> If set changes the request HTTP headers
 
 Continues request with optional request overrides. To use this, request interception should be enabled with `page.setRequestInterceptionEnabled`.
 Exception is immediately thrown if the request interception is not enabled.
 
 #### request.headers
-- <[Map]> A map of HTTP headers associated with the request.
+- <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.
 
 #### request.method
 - <[string]>
@@ -1278,7 +1278,7 @@ Contains the URL of the request.
 - returns: <Promise<[Buffer]>> Promise which resolves to a buffer with response body.
 
 #### response.headers
-- <[Map]> A map of HTTP headers associated with the response.
+- <[Object]> An object with HTTP headers associated with the response. All header names are lower-case.
 
 #### response.json()
 - returns: <Promise<[Object]>> Promise which resolves to a JSON representation of response body.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -29,8 +29,8 @@ class NetworkManager extends EventEmitter {
     this._requestIdToRequest = new Map();
     /** @type {!Map<string, !Request>} */
     this._interceptionIdToRequest = new Map();
-    /** @type {!Map<string, string>} */
-    this._extraHTTPHeaders = new Map();
+    /** @type {!Object<string, string>} */
+    this._extraHTTPHeaders = {};
 
     this._requestInterceptionEnabled = false;
     /** @type {!Multimap<string, string>} */
@@ -46,22 +46,21 @@ class NetworkManager extends EventEmitter {
   }
 
   /**
-   * @param {!Map<string, string>} extraHTTPHeaders
+   * @param {!Object<string, string>} extraHTTPHeaders
    * @return {!Promise}
    */
   async setExtraHTTPHeaders(extraHTTPHeaders) {
-    this._extraHTTPHeaders = new Map(extraHTTPHeaders);
-    const headers = {};
-    for (const entry of extraHTTPHeaders.entries())
-      headers[entry[0]] = entry[1];
-    await this._client.send('Network.setExtraHTTPHeaders', { headers });
+    this._extraHTTPHeaders = {};
+    for (const key of Object.keys(extraHTTPHeaders))
+      this._extraHTTPHeaders[key.toLowerCase()] = extraHTTPHeaders[key];
+    await this._client.send('Network.setExtraHTTPHeaders', { headers: this._extraHTTPHeaders });
   }
 
   /**
-   * @return {!Map<string, string>}
+   * @return {!Object<string, string>}
    */
   extraHTTPHeaders() {
-    return new Map(this._extraHTTPHeaders);
+    return Object.assign({}, this._extraHTTPHeaders);
   }
 
   /**
@@ -226,7 +225,9 @@ class Request {
     this.url = url;
     this.method = payload.method;
     this.postData = payload.postData;
-    this.headers = new Map(Object.entries(payload.headers));
+    this.headers = {};
+    for (const key of Object.keys(payload.headers))
+      this.headers[key.toLowerCase()] = payload.headers[key];
   }
 
   /**
@@ -246,18 +247,12 @@ class Request {
     console.assert(this._interceptionId, 'Request Interception is not enabled!');
     console.assert(!this._interceptionHandled, 'Request is already handled!');
     this._interceptionHandled = true;
-    let headers = undefined;
-    if (overrides.headers) {
-      headers = {};
-      for (const entry of overrides.headers)
-        headers[entry[0]] = entry[1];
-    }
     this._client.send('Network.continueInterceptedRequest', {
       interceptionId: this._interceptionId,
       url: overrides.url,
       method: overrides.method,
       postData: overrides.postData,
-      headers: headers
+      headers: overrides.headers,
     });
   }
 
@@ -288,10 +283,12 @@ class Response {
     this._request = request;
     this._contentPromise = null;
 
-    this.headers = new Map(Object.entries(headers));
     this.status = status;
     this.ok = status >= 200 && status <= 299;
     this.url = request.url;
+    this.headers = {};
+    for (const key of Object.keys(headers))
+      this.headers[key.toLowerCase()] = headers[key];
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -241,7 +241,7 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {!Map<string, string>} headers
+   * @param {!Object<string, string>} headers
    * @return {!Promise}
    */
   async setExtraHTTPHeaders(headers) {
@@ -344,7 +344,7 @@ class Page extends EventEmitter {
     const listener = helper.addEventListener(this._networkManager, NetworkManager.Events.Response, response => responses.set(response.url, response));
     const result = watcher.waitForNavigation();
 
-    const referrer = this._networkManager.extraHTTPHeaders().get('referer');
+    const referrer = this._networkManager.extraHTTPHeaders()['referer'];
     try {
       // Await for the command to throw exception in case of illegal arguments.
       await this._client.send('Page.navigate', {url, referrer});

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -218,9 +218,4 @@ class Helper {
   }
 }
 
-// Polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
-if (!Object.entries)
-  Object.entries = obj => Object.keys(obj).map(key => [key, obj[key]]);
-
-
 module.exports = Helper;

--- a/test/test.js
+++ b/test/test.js
@@ -802,7 +802,7 @@ describe('Page', function() {
       await page.setRequestInterceptionEnabled(true);
       page.on('request', request => {
         expect(request.url).toContain('empty.html');
-        expect(request.headers.has('User-Agent')).toBeTruthy();
+        expect(request.headers['user-agent']).toBeTruthy();
         expect(request.method).toBe('GET');
         expect(request.postData).toBe(undefined);
         request.continue();
@@ -811,12 +811,12 @@ describe('Page', function() {
       expect(response.ok).toBe(true);
     }));
     it('should show custom HTTP headers', SX(async function() {
-      await page.setExtraHTTPHeaders(new Map(Object.entries({
+      await page.setExtraHTTPHeaders({
         foo: 'bar'
-      })));
+      });
       await page.setRequestInterceptionEnabled(true);
       page.on('request', request => {
-        expect(request.headers.get('foo')).toBe('bar');
+        expect(request.headers['foo']).toBe('bar');
         request.continue();
       });
       const response = await page.goto(EMPTY_PAGE);
@@ -839,8 +839,8 @@ describe('Page', function() {
     it('should amend HTTP headers', SX(async function() {
       await page.setRequestInterceptionEnabled(true);
       page.on('request', request => {
-        const headers = new Map(request.headers);
-        headers.set('foo', 'bar');
+        const headers = Object.assign({}, request.headers);
+        headers['FOO'] = 'bar';
         request.continue({ headers });
       });
       await page.goto(EMPTY_PAGE);
@@ -1475,9 +1475,9 @@ describe('Page', function() {
   });
   describe('Page.setExtraHTTPHeaders', function() {
     it('should work', SX(async function() {
-      await page.setExtraHTTPHeaders(new Map(Object.entries({
+      await page.setExtraHTTPHeaders({
         foo: 'bar'
-      })));
+      });
       page.goto(EMPTY_PAGE);
       const request = await server.waitForRequest('/empty.html');
       expect(request.headers['foo']).toBe('bar');


### PR DESCRIPTION
This patch:
- switches to objects instead of maps for headers (in Request, Response and
  page.setExtraHTTPHeaders)
- converts all header names to lower case 

Fixes #547, fixes #509 