### PR TITLE
doc: add `await` to `browser.close` in usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const puppeteer = require('puppeteer');
   await page.goto('https://example.com');
   await page.screenshot({path: 'example.png'});
 
-  browser.close();
+  await browser.close();
 })();
 ```
 
@@ -64,7 +64,7 @@ const puppeteer = require('puppeteer');
   await page.goto('https://news.ycombinator.com', {waitUntil: 'networkidle'});
   await page.pdf({path: 'hn.pdf', format: 'A4'});
 
-  browser.close();
+  await browser.close();
 })();
 ```
 
@@ -91,7 +91,7 @@ const puppeteer = require('puppeteer');
 
   console.log('Dimensions:', dimensions);
 
-  browser.close();
+  await browser.close();
 })();
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -162,7 +162,7 @@ puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
   await page.goto('https://www.google.com');
   // other actions...
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -205,7 +205,7 @@ const puppeteer = require('puppeteer');
 puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
   await page.goto('https://example.com');
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -240,7 +240,7 @@ puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
   await page.goto('https://example.com');
   await page.screenshot({path: 'screenshot.png'});
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -441,7 +441,7 @@ puppeteer.launch().then(async browser => {
   await page.emulate(iPhone);
   await page.goto('https://www.google.com');
   // other actions...
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -520,7 +520,7 @@ puppeteer.launch().then(async browser => {
     const myHash = await window.md5(myString);
     console.log(`md5 of ${myString} is ${myHash}`);
   });
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -548,7 +548,7 @@ puppeteer.launch().then(async browser => {
     const content = await window.readfile('/etc/hosts');
     console.log(content);
   });
-  browser.close();
+  await browser.close();
 });
 
 ```
@@ -775,7 +775,7 @@ puppeteer.launch().then(async browser => {
       interceptedRequest.continue();
   });
   await page.goto('https://example.com');
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -876,7 +876,7 @@ puppeteer.launch().then(async browser => {
   const watchDog = page.waitForFunction('window.innerWidth < 100');
   page.setViewport({width: 50, height: 50});
   await watchDog;
-  browser.close();
+  await browser.close();
 });
 ```
 Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options, ...args])](#framewaitforfunctionpagefunction-options-args).
@@ -914,7 +914,7 @@ puppeteer.launch().then(async browser => {
     .then(() => console.log('First URL with image: ' + currentURL));
   for (currentURL of ['https://example.com', 'https://google.com', 'https://bbc.com'])
     await page.goto(currentURL);
-  browser.close();
+  await browser.close();
 });
 ```
 Shortcut for [page.mainFrame().waitForSelector(selector[, options])](#framewaitforselectorselector-options).
@@ -1050,7 +1050,7 @@ puppeteer.launch().then(async browser => {
   page.on('dialog', async dialog => {
     console.log(dialog.message());
     await dialog.dismiss();
-    browser.close();
+    await browser.close();
   });
   page.evaluate(() => alert('1'));
 });
@@ -1092,7 +1092,7 @@ puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
   await page.goto('https://www.google.com/chrome/browser/canary.html');
   dumpFrameTree(page.mainFrame(), '');
-  browser.close();
+  await browser.close();
 
   function dumpFrameTree(frame, indent) {
     console.log(indent + frame.url());
@@ -1227,7 +1227,7 @@ puppeteer.launch().then(async browser => {
   const watchDog = page.mainFrame().waitForFunction('window.innerWidth < 100');
   page.setViewport({width: 50, height: 50});
   await watchDog;
-  browser.close();
+  await browser.close();
 });
 ```
 
@@ -1254,7 +1254,7 @@ puppeteer.launch().then(async browser => {
     .then(() => console.log('First URL with image: ' + currentURL));
   for (currentURL of ['https://example.com', 'https://google.com', 'https://bbc.com'])
     await page.goto(currentURL);
-  browser.close();
+  await browser.close();
 });
 ```
 

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -32,7 +32,7 @@ page.on('request', request => {
 await page.goto('https://www.reuters.com/');
 await page.screenshot({path: 'news.png', fullPage: true});
 
-browser.close();
+await browser.close();
 
 })();
 

--- a/examples/custom-event.js
+++ b/examples/custom-event.js
@@ -45,6 +45,6 @@ await listenFor('app-ready'); // Listen for "app-ready" custom event on page loa
 
 await page.goto('https://www.chromestatus.com/features', {waitUntil: 'networkidle'});
 
-browser.close();
+await browser.close();
 
 })();

--- a/examples/detect-sniff.js
+++ b/examples/detect-sniff.js
@@ -41,6 +41,6 @@ await page.evaluateOnNewDocument(sniffDetector);
 await page.goto('https://www.google.com', {waitUntil: 'networkidle'});
 console.log('Sniffed: ' + (await page.evaluate(() => !!navigator.sniffed)));
 
-browser.close();
+await browser.close();
 
 })();

--- a/examples/pdf.js
+++ b/examples/pdf.js
@@ -30,6 +30,6 @@ await page.pdf({
   format: 'letter'
 });
 
-browser.close();
+await browser.close();
 
 })();

--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -28,6 +28,6 @@ const browser = await puppeteer.launch({
 });
 const page = await browser.newPage();
 await page.goto('https://google.com');
-browser.close();
+await browser.close();
 
 })();

--- a/examples/screenshot-fullpage.js
+++ b/examples/screenshot-fullpage.js
@@ -26,6 +26,6 @@ const page = await browser.newPage();
 await page.emulate(devices['iPhone 6']);
 await page.goto('https://www.nytimes.com/');
 await page.screenshot({path: 'full.png', fullPage: true});
-browser.close();
+await browser.close();
 
 })();

--- a/examples/screenshot.js
+++ b/examples/screenshot.js
@@ -25,6 +25,6 @@ const page = await browser.newPage();
 await page.goto('http://example.com');
 await page.screenshot({path: 'example.png'});
 
-browser.close();
+await browser.close();
 
 })();

--- a/examples/search.js
+++ b/examples/search.js
@@ -37,6 +37,6 @@ const links = await page.evaluate(() => {
   return anchors.map(anchor => anchor.textContent);
 });
 console.log(links.join('\n'));
-browser.close();
+await browser.close();
 
 })();


### PR DESCRIPTION
Since f398e69dbbedf1d0d20274a79d31bca24e5a7b2d updated `browser.close` to return a promise, the usage examples should be updated to reflect the new signature.