### PR TITLE
fail installation when puppeteer errors downloading chromium

### DIFF
--- a/install.js
+++ b/install.js
@@ -36,10 +36,7 @@ Downloader.downloadRevision(platform, revision, onProgress)
     .catch(onError);
 
 function onError(error) {
-  console.error(`ERROR: Failed to download Chromium r${revision}! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download or download Chromium manually:
-    ${revisionInfo.url}
-- Extract Chromium into ${revisionInfo.folderPath}
-  * Chromium executable should be at ${revisionInfo.executablePath}`);
+  console.error(`ERROR: Failed to download Chromium r${revision}! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download.`);
   process.exit(1);
 }
 

--- a/install.js
+++ b/install.js
@@ -36,11 +36,11 @@ Downloader.downloadRevision(platform, revision, onProgress)
     .catch(onError);
 
 function onError(error) {
-  console.error(`ERROR: Failed to download chromium r${revision}!
-- Download chromium manually:
+  console.error(`ERROR: Failed to download Chromium r${revision}! Set "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" env variable to skip download or download Chromium manually:
     ${revisionInfo.url}
-- Extract chromium into ${revisionInfo.folderPath}
+- Extract Chromium into ${revisionInfo.folderPath}
   * Chromium executable should be at ${revisionInfo.executablePath}`);
+  process.exit(1);
 }
 
 let progressBar = null;


### PR DESCRIPTION
This patch aborts "npm install" command if puppeteer fails to download bundled chromium.
It's better to fail installation then throw in runtime.