### PR TITLE
feat(console): dispatch JSHandles as console arguments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1161,7 +1161,7 @@ Dialog's type, could be one of the `alert`, `beforeunload`, `confirm` and `promp
 [ConsoleMessage] objects are dispatched by page via the ['console'](#event-console) event.
 
 #### consoleMessage.args
-- <[Array]<[string]>>
+- <[Array]<[JSHandle]>>
 
 #### consoleMessage.text
 - <[string]>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -331,7 +331,7 @@ class Page extends EventEmitter {
       event.args.map(arg => helper.releaseObject(this._client, arg));
       return;
     }
-    const values = await Promise.all(event.args.map(arg => helper.serializeRemoteObject(this._client, arg)));
+    const values = event.args.map(arg => this._frameManager.createJSHandle(event.executionContextId, arg));
     const text = values.join(' ');
     const message = new ConsoleMessage(event.type, text, values);
     this.emit(Page.Events.Console, message);

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -86,31 +86,6 @@ class Helper {
   /**
    * @param {!Session} client
    * @param {!Object} remoteObject
-   * @return {!Promise<!Object>}
-   */
-  static async serializeRemoteObject(client, remoteObject) {
-    if (!remoteObject.objectId)
-      return Helper.valueFromRemoteObject(remoteObject);
-    if (remoteObject.subtype === 'promise')
-      return remoteObject.description;
-    try {
-      const response = await client.send('Runtime.callFunctionOn', {
-        objectId: remoteObject.objectId,
-        functionDeclaration: 'function() { return this; }',
-        returnByValue: true,
-      });
-      return response.result.value;
-    } catch (e) {
-      // Return description for unserializable object, e.g. 'window'.
-      return remoteObject.description;
-    } finally {
-      Helper.releaseObject(client, remoteObject);
-    }
-  }
-
-  /**
-   * @param {!Session} client
-   * @param {!Object} remoteObject
    */
   static async releaseObject(client, remoteObject) {
     if (!remoteObject.objectId)

--- a/test/test.js
+++ b/test/test.js
@@ -696,9 +696,11 @@ describe('Page', function() {
         page.evaluate(() => console.log('hello', 5, {foo: 'bar'})),
         waitForEvents(page, 'console')
       ]);
-      expect(message.text).toEqual('hello 5 [object Object]');
+      expect(message.text).toEqual('hello 5 JSHandle@object');
       expect(message.type).toEqual('log');
-      expect(message.args).toEqual(['hello', 5, {foo: 'bar'}]);
+      expect(await message.args[0].jsonValue()).toEqual('hello');
+      expect(await message.args[1].jsonValue()).toEqual(5);
+      expect(await message.args[2].jsonValue()).toEqual({foo: 'bar'});
     }));
     it('should work for different console API calls', SX(async function() {
       const messages = [];
@@ -726,7 +728,7 @@ describe('Page', function() {
         'calling console.dir',
         'calling console.warn',
         'calling console.error',
-        'Promise',
+        'JSHandle@promise',
       ]);
     }));
     it('should not fail for window object', SX(async function() {
@@ -736,7 +738,7 @@ describe('Page', function() {
         page.evaluate(() => console.error(window)),
         waitForEvents(page, 'console')
       ]);
-      expect(message.text).toBe('Window');
+      expect(message.text).toBe('JSHandle@object');
     }));
   });
 


### PR DESCRIPTION
This patch starts dispatching JSHandle instances as console arguments.
In doing so, we no longer do hops to the page to serialize page arguments, which
removes races between events.

BREAKING CHANGE: this changes the API of the ConsoleMessage.

Fixes #324.