### PR TITLE
Get all cookies method

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -195,6 +195,13 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @return {!Promise<!Array<Network.Cookie>>}
+   */
+  async allCookies() {
+    return (await this._client.send('Network.getAllCookies', {})).cookies;
+  }
+
+  /**
    * @param {Array<Network.CookieParam>} cookies
    */
   async deleteCookie(...cookies) {


### PR DESCRIPTION
Page does not have `getAllCookies` method. Just added it.