### PR TITLE
Document headless mode restriction for PDF

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -608,6 +608,7 @@ The `page.goto` will throw an error if:
 
 > **NOTE** `page.goto` either throw or return a main resource response. The only exception is navigation to `about:blank`, which would succeed and return `null`.
 
+> **NOTE** Headless mode doesn't support navigating to a PDF document. See the [upstream issue](https://bugs.chromium.org/p/chromium/issues/detail?id=761295).
 
 #### page.hover(selector)
 - `selector` <[string]> A [selector] to search for element to hover. If there are multiple elements satisfying the selector, the first will be hovered.


### PR DESCRIPTION
Fixes: https://github.com/GoogleChrome/puppeteer/issues/830