### PR TITLE
add Puppeteer.executablePath() method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -174,6 +174,9 @@ puppeteer.launch().then(async browser => {
 
 This methods attaches Puppeteer to an existing Chromium instance.
 
+#### puppeteer.executablePath()
+- returns: <[string]> A path where Puppeteer expects to find bundled chromium. Chromium might not exist there if the download was skipped with `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`.
+
 #### puppeteer.launch([options])
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,7 @@
   * [Environment Variables](#environment-variables)
   * [class: Puppeteer](#class-puppeteer)
     + [puppeteer.connect(options)](#puppeteerconnectoptions)
+    + [puppeteer.executablePath()](#puppeteerexecutablepath)
     + [puppeteer.launch([options])](#puppeteerlaunchoptions)
   * [class: Browser](#class-browser)
     + [browser.close()](#browserclose)
@@ -175,7 +176,7 @@ puppeteer.launch().then(async browser => {
 This methods attaches Puppeteer to an existing Chromium instance.
 
 #### puppeteer.executablePath()
-- returns: <[string]> A path where Puppeteer expects to find bundled chromium. Chromium might not exist there if the download was skipped with `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`.
+- returns: <[string]> A path where Puppeteer expects to find bundled Chromium. Chromium might not exist there if the download was skipped with [`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`](#environment-variables).
 
 #### puppeteer.launch([options])
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -112,6 +112,14 @@ class Launcher {
   }
 
   /**
+   * @return {string}
+   */
+  static executablePath() {
+    const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
+    return revisionInfo.executablePath;
+  }
+
+  /**
    * @param {string} options
    * @return {!Promise<!Browser>}
    */

--- a/lib/Puppeteer.js
+++ b/lib/Puppeteer.js
@@ -32,6 +32,13 @@ class Puppeteer {
   static connect(options) {
     return Launcher.connect(options);
   }
+
+  /**
+   * @return {string}
+   */
+  static executablePath() {
+    return Launcher.executablePath();
+  }
 }
 
 module.exports = Puppeteer;

--- a/test/test.js
+++ b/test/test.js
@@ -133,6 +133,12 @@ describe('Puppeteer', function() {
       originalBrowser.close();
     }));
   });
+  describe('Puppeteer.executablePath', function() {
+    it('should work', SX(async function() {
+      const executablePath = puppeteer.executablePath();
+      expect(fs.existsSync(executablePath)).toBe(true);
+    }));
+  });
 });
 
 describe('Page', function() {


### PR DESCRIPTION
This patch adds Puppeteer.executablePath() method to query the path
of bundled chromium.

Fixes #745