### PR TITLE
fix: return undefined when Page.evaluate encounters circular JSON

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -500,6 +500,8 @@ List of all available devices is available in the source code: [DeviceDescriptor
 
 If the function, passed to the `page.evaluate`, returns a [Promise], then `page.evaluate` would wait for the promise to resolve and return its value.
 
+If the function passed into `page.evaluate` returns a non-[Serializable] value, then `page.evaluate` resolves to `undefined`.
+
 ```js
 const result = await page.evaluate(() => {
   return Promise.resolve(8 * 7);
@@ -1269,6 +1271,8 @@ Adds a `<link rel="stylesheet">` tag to the frame with the desired url.
 - returns: <[Promise]<[Serializable]>> Promise which resolves to function return value
 
 If the function, passed to the `frame.evaluate`, returns a [Promise], then `frame.evaluate` would wait for the promise to resolve and return its value.
+
+If the function passed into `frame.evaluate` returns a non-[Serializable] value, then `frame.evaluate` resolves to `undefined`.
 
 ```js
 const result = await frame.evaluate(() => {

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -35,7 +35,7 @@ class ExecutionContext {
    */
   async evaluate(pageFunction, ...args) {
     const handle = await this.evaluateHandle(pageFunction, ...args);
-    const result = await handle.jsonValue();
+    const result = await handle.jsonValue().catch(error => undefined);
     await handle.dispose();
     return result;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -266,9 +266,8 @@ describe('Page', function() {
       expect(result).toBe(true);
     }));
     it('should fail for window object', SX(async function() {
-      let error = null;
-      await page.evaluate(() => window).catch(e => error = e);
-      expect(error.message).toContain('Converting circular structure to JSON');
+      const result = await page.evaluate(() => window);
+      expect(result).toBe(undefined);
     }));
     it('should accept a string', SX(async function() {
       const result = await page.evaluate('1 + 2');


### PR DESCRIPTION
The new behavior of `page.evaluate` to convert to JSON makes it difficult to use if you don't care about the return value of your function. Consider 
```js
await page.evaluate(() => window.open('about:blank'));
await page.evaluate(() => $('body').hide());
```

I don't want to be paranoid about whether or not my evaluations unintentionally return circular json.