### PR TITLE
Being able to define custom chromium download URL

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -150,6 +150,7 @@ Puppeteer looks for certain environment variables to aid its operations:
 
 - `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` - defines HTTP proxy settings that are used to download and run Chromium.
 - `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` - do not download bundled Chromium during installation step.
+- `PUPPETEER_DOWNLOAD_CHROMIUM_URL` - download bundled Chromium from specified URL.
 
 ### class: Puppeteer
 

--- a/utils/ChromiumDownloader.js
+++ b/utils/ChromiumDownloader.js
@@ -27,12 +27,17 @@ const getProxyForUrl = require('proxy-from-env').getProxyForUrl;
 
 const DOWNLOADS_FOLDER = path.join(__dirname, '..', '.local-chromium');
 
+const downloadURLPrefix = process.env.PUPPETEER_DOWNLOAD_CHROMIUM_URL || 'https://storage.googleapis.com/chromium-browser-snapshots';
 const downloadURLs = {
-  linux: 'https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip',
-  mac: 'https://storage.googleapis.com/chromium-browser-snapshots/Mac/%d/chrome-mac.zip',
-  win32: 'https://storage.googleapis.com/chromium-browser-snapshots/Win/%d/chrome-win32.zip',
-  win64: 'https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/%d/chrome-win32.zip',
+  linux: `${downloadURLPrefix}/Linux_x64/%d/chrome-linux.zip`,
+  mac: `${downloadURLPrefix}/Mac/%d/chrome-mac.zip`,
+  win32: `${downloadURLPrefix}/Win/%d/chrome-win32.zip`,
+  win64: `${downloadURLPrefix}/Win_x64/%d/chrome-win32.zip`,
 };
+
+if (process.env.PUPPETEER_DOWNLOAD_CHROMIUM_URL)
+  console.log(`**INFO** Using custom chromium download url: ${downloadURLPrefix}`);
+
 
 module.exports = {
   /**


### PR DESCRIPTION
Hi, first thanks for the awesome work with puppeteer!
I need to be able to download chromium from a private repository (like Artifactory) mirroring the chromium repo `https://storage.googleapis.com/chromium-browser-snapshots`.
I added a env variable called `PUPPETEER_DOWNLOAD_CHROMIUM_URL` to specify it. I couldn't find any tests related to downloading chromium or process env variables.
Let me know what you think.
Thanks