### PR TITLE
Launcher: force kill chrome in case of working with temporary profile.

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -104,10 +104,23 @@ class Launcher {
 
     function killChrome() {
       helper.removeEventListeners(listeners);
-      if (process.platform === 'win32')
-        childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
-      else
-        process.kill(-chromeProcess.pid);
+      if (temporaryUserDataDir) {
+        // Force kill chrome.
+        if (process.platform === 'win32')
+          childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
+        else
+          process.kill(-chromeProcess.pid, 'SIGKILL');
+        // Attempt to remove temporary profile directory to avoid littering.
+        try {
+          removeSync(temporaryUserDataDir);
+        } catch (e) { }
+      } else {
+        // Terminate chrome gracefully.
+        if (process.platform === 'win32')
+          childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T`);
+        else
+          process.kill(-chromeProcess.pid, 'SIGTERM');
+      }
     }
   }
 


### PR DESCRIPTION
This patch:
- in case of user-supplied profile directory, starts gracefully closing
  chrome so that it doesn't corrupt profile
- in case of temp profile directory, force-closes chrome and proactively
  tries to remove temp directory to avoid littering

Fixes #527.