### PR TITLE
Clarify networkIdleInflight default in docs.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -557,7 +557,7 @@ Navigate to the next page in history.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Could be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
-  - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter.
+  - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter. Defaults to 2.
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter. Defaults to 1000 ms.
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 


### PR DESCRIPTION
Can see default here: https://github.com/GoogleChrome/puppeteer/blob/1f9b4fb4c83ad9f5963507675e6ad9011c4301ff/lib/NavigatorWatcher.js#L30