### PR TITLE
feat(Page): Support Page.getMetrics and metrics event.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,7 @@
     + [event: 'framedetached'](#event-framedetached)
     + [event: 'framenavigated'](#event-framenavigated)
     + [event: 'load'](#event-load)
+    + [event: 'metrics'](#event-metrics)
     + [event: 'pageerror'](#event-pageerror)
     + [event: 'request'](#event-request)
     + [event: 'requestfailed'](#event-requestfailed)
@@ -47,6 +48,7 @@
     + [page.exposeFunction(name, puppeteerFunction)](#pageexposefunctionname-puppeteerfunction)
     + [page.focus(selector)](#pagefocusselector)
     + [page.frames()](#pageframes)
+    + [page.getMetrics()](#pagegetmetrics)
     + [page.goBack(options)](#pagegobackoptions)
     + [page.goForward(options)](#pagegoforwardoptions)
     + [page.goto(url, options)](#pagegotourl-options)
@@ -298,6 +300,15 @@ Emitted when a frame is navigated to a new url.
 #### event: 'load'
 
 Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
+
+#### event: 'metrics'
+- <[Object]>
+  - `title` <[string]> The title passed to `console.timeStamp`.
+  - `metrics` <[Array]<[Object]>> The metrics array.
+    - `name` <[string]> Name of the metric.
+    - `value` <[number]> Value of the metric.
+
+Emitted when the JavaScript code makes a call to `console.timeStamp`.
 
 #### event: 'pageerror'
 - <[string]> The exception message
@@ -570,6 +581,11 @@ If there's no element matching `selector`, the method throws an error.
 
 #### page.frames()
 - returns: <[Array]<[Frame]>> An array of all frames attached to the page.
+
+#### page.getMetrics()
+- returns: <[Array]<[Object]>> An array of page metrics.
+  - `name` <[string]> Name of the metric.
+  - `value` <[number]> Value of the metric.
 
 #### page.goBack(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -601,6 +601,8 @@ If there's no element matching `selector`, the method throws an error.
   - `DomContentLoaded` <[number]> Timestamp of the DOM content loaded event.
   - `NavigationStart` <[number]> Timestamp of the navigation start event.
 
+> **NOTE** All timestamps are in monotonic time: monotonically increasing time in seconds since an arbitrary point in the past.
+
 #### page.goBack(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
   - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.

--- a/docs/api.md
+++ b/docs/api.md
@@ -308,7 +308,8 @@ Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/We
     - `name` <[string]> Name of the metric.
     - `value` <[number]> Value of the metric.
 
-Emitted when the JavaScript code makes a call to `console.timeStamp`.
+Emitted when the JavaScript code makes a call to `console.timeStamp`. For the list
+of metrics see `page.getMetrics`.
 
 #### event: 'pageerror'
 - <[string]> The exception message
@@ -586,6 +587,24 @@ If there's no element matching `selector`, the method throws an error.
 - returns: <[Array]<[Object]>> An array of page metrics.
   - `name` <[string]> Name of the metric.
   - `value` <[number]> Value of the metric.
+
+The list includes the following metrics:
+  - `Timestamp` - The timestamp when the metrics sample was taken.
+  - `DocumentCount` - Number of documents in the page.
+  - `FrameCount` - Number of frames in the page.
+  - `JSEventListenerCount` - Number of events in the page.
+  - `NodeCount` - Number of DOM nodes in the page.
+  - `LayoutCount` - Total number of full or partial page layout.
+  - `RecalcStyleCount` - Total number of page style recalculations.
+  - `LayoutDuration` - Combined durations of all page layouts.
+  - `RecalcStyleDuration` - Combined duration of all page style recalculations.
+  - `ScriptDuration` - Combined duration of JavaScript execution.
+  - `TaskDuration` - Combined duration of all tasks performed by the browser.
+  - `JSHeapUsedSize` - Used JavaScript heap size.
+  - `JSHeapTotalSize` - Total JavaScript heap size.
+  - `FirstMeaningfulPaint` - Timestamp of the first meaningful paint event.
+  - `DomContentLoaded` - Timestamp of the DOM content loaded event.
+  - `NavigationStart` - Timestamp of the navigation start event.
 
 #### page.goBack(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -304,9 +304,8 @@ Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/We
 #### event: 'metrics'
 - <[Object]>
   - `title` <[string]> The title passed to `console.timeStamp`.
-  - `metrics` <[Array]<[Object]>> The metrics array.
-    - `name` <[string]> Name of the metric.
-    - `value` <[number]> Value of the metric.
+  - `metrics` <[Object]> Object containing metrics as key/value pairs. The values
+    of metrics are of <[number]> type.
 
 Emitted when the JavaScript code makes a call to `console.timeStamp`. For the list
 of metrics see `page.getMetrics`.
@@ -584,27 +583,23 @@ If there's no element matching `selector`, the method throws an error.
 - returns: <[Array]<[Frame]>> An array of all frames attached to the page.
 
 #### page.getMetrics()
-- returns: <[Array]<[Object]>> An array of page metrics.
-  - `name` <[string]> Name of the metric.
-  - `value` <[number]> Value of the metric.
-
-The list includes the following metrics:
-  - `Timestamp` - The timestamp when the metrics sample was taken.
-  - `DocumentCount` - Number of documents in the page.
-  - `FrameCount` - Number of frames in the page.
-  - `JSEventListenerCount` - Number of events in the page.
-  - `NodeCount` - Number of DOM nodes in the page.
-  - `LayoutCount` - Total number of full or partial page layout.
-  - `RecalcStyleCount` - Total number of page style recalculations.
-  - `LayoutDuration` - Combined durations of all page layouts.
-  - `RecalcStyleDuration` - Combined duration of all page style recalculations.
-  - `ScriptDuration` - Combined duration of JavaScript execution.
-  - `TaskDuration` - Combined duration of all tasks performed by the browser.
-  - `JSHeapUsedSize` - Used JavaScript heap size.
-  - `JSHeapTotalSize` - Total JavaScript heap size.
-  - `FirstMeaningfulPaint` - Timestamp of the first meaningful paint event.
-  - `DomContentLoaded` - Timestamp of the DOM content loaded event.
-  - `NavigationStart` - Timestamp of the navigation start event.
+- returns: <[Object]> Object containing metrics as key/value pairs.
+  - `Timestamp` <[number]> The timestamp when the metrics sample was taken.
+  - `DocumentCount` <[number]> Number of documents in the page.
+  - `FrameCount` <[number]> Number of frames in the page.
+  - `JSEventListenerCount` <[number]> Number of events in the page.
+  - `NodeCount` <[number]> Number of DOM nodes in the page.
+  - `LayoutCount` <[number]> Total number of full or partial page layout.
+  - `RecalcStyleCount` <[number]> Total number of page style recalculations.
+  - `LayoutDuration` <[number]> Combined durations of all page layouts.
+  - `RecalcStyleDuration` <[number]> Combined duration of all page style recalculations.
+  - `ScriptDuration` <[number]> Combined duration of JavaScript execution.
+  - `TaskDuration` <[number]> Combined duration of all tasks performed by the browser.
+  - `JSHeapUsedSize` <[number]> Used JavaScript heap size.
+  - `JSHeapTotalSize` <[number]> Total JavaScript heap size.
+  - `FirstMeaningfulPaint` <[number]> Timestamp of the first meaningful paint event.
+  - `DomContentLoaded` <[number]> Timestamp of the DOM content loaded event.
+  - `NavigationStart` <[number]> Timestamp of the navigation start event.
 
 #### page.goBack(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -315,8 +315,10 @@ class Page extends EventEmitter {
    */
   _buildMetricsObject(metrics) {
     const result = {};
-    for (const metric of metrics || [])
-      result[metric.name] = metric.value;
+    for (const metric of metrics || []) {
+      if (Page._supportedMetrics.has(metric.name))
+        result[metric.name] = metric.value;
+    }
     return result;
   }
 
@@ -809,6 +811,26 @@ class Page extends EventEmitter {
     return this.mainFrame().waitForFunction(pageFunction, options, ...args);
   }
 }
+
+/** @type {!Set<string>} */
+Page._supportedMetrics = new Set([
+  'Timestamp',
+  'DocumentCount',
+  'FrameCount',
+  'JSEventListenerCount',
+  'NodeCount',
+  'LayoutCount',
+  'RecalcStyleCount',
+  'LayoutDuration',
+  'RecalcStyleDuration',
+  'ScriptDuration',
+  'TaskDuration',
+  'JSHeapUsedSize',
+  'JSHeapTotalSize',
+  'FirstMeaningfulPaint',
+  'DomContentLoaded',
+  'NavigationStart',
+]);
 
 /** @enum {string} */
 Page.PaperFormats = {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -89,7 +89,7 @@ class Page extends EventEmitter {
     client.on('Runtime.exceptionThrown', exception => this._handleException(exception.exceptionDetails));
     client.on('Security.certificateError', event => this._onCertificateError(event));
     client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
-    client.on('Performance.metrics', event => this.emit(Page.Events.Metrics, event));
+    client.on('Performance.metrics', event => this._emitMetrics(event));
   }
 
   _onTargetCrashed() {
@@ -292,10 +292,32 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @return {!Promise<!Array<!{name: string, value: number}>>}
+   * @return {!Promise<!Object>}
    */
   async getMetrics() {
-    return (await this._client.send('Performance.getMetrics')).metrics || [];
+    const response = await this._client.send('Performance.getMetrics');
+    return this._buildMetricsObject(response.metrics);
+  }
+
+  /**
+   * @param {*} event
+   */
+  _emitMetrics(event) {
+    this.emit(Page.Events.Metrics, {
+      title: event.title,
+      metrics: this._buildMetricsObject(event.metrics)
+    });
+  }
+
+  /**
+   * @param {?Array<!{name: string, value: number}>} metrics
+   * @return {!Object}
+   */
+  _buildMetricsObject(metrics) {
+    const result = {};
+    for (const metric of metrics || [])
+      result[metric.name] = metric.value;
+    return result;
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -316,7 +316,7 @@ class Page extends EventEmitter {
   _buildMetricsObject(metrics) {
     const result = {};
     for (const metric of metrics || []) {
-      if (Page._supportedMetrics.has(metric.name))
+      if (supportedMetrics.has(metric.name))
         result[metric.name] = metric.value;
     }
     return result;
@@ -813,7 +813,7 @@ class Page extends EventEmitter {
 }
 
 /** @type {!Set<string>} */
-Page._supportedMetrics = new Set([
+const supportedMetrics = new Set([
   'Timestamp',
   'DocumentCount',
   'FrameCount',

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -41,6 +41,7 @@ class Page extends EventEmitter {
       client.send('Page.enable', {}),
       client.send('Runtime.enable', {}),
       client.send('Security.enable', {}),
+      client.send('Performance.enable', {})
     ]);
     if (ignoreHTTPSErrors)
       await client.send('Security.setOverrideCertificateErrors', {override: true});
@@ -88,6 +89,7 @@ class Page extends EventEmitter {
     client.on('Runtime.exceptionThrown', exception => this._handleException(exception.exceptionDetails));
     client.on('Security.certificateError', event => this._onCertificateError(event));
     client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
+    client.on('Performance.metrics', event => this.emit(Page.Events.Metrics, event));
   }
 
   _onTargetCrashed() {
@@ -287,6 +289,13 @@ class Page extends EventEmitter {
    */
   async setUserAgent(userAgent) {
     return this._networkManager.setUserAgent(userAgent);
+  }
+
+  /**
+   * @return {!Promise<!Array<!{name: string, value: number}>>}
+   */
+  async getMetrics() {
+    return (await this._client.send('Performance.getMetrics')).metrics || [];
   }
 
   /**
@@ -847,6 +856,7 @@ Page.Events = {
   FrameDetached: 'framedetached',
   FrameNavigated: 'framenavigated',
   Load: 'load',
+  Metrics: 'metrics',
 };
 
 /** @typedef {{width: number, height: number, deviceScaleFactor: number|undefined, isMobile: boolean|undefined, isLandscape: boolean, hasTouch: boolean|undefined}} */

--- a/test/test.js
+++ b/test/test.js
@@ -601,22 +601,30 @@ describe('Page', function() {
       checkMetrics(metrics.metrics);
     }));
     function checkMetrics(metrics) {
-      expect(metrics['Timestamp']).toBeGreaterThan(0);
-      expect(metrics['DocumentCount']).toBeGreaterThan(0);
-      expect(metrics['FrameCount']).toBeGreaterThan(0);
-      expect(metrics['JSEventListenerCount']).toBeGreaterThanOrEqual(0);
-      expect(metrics['NodeCount']).toBeGreaterThan(0);
-      expect(metrics['LayoutCount']).toBeGreaterThan(0);
-      expect(metrics['RecalcStyleCount']).toBeGreaterThan(0);
-      expect(metrics['LayoutDuration']).toBeGreaterThan(0);
-      expect(metrics['RecalcStyleDuration']).toBeGreaterThan(0);
-      expect(metrics['ScriptDuration']).toBeGreaterThanOrEqual(0);
-      expect(metrics['TaskDuration']).toBeGreaterThan(0);
-      expect(metrics['JSHeapUsedSize']).toBeGreaterThan(0);
-      expect(metrics['JSHeapTotalSize']).toBeGreaterThan(0);
-      expect(metrics['FirstMeaningfulPaint']).toBeGreaterThanOrEqual(0);
-      expect(metrics['DomContentLoaded']).toBeGreaterThan(0);
-      expect(metrics['NavigationStart']).toBeGreaterThan(0);
+      const metricsToCheck = new Set([
+        'Timestamp',
+        'DocumentCount',
+        'FrameCount',
+        'JSEventListenerCount',
+        'NodeCount',
+        'LayoutCount',
+        'RecalcStyleCount',
+        'LayoutDuration',
+        'RecalcStyleDuration',
+        'ScriptDuration',
+        'TaskDuration',
+        'JSHeapUsedSize',
+        'JSHeapTotalSize',
+        'FirstMeaningfulPaint',
+        'DomContentLoaded',
+        'NavigationStart',
+      ]);
+      for (const name in metrics) {
+        expect(metricsToCheck.has(name)).toBeTruthy();
+        expect(metrics[name]).toBeGreaterThanOrEqual(0);
+        metricsToCheck.delete(name);
+      }
+      expect(metricsToCheck.size).toBe(0);
     }
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -601,24 +601,22 @@ describe('Page', function() {
       checkMetrics(metrics.metrics);
     }));
     function checkMetrics(metrics) {
-      const metric = name => metrics.find(m => m.name === name).value;
-      expect(metrics.length).toBeGreaterThan(0);
-      expect(metric('Timestamp')).toBeGreaterThan(0);
-      expect(metric('DocumentCount')).toBeGreaterThan(0);
-      expect(metric('FrameCount')).toBeGreaterThan(0);
-      expect(metric('JSEventListenerCount')).toBeGreaterThanOrEqual(0);
-      expect(metric('NodeCount')).toBeGreaterThan(0);
-      expect(metric('LayoutCount')).toBeGreaterThan(0);
-      expect(metric('RecalcStyleCount')).toBeGreaterThan(0);
-      expect(metric('LayoutDuration')).toBeGreaterThan(0);
-      expect(metric('RecalcStyleDuration')).toBeGreaterThan(0);
-      expect(metric('ScriptDuration')).toBeGreaterThanOrEqual(0);
-      expect(metric('TaskDuration')).toBeGreaterThan(0);
-      expect(metric('JSHeapUsedSize')).toBeGreaterThan(0);
-      expect(metric('JSHeapTotalSize')).toBeGreaterThan(0);
-      expect(metric('FirstMeaningfulPaint')).toBeGreaterThanOrEqual(0);
-      expect(metric('DomContentLoaded')).toBeGreaterThan(0);
-      expect(metric('NavigationStart')).toBeGreaterThan(0);
+      expect(metrics['Timestamp']).toBeGreaterThan(0);
+      expect(metrics['DocumentCount']).toBeGreaterThan(0);
+      expect(metrics['FrameCount']).toBeGreaterThan(0);
+      expect(metrics['JSEventListenerCount']).toBeGreaterThanOrEqual(0);
+      expect(metrics['NodeCount']).toBeGreaterThan(0);
+      expect(metrics['LayoutCount']).toBeGreaterThan(0);
+      expect(metrics['RecalcStyleCount']).toBeGreaterThan(0);
+      expect(metrics['LayoutDuration']).toBeGreaterThan(0);
+      expect(metrics['RecalcStyleDuration']).toBeGreaterThan(0);
+      expect(metrics['ScriptDuration']).toBeGreaterThanOrEqual(0);
+      expect(metrics['TaskDuration']).toBeGreaterThan(0);
+      expect(metrics['JSHeapUsedSize']).toBeGreaterThan(0);
+      expect(metrics['JSHeapTotalSize']).toBeGreaterThan(0);
+      expect(metrics['FirstMeaningfulPaint']).toBeGreaterThanOrEqual(0);
+      expect(metrics['DomContentLoaded']).toBeGreaterThan(0);
+      expect(metrics['NavigationStart']).toBeGreaterThan(0);
     }
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -587,6 +587,27 @@ describe('Page', function() {
     }));
   });
 
+  describe('Page.getMetrics', function() {
+    it('should get metrics from a page', SX(async function() {
+      await page.goto('about:blank');
+      const metrics = await page.getMetrics();
+      checkMetrics(metrics);
+    }));
+    it('metrics event fired on console.timeStamp', SX(async function() {
+      const metricsPromise = new Promise(fulfill => page.once('metrics', fulfill));
+      await page.evaluate(() => console.timeStamp('test42'));
+      const metrics = await metricsPromise;
+      expect(metrics.title).toBe('test42');
+      checkMetrics(metrics.metrics);
+    }));
+    function checkMetrics(metrics) {
+      expect(metrics.length).toBeGreaterThan(0);
+      expect(metrics.find(m => m.name === 'Timestamp').value).toBeGreaterThan(0);
+      expect(metrics.find(m => m.name === 'DocumentCount').value).toBeGreaterThan(0);
+      expect(metrics.find(m => m.name === 'DomContentLoaded').value).toBeGreaterThan(0);
+    }
+  });
+
   describe('Page.goto', function() {
     it('should navigate to about:blank', SX(async function() {
       const response = await page.goto('about:blank');

--- a/test/test.js
+++ b/test/test.js
@@ -601,10 +601,24 @@ describe('Page', function() {
       checkMetrics(metrics.metrics);
     }));
     function checkMetrics(metrics) {
+      const metric = name => metrics.find(m => m.name === name).value;
       expect(metrics.length).toBeGreaterThan(0);
-      expect(metrics.find(m => m.name === 'Timestamp').value).toBeGreaterThan(0);
-      expect(metrics.find(m => m.name === 'DocumentCount').value).toBeGreaterThan(0);
-      expect(metrics.find(m => m.name === 'DomContentLoaded').value).toBeGreaterThan(0);
+      expect(metric('Timestamp')).toBeGreaterThan(0);
+      expect(metric('DocumentCount')).toBeGreaterThan(0);
+      expect(metric('FrameCount')).toBeGreaterThan(0);
+      expect(metric('JSEventListenerCount')).toBeGreaterThanOrEqual(0);
+      expect(metric('NodeCount')).toBeGreaterThan(0);
+      expect(metric('LayoutCount')).toBeGreaterThan(0);
+      expect(metric('RecalcStyleCount')).toBeGreaterThan(0);
+      expect(metric('LayoutDuration')).toBeGreaterThan(0);
+      expect(metric('RecalcStyleDuration')).toBeGreaterThan(0);
+      expect(metric('ScriptDuration')).toBeGreaterThanOrEqual(0);
+      expect(metric('TaskDuration')).toBeGreaterThan(0);
+      expect(metric('JSHeapUsedSize')).toBeGreaterThan(0);
+      expect(metric('JSHeapTotalSize')).toBeGreaterThan(0);
+      expect(metric('FirstMeaningfulPaint')).toBeGreaterThanOrEqual(0);
+      expect(metric('DomContentLoaded')).toBeGreaterThan(0);
+      expect(metric('NavigationStart')).toBeGreaterThan(0);
     }
   });
 


### PR DESCRIPTION
Provides access to the current page performance metrics.
Allows to push page metrics from the page JavaScript with `console.timeStamp()`

Fixes https://github.com/GoogleChrome/puppeteer/issues/309