### PR TITLE
[WIP] Adding support for Experimental Page.setDownloadBehavior

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,7 @@
     + [page.select(selector, ...values)](#pageselectselector-values)
     + [page.setContent(html)](#pagesetcontenthtml)
     + [page.setCookie(...cookies)](#pagesetcookiecookies)
+    + [page.setDownloadBehavior(behavior, downloadPath)](#pagesetdownloadbehaviorbehavior-downloadpath)
     + [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
     + [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
     + [page.setRequestInterceptionEnabled(value)](#pagesetrequestinterceptionenabledvalue)
@@ -757,6 +758,11 @@ page.select('select#colors', 'red', 'green', 'blue'); // multiple selections
   - `httpOnly` <[boolean]>
   - `secure` <[boolean]>
   - `sameSite` <[string]> `"Strict"` or `"Lax"`.
+- returns: <[Promise]>
+
+#### page.setDownloadBehavior(behavior, downloadPath)
+- `behavior` <[string]> A string Whether to allow all or deny all download requests, or use default Chrome behavior if available (otherwise deny). Allowed values: deny, allow, default..
+- `downloadPath` <[string]> The default path to save downloaded files to. This is required if behavior is set to 'allow'.
 - returns: <[Promise]>
 
 #### page.setExtraHTTPHeaders(headers)

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -140,6 +140,13 @@ class Page extends EventEmitter {
   /**
    * @param {boolean} value
    */
+  async setDownloadBehavior(behavior, downloadPath) {
+    return this._client.send('Page.setDownloadBehavior', { behavior, downloadPath});
+  }
+
+  /**
+   * @param {boolean} value
+   */
   async setRequestInterceptionEnabled(value) {
     return this._networkManager.setRequestInterceptionEnabled(value);
   }

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -141,7 +141,7 @@ class Page extends EventEmitter {
    * @param {boolean} value
    */
   async setDownloadBehavior(behavior, downloadPath) {
-    return this._client.send('Page.setDownloadBehavior', { behavior, downloadPath});
+    await this._client.send('Page.setDownloadBehavior', { behavior, downloadPath});
   }
 
   /**


### PR DESCRIPTION
 - Work done on top https://github.com/GoogleChrome/puppeteer/pull/878
 - Fixes #299 
 - [ ] Needs test

I don't think the params are great right now, since it's just a plan passthrough of `(behavior, downloadPath)`.

Opening it up for feedback, I need this feature asap (which is why I'm using this hack). But I rather get feedback and put in a proper fix.

I'll spend sometime looking at the rest of puppeteer and see how other similar features are set up.