### PR TITLE
Screencast API

### DIFF
--- a/examples/screencast.js
+++ b/examples/screencast.js
@@ -30,11 +30,12 @@ page.screencast.on('frame', frame => {
   console.log('Frame captured @', frame.metadata.timestamp);
 });
 
-await page.screencast.start({path: 'video.webm'});
-
 console.log('Capturing screencast for actions...');
 
 const tic = Date.now();
+
+await page.screencast.start({path: 'video.webm'});
+
 await page.goto('https://www.chromestatus.com/', {waitUntil: 'networkidle'});
 
 // Wait for features list to show up.
@@ -57,12 +58,14 @@ await page.waitFor(2000); // pause
 await page.goto(nextURL);
 
 const seconds = (Date.now() - tic) / 1000;
+console.log(`Duration: ${seconds}s`);
+
+console.log('Creating video...');
 const frames = await page.screencast.stop();
 const fps = frames.length / seconds;
 
 console.log(`Captured ${frames.length} frames`);
-console.log(`Duration: ${seconds}s`);
-console.log(`FPS: ~${fps}`);
+console.log(`Average FPS: ~${fps}`);
 
 await browser.close();
 

--- a/examples/screencast.js
+++ b/examples/screencast.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2017 Google Inc., PhantomJS Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const puppeteer = require('puppeteer');
+
+(async() => {
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+
+// TODO: screencast API doesn't not support deviceScaleFactor atm.
+await page.setViewport({width: 1000, height: 800, deviceScaleFactor: 2});
+
+page.screencast.on('frame', frame => {
+  console.log('Frame captured @', frame.metadata.timestamp);
+});
+
+await page.screencast.start({path: 'video.webm'});
+
+console.log('Capturing screencast for actions...');
+
+const tic = Date.now();
+await page.goto('https://www.chromestatus.com/', {waitUntil: 'networkidle'});
+
+// Wait for features list to show up.
+await page.waitForFunction("document.querySelector('chromedash-featurelist').features.length > 1");
+
+await page.focus('.search input[type="search"]');
+await page.type('Headless Chrome', {delay: 100}); // slow down, as if user was typing.
+await page.waitFor(100); // wait for results to be filtered.
+
+// Search for the "Headless Chrome" feature and open the card.
+const nextURL = await page.$eval('chromedash-featurelist', features => {
+  const item = features.shadowRoot.querySelector('#ironlist .item:not([hidden])');
+  const card = item.querySelector('chromedash-feature');
+  card.toggle();
+  return card.feature.resources.docs[0]; // extract doc link from data model.
+});
+
+await page.waitFor(2000); // pause
+
+await page.goto(nextURL);
+
+const seconds = (Date.now() - tic) / 1000;
+const frames = await page.screencast.stop();
+const fps = frames.length / seconds;
+
+console.log(`Captured ${frames.length} frames`);
+console.log(`Duration: ${seconds}s`);
+console.log(`FPS: ~${fps}`);
+
+await browser.close();
+
+})();
+

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -20,6 +20,7 @@ const mime = require('mime');
 const NetworkManager = require('./NetworkManager');
 const NavigatorWatcher = require('./NavigatorWatcher');
 const Dialog = require('./Dialog');
+const Screencast = require('./Screencast');
 const EmulationManager = require('./EmulationManager');
 const FrameManager = require('./FrameManager');
 const {Keyboard, Mouse, Touchscreen} = require('./Input');
@@ -64,6 +65,7 @@ class Page extends EventEmitter {
     this._frameManager = new FrameManager(client, this._mouse, this._touchscreen);
     this._networkManager = new NetworkManager(client);
     this._emulationManager = new EmulationManager(client);
+    this._screencast = new Screencast(client);
     this._tracing = new Tracing(client);
     /** @type {!Map<string, function>} */
     this._pageBindings = new Map();
@@ -104,6 +106,13 @@ class Page extends EventEmitter {
    */
   get keyboard() {
     return this._keyboard;
+  }
+
+  /**
+   * @return {!Screencast}
+   */
+  get screencast()  {
+    return this._screencast;
   }
 
   /**
@@ -295,6 +304,9 @@ class Page extends EventEmitter {
     this.emit(Page.Events.PageError, new Error(message));
   }
 
+  /**
+   * @param {!Object} event
+   */
   async _onConsoleAPI(event) {
     if (event.type === 'debug' && event.args.length && event.args[0].value === 'driver:page-binding') {
       const {name, seq, args} = JSON.parse(event.args[1].value);
@@ -316,6 +328,9 @@ class Page extends EventEmitter {
     this.emit(Page.Events.Console, ...values);
   }
 
+  /**
+   * @param {!Object} event
+   */
   _onDialog(event) {
     let dialogType = null;
     if (event.type === 'alert')

--- a/lib/Screencast.js
+++ b/lib/Screencast.js
@@ -39,7 +39,7 @@ async function createVideo(frames, fps) {
   canvas.style.width = `${WIDTH / 2}px`;
   canvas.style.height = `${HEIGHT / 2}px`;
 
-  // Create video stream from canvas. Since we're not passing an fsp, it will
+  // Create video stream from canvas. Since we're not passing an fps, it will
   // match how fast the canvas is being drawn to.
   const stream = canvas.captureStream();
   const recorder = new MediaRecorder(stream, {mimeType: 'video/webm'});

--- a/lib/Screencast.js
+++ b/lib/Screencast.js
@@ -36,8 +36,6 @@ async function createVideo(frames, fps) {
   canvas.style.display = 'none';
   canvas.width = WIDTH;
   canvas.height = HEIGHT;
-  canvas.style.width = `${WIDTH / 2}px`;
-  canvas.style.height = `${HEIGHT / 2}px`;
 
   // Create video stream from canvas. Since we're not passing an fps, it will
   // match how fast the canvas is being drawn to.

--- a/lib/Screencast.js
+++ b/lib/Screencast.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const fs = require('fs');
+const path = require('path');
+const EventEmitter = require('events');
+const {helper, debugError} = require('./helper');
+
+
+class Screencast extends EventEmitter {
+  /**
+   * @param {!Session} client
+   */
+  constructor(client) {
+    super();
+    this._client = client;
+    /** @type {!Array<!Object>} */
+    this._frames = [];
+    /** @type {string} */
+    this._format = 'png';
+    /** @type {boolean} */
+    this._recording = false;
+
+    this._client.on('Page.screencastFrame', event => this._onScreencastFrame(event));
+  }
+
+  /**
+   * @return {!Array<!Screencast.Frame>}
+   */
+  frames() {
+    return this._frames;
+  }
+
+  /**
+   * Format of each frame.
+   * @return {!string}
+   */
+  format() {
+    return this._format;
+  }
+
+  /**
+   * @param {!Object} event
+   */
+  async _onScreencastFrame(event) {
+    console.assert(typeof event.sessionId === 'number',
+        'Expected screencast frame to have sessionId');
+    await this._client.send(
+        'Page.screencastFrameAck', {sessionId: event.sessionId}).catch(debugError);
+    const buffer = new Buffer(event.data, 'base64');
+    this.frames().push(buffer);
+    this.emit(Screencast.Events.Frame, {buffer, metadata: event.metadata});
+  }
+
+  /**
+   * @param {!Object=} options
+   */
+  async start(options = {}) {
+    if (this._recording)
+      throw new Error('Cannot start another screencast. One is already in progress.');
+
+    this._frames = [];
+
+    if (options.format) {
+      console.assert(options.format === 'png' || options.format === 'jpeg',
+          `Unknown options.format value: ${options.format}`);
+    } else {
+      options.format = 'png'; // default to png.
+    }
+
+    this._format = options.format;
+
+    if (options.quality) {
+      console.assert(options.format === 'jpeg',
+          `options.quality is unsupported for the jpeg screenshots`);
+      console.assert(typeof options.quality === 'number',
+          `Expected options.quality to be a number but found ${typeof options.quality}`);
+      console.assert(
+          Number.isInteger(options.quality), 'Expected options.quality to be an integer');
+      console.assert(options.quality >= 0 && options.quality <= 100,
+          `Expected options.quality to be between 0 and 100 (inclusive), got ${options.quality}`);
+    }
+    if (options.maxWidth) {
+      console.assert(typeof options.maxWidth === 'number',
+          `Expected options.maxWidth to be a number but found ${typeof options.maxWidth}`);
+      console.assert(
+          Number.isInteger(options.maxWidth), 'Expected options.maxWidth to be an integer');
+      console.assert(options.maxWidth >= 0,
+          `Expected options.maxWidth to be greater than 0, got ${options.maxWidth}`);
+    }
+    if (options.maxHeight) {
+      console.assert(typeof options.maxHeight === 'number',
+          `Expected options.maxHeight to be a number but found ${typeof options.maxHeight}`);
+      console.assert(
+          Number.isInteger(options.maxHeight), 'Expected options.maxHeight to be an integer');
+      console.assert(options.maxHeight >= 0,
+          `Expected options.maxHeight to be greater than 0, got ${options.maxHeight}`);
+    }
+    if (options.everyNthFrame) {
+      console.assert(typeof options.everyNthFrame === 'number',
+          `Expected options.everyNthFrame to be a number but found ${typeof options.everyNthFrame}`);
+      console.assert(Number.isInteger(options.everyNthFrame),
+          'Expected options.everyNthFrame to be an integer');
+      console.assert(options.everyNthFrame >= 0,
+          `Expected options.everyNthFrame to be greater than 0, got ${options.everyNthFrame}`);
+    } else {
+      options.everyNthFrame = 1; // default to every frame.
+    }
+    this._recording = true;
+    await this._client.send('Page.startScreencast', options).catch(debugError);
+  }
+
+  /**
+   * Stop capturing a screencast, optionally writing the frame images to a
+   * directory. Throws if options.path does not exist.
+   * @param {!Object=} options
+   * @return {!Array<!Screencast.Frame>}
+   */
+  async stop(options = {}) {
+    await this._client.send('Page.stopScreencast').catch(debugError);
+    this._recording = false;
+    if (options.path)
+      this._save(options.path);
+    return this.frames();
+  }
+
+  /**
+   * @param {string} dirname Directory to save image frames into.
+   */
+  _save(dirname) {
+    this.frames().forEach((frame, i) => {
+      const buffer = new Buffer(frame, 'base64');
+      fs.writeFileSync(path.join(dirname, `frame_${i}.${this.format()}`), buffer);
+    });
+  }
+}
+
+/** @typedef {{buffer: !Buffer, metadata: !Object}} */
+Screencast.Frame;
+
+Screencast.Events = {
+  Frame: 'frame',
+};
+
+helper.tracePublicAPI(Screencast);
+module.exports = Screencast;

--- a/lib/Screencast.js
+++ b/lib/Screencast.js
@@ -18,13 +18,12 @@ const EventEmitter = require('events');
 const {helper, debugError} = require('./helper');
 
 /**
- * @param {!Array<number>} frames
- * @param {number} fps Desired frames per second.
- * @return {!Promise<Blob>}
+ * @param {!Array<!Object>} frames
+ * @return {!Promise<!Array<number>>}
  */
-async function createVideo(frames, fps) {
+async function createVideo(frames) {
   const imageBitmaps = await Promise.all(frames.map(frame => {
-    const blob = new Blob([Uint8Array.from(frame)], {type: 'image/png'});
+    const blob = new Blob([Uint8Array.from(frame.buffer)], {type: 'image/png'});
     return window.createImageBitmap(blob);
   }));
 
@@ -45,7 +44,7 @@ async function createVideo(frames, fps) {
   let fulfill;
   const videoPromise = new Promise(r => fulfill = r);
 
-  const _startRecording = function() {
+  const setupAndStartRecording = function() {
     return new Promise((resolve, reject) => {
       const chunks = [];
       recorder.ondataavailable = e => chunks.push(e.data);
@@ -55,33 +54,37 @@ async function createVideo(frames, fps) {
     });
   };
 
-  _startRecording().then(chunks => {
-    const reader = new FileReader();
-    reader.onload = function(e) {
-      // Convert back to array for serialization.
-      fulfill(Array.from(new Uint8Array(e.target.result)));
-    };
-    const blob = new Blob(chunks, {type: 'video/webm'});
-    reader.readAsArrayBuffer(blob);
-  });
-
-  const _drawImagesToCanvas = function() {
-    return new Promise(resolve => {
-      const ctx = canvas.getContext('2d');
-
-      let frameIdx = 0;
-      // Draw to canvas at fps.
-      const id = setInterval(() => {
-        ctx.drawImage(imageBitmaps[frameIdx++], 0, 0);
-        if (frameIdx >= frames.length) {
-          clearInterval(id);
-          resolve();
-        }
-      }, 1000 / fps);
+  const blobToArrayBuffer = function(blob) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = reject;
+      reader.onload = e => {
+        resolve(e.target.result);
+      };
+      reader.readAsArrayBuffer(blob);
     });
   };
 
-  await _drawImagesToCanvas(); // Draw images to canvas at fps (in real-time).
+  const drawImagesToCanvas = async function() {
+    const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    const ctx = canvas.getContext('2d');
+
+    ctx.drawImage(imageBitmaps[0], 0, 0);
+    for (let i = 1; i < frames.length; ++i) {
+      const msDiff = (frames[i].metadata.timestamp - frames[i - 1].metadata.timestamp) * 1000;
+      await sleep(msDiff);
+      ctx.drawImage(imageBitmaps[i], 0, 0);
+    }
+  };
+
+  setupAndStartRecording().then(async chunks => {
+    const arrayBuffer = await blobToArrayBuffer(new Blob(chunks, {type: 'video/webm'}));
+    // Convert to array for serialization back to pptr.
+    fulfill(Array.from(new Uint8Array(arrayBuffer)));
+  });
+
+  await drawImagesToCanvas(); // Draw images to canvas in real-time.
 
   recorder.stop();
 
@@ -97,8 +100,6 @@ class Screencast extends EventEmitter {
     this._client = client;
     /** @type {!Array<!Object>} */
     this._frames = [];
-    /** @type {number} */
-    this._startTime;
     /** @type {string} */
     this._format = 'png';
     /** @type {string} */
@@ -113,7 +114,7 @@ class Screencast extends EventEmitter {
    * @return {!Array<!Screencast.Frame>}
    */
   frames() {
-    return this._frames;
+    return this._frames.map(frame => frame.buffer);
   }
 
   /**
@@ -132,9 +133,11 @@ class Screencast extends EventEmitter {
         'Expected screencast frame to have sessionId');
     await this._client.send(
         'Page.screencastFrameAck', {sessionId: event.sessionId}).catch(debugError);
-    const buffer = new Buffer(event.data, 'base64');
-    this.frames().push(buffer);
-    this.emit(Screencast.Events.Frame, {buffer, metadata: event.metadata});
+
+    const obj = {buffer: new Buffer(event.data, 'base64'), metadata: event.metadata};
+    this._frames.push(obj);
+
+    this.emit(Screencast.Events.Frame, obj);
   }
 
   /**
@@ -145,7 +148,6 @@ class Screencast extends EventEmitter {
       throw new Error('Cannot start another screencast. One is already in progress.');
 
     this._frames = [];
-    this._startTime = Date.now();
 
     if (options.format) {
       console.assert(options.format === 'png' || options.format === 'jpeg',
@@ -204,15 +206,13 @@ class Screencast extends EventEmitter {
    */
   async stop() {
     await this._client.send('Page.stopScreencast').catch(debugError);
-    const seconds = (Date.now() - this._startTime) / 1000;
-    this._startTime = null;
     this._recording = false;
-    const fps = this.frames().length / seconds;
-    if (this._path) {
-      // Convert for serialization.
-      const frames = this.frames().map(buffer => Array.from(buffer));
 
-      const expression = helper.evaluationString(createVideo, frames, fps);
+    if (this._path) {
+      // Convert Buffers to Arrays for serialization.
+      const frames = this._frames.map(frame => ({buffer: Array.from(frame.buffer), metadata: frame.metadata}));
+
+      const expression = helper.evaluationString(createVideo, frames);
       const result = await this._client.send('Runtime.evaluate',
           {expression, returnByValue: true, awaitPromise: true});
 

--- a/lib/Screencast.js
+++ b/lib/Screencast.js
@@ -32,8 +32,6 @@ async function createVideo(frames, fps) {
   const WIDTH = imageBitmaps[imageBitmaps.length - 1].width;
   const HEIGHT = imageBitmaps[imageBitmaps.length - 1].height;
 
-  const video = document.createElement('video');
-  video.style.display = 'none';
   const canvas = document.createElement('canvas');
   canvas.style.display = 'none';
   canvas.width = WIDTH;
@@ -41,11 +39,10 @@ async function createVideo(frames, fps) {
   canvas.style.width = `${WIDTH / 2}px`;
   canvas.style.height = `${HEIGHT / 2}px`;
 
-  // Create stream. Since we're not passing FPS, it will match how fast the
-  // canvas is being painting.
-  const stream = canvas.captureStream(fps);
-  video.srcObject = stream; // <video> src is the stream from the <canvas>.
-  const recorder = new MediaRecorder(stream);
+  // Create video stream from canvas. Since we're not passing an fsp, it will
+  // match how fast the canvas is being drawn to.
+  const stream = canvas.captureStream();
+  const recorder = new MediaRecorder(stream, {mimeType: 'video/webm'});
 
   let fulfill;
   const videoPromise = new Promise(r => fulfill = r);
@@ -73,9 +70,9 @@ async function createVideo(frames, fps) {
   const _drawImagesToCanvas = function() {
     return new Promise(resolve => {
       const ctx = canvas.getContext('2d');
-      // ctx.scale(2, 2);
 
       let frameIdx = 0;
+      // Draw to canvas at fps.
       const id = setInterval(() => {
         ctx.drawImage(imageBitmaps[frameIdx++], 0, 0);
         if (frameIdx >= frames.length) {

--- a/lib/Screencast.js
+++ b/lib/Screencast.js
@@ -14,10 +14,84 @@
  * limitations under the License.
  */
 const fs = require('fs');
-const path = require('path');
 const EventEmitter = require('events');
 const {helper, debugError} = require('./helper');
 
+/**
+ * @param {!Array<number>} frames
+ * @param {number} fps Desired frames per second.
+ * @return {!Promise<Blob>}
+ */
+async function createVideo(frames, fps) {
+  const imageBitmaps = await Promise.all(frames.map(frame => {
+    const blob = new Blob([Uint8Array.from(frame)], {type: 'image/png'});
+    return window.createImageBitmap(blob);
+  }));
+
+  // Use last image as width so we know the set viewport is correct.
+  const WIDTH = imageBitmaps[imageBitmaps.length - 1].width;
+  const HEIGHT = imageBitmaps[imageBitmaps.length - 1].height;
+
+  const video = document.createElement('video');
+  video.style.display = 'none';
+  const canvas = document.createElement('canvas');
+  canvas.style.display = 'none';
+  canvas.width = WIDTH;
+  canvas.height = HEIGHT;
+  canvas.style.width = `${WIDTH / 2}px`;
+  canvas.style.height = `${HEIGHT / 2}px`;
+
+  // Create stream. Since we're not passing FPS, it will match how fast the
+  // canvas is being painting.
+  const stream = canvas.captureStream(fps);
+  video.srcObject = stream; // <video> src is the stream from the <canvas>.
+  const recorder = new MediaRecorder(stream);
+
+  let fulfill;
+  const videoPromise = new Promise(r => fulfill = r);
+
+  const _startRecording = function() {
+    return new Promise((resolve, reject) => {
+      const chunks = [];
+      recorder.ondataavailable = e => chunks.push(e.data);
+      recorder.onstop = e => resolve(chunks);
+      recorder.onerror = reject;
+      recorder.start();
+    });
+  };
+
+  _startRecording().then(chunks => {
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      // Convert back to array for serialization.
+      fulfill(Array.from(new Uint8Array(e.target.result)));
+    };
+    const blob = new Blob(chunks, {type: 'video/webm'});
+    reader.readAsArrayBuffer(blob);
+  });
+
+  const _drawImagesToCanvas = function() {
+    return new Promise(resolve => {
+      const ctx = canvas.getContext('2d');
+      // ctx.scale(2, 2);
+
+      let frameIdx = 0;
+      const id = setInterval(() => {
+        ctx.drawImage(imageBitmaps[frameIdx++], 0, 0);
+        if (frameIdx >= frames.length) {
+          clearInterval(id);
+          resolve();
+        }
+      }, 1000 / fps);
+    });
+  };
+
+  await _drawImagesToCanvas(); // Draw images to canvas at fps (in real-time).
+
+  recorder.stop();
+
+  return videoPromise;
+}
 
 class Screencast extends EventEmitter {
   /**
@@ -28,8 +102,12 @@ class Screencast extends EventEmitter {
     this._client = client;
     /** @type {!Array<!Object>} */
     this._frames = [];
+    /** @type {number} */
+    this._startTime;
     /** @type {string} */
     this._format = 'png';
+    /** @type {string} */
+    this._path = '';
     /** @type {boolean} */
     this._recording = false;
 
@@ -72,6 +150,7 @@ class Screencast extends EventEmitter {
       throw new Error('Cannot start another screencast. One is already in progress.');
 
     this._frames = [];
+    this._startTime = Date.now();
 
     if (options.format) {
       console.assert(options.format === 'png' || options.format === 'jpeg',
@@ -81,6 +160,7 @@ class Screencast extends EventEmitter {
     }
 
     this._format = options.format;
+    this._path = options.path;
 
     if (options.quality) {
       console.assert(options.format === 'jpeg',
@@ -125,25 +205,26 @@ class Screencast extends EventEmitter {
   /**
    * Stop capturing a screencast, optionally writing the frame images to a
    * directory. Throws if options.path does not exist.
-   * @param {!Object=} options
    * @return {!Array<!Screencast.Frame>}
    */
-  async stop(options = {}) {
+  async stop() {
     await this._client.send('Page.stopScreencast').catch(debugError);
+    const seconds = (Date.now() - this._startTime) / 1000;
+    this._startTime = null;
     this._recording = false;
-    if (options.path)
-      this._save(options.path);
-    return this.frames();
-  }
+    const fps = this.frames().length / seconds;
+    if (this._path) {
+      // Convert for serialization.
+      const frames = this.frames().map(buffer => Array.from(buffer));
 
-  /**
-   * @param {string} dirname Directory to save image frames into.
-   */
-  _save(dirname) {
-    this.frames().forEach((frame, i) => {
-      const buffer = new Buffer(frame, 'base64');
-      fs.writeFileSync(path.join(dirname, `frame_${i}.${this.format()}`), buffer);
-    });
+      const expression = helper.evaluationString(createVideo, frames, fps);
+      const result = await this._client.send('Runtime.evaluate',
+          {expression, returnByValue: true, awaitPromise: true});
+
+      const webmVideo = new Buffer.from(result.result.value);
+      fs.writeFileSync(this._path, webmVideo);
+    }
+    return this.frames();
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/puppeteer/issues/478.

Want to get some feedback on this before finishing tests and api docs.

The shape of the API is similar to Tracing. This PR introduces `page.screencast`:

```js
page.screencast.on('frame', frame => {
  ...
});

await page.screencast.start();
await page.goto(...);
// ... other stuff ...
const frames = await page.screencast.stop();

// user can save frames themselves
frames.forEach((frame, i) => {
  fs.writeFileSync(`frame_${i}.png`, new Buffer(frame, 'base64'));
});
```

Passing a `path` creates a .webm video file when you call `stop()`. The solution uses **no dependencies**, only web platform APIs! The downside is that capturing a 'recording' is real-time, meaning longer videos will take more time to complete.

```js
await page.screencast.start({path: 'video.webm'});
```
