### PR TITLE
readme: note on how to skip chromium install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add puppeteer
 # or "npm i puppeteer"
 ```
 
-> **Note**: When you install Puppeteer, it downloads a recent version of Chromium (~71Mb Mac, ~90Mb Linux, ~110Mb Win) that is guaranteed to work with the API.
+> **Note**: When you install Puppeteer, it downloads a recent version of Chromium (~71Mb Mac, ~90Mb Linux, ~110Mb Win) that is guaranteed to work with the API. Although it's not recommend, you can skip the Chromium install with `npm i --ignore-scripts puppeteer`.
 
 ### Usage
 


### PR DESCRIPTION
adds note on how to skip install of chromium.

Related to https://github.com/GoogleChrome/puppeteer/issues/603