### PR TITLE
[fix]: handleSIGINT should trigger process.exit()

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -106,7 +106,7 @@ class Launcher {
 
     const listeners = [ helper.addEventListener(process, 'exit', killChrome) ];
     if (options.handleSIGINT !== false)
-      listeners.push(helper.addEventListener(process, 'SIGINT', killChrome));
+      listeners.push(helper.addEventListener(process, 'SIGINT', process.exit));
 
     try {
       const connectionDelay = options.slowMo || 0;


### PR DESCRIPTION
If launch option `handleSIGINT` not `false`, `Ctrl+C` should close process.