### PR TITLE
docs: fix anchor to `page.$$(selector)`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,7 @@
     + [event: 'requestfinished'](#event-requestfinished)
     + [event: 'response'](#event-response)
     + [page.$(selector)](#pageselector)
-    + [page.$$(selector)](#pageselector)
+    + [page.$$(selector)](#pageselector-1)
     + [page.$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.click(selector[, options])](#pageclickselector-options)


### PR DESCRIPTION
fixes anchor-name.
`page.$$(selector)` links to `#pageselector-1`.