### PR TITLE
Add basic authentication support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,7 @@
     + [page.$(selector)](#pageselector)
     + [page.$$(selector)](#pageselector)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
+    + [page.authenticate(username, password)](#pageauthenticateusername-password)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
     + [page.content()](#pagecontent)
@@ -322,6 +323,12 @@ Adds a `<script>` tag into the page with the desired url. Alternatively, a local
 
 Shortcut for [page.mainFrame().addScriptTag(url)](#frameaddscripttagurl).
 
+#### page.authenticate(username, password)
+- `username` <[string]> page or proxy username
+- `password` <[string]> page or proxy password
+- returns: <[Promise]>
+
+Define a username and password that will be used when a page or a proxy requires authentication.
 
 #### page.click(selector[, options])
 - `selector` <[string]> A [selector] to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -37,6 +37,10 @@ class NetworkManager extends EventEmitter {
     this._requestHashToRequestIds = new Multimap();
     /** @type {!Multimap<string, !Object>} */
     this._requestHashToInterceptions = new Multimap();
+    /** @type {!string} */
+    this._authUsername = undefined;
+    /** @type {!string} */
+    this._authPassword = undefined;
 
     this._client.on('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this));
     this._client.on('Network.requestIntercepted', this._onRequestIntercepted.bind(this));
@@ -81,6 +85,18 @@ class NetworkManager extends EventEmitter {
   }
 
   /**
+   * @param {string} username
+   * @param {string} password
+   */
+  async authenticate(username, password) {
+    if (!this._requestInterceptionEnabled)
+      await this.setRequestInterceptionEnabled(true);
+
+    this._authUser = username;
+    this._authPass = password;
+  }
+
+  /**
    * @param {!Object} event
    */
   _onRequestIntercepted(event) {
@@ -94,6 +110,14 @@ class NetworkManager extends EventEmitter {
       this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.request);
       return;
     }
+
+    if (event.authChallenge) {
+      const request = this._interceptionIdToRequest.get(event.interceptionId);
+      console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
+      this._handleAuthenticate(request, event.authChallenge);
+      return;
+    }
+
     const requestHash = generateRequestHash(event.request);
     this._requestHashToInterceptions.set(requestHash, event);
     this._maybeResolveInterception(requestHash);
@@ -111,6 +135,29 @@ class NetworkManager extends EventEmitter {
     this._interceptionIdToRequest.delete(request._interceptionId);
     this.emit(NetworkManager.Events.Response, response);
     this.emit(NetworkManager.Events.RequestFinished, request);
+  }
+
+  /**
+   * @param {!Request} request
+   * @param {!Object} authentification challenge
+   */
+  _handleAuthenticate(request, authChallenge) {
+    request._interceptionHandled = false;
+    if (this._authUser && this._authPass) {
+      request.continue({
+        authChallengeResponse: {
+          response: 'ProvideCredentials',
+          username: this._authUser,
+          password: this._authPass,
+        },
+      });
+    } else {
+      request.continue({
+        authChallengeResponse: {
+          response: 'Default',
+        },
+      });
+    }
   }
 
   /**
@@ -253,6 +300,7 @@ class Request {
       method: overrides.method,
       postData: overrides.postData,
       headers: overrides.headers,
+      authChallengeResponse: overrides.authChallengeResponse,
     });
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -74,7 +74,7 @@ class Page extends EventEmitter {
     this._frameManager.on(FrameManager.Events.FrameDetached, event => this.emit(Page.Events.FrameDetached, event));
     this._frameManager.on(FrameManager.Events.FrameNavigated, event => this.emit(Page.Events.FrameNavigated, event));
 
-    this._networkManager.on(NetworkManager.Events.Request, event => this.emit(Page.Events.Request, event));
+    this._networkManager.on(NetworkManager.Events.Request, event => this._onRequest(event));
     this._networkManager.on(NetworkManager.Events.Response, event => this.emit(Page.Events.Response, event));
     this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(Page.Events.RequestFailed, event));
     this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(Page.Events.RequestFinished, event));
@@ -254,6 +254,25 @@ class Page extends EventEmitter {
    */
   async setUserAgent(userAgent) {
     return this._networkManager.setUserAgent(userAgent);
+  }
+
+  /**
+   * @param {string} username
+   * @param {string} password
+   * @return {!Promise}
+   */
+  async authenticate(username, password) {
+    return this._networkManager.authenticate(username, password);
+  }
+
+  /**
+   * @param {!Object} event
+   */
+  _onRequest(event) {
+    if (this.listenerCount(Page.Events.Request) > 0)
+      this.emit(Page.Events.Request, event);
+    else if (this._networkManager._authUser && this._networkManager._authPass)
+      event.continue();
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -750,6 +750,11 @@ describe('Page', function() {
       expect(requests.length).toBe(1);
       expect(requests[0].url).toBe(EMPTY_PAGE);
     }));
+    it('should navigate to URL with authentication set but no challenge', SX(async function() {
+      await page.authenticate('anyuser', 'anypassword');
+      const response = await page.goto(EMPTY_PAGE);
+      expect(response.ok).toBe(true);
+    }));
   });
 
   describe('Page.waitForNavigation', function() {


### PR DESCRIPTION
This adds `page.authenticate(user, pass)` method to "fill" the authentication "window". Works for either a webpage auth or a proxy auth, and both on http and https.