### PR TITLE
Added mkdir recursively in `page.screenshot` and `page.pdf`

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -15,6 +15,7 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const EventEmitter = require('events');
 const mime = require('mime');
 const NetworkManager = require('./NetworkManager');
@@ -585,7 +586,7 @@ class Page extends EventEmitter {
 
     const buffer = new Buffer(result.data, 'base64');
     if (options.path)
-      fs.writeFileSync(options.path, buffer);
+      writeFileSyncWithMkdir(options.path, buffer);
     return buffer;
   }
 
@@ -633,7 +634,7 @@ class Page extends EventEmitter {
     });
     const buffer = new Buffer(result.data, 'base64');
     if (options.path)
-      fs.writeFileSync(options.path, buffer);
+      writeFileSyncWithMkdir(options.path, buffer);
     return buffer;
   }
 
@@ -801,6 +802,33 @@ function convertPrintParameterToInches(parameter) {
     throw new Error('page.pdf() Cannot handle parameter type: ' + (typeof parameter));
   }
   return pixels / 96;
+}
+
+/**
+ * @param {string} filePath
+ * @param {Buffer} buffer
+ */
+function writeFileSyncWithMkdir(filePath, buffer) {
+  const absolutePath = path.dirname(path.resolve(filePath));
+  const file = fs.existsSync(absolutePath)
+    ? filePath
+    : path.join(absolutePath, path.basename(filePath));
+  const mkdirRecursive = dir => {
+    if (!fs.existsSync(dir)) {
+      try {
+        fs.mkdirSync(dir);
+      } catch (e) {
+        if (e.code === 'ENOENT') {
+          mkdirRecursive(path.dirname(dir));
+          mkdirRecursive(dir);
+        } else {
+          throw e;
+        }
+      }
+    }
+  };
+  mkdirRecursive(absolutePath);
+  fs.writeFileSync(file, buffer);
 }
 
 Page.Events = {

--- a/test/test.js
+++ b/test/test.js
@@ -1944,6 +1944,15 @@ describe('Page', function() {
       const screenshot = await page.screenshot();
       expect(screenshot).toBeGolden('screenshot-sanity.png');
     }));
+    it('should mkdir, if no directory exits', SX(async function() {
+      const dir = 'test/.temp/';
+      await page.goto(PREFIX + '/grid.html');
+      await page.screenshot({
+        path: dir + 'screenshot-sanity.png'
+      });
+      expect(fs.existsSync(dir)).toBeTruthy();
+      rm(__dirname + '/.temp');
+    }));
     it('should clip rect', SX(async function() {
       await page.setViewport({width: 500, height: 500});
       await page.goto(PREFIX + '/grid.html');


### PR DESCRIPTION
Now `page.screenshot()` and `page.pdf()` can't receive directory that does not exist as `path` parameter.

`Error: ENOENT: no such file or directory, open`

So, this PR adds mkdir recuresively (if not exists) to these methods and adds some test.
Just me, nobody wants this one?