### PR TITLE
Fix evaluation in case of first "undefind" argument

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -28,7 +28,17 @@ class Helper {
       console.assert(args.length === 0, 'Cannot evaluate a string with arguments');
       return fun;
     }
-    return `(${fun})(${args.map(x => JSON.stringify(x)).join(',')})`;
+    return `(${fun})(${args.map(serializeArgument).join(',')})`;
+
+    /**
+     * @param {*} arg
+     * @return {string}
+     */
+    function serializeArgument(arg) {
+      if (Object.is(arg, undefined))
+        return 'undefined';
+      return JSON.stringify(arg);
+    }
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -246,6 +246,10 @@ describe('Page', function() {
       const result = await page.evaluate(() => -Infinity);
       expect(Object.is(result, -Infinity)).toBe(true);
     }));
+    it('should accept undefined as one of multiple parameters', SX(async function() {
+      const result = await page.evaluate((a, b) => a + b, undefined, '!');
+      expect(result).toBe('undefined!');
+    }));
     it('should not fail for window object', SX(async function() {
       const result = await page.evaluate(() => window);
       expect(result).toBe('Window');

--- a/test/test.js
+++ b/test/test.js
@@ -246,9 +246,9 @@ describe('Page', function() {
       const result = await page.evaluate(() => -Infinity);
       expect(Object.is(result, -Infinity)).toBe(true);
     }));
-    it('should accept undefined as one of multiple parameters', SX(async function() {
-      const result = await page.evaluate((a, b) => a + b, undefined, '!');
-      expect(result).toBe('undefined!');
+    it('should accept "undefined" as one of multiple parameters', SX(async function() {
+      const result = await page.evaluate((a, b) => Object.is(a, undefined) && Object.is(b, 'foo'), undefined, 'foo');
+      expect(result).toBe(true);
     }));
     it('should not fail for window object', SX(async function() {
       const result = await page.evaluate(() => window);


### PR DESCRIPTION
It turns out that `[undefined, 1].join(',')` results in `",1"` instead
of `"undefined,1"`. This causes a syntax error when trying to pass undefined
as a first argument to `page.evaluate` method.

Fixes #572.