### PR TITLE
Cleanup tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -354,13 +354,21 @@ describe('Page', function() {
     }));
     it('should throw on bad polling value', SX(async function() {
       let error = null;
-      await page.waitForFunction(() => !!document.body, {polling: 'unknown'}).catch(e => error = e);
+      try {
+        await page.waitForFunction(() => !!document.body, {polling: 'unknown'});
+      } catch (e) {
+        error = e;
+      }
       expect(error).toBeTruthy();
       expect(error.message).toContain('polling');
     }));
     it('should throw negative polling interval', SX(async function() {
       let error = null;
-      await page.waitForFunction(() => !!document.body, {polling: -10}).catch(e => error = e);
+      try {
+        await page.waitForFunction(() => !!document.body, {polling: -10});
+      } catch (e) {
+        error = e;
+      }
       expect(error).toBeTruthy();
       expect(error.message).toContain('Cannot poll with non-positive interval');
     }));
@@ -1871,18 +1879,26 @@ describe('Page', function() {
     }));
     it('should throw if format is unknown', SX(async function() {
       let error = null;
-      await getPDFPages(await page.pdf({
-        format: 'something'
-      })).catch(e => error = e);
+      try {
+        await getPDFPages(await page.pdf({
+          format: 'something'
+        }));
+      } catch (e) {
+        error = e;
+      }
       expect(error).toBeTruthy();
       expect(error.message).toContain('Unknown paper format');
     }));
     it('should throw if units are unknown', SX(async function() {
       let error = null;
-      await getPDFPages(await page.pdf({
-        width: '10em',
-        height: '10em',
-      })).catch(e => error = e);
+      try {
+        await getPDFPages(await page.pdf({
+          width: '10em',
+          height: '10em',
+        }));
+      } catch (e) {
+        error = e;
+      }
       expect(error).toBeTruthy();
       expect(error.message).toContain('Failed to parse parameter value');
     }));

--- a/test/test.js
+++ b/test/test.js
@@ -81,59 +81,58 @@ afterAll(SX(async function() {
   ]);
 }));
 
-describe('Browser', function() {
-  it('Browser.Options.ignoreHTTPSErrors', SX(async function() {
-    const options = Object.assign({ignoreHTTPSErrors: true}, defaultBrowserOptions);
-    const browser = await puppeteer.launch(options);
-    const page = await browser.newPage();
-    let error = null;
-    let response = null;
-    try {
-      response = await page.goto(HTTPS_PREFIX + '/empty.html');
-    } catch (e) {
-      error = e;
-    }
-    expect(error).toBe(null);
-    expect(response.ok).toBe(true);
-    browser.close();
-  }));
-  it('should reject all promises when browser is closed', SX(async function() {
-    const browser = await puppeteer.launch(defaultBrowserOptions);
-    const page = await browser.newPage();
-    let error = null;
-    const neverResolves = page.evaluate(() => new Promise(r => {})).catch(e => error = e);
-    browser.close();
-    await neverResolves;
-    expect(error.message).toContain('Protocol error');
-  }));
-  it('Puppeteer.connect', SX(async function() {
-    const originalBrowser = await puppeteer.launch(defaultBrowserOptions);
-    const browser = await puppeteer.connect({
-      browserWSEndpoint: originalBrowser.wsEndpoint()
-    });
-    const page = await browser.newPage();
-    expect(await page.evaluate(() => 7 * 8)).toBe(56);
-    originalBrowser.close();
-  }));
-  it('userDataDir option', SX(async function() {
-    const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
-    const options = Object.assign({userDataDir}, defaultBrowserOptions);
-    const browser = await puppeteer.launch(options);
-    expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-    browser.close();
-    expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-    rm(userDataDir);
-  }));
-  it('userDataDir argument', SX(async function() {
-    const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
-    const options = Object.assign({}, defaultBrowserOptions);
-    options.args = [`--user-data-dir=${userDataDir}`].concat(options.args);
-    const browser = await puppeteer.launch(options);
-    expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-    browser.close();
-    expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-    rm(userDataDir);
-  }));
+describe('Puppeteer', function() {
+  describe('Puppeteer.launch', function() {
+    it('should support ignoreHTTPSErrors option', SX(async function() {
+      const options = Object.assign({ignoreHTTPSErrors: true}, defaultBrowserOptions);
+      const browser = await puppeteer.launch(options);
+      const page = await browser.newPage();
+      let error = null;
+      const response = await page.goto(HTTPS_PREFIX + '/empty.html').catch(e => error = e);
+      expect(error).toBe(null);
+      expect(response.ok).toBe(true);
+      browser.close();
+    }));
+    it('should reject all promises when browser is closed', SX(async function() {
+      const browser = await puppeteer.launch(defaultBrowserOptions);
+      const page = await browser.newPage();
+      let error = null;
+      const neverResolves = page.evaluate(() => new Promise(r => {})).catch(e => error = e);
+      browser.close();
+      await neverResolves;
+      expect(error.message).toContain('Protocol error');
+    }));
+    it('userDataDir option', SX(async function() {
+      const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
+      const options = Object.assign({userDataDir}, defaultBrowserOptions);
+      const browser = await puppeteer.launch(options);
+      expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
+      browser.close();
+      expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
+      rm(userDataDir);
+    }));
+    it('userDataDir argument', SX(async function() {
+      const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
+      const options = Object.assign({}, defaultBrowserOptions);
+      options.args = [`--user-data-dir=${userDataDir}`].concat(options.args);
+      const browser = await puppeteer.launch(options);
+      expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
+      browser.close();
+      expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
+      rm(userDataDir);
+    }));
+  });
+  describe('Puppeteer.connect', function() {
+    it('should work', SX(async function() {
+      const originalBrowser = await puppeteer.launch(defaultBrowserOptions);
+      const browser = await puppeteer.connect({
+        browserWSEndpoint: originalBrowser.wsEndpoint()
+      });
+      const page = await browser.newPage();
+      expect(await page.evaluate(() => 7 * 8)).toBe(56);
+      originalBrowser.close();
+    }));
+  });
 });
 
 describe('Page', function() {
@@ -176,11 +175,7 @@ describe('Page', function() {
       const neverResolves = newPage.evaluate(() => new Promise(r => {}));
       newPage.close();
       let error = null;
-      try {
-        await neverResolves;
-      } catch (e) {
-        error = e;
-      }
+      await neverResolves.catch(e => error = e);
       expect(error.message).toContain('Protocol error');
     }));
   });
@@ -216,11 +211,7 @@ describe('Page', function() {
     }));
     it('should reject promise with exception', SX(async function() {
       let error = null;
-      try {
-        await page.evaluate(() => not.existing.object.property);
-      } catch (e) {
-        error = e;
-      }
+      await page.evaluate(() => not.existing.object.property).catch(e => error = e);
       expect(error).toBeTruthy();
       expect(error.message).toContain('not is not defined');
     }));
@@ -363,21 +354,13 @@ describe('Page', function() {
     }));
     it('should throw on bad polling value', SX(async function() {
       let error = null;
-      try {
-        await page.waitForFunction(() => !!document.body, {polling: 'unknown'});
-      } catch (e) {
-        error = e;
-      }
+      await page.waitForFunction(() => !!document.body, {polling: 'unknown'}).catch(e => error = e);
       expect(error).toBeTruthy();
       expect(error.message).toContain('polling');
     }));
     it('should throw negative polling interval', SX(async function() {
       let error = null;
-      try {
-        await page.waitForFunction(() => !!document.body, {polling: -10});
-      } catch (e) {
-        error = e;
-      }
+      await page.waitForFunction(() => !!document.body, {polling: -10}).catch(e => error = e);
       expect(error).toBeTruthy();
       expect(error.message).toContain('Cannot poll with non-positive interval');
     }));
@@ -455,12 +438,9 @@ describe('Page', function() {
         document.querySelector = null;
       });
       await page.goto(EMPTY_PAGE);
-      try {
-        await page.waitForSelector('*');
-        fail('Failed waitForSelector did not throw.');
-      } catch (e) {
-        expect(e.message).toContain('document.querySelector is not a function');
-      }
+      let error = null;
+      await page.waitForSelector('*').catch(e => error = e);
+      expect(error.message).toContain('document.querySelector is not a function');
     }));
     it('should throw when frame is detached', SX(async function() {
       await FrameUtils.attachFrame(page, 'frame1', EMPTY_PAGE);
@@ -532,12 +512,9 @@ describe('Page', function() {
       await watchdog;
     }));
     it('should throw when unknown type', SX(async function() {
-      try {
-        await page.waitFor({foo: 'bar'});
-        fail('Failed to throw exception');
-      } catch (e) {
-        expect(e.message).toContain('Unsupported target type');
-      }
+      let error = null;
+      await page.waitFor({foo: 'bar'}).catch(e => error = e);
+      expect(error.message).toContain('Unsupported target type');
     }));
   });
 
@@ -595,11 +572,7 @@ describe('Page', function() {
     }));
     it('should fail when navigating to bad url', SX(async function() {
       let error = null;
-      try {
-        await page.goto('asdfasdf');
-      } catch (e) {
-        error = e;
-      }
+      await page.goto('asdfasdf').catch(e => error = e);
       expect(error.message).toContain('Cannot navigate to invalid URL');
     }));
     it('should fail when navigating to bad SSL', SX(async function() {
@@ -609,20 +582,12 @@ describe('Page', function() {
       page.on('requestfinished', request => expect(request).toBeTruthy());
       page.on('requestfailed', request => expect(request).toBeTruthy());
       let error = null;
-      try {
-        await page.goto(HTTPS_PREFIX + '/empty.html');
-      } catch (e) {
-        error = e;
-      }
+      await page.goto(HTTPS_PREFIX + '/empty.html').catch(e => error = e);
       expect(error.message).toContain('SSL Certificate error');
     }));
     it('should fail when main resources failed to load', SX(async function() {
       let error = null;
-      try {
-        await page.goto('http://localhost:44123/non-existing-url');
-      } catch (e) {
-        error = e;
-      }
+      await page.goto('http://localhost:44123/non-existing-url').catch(e => error = e);
       expect(error.message).toContain('Failed to navigate');
     }));
     it('should fail when exceeding maximum navigation timeout', SX(async function() {
@@ -903,11 +868,7 @@ describe('Page', function() {
       await page.setRequestInterceptionEnabled(true);
       page.on('request', request => request.abort());
       let error = null;
-      try {
-        await page.goto(EMPTY_PAGE);
-      } catch (e) {
-        error = e;
-      }
+      await page.goto(EMPTY_PAGE).catch(e => error = e);
       expect(error).toBeTruthy();
       expect(error.message).toContain('Failed to navigate');
     }));
@@ -1240,12 +1201,9 @@ describe('Page', function() {
     }));
     it('should fail to click a missing button', SX(async function() {
       await page.goto(PREFIX + '/input/button.html');
-      try {
-        await page.click('button.does-not-exist');
-        fail('Clicking the button did not throw.');
-      } catch (error) {
-        expect(error.message).toBe('No node found for selector: button.does-not-exist');
-      }
+      let error = null;
+      await page.click('button.does-not-exist').catch(e => error = e);
+      expect(error.message).toBe('No node found for selector: button.does-not-exist');
     }));
     // @see https://github.com/GoogleChrome/puppeteer/issues/161
     it('should not hang with touch-enabled viewports', SX(async function() {
@@ -1843,11 +1801,7 @@ describe('Page', function() {
       await page.setJavaScriptEnabled(false);
       await page.goto('data:text/html, <script>var something = "forbidden"</script>');
       let error = null;
-      try {
-        await page.evaluate('something');
-      } catch (e) {
-        error = e;
-      }
+      await page.evaluate('something').catch(e => error = e);
       expect(error.message).toContain('something is not defined');
 
       await page.setJavaScriptEnabled(true);
@@ -1917,26 +1871,18 @@ describe('Page', function() {
     }));
     it('should throw if format is unknown', SX(async function() {
       let error = null;
-      try {
-        await getPDFPages(await page.pdf({
-          format: 'something'
-        }));
-      } catch (e) {
-        error = e;
-      }
+      await getPDFPages(await page.pdf({
+        format: 'something'
+      })).catch(e => error = e);
       expect(error).toBeTruthy();
       expect(error.message).toContain('Unknown paper format');
     }));
     it('should throw if units are unknown', SX(async function() {
       let error = null;
-      try {
-        await getPDFPages(await page.pdf({
-          width: '10em',
-          height: '10em',
-        }));
-      } catch (e) {
-        error = e;
-      }
+      await getPDFPages(await page.pdf({
+        width: '10em',
+        height: '10em',
+      })).catch(e => error = e);
       expect(error).toBeTruthy();
       expect(error.message).toContain('Failed to parse parameter value');
     }));
@@ -2052,11 +1998,7 @@ describe('Page', function() {
       await page.tracing.start({path: outputFile});
       const newPage = await browser.newPage();
       let error = null;
-      try {
-        await newPage.tracing.start({path: outputFile});
-      } catch (e) {
-        error = e;
-      }
+      await newPage.tracing.start({path: outputFile}).catch(e => error = e);
       await newPage.close();
       expect(error).toBeTruthy();
       await page.tracing.stop();


### PR DESCRIPTION
This patch:
- cleans up a bunch of try-catch statements in favor of a concise pattern
- renames "Browser" test suite into "Puppeteer" test suite