### PR TITLE
feat(page): waitForSelector hidden option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -928,8 +928,8 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
 #### page.waitForSelector(selector[, options])
 - `selector` <[string]> A [selector] of an element to wait for,
 - `options` <[Object]> Optional waiting parameters
-  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties or have an ancestor with those properties. Defaults to `false`.
-  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties or have an ancestor with those properties. Defaults to `false`.
+  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds).
 - returns: <[Promise]> Promise which resolves when element specified by selector string is added to DOM.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -929,6 +929,7 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
 - `selector` <[string]> A [selector] of an element to wait for,
 - `options` <[Object]> Optional waiting parameters
   - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `hidden` <[boolean]> wait for element to be present in DOM and to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds).
 - returns: <[Promise]> Promise which resolves when element specified by selector string is added to DOM.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -928,8 +928,9 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
 #### page.waitForSelector(selector[, options])
 - `selector` <[string]> A [selector] of an element to wait for,
 - `options` <[Object]> Optional waiting parameters
-  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
-  - `hidden` <[boolean]> wait for element to be present in DOM and to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties, or have an ancestor with those properties. Defaults to `false`.
+  - `reverse` <[boolean]> wait for element to not be found in DOM. Defaults to `false`.
+  - `hidden` <[boolean]> wait for element to be present in DOM and to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties, or have an ancestor with those properties. Defaults to `false`.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds).
 - returns: <[Promise]> Promise which resolves when element specified by selector string is added to DOM.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -928,9 +928,8 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
 #### page.waitForSelector(selector[, options])
 - `selector` <[string]> A [selector] of an element to wait for,
 - `options` <[Object]> Optional waiting parameters
-  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties, or have an ancestor with those properties. Defaults to `false`.
-  - `reverse` <[boolean]> wait for element to not be found in DOM. Defaults to `false`.
-  - `hidden` <[boolean]> wait for element to be present in DOM and to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties, or have an ancestor with those properties. Defaults to `false`.
+  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties or have an ancestor with those properties. Defaults to `false`.
+  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties or have an ancestor with those properties. Defaults to `false`.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds).
 - returns: <[Promise]> Promise which resolves when element specified by selector string is added to DOM.
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -401,22 +401,26 @@ class Frame {
   waitForSelector(selector, options = {}) {
     const timeout = options.timeout || 30000;
     const waitForVisible = !!options.visible;
-    const polling = waitForVisible ? 'raf' : 'mutation';
-    return this.waitForFunction(predicate, {timeout, polling}, selector, waitForVisible);
+    const waitForHidden = !!options.hidden;
+    const polling = waitForVisible || waitForHidden ? 'raf' : 'mutation';
+    return this.waitForFunction(predicate, {timeout, polling}, selector, waitForVisible, waitForHidden);
 
     /**
      * @param {string} selector
      * @param {boolean} waitForVisible
+     * @param {boolean} waitForHidden
      * @return {boolean}
      */
-    function predicate(selector, waitForVisible) {
+    function predicate(selector, waitForVisible, waitForHidden) {
       const node = document.querySelector(selector);
       if (!node)
         return false;
-      if (!waitForVisible)
+      if (!waitForVisible && !waitForHidden)
         return true;
       const style = window.getComputedStyle(node);
-      return style && style.display !== 'none' && style.visibility !== 'hidden';
+      if (waitForVisible)
+        return style && style.display !== 'none' && style.visibility !== 'hidden';
+      return style && (style.display === 'none' || style.visibility === 'hidden');
     }
   }
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -417,17 +417,10 @@ class Frame {
         return waitForHidden;
       if (!waitForVisible && !waitForHidden)
         return true;
-      let ancestorsVisible = true;
-      let parent = node.parentElement;
-      while (parent && ancestorsVisible){
-        const parentStyle = window.getComputedStyle(parent);
-        ancestorsVisible = parentStyle && parentStyle.display !== 'none';
-        parent = parent.parentElement;
-      }
       const style = window.getComputedStyle(node);
       if (waitForVisible)
-        return style && style.display !== 'none' && style.visibility !== 'hidden' && ancestorsVisible;
-      return style && (style.display === 'none' || style.visibility === 'hidden' || !ancestorsVisible);
+        return style && style.display !== 'none' && style.visibility !== 'hidden';
+      return style && (style.display === 'none' || style.visibility === 'hidden');
     }
   }
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -418,9 +418,8 @@ class Frame {
       if (!waitForVisible && !waitForHidden)
         return true;
       const style = window.getComputedStyle(node);
-      if (waitForVisible)
-        return style && style.display !== 'none' && style.visibility !== 'hidden';
-      return style && (style.display === 'none' || style.visibility === 'hidden');
+      const isVisible = style && style.display !== 'none' && style.visibility !== 'hidden';
+      return (waitForVisible === isVisible || waitForHidden === !isVisible);
     }
   }
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -420,7 +420,7 @@ class Frame {
       let ancestorsVisible = true;
       let parent = node.parentElement;
       while (parent && ancestorsVisible){
-        parentStyle = window.getComputedStyle(parent);
+        const parentStyle = window.getComputedStyle(parent);
         ancestorsVisible = parentStyle && parentStyle.display !== 'none';
         parent = parent.parentElement;
       }

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -410,6 +410,7 @@ class Frame {
      * @param {string} selector
      * @param {boolean} waitForVisible
      * @param {boolean} waitForHidden
+     * @param {boolean} waitForRemoval
      * @return {boolean}
      */
     function predicate(selector, waitForVisible, waitForHidden, waitForRemoval) {
@@ -420,17 +421,17 @@ class Frame {
         return false;
       if (!waitForVisible && !waitForHidden)
         return true;
-      let ancestorDisplayed = true;
+      let ancestorsVisible = true;
       let parent = node.parentElement;
-      while (parent && ancestorDisplayed){
+      while (parent && ancestorsVisible){
         parentStyle = window.getComputedStyle(parent);
-        ancestorDisplayed = parentStyle && parentStyle.display !== 'none';
+        ancestorsVisible = parentStyle && parentStyle.display !== 'none';
         parent = parent.parentElement;
       }
       const style = window.getComputedStyle(node);
       if (waitForVisible)
-        return style && style.display !== 'none' && style.visibility !== 'hidden' && ancestorDisplayed;
-      return style && (style.display === 'none' || style.visibility === 'hidden' || !ancestorDisplayed);
+        return style && style.display !== 'none' && style.visibility !== 'hidden' && ancestorsVisible;
+      return style && (style.display === 'none' || style.visibility === 'hidden' || !ancestorsVisible);
     }
   }
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -402,23 +402,19 @@ class Frame {
     const timeout = options.timeout || 30000;
     const waitForVisible = !!options.visible;
     const waitForHidden = !!options.hidden;
-    const waitForRemoval = !!options.reverse;
-    const polling = waitForVisible || waitForHidden || waitForRemoval ? 'raf' : 'mutation';
-    return this.waitForFunction(predicate, {timeout, polling}, selector, waitForVisible, waitForHidden, waitForRemoval);
+    const polling = waitForVisible || waitForHidden ? 'raf' : 'mutation';
+    return this.waitForFunction(predicate, {timeout, polling}, selector, waitForVisible, waitForHidden);
 
     /**
      * @param {string} selector
      * @param {boolean} waitForVisible
      * @param {boolean} waitForHidden
-     * @param {boolean} waitForRemoval
      * @return {boolean}
      */
-    function predicate(selector, waitForVisible, waitForHidden, waitForRemoval) {
+    function predicate(selector, waitForVisible, waitForHidden) {
       const node = document.querySelector(selector);
-      if (waitForRemoval)
-        return !node;
       if (!node)
-        return false;
+        return waitForHidden;
       if (!waitForVisible && !waitForHidden)
         return true;
       let ancestorsVisible = true;

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -402,8 +402,9 @@ class Frame {
     const timeout = options.timeout || 30000;
     const waitForVisible = !!options.visible;
     const waitForHidden = !!options.hidden;
-    const polling = waitForVisible || waitForHidden ? 'raf' : 'mutation';
-    return this.waitForFunction(predicate, {timeout, polling}, selector, waitForVisible, waitForHidden);
+    const waitForRemoval = !!options.reverse;
+    const polling = waitForVisible || waitForHidden || waitForRemoval ? 'raf' : 'mutation';
+    return this.waitForFunction(predicate, {timeout, polling}, selector, waitForVisible, waitForHidden, waitForRemoval);
 
     /**
      * @param {string} selector
@@ -411,16 +412,25 @@ class Frame {
      * @param {boolean} waitForHidden
      * @return {boolean}
      */
-    function predicate(selector, waitForVisible, waitForHidden) {
+    function predicate(selector, waitForVisible, waitForHidden, waitForRemoval) {
       const node = document.querySelector(selector);
+      if (waitForRemoval)
+        return !node;
       if (!node)
         return false;
       if (!waitForVisible && !waitForHidden)
         return true;
+      let ancestorDisplayed = true;
+      let parent = node.parentElement;
+      while (parent && ancestorDisplayed){
+        parentStyle = window.getComputedStyle(parent);
+        ancestorDisplayed = parentStyle && parentStyle.display !== 'none';
+        parent = parent.parentElement;
+      }
       const style = window.getComputedStyle(node);
       if (waitForVisible)
-        return style && style.display !== 'none' && style.visibility !== 'hidden';
-      return style && (style.display === 'none' || style.visibility === 'hidden');
+        return style && style.display !== 'none' && style.visibility !== 'hidden' && ancestorDisplayed;
+      return style && (style.display === 'none' || style.visibility === 'hidden' || !ancestorDisplayed);
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -509,7 +509,6 @@ describe('Page', function() {
     it('hidden should wait for visibility: hidden', SX(async function() {
       let divHidden = false;
       await page.setContent(`<div style='display: block;'></div>`);
-      expect(divHidden).toBe(false);
       const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.evaluate(() => document.querySelector('div').style.setProperty('visibility', 'hidden'));
       expect(await waitForSelector).toBe(true);
@@ -518,7 +517,6 @@ describe('Page', function() {
     it('hidden should wait for display: none', SX(async function() {
       let divHidden = false;
       await page.setContent(`<div style='display: block;'></div>`);
-      expect(divHidden).toBe(false);
       const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.evaluate(() => document.querySelector('div').style.setProperty('display', 'none'));
       expect(await waitForSelector).toBe(true);

--- a/test/test.js
+++ b/test/test.js
@@ -498,7 +498,7 @@ describe('Page', function() {
     it('should wait for visible', SX(async function() {
       let divFound = false;
       const waitForSelector = page.waitForSelector('div', {visible: true}).then(() => divFound = true);
-      await page.setContent(`<div style='display: none;visibility: hidden'></div>`);
+      await page.setContent(`<div style='display: none; visibility: hidden;'></div>`);
       expect(divFound).toBe(false);
       await page.evaluate(() => document.querySelector('div').style.removeProperty('display'));
       expect(divFound).toBe(false);
@@ -506,25 +506,53 @@ describe('Page', function() {
       expect(await waitForSelector).toBe(true);
       expect(divFound).toBe(true);
     }));
-    it('should wait for visibility: hidden', SX(async function() {
+    it('should check ancestors are visible', SX(async function() {
       let divFound = false;
-      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divFound = true);
-      await page.setContent(`<div style='display: block;'></div>`);
+      const waitForSelector = page.waitForSelector('div', {visible: true}).then(() => divFound = true);
+      await page.setContent(`<div class="parent" style='display: none;'><div class="child" style='display: none; visibility: hidden;'></div></div>`);
       expect(divFound).toBe(false);
-      await page.evaluate(() => document.querySelector('div').style.setProperty('visibility', 'hidden'));
+      await page.evaluate(() => document.querySelector('.child').style.removeProperty('display'));
       expect(divFound).toBe(false);
+      await page.evaluate(() => document.querySelector('.child').style.removeProperty('visibility'));
+      expect(divFound).toBe(false);
+      await page.evaluate(() => document.querySelector('.parent').style.removeProperty('display'));
       expect(await waitForSelector).toBe(true);
       expect(divFound).toBe(true);
     }));
-    it('should wait for display: none', SX(async function() {
+    it('should check ancestors are hidden', SX(async function() {
       let divFound = false;
       const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divFound = true);
-      await page.setContent(`<div style='display: block;'></div>`);
+      await page.setContent(`<div class="parent" style='display: block;'><div class="child"></div></div>`);
       expect(divFound).toBe(false);
-      await page.evaluate(() => document.querySelector('div').style.setProperty('display', 'none'));
-      expect(divFound).toBe(false);
+      await page.evaluate(() => document.querySelector('.parent').style.setProperty('display', 'none'));
       expect(await waitForSelector).toBe(true);
       expect(divFound).toBe(true);
+    }));
+    it('should wait for visibility: hidden', SX(async function() {
+      let divHidden = false;
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
+      await page.setContent(`<div style='display: block;'></div>`);
+      expect(divHidden).toBe(false);
+      await page.evaluate(() => document.querySelector('div').style.setProperty('visibility', 'hidden'));
+      expect(await waitForSelector).toBe(true);
+      expect(divHidden).toBe(true);
+    }));
+    it('should wait for display: none', SX(async function() {
+      let divHidden = false;
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
+      await page.setContent(`<div style='display: block;'></div>`);
+      expect(divHidden).toBe(false);
+      await page.evaluate(() => document.querySelector('div').style.setProperty('display', 'none'));
+      expect(await waitForSelector).toBe(true);
+      expect(divHidden).toBe(true);
+    }));
+    it('should wait for reverse', SX(async function() {
+      await page.setContent(`<div></div>`);
+      let divRemoved = false;
+      const waitForSelector = page.waitForSelector('div', {reverse: true}).then(() => divRemoved = true);
+      await page.evaluate(() => document.querySelector('div').remove());
+      expect(await waitForSelector).toBe(true);
+      expect(divRemoved).toBe(true);
     }));
     it('should respect timeout', SX(async function() {
       let error = null;

--- a/test/test.js
+++ b/test/test.js
@@ -504,6 +504,27 @@ describe('Page', function() {
       expect(divFound).toBe(false);
       await page.evaluate(() => document.querySelector('div').style.removeProperty('visibility'));
       expect(await waitForSelector).toBe(true);
+      expect(divFound).toBe(true);
+    }));
+    it('should wait for visibility: hidden', SX(async function() {
+      let divFound = false;
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divFound = true);
+      await page.setContent(`<div style='display: block;'></div>`);
+      expect(divFound).toBe(false);
+      await page.evaluate(() => document.querySelector('div').style.setProperty('visibility', 'hidden'));
+      expect(divFound).toBe(false);
+      expect(await waitForSelector).toBe(true);
+      expect(divFound).toBe(true);
+    }));
+    it('should wait for display: none', SX(async function() {
+      let divFound = false;
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divFound = true);
+      await page.setContent(`<div style='display: block;'></div>`);
+      expect(divFound).toBe(false);
+      await page.evaluate(() => document.querySelector('div').style.setProperty('display', 'none'));
+      expect(divFound).toBe(false);
+      expect(await waitForSelector).toBe(true);
+      expect(divFound).toBe(true);
     }));
     it('should respect timeout', SX(async function() {
       let error = null;

--- a/test/test.js
+++ b/test/test.js
@@ -506,25 +506,7 @@ describe('Page', function() {
       expect(await waitForSelector).toBe(true);
       expect(divFound).toBe(true);
     }));
-    it('should check ancestors are visible', SX(async function() {
-      let divFound = false;
-      const waitForSelector = page.waitForSelector('.child', {visible: true}).then(() => divFound = true);
-      await page.setContent(`<div class="parent" style='display: none;'><div class="child"></div></div>`);
-      expect(divFound).toBe(false);
-      await page.evaluate(() => document.querySelector('.parent').style.removeProperty('display'));
-      expect(await waitForSelector).toBe(true);
-      expect(divFound).toBe(true);
-    }));
-    it('should check ancestors are hidden', SX(async function() {
-      let divHidden = false;
-      await page.setContent(`<div class="parent" style='display: block;'><div class="child"></div></div>`);
-      expect(divHidden).toBe(false);
-      const waitForSelector = page.waitForSelector('.child', {hidden: true}).then(() => divHidden = true);
-      await page.evaluate(() => document.querySelector('.parent').style.setProperty('display', 'none'));
-      expect(await waitForSelector).toBe(true);
-      expect(divHidden).toBe(true);
-    }));
-    it('should wait for visibility: hidden', SX(async function() {
+    it('hidden should wait for visibility: hidden', SX(async function() {
       let divHidden = false;
       await page.setContent(`<div style='display: block;'></div>`);
       expect(divHidden).toBe(false);
@@ -533,7 +515,7 @@ describe('Page', function() {
       expect(await waitForSelector).toBe(true);
       expect(divHidden).toBe(true);
     }));
-    it('should wait for display: none', SX(async function() {
+    it('hidden should wait for display: none', SX(async function() {
       let divHidden = false;
       await page.setContent(`<div style='display: block;'></div>`);
       expect(divHidden).toBe(false);
@@ -542,10 +524,11 @@ describe('Page', function() {
       expect(await waitForSelector).toBe(true);
       expect(divHidden).toBe(true);
     }));
-    it('should wait for removal', SX(async function() {
+    it('hidden should wait for removal', SX(async function() {
       await page.setContent(`<div></div>`);
       let divRemoved = false;
       const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divRemoved = true);
+      expect(divRemoved).toBe(false);
       await page.evaluate(() => document.querySelector('div').remove());
       expect(await waitForSelector).toBe(true);
       expect(divRemoved).toBe(true);

--- a/test/test.js
+++ b/test/test.js
@@ -508,12 +508,8 @@ describe('Page', function() {
     }));
     it('should check ancestors are visible', SX(async function() {
       let divFound = false;
-      const waitForSelector = page.waitForSelector('div', {visible: true}).then(() => divFound = true);
-      await page.setContent(`<div class="parent" style='display: none;'><div class="child" style='display: none; visibility: hidden;'></div></div>`);
-      expect(divFound).toBe(false);
-      await page.evaluate(() => document.querySelector('.child').style.removeProperty('display'));
-      expect(divFound).toBe(false);
-      await page.evaluate(() => document.querySelector('.child').style.removeProperty('visibility'));
+      const waitForSelector = page.waitForSelector('.child', {visible: true}).then(() => divFound = true);
+      await page.setContent(`<div class="parent" style='display: none;'><div class="child"></div></div>`);
       expect(divFound).toBe(false);
       await page.evaluate(() => document.querySelector('.parent').style.removeProperty('display'));
       expect(await waitForSelector).toBe(true);
@@ -521,35 +517,35 @@ describe('Page', function() {
     }));
     it('should check ancestors are hidden', SX(async function() {
       let divHidden = false;
-      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.setContent(`<div class="parent" style='display: block;'><div class="child"></div></div>`);
       expect(divHidden).toBe(false);
+      const waitForSelector = page.waitForSelector('.child', {hidden: true}).then(() => divHidden = true);
       await page.evaluate(() => document.querySelector('.parent').style.setProperty('display', 'none'));
       expect(await waitForSelector).toBe(true);
       expect(divHidden).toBe(true);
     }));
     it('should wait for visibility: hidden', SX(async function() {
       let divHidden = false;
-      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.setContent(`<div style='display: block;'></div>`);
       expect(divHidden).toBe(false);
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.evaluate(() => document.querySelector('div').style.setProperty('visibility', 'hidden'));
       expect(await waitForSelector).toBe(true);
       expect(divHidden).toBe(true);
     }));
     it('should wait for display: none', SX(async function() {
       let divHidden = false;
-      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.setContent(`<div style='display: block;'></div>`);
       expect(divHidden).toBe(false);
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.evaluate(() => document.querySelector('div').style.setProperty('display', 'none'));
       expect(await waitForSelector).toBe(true);
       expect(divHidden).toBe(true);
     }));
-    it('should wait for reverse', SX(async function() {
+    it('should wait for removal', SX(async function() {
       await page.setContent(`<div></div>`);
       let divRemoved = false;
-      const waitForSelector = page.waitForSelector('div', {reverse: true}).then(() => divRemoved = true);
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divRemoved = true);
       await page.evaluate(() => document.querySelector('div').remove());
       expect(await waitForSelector).toBe(true);
       expect(divRemoved).toBe(true);

--- a/test/test.js
+++ b/test/test.js
@@ -520,13 +520,13 @@ describe('Page', function() {
       expect(divFound).toBe(true);
     }));
     it('should check ancestors are hidden', SX(async function() {
-      let divFound = false;
-      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divFound = true);
+      let divHidden = false;
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
       await page.setContent(`<div class="parent" style='display: block;'><div class="child"></div></div>`);
-      expect(divFound).toBe(false);
+      expect(divHidden).toBe(false);
       await page.evaluate(() => document.querySelector('.parent').style.setProperty('display', 'none'));
       expect(await waitForSelector).toBe(true);
-      expect(divFound).toBe(true);
+      expect(divHidden).toBe(true);
     }));
     it('should wait for visibility: hidden', SX(async function() {
       let divHidden = false;


### PR DESCRIPTION
Waits for a selector to be present and hidden, opposite behavior of the option visible.