### PR TITLE
Implement page.authenticate method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@
     + [page.$$(selector)](#pageselector)
     + [page.$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
+    + [page.authenticate(credentials)](#pageauthenticatecredentials)
     + [page.click(selector[, options])](#pageclickselector-options)
     + [page.close()](#pageclose)
     + [page.content()](#pagecontent)
@@ -356,6 +357,15 @@ Adds a `<script>` tag into the page with the desired url. Alternatively, a local
 
 Shortcut for [page.mainFrame().addScriptTag(url)](#frameaddscripttagurl).
 
+#### page.authenticate(credentials)
+- `credentials` <[Object]>
+  - `username` <[string]>
+  - `password` <[string]>
+- returns: <[Promise]>
+
+Provide credentials for [http authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
+
+To disable authentication, pass `null`.
 
 #### page.click(selector[, options])
 - `selector` <[string]> A [selector] to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -32,7 +32,12 @@ class NetworkManager extends EventEmitter {
     /** @type {!Object<string, string>} */
     this._extraHTTPHeaders = {};
 
-    this._requestInterceptionEnabled = false;
+    /** @type {?{username: string, password: string}} */
+    this._credentials = null;
+    /** @type {!Set<string>} */
+    this._attemptedAuthentications = new Set();
+    this._userRequestInterceptionEnabled = false;
+    this._protocolRequestInterceptionEnabled = false;
     /** @type {!Multimap<string, string>} */
     this._requestHashToRequestIds = new Multimap();
     /** @type {!Multimap<string, !Object>} */
@@ -43,6 +48,14 @@ class NetworkManager extends EventEmitter {
     this._client.on('Network.responseReceived', this._onResponseReceived.bind(this));
     this._client.on('Network.loadingFinished', this._onLoadingFinished.bind(this));
     this._client.on('Network.loadingFailed', this._onLoadingFailed.bind(this));
+  }
+
+  /**
+   * @param {?{username: string, password: string}} credentials
+   */
+  async authenticate(credentials) {
+    this._credentials = credentials;
+    await this._updateProtocolRequestInterception();
   }
 
   /**
@@ -73,8 +86,16 @@ class NetworkManager extends EventEmitter {
    * @param {boolean} value
    */
   async setRequestInterceptionEnabled(value) {
-    await this._client.send('Network.setRequestInterceptionEnabled', {enabled: !!value});
-    this._requestInterceptionEnabled = value;
+    this._userRequestInterceptionEnabled = value;
+    await this._updateProtocolRequestInterception();
+  }
+
+  async _updateProtocolRequestInterception() {
+    const enabled = this._userRequestInterceptionEnabled || !!this._credentials;
+    if (enabled === this._protocolRequestInterceptionEnabled)
+      return;
+    this._protocolRequestInterceptionEnabled = enabled;
+    await this._client.send('Network.setRequestInterceptionEnabled', {enabled});
   }
 
   /**
@@ -83,6 +104,22 @@ class NetworkManager extends EventEmitter {
   _onRequestIntercepted(event) {
     // Strip out url hash to be consistent with requestWillBeSent. @see crbug.com/755456
     event.request.url = removeURLHash(event.request.url);
+
+    if (event.authChallenge) {
+      let response = 'Default';
+      if (this._attemptedAuthentications.has(event.interceptionId)) {
+        response = 'CancelAuth';
+      } else if (this._credentials) {
+        response = 'ProvideCredentials';
+        this._attemptedAuthentications.add(event.interceptionId);
+      }
+      const {username, password} = this._credentials || {};
+      this._client.send('Network.continueInterceptedRequest', {
+        interceptionId: event.interceptionId,
+        authChallengeResponse: { response, username, password }
+      });
+      return;
+    }
 
     if (event.redirectStatusCode) {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
@@ -106,6 +143,7 @@ class NetworkManager extends EventEmitter {
     request._response = response;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
+    this._attemptedAuthentications.delete(request._interceptionId);
     this.emit(NetworkManager.Events.Response, response);
     this.emit(NetworkManager.Events.RequestFinished, request);
   }
@@ -118,9 +156,11 @@ class NetworkManager extends EventEmitter {
    * @param {!Object} requestPayload
    */
   _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload) {
-    const request = new Request(this._client, requestId, interceptionId, url, resourceType, requestPayload);
+    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload);
     this._requestIdToRequest.set(requestId, request);
     this._interceptionIdToRequest.set(interceptionId, request);
+    if (!this._userRequestInterceptionEnabled && this._protocolRequestInterceptionEnabled)
+      this._client.send('Network.continueInterceptedRequest', { interceptionId });
     this.emit(NetworkManager.Events.Request, request);
   }
 
@@ -128,7 +168,7 @@ class NetworkManager extends EventEmitter {
    * @param {!Object} event
    */
   _onRequestWillBeSent(event) {
-    if (this._requestInterceptionEnabled && !event.request.url.startsWith('data:')) {
+    if (this._protocolRequestInterceptionEnabled && !event.request.url.startsWith('data:')) {
       // All redirects are handled in requestIntercepted.
       if (event.redirectResponse)
         return;
@@ -181,8 +221,9 @@ class NetworkManager extends EventEmitter {
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
-    this._requestIdToRequest.delete(event.requestId);
-    this._interceptionIdToRequest.delete(event.interceptionId);
+    this._requestIdToRequest.delete(request._requestId);
+    this._interceptionIdToRequest.delete(request._interceptionId);
+    this._attemptedAuthentications.delete(request._interceptionId);
     this.emit(NetworkManager.Events.RequestFinished, request);
   }
 
@@ -196,8 +237,9 @@ class NetworkManager extends EventEmitter {
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
-    this._requestIdToRequest.delete(event.requestId);
-    this._interceptionIdToRequest.delete(event.interceptionId);
+    this._requestIdToRequest.delete(request._requestId);
+    this._interceptionIdToRequest.delete(request._interceptionId);
+    this._attemptedAuthentications.delete(request._interceptionId);
     this.emit(NetworkManager.Events.RequestFailed, request);
   }
 }
@@ -207,14 +249,16 @@ class Request {
    * @param {!Connection} client
    * @param {string} requestId
    * @param {string} interceptionId
+   * @param {string} allowInterception
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} payload
    */
-  constructor(client, requestId, interceptionId, url, resourceType, payload) {
+  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload) {
     this._client = client;
     this._requestId = requestId;
     this._interceptionId = interceptionId;
+    this._allowInterception = allowInterception;
     this._interceptionHandled = false;
     this._response = null;
     this._completePromise = new Promise(fulfill => {
@@ -244,7 +288,7 @@ class Request {
     // DataURL's are not interceptable. In this case, do nothing.
     if (this.url.startsWith('data:'))
       return;
-    console.assert(this._interceptionId, 'Request Interception is not enabled!');
+    console.assert(this._allowInterception, 'Request Interception is not enabled!');
     console.assert(!this._interceptionHandled, 'Request is already handled!');
     this._interceptionHandled = true;
     await this._client.send('Network.continueInterceptedRequest', {
@@ -264,7 +308,7 @@ class Request {
     // DataURL's are not interceptable. In this case, do nothing.
     if (this.url.startsWith('data:'))
       return;
-    console.assert(this._interceptionId, 'Request Interception is not enabled!');
+    console.assert(this._allowInterception, 'Request Interception is not enabled!');
     console.assert(!this._interceptionHandled, 'Request is already handled!');
     this._interceptionHandled = true;
     await this._client.send('Network.continueInterceptedRequest', {

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -117,8 +117,13 @@ class NetworkManager extends EventEmitter {
       this._client.send('Network.continueInterceptedRequest', {
         interceptionId: event.interceptionId,
         authChallengeResponse: { response, username, password }
-      });
+      }).catch(debugError);
       return;
+    }
+    if (!this._userRequestInterceptionEnabled && this._protocolRequestInterceptionEnabled) {
+      this._client.send('Network.continueInterceptedRequest', {
+        interceptionId: event.interceptionId
+      }).catch(debugError);
     }
 
     if (event.redirectStatusCode) {
@@ -159,8 +164,6 @@ class NetworkManager extends EventEmitter {
     const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload);
     this._requestIdToRequest.set(requestId, request);
     this._interceptionIdToRequest.set(interceptionId, request);
-    if (!this._userRequestInterceptionEnabled && this._protocolRequestInterceptionEnabled)
-      this._client.send('Network.continueInterceptedRequest', { interceptionId });
     this.emit(NetworkManager.Events.Request, request);
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -267,6 +267,13 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {?{username: string, password: string}} credentials
+   */
+  async authenticate(credentials) {
+    return this._networkManager.authenticate(credentials);
+  }
+
+  /**
    * @param {!Object<string, string>} headers
    */
   async setExtraHTTPHeaders(headers) {


### PR DESCRIPTION
This patch implements `page.authenticate` which should cover all
cases of HTTP authentication.

Implementation notes:
1. Since HTTP authentication is based on request interception internally, the implementation
of NetworkManager splits the "requestInterceptionEnabled" flag into two:
    - `userRequestInterceptionEnabled` - `true` if the user has enabled request interception
    - `protocolRequestInterceptionEnabled` - `true` if we've enabled request interception in protocol
2. In case of invalid credentials, in order to escape infinite authentication loop we maintain the `attemptedAuthentications` set that stores all the interception ids we've tried to authenticate.


Fixes #426.