### PR TITLE
Implement Request.resourceType getter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -117,6 +117,7 @@
     + [request.headers](#requestheaders)
     + [request.method](#requestmethod)
     + [request.postData](#requestpostdata)
+    + [request.resourceType](#requestresourcetype)
     + [request.response()](#requestresponse)
     + [request.url](#requesturl)
   * [class: Response](#class-response)
@@ -1262,6 +1263,12 @@ Contains the request's method (GET, POST, etc.)
 - <[string]>
 
 Contains the request's post body, if any.
+
+#### request.resourceType
+- <[string]>
+
+Contains the request's resource type as it was perceived by the rendering engine.
+ResourceType will be one of the following: `Document`, `Stylesheet`, `Image`, `Media`, `Font`, `Script`, `TextTrack`, `XHR`, `Fetch`, `EventSource`, `WebSocket`, `Manifest`, `Other`.
 
 #### request.response()
 - returns: <[Response]> A matching [Response] object, or `null` if the response has not been received yet.

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -24,7 +24,7 @@ const browser = await puppeteer.launch();
 const page = await browser.newPage();
 await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {
-  if (/\.(png|jpg|jpeg|gif|webp)$/i.test(request.url))
+  if (request.resourceType === 'Image')
     request.abort();
   else
     request.continue();

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -91,7 +91,7 @@ class NetworkManager extends EventEmitter {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
       console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
       this._handleRequestRedirect(request, event.redirectStatusCode, event.redirectHeaders);
-      this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.request);
+      this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request);
       return;
     }
     const requestHash = generateRequestHash(event.request);
@@ -117,10 +117,11 @@ class NetworkManager extends EventEmitter {
    * @param {string} requestId
    * @param {string} interceptionId
    * @param {string} url
+   * @param {string} resourceType
    * @param {!Object} requestPayload
    */
-  _handleRequestStart(requestId, interceptionId, url, requestPayload) {
-    const request = new Request(this._client, requestId, interceptionId, url, requestPayload);
+  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload) {
+    const request = new Request(this._client, requestId, interceptionId, url, resourceType, requestPayload);
     this._requestIdToRequest.set(requestId, request);
     this._interceptionIdToRequest.set(interceptionId, request);
     this.emit(NetworkManager.Events.Request, request);
@@ -143,7 +144,7 @@ class NetworkManager extends EventEmitter {
       const request = this._requestIdToRequest.get(event.requestId);
       this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
     }
-    this._handleRequestStart(event.requestId, null, event.request.url, event.request);
+    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request);
   }
 
   /**
@@ -157,7 +158,7 @@ class NetworkManager extends EventEmitter {
       return;
     this._requestHashToRequestIds.delete(requestHash, requestId);
     this._requestHashToInterceptions.delete(requestHash, interception);
-    this._handleRequestStart(requestId, interception.interceptionId, interception.request.url, interception.request);
+    this._handleRequestStart(requestId, interception.interceptionId, interception.request.url, interception.resourceType, interception.request);
   }
 
   /**
@@ -210,9 +211,10 @@ class Request {
    * @param {string} requestId
    * @param {string} interceptionId
    * @param {string} url
+   * @param {string} resourceType
    * @param {!Object} payload
    */
-  constructor(client, requestId, interceptionId, url, payload) {
+  constructor(client, requestId, interceptionId, url, resourceType, payload) {
     this._client = client;
     this._requestId = requestId;
     this._interceptionId = interceptionId;
@@ -223,6 +225,7 @@ class Request {
     });
 
     this.url = url;
+    this.resourceType = resourceType;
     this.method = payload.method;
     this.postData = payload.postData;
     this.headers = {};

--- a/test/test.js
+++ b/test/test.js
@@ -1613,6 +1613,7 @@ describe('Page', function() {
       expect(failedRequests.length).toBe(1);
       expect(failedRequests[0].url).toContain('one-style.css');
       expect(failedRequests[0].response()).toBe(null);
+      expect(failedRequests[0].resourceType).toBe('Stylesheet');
     }));
     it('Page.Events.RequestFinished', SX(async function() {
       const requests = [];

--- a/test/test.js
+++ b/test/test.js
@@ -824,6 +824,7 @@ describe('Page', function() {
         expect(request.headers['user-agent']).toBeTruthy();
         expect(request.method).toBe('GET');
         expect(request.postData).toBe(undefined);
+        expect(request.resourceType).toBe('Document');
         request.continue();
       });
       const response = await page.goto(EMPTY_PAGE);
@@ -883,7 +884,11 @@ describe('Page', function() {
     }));
     it('should work with redirects', SX(async function() {
       await page.setRequestInterceptionEnabled(true);
-      page.on('request', request => request.continue());
+      const requests = [];
+      page.on('request', request => {
+        request.continue();
+        requests.push(request);
+      });
       server.setRedirect('/non-existing-page.html', '/non-existing-page-2.html');
       server.setRedirect('/non-existing-page-2.html', '/non-existing-page-3.html');
       server.setRedirect('/non-existing-page-3.html', '/non-existing-page-4.html');
@@ -891,6 +896,8 @@ describe('Page', function() {
       const response = await page.goto(PREFIX + '/non-existing-page.html');
       expect(response.status).toBe(200);
       expect(response.url).toContain('empty.html');
+      expect(requests.length).toBe(5);
+      expect(requests[2].resourceType).toBe('Document');
     }));
     it('should be able to abort redirects', SX(async function() {
       await page.setRequestInterceptionEnabled(true);
@@ -1530,6 +1537,7 @@ describe('Page', function() {
       await page.goto(EMPTY_PAGE);
       expect(requests.length).toBe(1);
       expect(requests[0].url).toBe(EMPTY_PAGE);
+      expect(requests[0].resourceType).toBe('Document');
       expect(requests[0].method).toBe('GET');
       expect(requests[0].response()).toBeTruthy();
     }));


### PR DESCRIPTION
This patch introduces Request.resourceType getter that represents resource type as it was perceived by the rendering engine. Possible values are inherited as-is from protocol:
- Document, Stylesheet, Image, Media, Font, Script, TextTrack, XHR, Fetch, EventSource, WebSocket, Manifest, Other

This patch also updates an example to effectively block images.