### PR TITLE
use deprecated initEvent on change and input events

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -722,14 +722,8 @@ class Page extends EventEmitter {
       } else {
         element.value = values.shift();
       }
-      // init events are deprecated but still have an effect
-      const inputEvent = new Event('input');
-      inputEvent.initEvent('input', true, true);
-      element.dispatchEvent(inputEvent);
-
-      const changeEvent = new Event('change');
-      changeEvent.initEvent('change', true, true);
-      element.dispatchEvent(changeEvent);
+      element.dispatchEvent(new Event('input', {'bubbles': true, 'cancelable': true}));
+      element.dispatchEvent(new Event('change', {'bubbles': true, 'cancelable': true}));
     }, values);
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -722,8 +722,8 @@ class Page extends EventEmitter {
       } else {
         element.value = values.shift();
       }
-      element.dispatchEvent(new Event('input', {'bubbles': true, 'cancelable': true}));
-      element.dispatchEvent(new Event('change', {'bubbles': true, 'cancelable': true}));
+      element.dispatchEvent(new Event('input', { 'bubbles': true }));
+      element.dispatchEvent(new Event('change', { 'bubbles': true }));
     }, values);
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -722,9 +722,14 @@ class Page extends EventEmitter {
       } else {
         element.value = values.shift();
       }
+      // init events are deprecated but still have an effect
+      const inputEvent = new Event('input');
+      inputEvent.initEvent('input', true, true);
+      element.dispatchEvent(inputEvent);
 
-      element.dispatchEvent(new Event('change'));
-      element.dispatchEvent(new Event('input'));
+      const changeEvent = new Event('change');
+      changeEvent.initEvent('change', true, true);
+      element.dispatchEvent(changeEvent);
     }, values);
   }
 

--- a/test/assets/input/select.html
+++ b/test/assets/input/select.html
@@ -25,6 +25,8 @@
       window.result = {
         onInput: null,
         onChange: null,
+        onBubblingChange: null,
+        onBubblingInput: null,
       };
 
       let select = document.querySelector('select');
@@ -47,6 +49,18 @@
 
       select.addEventListener('change', () => {
         result.onChange = Array.from(select.querySelectorAll('option:checked')).map((option) => {
+          return option.value;
+        });
+      }, false);
+
+      document.body.addEventListener('input', () => {
+        result.onBubblingInput = Array.from(select.querySelectorAll('option:checked')).map((option) => {
+          return option.value;
+        });
+      }, false);
+
+      document.body.addEventListener('change', () => {
+        result.onBubblingChange = Array.from(select.querySelectorAll('option:checked')).map((option) => {
           return option.value;
         });
       }, false);

--- a/test/test.js
+++ b/test/test.js
@@ -2076,6 +2076,13 @@ describe('Page', function() {
       expect(await page.evaluate(() => result.onChange)).toEqual(['blue', 'green', 'red']);
     }));
 
+    it('should respect event bubbling', SX(async function() {
+      await page.goto(PREFIX + '/input/select.html');
+      await page.select('select', 'blue');
+      expect(await page.evaluate(() => result.onBubblingInput)).toEqual(['blue']);
+      expect(await page.evaluate(() => result.onBubblingChange)).toEqual(['blue']);
+    }));
+
     it('should work with no options', SX(async function() {
       await page.goto(PREFIX + '/input/select.html');
       await page.evaluate(() => makeEmpty());


### PR DESCRIPTION
Without the deprecated initEvent method, my use case fails to recognize the 'change' or 'input' event for select elements.

Adding it doesn't cause the tests to fail and it causes my use case to pass. 

I swapped some nightmare scripts over to puppeteer, and on healthcare.gov it wouldn't register input or change on a select. The nightmare implementation uses the deprecated syntax, but I just added a call to initEvent on the new event syntax and that solved it. 

I tried coming up with a replica scenario to add to a test, but I couldn't replicate outside the scraping target's website. I'm guessing it's some manual checking done in older JS libraries that might be missing something. I'll revisit adding a new test. 

adding @alixaxel because he implemented the select function
