### PR TITLE
Assert that all extra HTTP header values are strings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -743,7 +743,7 @@ Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#ke
 - returns: <[Promise]>
 
 #### page.setExtraHTTPHeaders(headers)
-- `headers` <[Object]> An object containing additional http headers to be sent with every request.
+- `headers` <[Object]> An object containing additional http headers to be sent with every request. All header values must be strings.
 - returns: <[Promise]>
 
 The extra HTTP headers will be sent with every request the page initiates.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -63,8 +63,11 @@ class NetworkManager extends EventEmitter {
    */
   async setExtraHTTPHeaders(extraHTTPHeaders) {
     this._extraHTTPHeaders = {};
-    for (const key of Object.keys(extraHTTPHeaders))
-      this._extraHTTPHeaders[key.toLowerCase()] = extraHTTPHeaders[key];
+    for (const key of Object.keys(extraHTTPHeaders)) {
+      const value = extraHTTPHeaders[key];
+      console.assert(helper.isString(value), `Expected value of header "${key}" to be String, but "${typeof value}" is found.`);
+      this._extraHTTPHeaders[key.toLowerCase()] = value;
+    }
     await this._client.send('Network.setExtraHTTPHeaders', { headers: this._extraHTTPHeaders });
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1538,6 +1538,15 @@ describe('Page', function() {
       ]);
       expect(request.headers['foo']).toBe('bar');
     }));
+    it('should throw for non-string header values', SX(async function() {
+      let error = null;
+      try {
+        await page.setExtraHTTPHeaders({ 'foo': 1 });
+      } catch (e) {
+        error = e;
+      }
+      expect(error.message).toBe('Expected value of header "foo" to be String, but "number" is found.');
+    }));
   });
   describe('Page.authenticate', function() {
     it('should work', SX(async function() {


### PR DESCRIPTION
Since protocol ignores all HTTP headers that don't have string
value, this patch starts validating header key-values before
sending them over the protocol.

Fixes #713.