### PR TITLE
Update package.json with Apache License 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "unit-node6": "jasmine node6-test/test.js"
   },
   "author": "The Chromium Authors",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache License 2.0",
   "dependencies": {
     "debug": "^2.6.8",
     "extract-zip": "^1.6.5",


### PR DESCRIPTION
The license used is Apache License 2.0, so I think it makes sense to update the package.json file with the correct string as a some software use this field to approve or not packages.