### PR TITLE
chore(doclint): exclude constructors by default

### DIFF
--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -35,22 +35,8 @@ const EXCLUDE_CLASSES = new Set([
 ]);
 
 const EXCLUDE_METHODS = new Set([
-  'Body.constructor',
-  'Browser.constructor',
-  'ConsoleMessage.constructor',
-  'Dialog.constructor',
-  'ElementHandle.constructor',
-  'Frame.constructor',
-  'Headers.constructor',
   'Headers.fromPayload',
-  'Keyboard.constructor',
-  'Mouse.constructor',
-  'Touchscreen.constructor',
-  'Tracing.constructor',
-  'Page.constructor',
   'Page.create',
-  'Request.constructor',
-  'Response.constructor',
 ]);
 
 /**
@@ -144,6 +130,9 @@ function filterJSDocumentation(jsDocumentation) {
       continue;
     const members = cls.membersArray.filter(member => {
       if (member.name.startsWith('_'))
+        return false;
+      // Exclude all constructors by default.
+      if (member.name === 'constructor' && member.type === 'method')
         return false;
       return !EXCLUDE_METHODS.has(`${cls.name}.${member.name}`);
     });


### PR DESCRIPTION
Our API does not expose any classes; thus all the constructors
should be excluded from the API.