### PR TITLE
[roll] Roll chromium to r503964

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -30,6 +30,8 @@ const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile-');
 const DEFAULT_ARGS = [
   '--disable-background-networking',
   '--disable-background-timer-throttling',
+  // TODO(aslushnikov): this flag should be removed. @see https://github.com/GoogleChrome/puppeteer/issues/877
+  '--disable-browser-side-navigation',
   '--disable-client-side-phishing-detection',
   '--disable-default-apps',
   '--disable-extensions',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "499413"
+    "chromium_revision": "503964"
   },
   "devDependencies": {
     "commonmark": "^0.27.0",


### PR DESCRIPTION
This patch rolls chromium to r503964.

**Note:** since the plznavigate is not supported by puppeteer right now, the
patch also starts passing the `--disable-browser-side-navigation` flag.
This is a temporary work around for us.

References #877.