### PR TITLE
doc: add `await` to `browser.close` in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const puppeteer = require('puppeteer');
   await page.goto('https://example.com');
   await page.screenshot({path: 'example.png'});
 
-  browser.close();
+  await browser.close();
 })();
 ```
 
@@ -64,7 +64,7 @@ const puppeteer = require('puppeteer');
   await page.goto('https://news.ycombinator.com', {waitUntil: 'networkidle'});
   await page.pdf({path: 'hn.pdf', format: 'A4'});
 
-  browser.close();
+  await browser.close();
 })();
 ```
 
@@ -91,7 +91,7 @@ const puppeteer = require('puppeteer');
 
   console.log('Dimensions:', dimensions);
 
-  browser.close();
+  await browser.close();
 })();
 ```
 


### PR DESCRIPTION
Since f398e69dbbedf1d0d20274a79d31bca24e5a7b2d updated `browser.close` to return a promise, the usage examples should be updated to reflect the new signature.