### PR TITLE
Avoid url malformed error

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -338,7 +338,8 @@ helper.tracePublicAPI(Response);
 function generateRequestHash(request) {
   const hash = {
     // Decoding is necessary to normalize URLs. @see crbug.com/759388
-    url: decodeURI(request.url),
+    // Avoid uri malformed error
+    url: decodeURI(escape(request.url)),
     method: request.method,
     postData: request.postData,
     headers: {},


### PR DESCRIPTION
decodeURI will cause URI malformed error is url contains '%'

test decodeURI('%')

```
2017-09-03 14:52:25,099 ERROR 86498 nodejs.URIError: URI malformed
    at decodeURI (<anonymous>)
    at generateRequestHash (/Users/Alex/AliDrive/MovieSpace/amaziGo/node_modules/_puppeteer@0.10.2@puppeteer/lib/NetworkManager.js:342:10)
    at NetworkManager._onRequestIntercepted (/Users/Alex/AliDrive/MovieSpace/amaziGo/node_modules/_puppeteer@0.10.2@puppeteer/lib/NetworkManager.js:94:25)
    at emitOne (events.js:115:13)
    at Session.emit (events.js:210:7)
    at Session._onMessage (/Users/Alex/AliDrive/MovieSpace/amaziGo/node_modules/_puppeteer@0.10.2@puppeteer/lib/Connection.js:199:12)
    at Connection._onMessage (/Users/Alex/AliDrive/MovieSpace/amaziGo/node_modules/_puppeteer@0.10.2@puppeteer/lib/Connection.js:98:19)
    at emitOne (events.js:115:13)
    at WebSocket.emit (events.js:210:7)
    at Receiver._receiver.onmessage (/Users/Alex/AliDrive/MovieSpace/amaziGo/node_modules/_ws@3.1.0@ws/lib/WebSocket.js:143:47)
```