### PR TITLE
Launcher: Close gracefully when a userDataDir is specified

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@
     + [puppeteer.executablePath()](#puppeteerexecutablepath)
     + [puppeteer.launch([options])](#puppeteerlaunchoptions)
   * [class: Browser](#class-browser)
+    + [event: 'close'](#event-close)
     + [browser.close()](#browserclose)
     + [browser.newPage()](#browsernewpage)
     + [browser.version()](#browserversion)
@@ -209,6 +210,10 @@ puppeteer.launch().then(async browser => {
   browser.close();
 });
 ```
+
+#### event: 'close'
+
+Emitted when the Chromium process [`close`](https://nodejs.org/api/child_process.html#child_process_event_close) event is dispatched.
 
 #### browser.close()
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,6 @@
     + [puppeteer.executablePath()](#puppeteerexecutablepath)
     + [puppeteer.launch([options])](#puppeteerlaunchoptions)
   * [class: Browser](#class-browser)
-    + [event: 'close'](#event-close)
     + [browser.close()](#browserclose)
     + [browser.newPage()](#browsernewpage)
     + [browser.version()](#browserversion)
@@ -211,11 +210,8 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
-#### event: 'close'
-
-Emitted when the Chromium process [`close`](https://nodejs.org/api/child_process.html#child_process_event_close) event is dispatched.
-
 #### browser.close()
+- returns: <[Promise]>
 
 Closes browser with all the pages (if any were opened). The browser object itself is considered to be disposed and could not be used anymore.
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -22,7 +22,7 @@ class Browser extends EventEmitter {
   /**
    * @param {!Connection} connection
    * @param {boolean} ignoreHTTPSErrors
-   * @param {function()=} closeCallback
+   * @param {function():Promise=} closeCallback
    */
   constructor(connection, ignoreHTTPSErrors, closeCallback) {
     super();
@@ -56,16 +56,11 @@ class Browser extends EventEmitter {
     return version.product;
   }
 
-  close() {
+  async close() {
     this._connection.dispose();
-    this._closeCallback.call(null);
+    await this._closeCallback.call(null);
   }
 }
-
-/** @enum {string} */
-Browser.Events = {
-  Close: 'close'
-};
 
 module.exports = Browser;
 helper.tracePublicAPI(Browser);

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -16,14 +16,16 @@
 
 const {helper} = require('./helper');
 const Page = require('./Page');
+const EventEmitter = require('events');
 
-class Browser {
+class Browser extends EventEmitter {
   /**
    * @param {!Connection} connection
    * @param {boolean} ignoreHTTPSErrors
    * @param {function()=} closeCallback
    */
   constructor(connection, ignoreHTTPSErrors, closeCallback) {
+    super();
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
     this._screenshotTaskQueue = new TaskQueue();
     this._connection = connection;
@@ -59,6 +61,11 @@ class Browser {
     this._closeCallback.call(null);
   }
 }
+
+/** @enum {string} */
+Browser.Events = {
+  Close: 'close'
+};
 
 module.exports = Browser;
 helper.tracePublicAPI(Browser);

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -84,13 +84,13 @@ class Launcher {
       chromeProcess.stderr.pipe(process.stderr);
     }
 
-    let browser = null;
-    chromeProcess.once('close', () => {
-      // Cleanup as processes exit.
-      if (temporaryUserDataDir)
-        removeSync(temporaryUserDataDir);
-      if (browser)
-        browser.emit(Browser.Events.Close);
+    const waitForChromeToClose = new Promise(fulfill => {
+      chromeProcess.once('close', () => {
+        // Cleanup as processes exit.
+        if (temporaryUserDataDir)
+          removeSync(temporaryUserDataDir);
+        fulfill();
+      });
     });
 
     const listeners = [ helper.addEventListener(process, 'exit', killChrome) ];
@@ -101,13 +101,15 @@ class Launcher {
       const connectionDelay = options.slowMo || 0;
       const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, options.timeout || 30 * 1000);
       const connection = await Connection.create(browserWSEndpoint, connectionDelay);
-      browser = new Browser(connection, !!options.ignoreHTTPSErrors, killChrome);
-      return browser;
+      return new Browser(connection, !!options.ignoreHTTPSErrors, killChrome);
     } catch (e) {
       killChrome();
       throw e;
     }
 
+    /**
+     * @return {Promise}
+     */
     function killChrome() {
       helper.removeEventListeners(listeners);
       if (temporaryUserDataDir) {
@@ -127,6 +129,7 @@ class Launcher {
         else
           process.kill(-chromeProcess.pid, 'SIGTERM');
       }
+      return waitForChromeToClose;
     }
   }
 

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -84,9 +84,14 @@ class Launcher {
       chromeProcess.stderr.pipe(process.stderr);
     }
 
-    // Cleanup as processes exit.
-    if (temporaryUserDataDir)
-      chromeProcess.once('close', () => removeSync(temporaryUserDataDir));
+    let browser = null;
+    chromeProcess.once('close', () => {
+      // Cleanup as processes exit.
+      if (temporaryUserDataDir)
+        removeSync(temporaryUserDataDir);
+      if (browser)
+        browser.emit(Browser.Events.Close);
+    });
 
     const listeners = [ helper.addEventListener(process, 'exit', killChrome) ];
     if (options.handleSIGINT !== false)
@@ -96,7 +101,8 @@ class Launcher {
       const connectionDelay = options.slowMo || 0;
       const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, options.timeout || 30 * 1000);
       const connection = await Connection.create(browserWSEndpoint, connectionDelay);
-      return new Browser(connection, !!options.ignoreHTTPSErrors, killChrome);
+      browser = new Browser(connection, !!options.ignoreHTTPSErrors, killChrome);
+      return browser;
     } catch (e) {
       killChrome();
       throw e;
@@ -104,10 +110,23 @@ class Launcher {
 
     function killChrome() {
       helper.removeEventListeners(listeners);
-      if (process.platform === 'win32')
-        childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
-      else
-        process.kill(-chromeProcess.pid);
+      if (temporaryUserDataDir) {
+        // Force kill chrome.
+        if (process.platform === 'win32')
+          childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
+        else
+          process.kill(-chromeProcess.pid, 'SIGKILL');
+        // Attempt to remove temporary profile directory to avoid littering.
+        try {
+          removeSync(temporaryUserDataDir);
+        } catch (e) { }
+      } else {
+        // Terminate chrome gracefully.
+        if (process.platform === 'win32')
+          chromeProcess.kill();
+        else
+          process.kill(-chromeProcess.pid, 'SIGTERM');
+      }
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -107,7 +107,7 @@ describe('Puppeteer', function() {
       const options = Object.assign({userDataDir}, defaultBrowserOptions);
       const browser = await puppeteer.launch(options);
       expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-      browser.close();
+      await browser.close();
       expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
       rm(userDataDir);
     }));
@@ -117,7 +117,7 @@ describe('Puppeteer', function() {
       options.args = [`--user-data-dir=${userDataDir}`].concat(options.args);
       const browser = await puppeteer.launch(options);
       expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-      browser.close();
+      await browser.close();
       expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
       rm(userDataDir);
     }));

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -165,9 +165,9 @@ function checkDuplicates(doc) {
     classes.add(cls.name);
     const members = new Set();
     for (const member of cls.membersArray) {
-      if (members.has(member.name))
-        errors.push(`Duplicate declaration of method ${cls.name}.${member.name}()`);
-      members.add(member.name);
+      if (members.has(member.type + ' ' + member.name))
+        errors.push(`Duplicate declaration of ${member.type} ${cls.name}.${member.name}()`);
+      members.add(member.type + ' ' + member.name);
       const args = new Set();
       for (const arg of member.argsArray) {
         if (args.has(arg.name))


### PR DESCRIPTION
My version of #693 

In order to make tests work, I needed to add a `'close'` event to `Browser`. This broke the doclint, which didn't like browser having a `'close'` event and a `.close` method. So that is why this patch is bigger than it should be.

Fixes #527 