### PR TITLE
Roll chromium to r499413

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "497674"
+    "chromium_revision": "499413"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",


### PR DESCRIPTION
The new chromium:
- supports executionContextId in Runtime.callFunctionOn protocol method
- supports passing objects as arguments in Runtime.callFuntionOn
  protocol method

This roll also fixes #487.