### PR TITLE
Allow options.timeout to be `0` to disable timeout

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -594,7 +594,7 @@ Navigate to the next page in history.
 #### page.goto(url, options)
 - `url` <[string]> URL to navigate page to. The url should include scheme, e.g. `https://`.
 - `options` <[Object]> Navigation parameters which might have the following properties:
-  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds.
+  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Could be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.

--- a/docs/api.md
+++ b/docs/api.md
@@ -567,7 +567,7 @@ If there's no element matching `selector`, the method throws an error.
 
 #### page.goBack(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
-  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds.
+  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.
   - `waitUntil` <[string]> When to consider a navigation finished, defaults to `load`. Could be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
@@ -580,7 +580,7 @@ Navigate to the previous page in history.
 
 #### page.goForward(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
-  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds.
+  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Could be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
@@ -705,7 +705,7 @@ Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#ke
 
 #### page.reload(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
-  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds.
+  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Could be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
@@ -900,7 +900,7 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
 
 #### page.waitForNavigation(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
-  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds.
+  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Could be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -40,11 +40,12 @@ class NavigatorWatcher {
 
     this._eventListeners = [];
 
-    const watchdog = new Promise(fulfill => {
-      this._maximumTimer = this._timeout === 0 ? this._timeout : setTimeout(fulfill, this._timeout);
-      return this._maximumTimer;
-    }).then(() => 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded');
-    const navigationPromises = [watchdog];
+    const navigationPromises = [];
+    if (this._timeout) {
+      const watchdog = new Promise(fulfill => this._maximumTimer = setTimeout(fulfill, this._timeout))
+          .then(() => 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded');
+      navigationPromises.push(watchdog);
+    }
 
     if (!this._ignoreHTTPSErrors) {
       const certificateError = new Promise(fulfill => {

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -40,8 +40,10 @@ class NavigatorWatcher {
 
     this._eventListeners = [];
 
-    const watchdog = new Promise(fulfill => this._maximumTimer = setTimeout(fulfill, this._timeout))
-        .then(() => 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded');
+    const watchdog = new Promise(fulfill => {
+      this._maximumTimer = this._timeout === 0 ? this._timeout : setTimeout(fulfill, this._timeout);
+      return this._maximumTimer;
+    }).then(() => 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded');
     const navigationPromises = [watchdog];
 
     if (!this._ignoreHTTPSErrors) {

--- a/test/test.js
+++ b/test/test.js
@@ -620,9 +620,8 @@ describe('Page', function() {
       process.removeListener('unhandledRejection', unhandledRejectionHandler);
     }));
     it('should disable timeout when its set to 0', SX(async function() {
-      server.setRoute('/empty.html', (req, res) => {});
       let error = null;
-      await page.goto(PREFIX + '/empty.html', {timeout: 0}).catch(e => error = e);
+      await page.goto(PREFIX + '/grid.html', {timeout: 0}).catch(e => error = e);
       expect(error).toBe(null);
     }));
     it('should work when navigating to valid url', SX(async function() {

--- a/test/test.js
+++ b/test/test.js
@@ -619,15 +619,13 @@ describe('Page', function() {
       expect(error.message).toContain('Navigation Timeout Exceeded: 1ms');
       process.removeListener('unhandledRejection', unhandledRejectionHandler);
     }));
-    it('should work when option.timeout set to 0', SX(async function() {
+    it('should disable timeout when its set to 0', SX(async function() {
       server.setRoute('/empty.html', (req, res) => {});
-      let error = null, isPageLoaded = false;
-      page.on('load', e => isPageLoaded = true);
+      let error = null;
       page.goto(PREFIX + '/empty.html', {timeout: 0}).catch(e => error = e);
-      const sleep = e => new Promise(ff => setTimeout(ff, e));
-      await sleep(9000);
+      // const sleep = e => new Promise(ff => setTimeout(ff, e));
+      // await sleep(90000);
       expect(error).toBe(null);
-      expect(isPageLoaded).toBe(false);
     }));// 100000
     it('should work when navigating to valid url', SX(async function() {
       const response = await page.goto(EMPTY_PAGE);

--- a/test/test.js
+++ b/test/test.js
@@ -619,6 +619,16 @@ describe('Page', function() {
       expect(error.message).toContain('Navigation Timeout Exceeded: 1ms');
       process.removeListener('unhandledRejection', unhandledRejectionHandler);
     }));
+    it('should work when option.timeout set to 0', SX(async function() {
+      server.setRoute('/empty.html', (req, res) => {});
+      let error = null, isPageLoaded = false;
+      page.on('load', e => isPageLoaded = true);
+      page.goto(PREFIX + '/empty.html', {timeout: 0}).catch(e => error = e);
+      const sleep = e => new Promise(ff => setTimeout(ff, e));
+      await sleep(9000);
+      expect(error).toBe(null);
+      expect(isPageLoaded).toBe(false);
+    }));// 100000
     it('should work when navigating to valid url', SX(async function() {
       const response = await page.goto(EMPTY_PAGE);
       expect(response.ok).toBe(true);

--- a/test/test.js
+++ b/test/test.js
@@ -622,11 +622,9 @@ describe('Page', function() {
     it('should disable timeout when its set to 0', SX(async function() {
       server.setRoute('/empty.html', (req, res) => {});
       let error = null;
-      page.goto(PREFIX + '/empty.html', {timeout: 0}).catch(e => error = e);
-      // const sleep = e => new Promise(ff => setTimeout(ff, e));
-      // await sleep(90000);
+      await page.goto(PREFIX + '/empty.html', {timeout: 0}).catch(e => error = e);
       expect(error).toBe(null);
-    }));// 100000
+    }));
     it('should work when navigating to valid url', SX(async function() {
       const response = await page.goto(EMPTY_PAGE);
       expect(response.ok).toBe(true);


### PR DESCRIPTION
Intended to close #782 , sorry if this one look really premature.

As the [first point](https://github.com/GoogleChrome/puppeteer/blob/master/CONTRIBUTING.md#writing-tests) 

> every feature should be accompanied by a test
are we count this one count as feature? if yes is this correct way to test it?

Clarification:
the puppeteer launch [options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions) is documented accept `0` to disable timeout. Is #782 only match `goto` options?


i already test with `fit` with 100 sec, and it pass.

on my windows machine test 1 spec always fail and that is:
> Page Network Events Page.Events.Response should not report body unless request is finished

so i just rely on travis

documentation: 
should i also change `page.goBack(options)` , `page.goForward(options)`  ? let me know if i miss some
