### PR TITLE
[fix] Do not attempt to normalize malformed URLs.

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -394,9 +394,16 @@ helper.tracePublicAPI(Response);
  * @return {string}
  */
 function generateRequestHash(request) {
-  const hash = {
+  let normalizedURL = request.url;
+  try {
     // Decoding is necessary to normalize URLs. @see crbug.com/759388
-    url: decodeURI(request.url),
+    // The method will throw if the URL is malformed. In this case,
+    // consider URL to be normalized as-is.
+    normalizedURL = decodeURI(request.url);
+  } catch (e) {
+  }
+  const hash = {
+    url: normalizedURL,
     method: request.method,
     postData: request.postData,
     headers: {},

--- a/test/test.js
+++ b/test/test.js
@@ -979,6 +979,13 @@ describe('Page', function() {
       const response = await page.goto(PREFIX + '/some nonexisting page');
       expect(response.status).toBe(404);
     }));
+    it('should work with badly encoded URLs', SX(async function() {
+      await page.setRequestInterceptionEnabled(true);
+      server.setRoute('/malformed?rnd=%911', (req, res) => res.end());
+      page.on('request', request => request.continue());
+      const response = await page.goto(PREFIX + '/malformed?rnd=%911');
+      expect(response.status).toBe(200);
+    }));
     it('should work with encoded URLs - 2', SX(async function() {
       // The requestWillBeSent will report URL as-is, whereas interception will
       // report encoded URL for stylesheet. @see crbug.com/759388


### PR DESCRIPTION
This patch avoids throwing 'url malformed' error during generating
request hash for request interception.

Fixes #869.