### PR TITLE
Node6: Remove parentheses around the body of async arrow functions

### DIFF
--- a/utils/node6-transform/TransformAsyncFunctions.js
+++ b/utils/node6-transform/TransformAsyncFunctions.js
@@ -88,7 +88,19 @@ function transformAsyncFunctions(text) {
     if (node.body.type !== 'BlockStatement') {
       before += `{ return `;
       after = `; }` + after;
+
+      // Remove parentheses that might wrap an arrow function
+      const beforeBody = text.substring(node.range[0], node.body.range[0]);
+      if (/\(\s*$/.test(beforeBody)) {
+        const afterBody = text.substring(node.body.range[1], node.range[1]);
+        const openParen = node.range[0] + beforeBody.lastIndexOf('(');
+        insertText(openParen, openParen + 1, ' ');
+        const closeParen = node.body.range[1] + afterBody.indexOf(')');
+        insertText(closeParen, closeParen + 1, ' ');
+      }
     }
+
+
     insertText(node.body.range[0], node.body.range[0], before);
     insertText(node.body.range[1], node.body.range[1], after);
   }

--- a/utils/node6-transform/test/test.js
+++ b/utils/node6-transform/test/test.js
@@ -70,4 +70,10 @@ describe('TransformAsyncFunctions', function() {
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
+  it('should work paren around arrow function', function(done) {
+    const input = `(async x => ( 123))()`;
+    const output = eval(transformAsyncFunctions(input));
+    expect(output instanceof Promise).toBe(true);
+    output.then(result => expect(result).toBe(123)).then(done);
+  });
 });


### PR DESCRIPTION
Single line arrow functions can have parenthesis wrapping their body, but multi-line arrow functions cannot.