### PR TITLE
Roll chromium to r497674

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "496140"
+    "chromium_revision": "497674"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",


### PR DESCRIPTION
This patch rolls chromium to r497674, which is current Canary.
This should hopefully make is more stable and address #583 and #585.