### PR TITLE
Add setBlockedURLs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,7 @@
     + [page.press(key[, options])](#pagepresskey-options)
     + [page.reload(options)](#pagereloadoptions)
     + [page.screenshot([options])](#pagescreenshotoptions)
+    + [page.setBlockedURLs(urls)](#pagesetblockedURLs)
     + [page.setContent(html)](#pagesetcontenthtml)
     + [page.setCookie(...cookies)](#pagesetcookiecookies)
     + [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
@@ -704,6 +705,10 @@ Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#ke
         - `height` <[number]> height of clipping area
     - `omitBackground` <[boolean]> Hides default white background and allows capturing screenshots with transparency. Defaults to `false`.
 - returns: <[Promise]<[Buffer]>> Promise which resolves to buffer with captured screenshot
+
+#### page.setBlockedURLs(urls)
+- `urls` <[Array]<[url]>> URL patterns to block. Wildcards ('*') are allowed.
+- returns: <[Promise]>
 
 #### page.setContent(html)
 - `html` <[string]> HTML markup to assign to the page.

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,7 +58,7 @@
     + [page.press(key[, options])](#pagepresskey-options)
     + [page.reload(options)](#pagereloadoptions)
     + [page.screenshot([options])](#pagescreenshotoptions)
-    + [page.setBlockedURLs(urls)](#pagesetblockedURLs)
+    + [page.setBlockedURLs(urls)](#pagesetblockedurlsurls)
     + [page.setContent(html)](#pagesetcontenthtml)
     + [page.setCookie(...cookies)](#pagesetcookiecookies)
     + [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
@@ -707,7 +707,7 @@ Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#ke
 - returns: <[Promise]<[Buffer]>> Promise which resolves to buffer with captured screenshot
 
 #### page.setBlockedURLs(urls)
-- `urls` <[Array]<[url]>> URL patterns to block. Wildcards ('*') are allowed.
+- `urls` <[Array]<[string]>> URL patterns to block. Wildcards ('*') are allowed.
 - returns: <[Promise]>
 
 #### page.setContent(html)

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -22,13 +22,7 @@ const puppeteer = require('puppeteer');
 
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
-await page.setRequestInterceptionEnabled(true);
-page.on('request', request => {
-  if (request.resourceType === 'Image')
-    request.abort();
-  else
-    request.continue();
-});
+await page.setBlockedURLs(['.png', '.svg', '.jpg']);
 await page.goto('https://bbc.com');
 await page.screenshot({path: 'news.png', fullPage: true});
 

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -46,6 +46,13 @@ class NetworkManager extends EventEmitter {
   }
 
   /**
+   * @param {!Array<string>} urls
+   */
+  async setBlockedURLs(urls) {
+    return this._client.send('Network.setBlockedURLs', { urls });
+  }
+
+  /**
    * @param {!Object<string, string>} extraHTTPHeaders
    */
   async setExtraHTTPHeaders(extraHTTPHeaders) {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -249,6 +249,13 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {!Array<string>} urls
+   */
+  async setBlockedURLs(urls) {
+    return this._networkManager.setBlockedURLs(urls);
+  }
+
+  /**
    * @param {!Object<string, string>} headers
    */
   async setExtraHTTPHeaders(headers) {

--- a/test/test.js
+++ b/test/test.js
@@ -1537,7 +1537,7 @@ describe('Page', function() {
   });
 
   describe('Page.setBlockedURLs', function() {
-    fit('should block image requests', SX(async function() {
+    it('should block image requests', SX(async function() {
       await page.setBlockedURLs(['.png']);
       const failedRequests = [];
       page.on('requestfailed', request => failedRequests.push(request));

--- a/test/test.js
+++ b/test/test.js
@@ -1535,6 +1535,17 @@ describe('Page', function() {
       expect(await page.evaluate(() => navigator.userAgent)).toContain('Safari');
     }));
   });
+
+  describe('Page.setBlockedURLs', function() {
+    fit('should block image requests', SX(async function() {
+      await page.setBlockedURLs(['.png']);
+      const failedRequests = [];
+      page.on('requestfailed', request => failedRequests.push(request));
+      await page.goto(PREFIX + '/grid.html');
+      expect(failedRequests.length).toBe(490);
+    }));
+  });
+
   describe('Page.setExtraHTTPHeaders', function() {
     it('should work', SX(async function() {
       await page.setExtraHTTPHeaders({


### PR DESCRIPTION
[Network.setBlockedURLs](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setBlockedURLs)
The interception looks too expensive when used with several workers. Looking up with the timeline/tracing I can see that every request can take initially 100-300ms longer** 

The browser blocker should be more efficient and eventually I will add patterns to the interception since I still need to modify some specific requests. But for this I will create another PR.
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setRequestInterceptionEnabled

I never did this kind of documentation so feel free to point me on the right direction.

** I am still trying to check this issue, or if it is even real. If the same image is requested more than once, like on the grid.html the previous implemention looks to be faster. With a lot of different unique resources I think I get a better result with the blockURLs.