### PR TITLE
add page navigation load handlers to setContent

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -355,12 +355,13 @@ class Page extends EventEmitter {
   /**
    * @param {string} html
    */
-  async setContent(html) {
+  async setContent(html, options) {
     await this.evaluate(html => {
       document.open();
       document.write(html);
       document.close();
     }, html);
+    if (options) await this.waitForNavigation(options);
   }
 
   /**


### PR DESCRIPTION
this should allow doing stuff like `setContent('...', { waitUntil: 'networkidle' })`

closes #728 