### PR TITLE
Kill child process group

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -78,7 +78,7 @@ class Launcher {
     if (Array.isArray(options.args))
       chromeArguments.push(...options.args);
 
-    const chromeProcess = childProcess.spawn(chromeExecutable, chromeArguments, {});
+    const chromeProcess = childProcess.spawn(chromeExecutable, chromeArguments, {detached: true});
     if (options.dumpio) {
       chromeProcess.stdout.pipe(process.stdout);
       chromeProcess.stderr.pipe(process.stderr);
@@ -107,7 +107,7 @@ class Launcher {
       if (process.platform === 'win32')
         childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
       else
-        chromeProcess.kill('SIGKILL');
+        process.kill(-chromeProcess.pid);
     }
   }
 


### PR DESCRIPTION
This patch starts creating process groups and later killing it (reusing chrome-launcher approach).
 Fixes #615 