### PR TITLE
Implement page.$eval

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@
     + [event: 'response'](#event-response)
     + [page.$(selector)](#pageselector)
     + [page.$$(selector)](#pageselector)
-    + [page.$eval(selector, pageFunction)](#pageevalselector-pagefunction)
+    + [page.$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
@@ -95,7 +95,7 @@
   * [class: Frame](#class-frame)
     + [frame.$(selector)](#frameselector)
     + [frame.$$(selector)](#frameselector)
-    + [frame.$eval(selector, pageFunction)](#frameevalselector-pagefunction)
+    + [frame.$eval(selector, pageFunction[, ...args])](#frameevalselector-pagefunction-args)
     + [frame.addScriptTag(url)](#frameaddscripttagurl)
     + [frame.childFrames()](#framechildframes)
     + [frame.evaluate(pageFunction, ...args)](#frameevaluatepagefunction-args)
@@ -324,7 +324,7 @@ The method runs `document.querySelectorAll` within the page. If no elements matc
 
 Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
 
-#### page.$eval(selector, pageFunction, ...args)
+#### page.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> Selector to query page for
 - `pageFunction` <[function]> Function to be evaluated in browser context
 - `...args` <...[Serializable]> Arguments to pass to `pageFunction`
@@ -341,7 +341,7 @@ const preloadHref = await page.$eval('link[rel=preload]', el => el.href);
 const html = await page.$eval('.main-container', e => e.outerHTML);
 ```
 
-Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector-pagefunction).
+Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector-pagefunction-args).
 
 #### page.addScriptTag(url)
 - `url` <[string]> Url of the `<script>` tag
@@ -1076,7 +1076,7 @@ The method queries frame for the selector. If there's no such element within the
 
 The method runs `document.querySelectorAll` within the frame. If no elements match the selector, the return value resolve to `[]`.
 
-#### frame.$eval(selector, pageFunction)
+#### frame.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> Selector to query frame for
 - `pageFunction` <[function]> Function to be evaluated in browser context
 - `...args` <...[Serializable]> Arguments to pass to `pageFunction`

--- a/docs/api.md
+++ b/docs/api.md
@@ -324,16 +324,24 @@ The method runs `document.querySelectorAll` within the page. If no elements matc
 
 Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
 
-#### page.$eval(selector, pageFunction)
+#### page.$eval(selector, pageFunction, ...args)
 - `selector` <[string]> Selector to query page for
 - `pageFunction` <[function]> Function to be evaluated in browser context
+- `...args` <...[Serializable]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
 
 This method runs `document.querySelector` within the page and passes it as the first argument to `pageFunction`. If there's no element matching `selector`, the method throws an error.
 
 If `pageFunction` returns a [Promise], then `page.$eval` would wait for the promise to resolve and return it's value.
 
-Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector-pageFunction).
+Examples:
+```js
+const searchValue = await page.$eval('#search', el => el.value);
+const preloadHref = await page.$eval('link[rel=preload]', el => el.href);
+const html = await page.$eval('.main-container', e => e.outerHTML);
+```
+
+Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector-pagefunction).
 
 #### page.addScriptTag(url)
 - `url` <[string]> Url of the `<script>` tag
@@ -1071,11 +1079,19 @@ The method runs `document.querySelectorAll` within the frame. If no elements mat
 #### frame.$eval(selector, pageFunction)
 - `selector` <[string]> Selector to query frame for
 - `pageFunction` <[function]> Function to be evaluated in browser context
+- `...args` <...[Serializable]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
 
 This method runs `document.querySelector` within the frame and passes it as the first argument to `pageFunction`. If there's no element matching `selector`, the method throws an error.
 
 If `pageFunction` returns a [Promise], then `frame.$eval` would wait for the promise to resolve and return it's value.
+
+Examples:
+```js
+const searchValue = await frame.$eval('#search', el => el.value);
+const preloadHref = await frame.$eval('link[rel=preload]', el => el.href);
+const html = await frame.$eval('.main-container', e => e.outerHTML);
+```
 
 #### frame.addScriptTag(url)
 - `url` <[string]> Url of a script to be added

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,7 @@
     + [event: 'response'](#event-response)
     + [page.$(selector)](#pageselector)
     + [page.$$(selector)](#pageselector)
+    + [page.$eval(selector, pageFunction)](#pageevalselector-pagefunction)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
@@ -94,6 +95,7 @@
   * [class: Frame](#class-frame)
     + [frame.$(selector)](#frameselector)
     + [frame.$$(selector)](#frameselector)
+    + [frame.$eval(selector, pageFunction)](#frameevalselector-pagefunction)
     + [frame.addScriptTag(url)](#frameaddscripttagurl)
     + [frame.childFrames()](#framechildframes)
     + [frame.evaluate(pageFunction, ...args)](#frameevaluatepagefunction-args)
@@ -107,7 +109,6 @@
     + [frame.waitForFunction(pageFunction[, options, ...args])](#framewaitforfunctionpagefunction-options-args)
     + [frame.waitForSelector(selector[, options])](#framewaitforselectorselector-options)
   * [class: ElementHandle](#class-elementhandle)
-    + [elementHandle.attribute(key)](#elementhandleattributekey)
     + [elementHandle.click([options])](#elementhandleclickoptions)
     + [elementHandle.dispose()](#elementhandledispose)
     + [elementHandle.evaluate(pageFunction, ...args)](#elementhandleevaluatepagefunction-args)
@@ -322,6 +323,17 @@ Shortcut for [page.mainFrame().$(selector)](#frameselector).
 The method runs `document.querySelectorAll` within the page. If no elements match the selector, the return value resolve to `[]`.
 
 Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
+
+#### page.$eval(selector, pageFunction)
+- `selector` <[string]> Selector to query page for
+- `pageFunction` <[function]> Function to be evaluated in browser context
+- returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
+
+This method runs `document.querySelector` within the page and passes it as the first argument to `pageFunction`. If there's no element matching `selector`, the method throws an error.
+
+If `pageFunction` returns a [Promise], then `page.$eval` would wait for the promise to resolve and return it's value.
+
+Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector-pageFunction).
 
 #### page.addScriptTag(url)
 - `url` <[string]> Url of the `<script>` tag
@@ -1056,6 +1068,15 @@ The method queries frame for the selector. If there's no such element within the
 
 The method runs `document.querySelectorAll` within the frame. If no elements match the selector, the return value resolve to `[]`.
 
+#### frame.$eval(selector, pageFunction)
+- `selector` <[string]> Selector to query frame for
+- `pageFunction` <[function]> Function to be evaluated in browser context
+- returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
+
+This method runs `document.querySelector` within the frame and passes it as the first argument to `pageFunction`. If there's no element matching `selector`, the method throws an error.
+
+If `pageFunction` returns a [Promise], then `frame.$eval` would wait for the promise to resolve and return it's value.
+
 #### frame.addScriptTag(url)
 - `url` <[string]> Url of a script to be added
 - returns: <[Promise]> Promise which resolves as the script gets added and loads.
@@ -1199,21 +1220,6 @@ puppeteer.launch().then(async browser => {
 ```
 
 ElementHandle prevents DOM element from garbage collection unless the handle is [disposed](#elementhandledispose). ElementHandles are auto-disposed when their origin frame gets navigated.
-
-#### elementHandle.attribute(key)
-- `key` <string> the name the attribute of this Element.
-- returns: <[Promise]>
-
-```js
-const puppeteer = require('puppeteer');
-
-puppeteer.launch().then(async browser => {
-  const page = await browser.newPage();
-  await page.goto('https://google.com');
-  const inputElement = await page.$('input');
-  const inputType = await inputElement.attribute('type');
-});
-```
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -309,7 +309,7 @@ Emitted when a request finishes successfully.
 Emitted when a [response] is received.
 
 #### page.$(selector)
-- `selector` <[string]> Selector to query page for
+- `selector` <[string]> A [selector] to query page for
 - returns: <[Promise]<[ElementHandle]>>
 
 The method runs `document.querySelector` within the page. If no element matches the selector, the return value resolve to `null`.
@@ -317,7 +317,7 @@ The method runs `document.querySelector` within the page. If no element matches 
 Shortcut for [page.mainFrame().$(selector)](#frameselector).
 
 #### page.$$(selector)
-- `selector` <[string]> Selector to query page for
+- `selector` <[string]> A [selector] to query page for
 - returns: <[Promise]<[Array]<[ElementHandle]>>>
 
 The method runs `document.querySelectorAll` within the page. If no elements match the selector, the return value resolve to `[]`.
@@ -325,7 +325,7 @@ The method runs `document.querySelectorAll` within the page. If no elements matc
 Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
 
 #### page.$eval(selector, pageFunction[, ...args])
-- `selector` <[string]> Selector to query page for
+- `selector` <[string]> A [selector] to query page for
 - `pageFunction` <[function]> Function to be evaluated in browser context
 - `...args` <...[Serializable]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
@@ -1077,7 +1077,7 @@ The method queries frame for the selector. If there's no such element within the
 The method runs `document.querySelectorAll` within the frame. If no elements match the selector, the return value resolve to `[]`.
 
 #### frame.$eval(selector, pageFunction[, ...args])
-- `selector` <[string]> Selector to query frame for
+- `selector` <[string]> A [selector] to query frame for
 - `pageFunction` <[function]> Function to be evaluated in browser context
 - `...args` <...[Serializable]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -103,15 +103,6 @@ class ElementHandle {
     const objectId = this._remoteObject.objectId;
     return this._client.send('DOM.setFileInputFiles', { objectId, files });
   }
-
-  /**
-   * @param {!<string} key
-   * @return {!Promise}
-   */
-  async attribute(key) {
-    return await this.evaluate((element, key) => element.getAttribute(key), key);
-  }
-
 }
 
 module.exports = ElementHandle;

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -197,6 +197,20 @@ class Frame {
 
   /**
    * @param {string} selector
+   * @param {function()|string} pageFunction
+   * @return {!Promise<?ElementHandle>}
+   */
+  async $eval(selector, pageFunction) {
+    const elementHandle = await this.$(selector);
+    if (!elementHandle)
+      throw new Error(`Error: failed to find element matching selector "${selector}"`);
+    const result = await elementHandle.evaluate(pageFunction);
+    await elementHandle.dispose();
+    return result;
+  }
+
+  /**
+   * @param {string} selector
    * @return {!Promise<!Array<!ElementHandle>>}
    */
   async $$(selector) {

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -198,13 +198,14 @@ class Frame {
   /**
    * @param {string} selector
    * @param {function()|string} pageFunction
+   * @param {!Array<*>} args
    * @return {!Promise<?ElementHandle>}
    */
-  async $eval(selector, pageFunction) {
+  async $eval(selector, pageFunction, ...args) {
     const elementHandle = await this.$(selector);
     if (!elementHandle)
       throw new Error(`Error: failed to find element matching selector "${selector}"`);
-    const result = await elementHandle.evaluate(pageFunction);
+    const result = await elementHandle.evaluate(pageFunction, ...args);
     await elementHandle.dispose();
     return result;
   }

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -199,7 +199,7 @@ class Frame {
    * @param {string} selector
    * @param {function()|string} pageFunction
    * @param {!Array<*>} args
-   * @return {!Promise<?ElementHandle>}
+   * @return {!Promise<(!Object|undefined)>}
    */
   async $eval(selector, pageFunction, ...args) {
     const elementHandle = await this.$(selector);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -150,7 +150,7 @@ class Page extends EventEmitter {
    * @param {string} selector
    * @param {function()|string} pageFunction
    * @param {!Array<*>} args
-   * @return {!Promise<?ElementHandle>}
+   * @return {!Promise<(!Object|undefined)>}
    */
   async $eval(selector, pageFunction, ...args) {
     return this.mainFrame().$eval(selector, pageFunction, ...args);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -148,6 +148,15 @@ class Page extends EventEmitter {
 
   /**
    * @param {string} selector
+   * @param {function()|string} pageFunction
+   * @return {!Promise<?ElementHandle>}
+   */
+  async $eval(selector, pageFunction) {
+    return this.mainFrame().$eval(selector, pageFunction);
+  }
+
+  /**
+   * @param {string} selector
    * @return {!Promise<!Array<!ElementHandle>>}
    */
   async $$(selector) {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -149,10 +149,11 @@ class Page extends EventEmitter {
   /**
    * @param {string} selector
    * @param {function()|string} pageFunction
+   * @param {!Array<*>} args
    * @return {!Promise<?ElementHandle>}
    */
-  async $eval(selector, pageFunction) {
-    return this.mainFrame().$eval(selector, pageFunction);
+  async $eval(selector, pageFunction, ...args) {
+    return this.mainFrame().$eval(selector, pageFunction, ...args);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1127,6 +1127,11 @@ describe('Page', function() {
       const idAttribute = await page.$eval('section', e => e.id);
       expect(idAttribute).toBe('testAttribute');
     }));
+    it('should accept arguments', SX(async function() {
+      await page.setContent('<section>hello</section>');
+      const text = await page.$eval('section', (e, suffix) => e.textContent + suffix, ' world!');
+      expect(text).toBe('hello world!');
+    }));
     it('should throw error if no element is found', SX(async function() {
       let error = null;
       await page.$eval('section', e => e.id).catch(e => error = e);

--- a/test/test.js
+++ b/test/test.js
@@ -1121,6 +1121,19 @@ describe('Page', function() {
     }));
   });
 
+  describe('Page.$eval', function() {
+    it('should work', SX(async function() {
+      await page.setContent('<section id="testAttribute">43543</section>');
+      const idAttribute = await page.$eval('section', e => e.id);
+      expect(idAttribute).toBe('testAttribute');
+    }));
+    it('should throw error if no element is found', SX(async function() {
+      let error = null;
+      await page.$eval('section', e => e.id).catch(e => error = e);
+      expect(error.message).toContain('failed to find element matching selector "section"');
+    }));
+  });
+
   describe('Page.$', function() {
     it('should query existing element', SX(async function() {
       await page.setContent('<section>test</section>');
@@ -1186,12 +1199,6 @@ describe('Page', function() {
         error = e;
       }
       expect(error.message).toContain('ElementHandle is disposed');
-    }));
-    it('should return attribute', SX(async function() {
-      await page.setContent('<section id="testAttribute">43543</section>');
-      const element = await page.$('section');
-      expect(element).toBeTruthy();
-      expect(await element.attribute('id')).toBe('testAttribute');
     }));
   });
 


### PR DESCRIPTION
This patch:
- implements page.$eval and frame.$eval
- drops elementHandle.attribute() method in favor of the page.$eval

References #625