### PR TITLE
Fix launcher to not fail in case of empty arguments

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -55,7 +55,7 @@ class Launcher {
     options = options || {};
     let temporaryUserDataDir = null;
     const chromeArguments = [].concat(DEFAULT_ARGS);
-    if (!options.args.some(arg => arg.startsWith('--user-data-dir'))) {
+    if (!options.args || !options.args.some(arg => arg.startsWith('--user-data-dir'))) {
       if (!options.userDataDir)
         temporaryUserDataDir = fs.mkdtempSync(CHROME_PROFILE_PATH);
 


### PR DESCRIPTION
The regression was introduced in
d5327e6a0fd384cd36bfd0b4a12b27ab362543a7