### PR TITLE
chore(doclint): fix doclint tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install:
   - yarn install
   # puppeteer's install script downloads Chrome
 script:
-  - 'if [ "$NODE7" = "true" ]; then yarn run test-doclint; fi'
   - 'if [ "$NODE7" = "true" ]; then yarn run lint; fi'
   - 'if [ "$NODE7" = "true" ]; then yarn run coverage; fi'
+  - 'if [ "$NODE7" = "true" ]; then yarn run test-doclint; fi'
   - 'if [ "$NODE6" = "true" ]; then yarn run test-node6-transformer; fi'
   - 'if [ "$NODE6" = "true" ]; then yarn run build; fi'
   - 'if [ "$NODE6" = "true" ]; then yarn run unit-node6; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - yarn install
   # puppeteer's install script downloads Chrome
 script:
+  - 'if [ "$NODE7" = "true" ]; then yarn run test-doclint; fi'
   - 'if [ "$NODE7" = "true" ]; then yarn run lint; fi'
   - 'if [ "$NODE7" = "true" ]; then yarn run coverage; fi'
   - 'if [ "$NODE6" = "true" ]; then yarn run test-node6-transformer; fi'

--- a/utils/doclint/check_public_api/test/check-sorting/doc.md
+++ b/utils/doclint/check_public_api/test/check-sorting/doc.md
@@ -10,8 +10,6 @@
 
 #### foo.ddd
 
-#### new Foo()
-
 #### foo.ccc()
 
 #### foo.bbb()

--- a/utils/doclint/check_public_api/test/check-sorting/result.txt
+++ b/utils/doclint/check_public_api/test/check-sorting/result.txt
@@ -1,5 +1,4 @@
 [MarkDown] Events should go first. Event 'b' in class Foo breaks order
-[MarkDown] Constructor of Foo should go before other methods
 [MarkDown] Event 'c' in class Foo breaks alphabetic ordering of events
-[MarkDown] Bad alphabetic ordering of Foo members: Foo.ddd should go after Foo.constructor()
+[MarkDown] Bad alphabetic ordering of Foo members: Foo.ddd should go after Foo.ccc()
 [MarkDown] Bad alphabetic ordering of Foo members: Foo.ccc() should go after Foo.bbb()

--- a/utils/doclint/check_public_api/test/diff-arguments/doc.md
+++ b/utils/doclint/check_public_api/test/diff-arguments/doc.md
@@ -1,10 +1,10 @@
 ### class: Foo
-#### new Foo(arg1, arg2)
-- `arg1` <[string]>
-- `arg2` <[string]>
-
 #### foo.bar(options)
 - `options` <[Object]>
+
+#### foo.foo(arg1, arg2)
+- `arg1` <[string]>
+- `arg2` <[string]>
 
 #### foo.test(...files)
 - `...filePaths` <[string]>

--- a/utils/doclint/check_public_api/test/diff-arguments/foo.js
+++ b/utils/doclint/check_public_api/test/diff-arguments/foo.js
@@ -1,5 +1,5 @@
 class Foo {
-  constructor(arg1, arg3 = {}) {
+  foo(arg1, arg3 = {}) {
   }
 
   test(...filePaths) {

--- a/utils/doclint/check_public_api/test/diff-arguments/result.txt
+++ b/utils/doclint/check_public_api/test/diff-arguments/result.txt
@@ -1,4 +1,4 @@
 [MarkDown] Heading arguments for "foo.test(...files)" do not match described ones, i.e. "...files" != "...filePaths"
-[MarkDown] Method Foo.constructor() fails to describe its parameters:
+[MarkDown] Method Foo.foo() fails to describe its parameters:
 - Argument not found: arg3
 - Non-existing argument found: arg2

--- a/utils/doclint/check_public_api/test/diff-properties/result.txt
+++ b/utils/doclint/check_public_api/test/diff-properties/result.txt
@@ -1,3 +1,2 @@
-[MarkDown] Method not found: Foo.constructor()
 [MarkDown] Non-existing property found: Foo.c
 [MarkDown] Property not found: Foo.b


### PR DESCRIPTION
Last commit 017429eef1f1fbb83bb2df4817845a233314ee88 broke doclint
tests. Try bots didn't catch this because they were not running doclint
tests.

This patch:
- fixes doclint tests
- starts running doclint tests on travis