### PR TITLE
[docs] Add CentOS troubleshooting notes

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,12 +1,11 @@
 # Troubleshooting
 
-## Chrome headless doesn't start on Debian (e.g. Ubuntu)
+## Chrome headless doesn't launch
 
-- Make sure all the necessary dependencies are installed
-- The broad discussion on the topic can be found in [#290](https://github.com/GoogleChrome/puppeteer/issues/290)
+- Make sure all the necessary dependencies are installed:
 
 <details>
-<summary>Debian Dependencies</summary>
+<summary>Debian (e.g. Ubuntu) Dependencies</summary>
 
 ```
 gconf-service
@@ -49,6 +48,39 @@ xdg-utils
 wget
 ```
 </details>
+
+<details>
+<summary>CentOS Dependencies</summary>
+
+```
+pango.x86_64
+libXcomposite.x86_64
+libXcursor.x86_64
+libXdamage.x86_64
+libXext.x86_64
+libXi.x86_64
+libXtst.x86_64
+cups-libs.x86_64
+libXScrnSaver.x86_64
+libXrandr.x86_64
+GConf2.x86_64
+alsa-lib.x86_64
+atk.x86_64
+gtk3.x86_64
+ipa-gothic-fonts
+xorg-x11-fonts-100dpi
+xorg-x11-fonts-75dpi
+xorg-x11-utils
+xorg-x11-fonts-cyrillic
+xorg-x11-fonts-Type1
+xorg-x11-fonts-misc
+```
+</details>
+
+- Check out discussions:
+  - [#290](https://github.com/GoogleChrome/puppeteer/issues/290) - Debian troubleshooting
+  - [#391](https://github.com/GoogleChrome/puppeteer/issues/391) - CentOS troubleshooting
+
 
 ## Chrome Headless fails due to sandbox issues
 


### PR DESCRIPTION
This patch adds CentOS dependencies into the troubleshooting.md as discussed
in #560.
