### PR TITLE
[fix] Terminate chrome gracefully on Windows

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -127,7 +127,7 @@ class Launcher {
       } else {
         // Terminate chrome gracefully.
         if (process.platform === 'win32')
-          chromeProcess.kill();
+          childProcess.execSync(`taskkill /pid ${chromeProcess.pid} >nul`);
         else
           process.kill(-chromeProcess.pid, 'SIGTERM');
       }

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -127,7 +127,7 @@ class Launcher {
       } else {
         // Terminate chrome gracefully.
         if (process.platform === 'win32')
-          childProcess.execSync(`taskkill /pid ${chromeProcess.pid} >nul`);
+          childProcess.execSync(`taskkill /pid ${chromeProcess.pid}`);
         else
           process.kill(-chromeProcess.pid, 'SIGTERM');
       }


### PR DESCRIPTION
This patch starts using `taskkill` program on windows to gracefully
terminate chrome.

Fixes #839.