### PR TITLE
chore(doclint): add basic tests for documentation parsers

### DIFF
--- a/utils/doclint/check_public_api/test/09-js-builder/foo.js
+++ b/utils/doclint/check_public_api/test/09-js-builder/foo.js
@@ -1,0 +1,17 @@
+class A {
+  constructor(delegate) {
+    this.property1 = 1;
+    this._property2 = 2;
+  }
+
+  get getter() {
+    return null;
+  }
+
+  async method(foo, bar) {
+  }
+}
+
+A.Events = {
+  AnEvent: 'anevent'
+};

--- a/utils/doclint/check_public_api/test/09-js-builder/result.txt
+++ b/utils/doclint/check_public_api/test/09-js-builder/result.txt
@@ -1,0 +1,56 @@
+{
+  "classes": [
+    {
+      "name": "A",
+      "members": [
+        {
+          "name": "property1",
+          "type": "property",
+          "hasReturn": false,
+          "async": false,
+          "args": []
+        },
+        {
+          "name": "_property2",
+          "type": "property",
+          "hasReturn": false,
+          "async": false,
+          "args": []
+        },
+        {
+          "name": "constructor",
+          "type": "method",
+          "hasReturn": false,
+          "async": false,
+          "args": [
+            "delegate"
+          ]
+        },
+        {
+          "name": "getter",
+          "type": "property",
+          "hasReturn": false,
+          "async": false,
+          "args": []
+        },
+        {
+          "name": "method",
+          "type": "method",
+          "hasReturn": true,
+          "async": true,
+          "args": [
+            "foo",
+            "bar"
+          ]
+        },
+        {
+          "name": "anevent",
+          "type": "event",
+          "hasReturn": false,
+          "async": false,
+          "args": []
+        }
+      ]
+    }
+  ]
+}

--- a/utils/doclint/check_public_api/test/10-md-builder/doc.md
+++ b/utils/doclint/check_public_api/test/10-md-builder/doc.md
@@ -1,0 +1,19 @@
+### class: Foo
+
+This is a class.
+
+#### event: 'frame'
+- <[Frame]> 
+
+This event is dispatched.
+
+#### foo.$(selector)
+- `selector` <[string]> A selector to query page for
+- returns: <[Promise]<[ElementHandle]>>
+
+The method runs document.querySelector.
+
+#### foo.url
+- <[string]>
+
+Contains the URL of the request.

--- a/utils/doclint/check_public_api/test/10-md-builder/result.txt
+++ b/utils/doclint/check_public_api/test/10-md-builder/result.txt
@@ -1,0 +1,32 @@
+{
+  "classes": [
+    {
+      "name": "Foo",
+      "members": [
+        {
+          "name": "frame",
+          "type": "event",
+          "hasReturn": false,
+          "async": false,
+          "args": []
+        },
+        {
+          "name": "$",
+          "type": "method",
+          "hasReturn": true,
+          "async": false,
+          "args": [
+            "selector"
+          ]
+        },
+        {
+          "name": "url",
+          "type": "property",
+          "hasReturn": false,
+          "async": false,
+          "args": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This patch adds basic tests to verify javascript and markdown
documentation parsers.