### PR TITLE
[api] Teach page.evaluate to accept element handles as parameters

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -442,13 +442,6 @@ List of all available devices is available in the source code: [DeviceDescriptor
 - `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Resolves to the return value of `pageFunction`
 
-[ElementHandle] instances could be passed as arguments to the `page.evaluate`:
-```js
-const bodyHandle = await page.$('body');
-const html = await page.evaluate(body => body.innerHTML, bodyHandle);
-await bodyHandle.dispose();
-```
-
 If the function, passed to the `page.evaluate`, returns a [Promise], then `page.evaluate` would wait for the promise to resolve and return it's value.
 
 ```js
@@ -462,6 +455,13 @@ A string can also be passed in instead of a function.
 
 ```js
 console.log(await page.evaluate('1 + 2')); // prints "3"
+```
+
+[ElementHandle] instances could be passed as arguments to the `page.evaluate`:
+```js
+const bodyHandle = await page.$('body');
+const html = await page.evaluate(body => body.innerHTML, bodyHandle);
+await bodyHandle.dispose();
 ```
 
 Shortcut for [page.mainFrame().evaluate(pageFunction, ...args)](#frameevaluatepagefunction-args).
@@ -1131,13 +1131,6 @@ Adds a `<script>` tag to the frame with the desired url. Alternatively, JavaScri
 - `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to  `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to function return value
 
-[ElementHandle] instances could be passed as arguments to the `frame.evaluate`:
-```js
-const bodyHandle = await frame.$('body');
-const html = await frame.evaluate(body => body.innerHTML, bodyHandle);
-await bodyHandle.dispose();
-```
-
 If the function, passed to the `frame.evaluate`, returns a [Promise], then `frame.evaluate` would wait for the promise to resolve and return it's value.
 
 ```js
@@ -1151,6 +1144,13 @@ A string can also be passed in instead of a function.
 
 ```js
 console.log(await frame.evaluate('1 + 2')); // prints "3"
+```
+
+[ElementHandle] instances could be passed as arguments to the `frame.evaluate`:
+```js
+const bodyHandle = await frame.$('body');
+const html = await frame.evaluate(body => body.innerHTML, bodyHandle);
+await bodyHandle.dispose();
 ```
 
 #### frame.injectFile(filePath)

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,6 @@
   * [class: ElementHandle](#class-elementhandle)
     + [elementHandle.click([options])](#elementhandleclickoptions)
     + [elementHandle.dispose()](#elementhandledispose)
-    + [elementHandle.evaluate(pageFunction, ...args)](#elementhandleevaluatepagefunction-args)
     + [elementHandle.hover()](#elementhandlehover)
     + [elementHandle.tap()](#elementhandletap)
     + [elementHandle.uploadFile(...filePaths)](#elementhandleuploadfilefilepaths)
@@ -332,7 +331,7 @@ Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
 #### page.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> A [selector] to query page for
 - `pageFunction` <[function]> Function to be evaluated in browser context
-- `...args` <...[Serializable]> Arguments to pass to `pageFunction`
+- `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
 
 This method runs `document.querySelector` within the page and passes it as the first argument to `pageFunction`. If there's no element matching `selector`, the method throws an error.
@@ -440,22 +439,23 @@ List of all available devices is available in the source code: [DeviceDescriptor
 
 #### page.evaluate(pageFunction, ...args)
 - `pageFunction` <[function]|[string]> Function to be evaluated in the page context
-- `...args` <...[Serializable]> Arguments to pass to `pageFunction`
+- `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Resolves to the return value of `pageFunction`
+
+[ElementHandle] instances could be passed as arguments to the `page.evaluate`:
+```js
+const bodyHandle = await page.$('body');
+const html = await page.evaluate(body => body.innerHTML, bodyHandle);
+await bodyHandle.dispose();
+```
 
 If the function, passed to the `page.evaluate`, returns a [Promise], then `page.evaluate` would wait for the promise to resolve and return it's value.
 
 ```js
-const puppeteer = require('puppeteer');
-
-puppeteer.launch().then(async browser => {
-  const page = await browser.newPage();
-  const result = await page.evaluate(() => {
-    return Promise.resolve(8 * 7);
-  });
-  console.log(result); // prints "56"
-  browser.close();
+const result = await page.evaluate(() => {
+  return Promise.resolve(8 * 7);
 });
+console.log(result); // prints "56"
 ```
 
 A string can also be passed in instead of a function.
@@ -1103,7 +1103,7 @@ The method runs `document.querySelectorAll` within the frame. If no elements mat
 #### frame.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> A [selector] to query frame for
 - `pageFunction` <[function]> Function to be evaluated in browser context
-- `...args` <...[Serializable]> Arguments to pass to `pageFunction`
+- `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
 
 This method runs `document.querySelector` within the frame and passes it as the first argument to `pageFunction`. If there's no element matching `selector`, the method throws an error.
@@ -1128,28 +1128,29 @@ Adds a `<script>` tag to the frame with the desired url. Alternatively, JavaScri
 
 #### frame.evaluate(pageFunction, ...args)
 - `pageFunction` <[function]|[string]> Function to be evaluated in browser context
-- `...args` <...[Serializable]> Arguments to pass to  `pageFunction`
+- `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to  `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to function return value
 
-If the function, passed to the `page.evaluate`, returns a [Promise], then `page.evaluate` would wait for the promise to resolve and return it's value.
+[ElementHandle] instances could be passed as arguments to the `frame.evaluate`:
+```js
+const bodyHandle = await frame.$('body');
+const html = await frame.evaluate(body => body.innerHTML, bodyHandle);
+await bodyHandle.dispose();
+```
+
+If the function, passed to the `frame.evaluate`, returns a [Promise], then `frame.evaluate` would wait for the promise to resolve and return it's value.
 
 ```js
-const puppeteer = require('puppeteer');
-
-puppeteer.launch().then(async browser => {
-  const page = await browser.newPage();
-  const result = await page.mainFrame().evaluate(() => {
-    return Promise.resolve(8 * 7);
-  });
-  console.log(result); // prints "56"
-  browser.close();
+const result = await frame.evaluate(() => {
+  return Promise.resolve(8 * 7);
 });
+console.log(result); // prints "56"
 ```
 
 A string can also be passed in instead of a function.
 
 ```js
-console.log(await page.mainFrame().evaluate('1 + 2')); // prints "3"
+console.log(await frame.evaluate('1 + 2')); // prints "3"
 ```
 
 #### frame.injectFile(filePath)
@@ -1275,14 +1276,6 @@ If the element is detached from DOM, the method throws an error.
 - returns: <[Promise]> Promise which resolves when the element handle is successfully disposed.
 
 The `elementHandle.dispose` method stops referencing the element handle.
-
-#### elementHandle.evaluate(pageFunction, ...args)
-- `pageFunction` <[function]> Function to be evaluated in browser context
-- `...args` <...[Serializable]> Arguments to pass to  `pageFunction`
-- returns: <[Promise]<[Serializable]>> Promise which resolves to function return value
-
-If the function, passed to the `elementHandle.evaluate`, returns a [Promise], then `elementHandle.evaluate` would wait for the promise to resolve and return it's value.
-The element will be passed as the first argument to `pageFunction`, followed by any `args`.
 
 #### elementHandle.hover()
 - returns: <[Promise]> Promise which resolves when the element is successfully hovered.

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -18,17 +18,26 @@ const helper = require('./helper');
 
 class ElementHandle {
   /**
+   * @param {!Frame} frame
    * @param {!Connection} client
    * @param {!Object} remoteObject
    * @param {!Mouse} mouse
    * @param {!Touchscreen} touchscreen;
    */
-  constructor(client, remoteObject, mouse, touchscreen) {
+  constructor(frame, client, remoteObject, mouse, touchscreen) {
+    this._frame = frame;
     this._client = client;
     this._remoteObject = remoteObject;
     this._mouse = mouse;
     this._touchscreen = touchscreen;
     this._disposed = false;
+  }
+
+  /**
+   * @return {?string}
+   */
+  _remoteObjectId() {
+    return this._disposed ? null : this._remoteObject.objectId;
   }
 
   async dispose() {
@@ -39,29 +48,10 @@ class ElementHandle {
   }
 
   /**
-   * @param {function()} pageFunction
-   * @param {!Array<*>} args
-   * @return {!Promise<(!Object|undefined)>}
-   */
-  async evaluate(pageFunction, ...args) {
-    console.assert(!this._disposed, 'ElementHandle is disposed!');
-    console.assert(typeof pageFunction === 'function', 'First argument to ElementHandle.evaluate must be a function!');
-
-    const stringifiedArgs = ['this'];
-    stringifiedArgs.push(...args.map(x => JSON.stringify(x)));
-    const functionDeclaration = `function() { return (${pageFunction})(${stringifiedArgs.join(',')}) }`;
-    const objectId = this._remoteObject.objectId;
-    const { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.callFunctionOn', { objectId, functionDeclaration, returnByValue: false, awaitPromise: true});
-    if (exceptionDetails)
-      throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
-    return await helper.serializeRemoteObject(this._client, remoteObject);
-  }
-
-  /**
    * @return {!Promise<{x: number, y: number}>}
    */
   async _visibleCenter() {
-    const center = await this.evaluate(element => {
+    const center = await this._frame.evaluate(element => {
       if (!element.ownerDocument.contains(element))
         return null;
       element.scrollIntoViewIfNeeded();
@@ -70,7 +60,7 @@ class ElementHandle {
         x: (Math.max(rect.left, 0) + Math.min(rect.right, window.innerWidth)) / 2,
         y: (Math.max(rect.top, 0) + Math.min(rect.bottom, window.innerHeight)) / 2
       };
-    });
+    }, this);
     if (!center)
       throw new Error('No node found for selector: ' + selector);
     return center;

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -256,7 +256,7 @@ class Frame {
     const { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.callFunctionOn', {
       functionDeclaration: pageFunction.toString(),
       executionContextId: this._defaultContextId,
-      arguments: args.map(convertArgument),
+      arguments: args.map(convertArgument.bind(this)),
       returnByValue: false,
       awaitPromise: true
     });
@@ -267,6 +267,7 @@ class Frame {
     /**
      * @param {*} arg
      * @return {*}
+     * @this {Frame}
      */
     function convertArgument(arg) {
       if (Object.is(arg, -0))
@@ -278,6 +279,8 @@ class Frame {
       if (Object.is(arg, NaN))
         return { unserializableValue: 'NaN' };
       if (arg instanceof ElementHandle) {
+        if (arg._frame !== this)
+          throw new Error('ElementHandles passed as arguments should belong to the frame that does evaluation');
         const objectId = arg._remoteObjectId();
         if (!objectId)
           throw new Error('ElementHandle is disposed!');

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -194,7 +194,7 @@ class Frame {
   async $(selector) {
     const remoteObject = await this._rawEvaluate(selector => document.querySelector(selector), selector);
     if (remoteObject.subtype === 'node')
-      return new ElementHandle(this._client, remoteObject, this._mouse, this._touchscreen);
+      return new ElementHandle(this, this._client, remoteObject, this._mouse, this._touchscreen);
     await helper.releaseObject(this._client, remoteObject);
     return null;
   }
@@ -209,7 +209,8 @@ class Frame {
     const elementHandle = await this.$(selector);
     if (!elementHandle)
       throw new Error(`Error: failed to find element matching selector "${selector}"`);
-    const result = await elementHandle.evaluate(pageFunction, ...args);
+    args = [elementHandle].concat(args);
+    const result = await this.evaluate(pageFunction, ...args);
     await elementHandle.dispose();
     return result;
   }
@@ -229,7 +230,7 @@ class Frame {
     const releasePromises = [helper.releaseObject(this._client, remoteObject)];
     for (const property of properties) {
       if (property.enumerable && property.value.subtype === 'node')
-        result.push(new ElementHandle(this._client, property.value, this._mouse, this._touchscreen));
+        result.push(new ElementHandle(this, this._client, property.value, this._mouse, this._touchscreen));
       else
         releasePromises.push(helper.releaseObject(this._client, property.value));
     }
@@ -243,12 +244,47 @@ class Frame {
    * @return {!Promise<(!Object|undefined)>}
    */
   async _rawEvaluate(pageFunction, ...args) {
-    const expression = helper.evaluationString(pageFunction, ...args);
-    const contextId = this._defaultContextId;
-    const { exceptionDetails, result: remoteObject }  = await this._client.send('Runtime.evaluate', { expression, contextId, returnByValue: false, awaitPromise: true});
+    if (helper.isString(pageFunction)) {
+      const contextId = this._defaultContextId;
+      const expression = pageFunction;
+      const { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.evaluate', { expression, contextId, returnByValue: false, awaitPromise: true});
+      if (exceptionDetails)
+        throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
+      return remoteObject;
+    }
+
+    const { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.callFunctionOn', {
+      functionDeclaration: pageFunction.toString(),
+      executionContextId: this._defaultContextId,
+      arguments: args.map(convertArgument),
+      returnByValue: false,
+      awaitPromise: true
+    });
     if (exceptionDetails)
       throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
     return remoteObject;
+
+    /**
+     * @param {*} arg
+     * @return {*}
+     */
+    function convertArgument(arg) {
+      if (Object.is(arg, -0))
+        return { unserializableValue: '-0' };
+      if (Object.is(arg, Infinity))
+        return { unserializableValue: 'Infinity' };
+      if (Object.is(arg, -Infinity))
+        return { unserializableValue: '-Infinity' };
+      if (Object.is(arg, NaN))
+        return { unserializableValue: 'NaN' };
+      if (arg instanceof ElementHandle) {
+        const objectId = arg._remoteObjectId();
+        if (!objectId)
+          throw new Error('ElementHandle is disposed!');
+        return { objectId };
+      }
+      return { value: arg };
+    }
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -674,7 +674,7 @@ class Page extends EventEmitter {
   async focus(selector) {
     const handle = await this.$(selector);
     console.assert(handle, 'No node found for selector: ' + selector);
-    await handle.evaluate(element => element.focus());
+    await this.evaluate(element => element.focus(), handle);
     await handle.dispose();
   }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "497674"
+    "chromium_revision": "499413"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",

--- a/test/test.js
+++ b/test/test.js
@@ -277,6 +277,15 @@ describe('Page', function() {
       await page.evaluate(e => e.textContent, element).catch(e => error = e);
       expect(error.message).toContain('ElementHandle is disposed');
     }));
+    it('should throw if elementHandles are from other frames', SX(async function() {
+      const FrameUtils = require('./frame-utils');
+      await FrameUtils.attachFrame(page, 'frame1', EMPTY_PAGE);
+      const bodyHandle = await page.frames()[1].$('body');
+      let error = null;
+      await page.evaluate(body => body.innerHTML, bodyHandle).catch(e => error = e);
+      expect(error).toBeTruthy();
+      expect(error.message).toContain('ElementHandles passed as arguments should belong');
+    }));
   });
 
   describe('Page.injectFile', function() {


### PR DESCRIPTION
This patch:
- rolls chromium to r499413 that supports necessary v8 changes
- teaches `page.evaluate` to accept ElementHandles as parameters
- removes `ElementHandle.evaluate` method since it's not needed any
  more

References #382