### PR TITLE
[feat] Allow environment variables definition when launching chromium

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -190,6 +190,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
   - `timeout` <[number]> Maximum time in milliseconds to wait for the Chrome instance to start. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
   - `dumpio` <[boolean]> Whether to pipe browser process stdout and stderr into `process.stdout` and `process.stderr`. Defaults to `false`.
   - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md).
+  - `env` <[Object]> Specify environment variables that will be visible to Chromium. Defaults to `process.env`.
 - returns: <[Promise]<[Browser]>> Promise which resolves to browser instance.
 
 The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed.

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -82,7 +82,14 @@ class Launcher {
     if (Array.isArray(options.args))
       chromeArguments.push(...options.args);
 
-    const chromeProcess = childProcess.spawn(chromeExecutable, chromeArguments, {detached: true});
+    const chromeProcess = childProcess.spawn(
+        chromeExecutable,
+        chromeArguments,
+        {
+          detached: true,
+          env: options.env || process.env
+        }
+    );
     if (options.dumpio) {
       chromeProcess.stdout.pipe(process.stdout);
       chromeProcess.stderr.pipe(process.stderr);


### PR DESCRIPTION
I'd like to launch Chromium with a specific timezone for my tests.  On Linux and macOS, I just need to define the `TZ` environment variable to the wanted timezone. So I added a new `puppeteer.launch()` option to allow defining the environment variables of the forked process.

I read the contributing rules, but I failed to write a good unit test for Windows, because Chromium seems to [ignore the TZ environment variable](https://bugs.chromium.org/p/chromium/issues/detail?id=125614) on this platform. If anyone have an idea for a more cross-platform unit test, I'd be happy to amend my PR. For now, the test is simply disabled on Windows.

FWIW, a similar issue is open at the [chrome-launcher project](https://github.com/GoogleChrome/chrome-launcher/issues/29).