### PR TITLE
block-images example: use reuters.com

### DIFF
--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -29,7 +29,7 @@ page.on('request', request => {
   else
     request.continue();
 });
-await page.goto('https://news.google.com/news');
+await page.goto('https://www.reuters.com/');
 await page.screenshot({path: 'news.png', fullPage: true});
 
 browser.close();


### PR DESCRIPTION
@JoelEinbinder 3rd time is the charm!

Due to https://github.com/GoogleChrome/puppeteer/issues/746. The screenshot news.google.com isn't "full page", which may confuse folks. reuters.com also uses more images.