### PR TITLE
Throw an error when Chromium download is failed

### DIFF
--- a/utils/ChromiumDownloader.js
+++ b/utils/ChromiumDownloader.js
@@ -97,10 +97,12 @@ module.exports = {
       fs.mkdirSync(DOWNLOADS_FOLDER);
     return downloadFile(url, zipPath, progressCallback)
         .then(() => extractZip(zipPath, folderPath))
-        .catch(err => { throw err; })
-        .then(() => {
+        .catch(err => err)
+        .then(err => {
           if (fs.existsSync(zipPath))
             fs.unlinkSync(zipPath);
+          if (err)
+            throw err;
         });
   },
 

--- a/utils/ChromiumDownloader.js
+++ b/utils/ChromiumDownloader.js
@@ -97,7 +97,7 @@ module.exports = {
       fs.mkdirSync(DOWNLOADS_FOLDER);
     return downloadFile(url, zipPath, progressCallback)
         .then(() => extractZip(zipPath, folderPath))
-        .catch(err => err)
+        .catch(err => { throw err; })
         .then(() => {
           if (fs.existsSync(zipPath))
             fs.unlinkSync(zipPath);


### PR DESCRIPTION
Hi,

When Chromium download is failed (no internet connection for example) **downloadRevision** will not emit an error and therefore **onError** function in the install file will not be triggered and the user will not see the message:
> ERROR: Failed to download chromium ....




I'm using Node v6.11.2
