### PR TITLE
Add 'allCookies' method

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -163,7 +163,14 @@ class Page extends EventEmitter {
       urls: urls.length ? urls : [this.url()]
     })).cookies;
   }
-
+  
+  /**
+   * @return {!Promise<!Array<Network.Cookie>>}
+   */
+  async allCookies() {
+    return (await this._client.send('Network.getAllCookies')).cookies;
+  }
+  
   /**
    * @param {Array<Network.CookieParam>} cookies
    */

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -163,12 +163,14 @@ class Page extends EventEmitter {
       urls: urls.length ? urls : [this.url()]
     })).cookies;
   }
+
   /**
   * @return {!Promise<!Array<Network.Cookie>>}
   */
   async allCookies() {
     return (await this._client.send('Network.getAllCookies')).cookies;
   }
+
   /**
    * @param {Array<Network.CookieParam>} cookies
    */

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -163,14 +163,12 @@ class Page extends EventEmitter {
       urls: urls.length ? urls : [this.url()]
     })).cookies;
   }
-  
-/**
-* @return {!Promise<!Array<Network.Cookie>>}
-*/
-async allCookies() {
-return (await this._client.send('Network.getAllCookies')).cookies;
-}
-  
+  /**
+  * @return {!Promise<!Array<Network.Cookie>>}
+  */
+  async allCookies() {
+    return (await this._client.send('Network.getAllCookies')).cookies;
+  }
   /**
    * @param {Array<Network.CookieParam>} cookies
    */

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -164,12 +164,12 @@ class Page extends EventEmitter {
     })).cookies;
   }
   
-  /**
-   * @return {!Promise<!Array<Network.Cookie>>}
-   */
-  async allCookies() {
-    return (await this._client.send('Network.getAllCookies')).cookies;
-  }
+/**
+* @return {!Promise<!Array<Network.Cookie>>}
+*/
+async allCookies() {
+return (await this._client.send('Network.getAllCookies')).cookies;
+}
   
   /**
    * @param {Array<Network.CookieParam>} cookies


### PR DESCRIPTION
page.allCookies() returns all cookies, even third party ones.
Based on the command Network.getAllCookies(): https://bugs.chromium.org/p/chromium/issues/detail?id=668932#c15