### PR TITLE
page.waitFor should send ...args to page.waitForFunction

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -74,8 +74,8 @@
     + [page.type(text, options)](#pagetypetext-options)
     + [page.url()](#pageurl)
     + [page.viewport()](#pageviewport)
-    + [page.waitFor(selectorOrFunctionOrTimeout[, options])](#pagewaitforselectororfunctionortimeout-options)
-    + [page.waitForFunction(pageFunction[, options, ...args])](#pagewaitforfunctionpagefunction-options-args)
+    + [page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#pagewaitforselectororfunctionortimeout-options-args)
+    + [page.waitForFunction(pageFunction[, options[, ...args]])](#pagewaitforfunctionpagefunction-options-args)
     + [page.waitForNavigation(options)](#pagewaitfornavigationoptions)
     + [page.waitForSelector(selector[, options])](#pagewaitforselectorselector-options)
   * [class: Keyboard](#class-keyboard)
@@ -111,8 +111,8 @@
     + [frame.parentFrame()](#frameparentframe)
     + [frame.title()](#frametitle)
     + [frame.url()](#frameurl)
-    + [frame.waitFor(selectorOrFunctionOrTimeout[, options])](#framewaitforselectororfunctionortimeout-options)
-    + [frame.waitForFunction(pageFunction[, options, ...args])](#framewaitforfunctionpagefunction-options-args)
+    + [frame.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#framewaitforselectororfunctionortimeout-options-args)
+    + [frame.waitForFunction(pageFunction[, options[, ...args]])](#framewaitforfunctionpagefunction-options-args)
     + [frame.waitForSelector(selector[, options])](#framewaitforselectorselector-options)
   * [class: ElementHandle](#class-elementhandle)
     + [elementHandle.click([options])](#elementhandleclickoptions)
@@ -844,9 +844,10 @@ This is a shortcut for [page.mainFrame().url()](#frameurl)
   - `hasTouch`<[boolean]> Specifies if viewport supports touch events. Defaults to `false`
   - `isLandscape` <[boolean]> Specifies if viewport is in landscape mode. Defaults to `false`.
 
-#### page.waitFor(selectorOrFunctionOrTimeout[, options])
+#### page.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
 - `selectorOrFunctionOrTimeout` <[string]|[number]|[function]> A [selector], predicate or timeout to wait for
 - `options` <[Object]> Optional waiting parameters
+- `...args` <...[Serializable]> Arguments to pass to  `pageFunction`
 - returns: <[Promise]>
 
 This method behaves differently with respect to the type of the first parameter:
@@ -855,9 +856,9 @@ This method behaves differently with respect to the type of the first parameter:
 - if `selectorOrFunctionOrTimeout` is a `number`, than the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
 - otherwise, an exception is thrown
 
-Shortcut for [page.mainFrame().waitFor(selectorOrFunctionOrTimeout[, options])](#framewaitforselectororfunctionortimeout-options).
+Shortcut for [page.mainFrame().waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#framewaitforselectororfunctionortimeout-options).
 
-#### page.waitForFunction(pageFunction[, options, ...args])
+#### page.waitForFunction(pageFunction[, options[, ...args]])
 - `pageFunction` <[function]|[string]> Function to be evaluated in browser context
 - `options` <[Object]> Optional waiting parameters
   - `polling` <[string]|[number]> An interval at which the `pageFunction` is executed, defaults to `raf`. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. If `polling` is a string, then it could be one of the following values:
@@ -879,7 +880,7 @@ puppeteer.launch().then(async browser => {
   browser.close();
 });
 ```
-Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options, ...args])](#framewaitforfunctionpagefunction-options-args).
+Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]])](#framewaitforfunctionpagefunction-options-args).
 
 #### page.waitForNavigation(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
@@ -1196,9 +1197,10 @@ If the name is empty, returns the id attribute instead.
 
 Returns frame's url.
 
-#### frame.waitFor(selectorOrFunctionOrTimeout[, options])
+#### frame.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])
 - `selectorOrFunctionOrTimeout` <[string]|[number]|[function]> A [selector], predicate or timeout to wait for
 - `options` <[Object]> Optional waiting parameters
+- `...args` <...[Serializable]> Arguments to pass to  `pageFunction`
 - returns: <[Promise]>
 
 This method behaves differently with respect to the type of the first parameter:
@@ -1208,7 +1210,7 @@ This method behaves differently with respect to the type of the first parameter:
 - otherwise, an exception is thrown
 
 
-#### frame.waitForFunction(pageFunction[, options, ...args])
+#### frame.waitForFunction(pageFunction[, options[, ...args]])
 - `pageFunction` <[function]|[string]> Function to be evaluated in browser context
 - `options` <[Object]> Optional waiting parameters
   - `polling` <[string]|[number]> An interval at which the `pageFunction` is executed, defaults to `raf`. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. If `polling` is a string, then it could be one of the following values:

--- a/docs/api.md
+++ b/docs/api.md
@@ -856,7 +856,7 @@ This method behaves differently with respect to the type of the first parameter:
 - if `selectorOrFunctionOrTimeout` is a `number`, than the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
 - otherwise, an exception is thrown
 
-Shortcut for [page.mainFrame().waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#framewaitforselectororfunctionortimeout-options).
+Shortcut for [page.mainFrame().waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#framewaitforselectororfunctionortimeout-options-args).
 
 #### page.waitForFunction(pageFunction[, options[, ...args]])
 - `pageFunction` <[function]|[string]> Function to be evaluated in browser context

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -361,15 +361,16 @@ class Frame {
   /**
    * @param {(string|number|function())} selectorOrTimeout
    * @param {!Object=} options
+   * @param {!Array<*>} args
    * @return {!Promise}
    */
-  waitFor(selectorOrFunctionOrTimeout, options = {}) {
+  waitFor(selectorOrFunctionOrTimeout, options = {}, ...args) {
     if (helper.isString(selectorOrFunctionOrTimeout))
       return this.waitForSelector(selectorOrFunctionOrTimeout, options);
     if (helper.isNumber(selectorOrFunctionOrTimeout))
       return new Promise(fulfill => setTimeout(fulfill, selectorOrFunctionOrTimeout));
     if (typeof selectorOrFunctionOrTimeout === 'function')
-      return this.waitForFunction(selectorOrFunctionOrTimeout, options);
+      return this.waitForFunction(selectorOrFunctionOrTimeout, options, ...args);
     return Promise.reject(new Error('Unsupported target type: ' + (typeof selectorOrFunctionOrTimeout)));
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -724,10 +724,11 @@ class Page extends EventEmitter {
   /**
    * @param {(string|number|function())} selectorOrTimeout
    * @param {!Object=} options
+   * @param {!Array<*>} args
    * @return {!Promise}
    */
-  waitFor(selectorOrFunctionOrTimeout, options = {}) {
-    return this.mainFrame().waitFor(selectorOrFunctionOrTimeout, options);
+  waitFor(selectorOrFunctionOrTimeout, options = {}, ...args) {
+    return this.mainFrame().waitFor(selectorOrFunctionOrTimeout, options, ...args);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -530,6 +530,11 @@ describe('Page', function() {
       await page.waitFor({foo: 'bar'}).catch(e => error = e);
       expect(error.message).toContain('Unsupported target type');
     }));
+    it('should wait for predicate with arguments', SX(async function() {
+      const watchdog = page.waitFor((arg1, arg2) => window[arg1] < arg2, {}, 'innerWidth', 100);
+      page.setViewport({width: 10, height: 10});
+      await watchdog;
+    }));
   });
 
   describe('Page.Events.Console', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -531,9 +531,7 @@ describe('Page', function() {
       expect(error.message).toContain('Unsupported target type');
     }));
     it('should wait for predicate with arguments', SX(async function() {
-      const watchdog = page.waitFor((arg1, arg2) => window[arg1] < arg2, {}, 'innerWidth', 100);
-      page.setViewport({width: 10, height: 10});
-      await watchdog;
+      await page.waitFor((arg1, arg2) => arg1 !== arg2, {}, 1, 2);
     }));
   });
 


### PR DESCRIPTION
This lets the user pass `...args` into `page.waitFor`. It also clarifies that the docs that `options` is not optional if `...args` are specified.

Fixes #770