### PR TITLE
fix(Request): convert resourceType to all small-caps

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1696,7 +1696,7 @@ Contains the request's post body, if any.
 - <[string]>
 
 Contains the request's resource type as it was perceived by the rendering engine.
-ResourceType will be one of the following: `Document`, `Stylesheet`, `Image`, `Media`, `Font`, `Script`, `TextTrack`, `XHR`, `Fetch`, `EventSource`, `WebSocket`, `Manifest`, `Other`.
+ResourceType will be one of the following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`, `websocket`, `manifest`, `other`.
 
 #### request.response()
 - returns: <[Response]> A matching [Response] object, or `null` if the response has not been received yet.

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -24,7 +24,7 @@ const browser = await puppeteer.launch();
 const page = await browser.newPage();
 await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {
-  if (request.resourceType === 'Image')
+  if (request.resourceType === 'image')
     request.abort();
   else
     request.continue();

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -271,7 +271,7 @@ class Request {
     });
 
     this.url = url;
-    this.resourceType = resourceType;
+    this.resourceType = resourceType.toLowerCase();
     this.method = payload.method;
     this.postData = payload.postData;
     this.headers = {};

--- a/test/test.js
+++ b/test/test.js
@@ -1008,7 +1008,7 @@ describe('Page', function() {
         expect(request.headers['user-agent']).toBeTruthy();
         expect(request.method).toBe('GET');
         expect(request.postData).toBe(undefined);
-        expect(request.resourceType).toBe('Document');
+        expect(request.resourceType).toBe('document');
         request.continue();
       });
       const response = await page.goto(EMPTY_PAGE);
@@ -1077,7 +1077,7 @@ describe('Page', function() {
       expect(response.status).toBe(200);
       expect(response.url).toContain('empty.html');
       expect(requests.length).toBe(5);
-      expect(requests[2].resourceType).toBe('Document');
+      expect(requests[2].resourceType).toBe('document');
     }));
     it('should be able to abort redirects', SX(async function() {
       await page.setRequestInterceptionEnabled(true);
@@ -1866,7 +1866,7 @@ describe('Page', function() {
       await page.goto(EMPTY_PAGE);
       expect(requests.length).toBe(1);
       expect(requests[0].url).toBe(EMPTY_PAGE);
-      expect(requests[0].resourceType).toBe('Document');
+      expect(requests[0].resourceType).toBe('document');
       expect(requests[0].method).toBe('GET');
       expect(requests[0].response()).toBeTruthy();
     }));
@@ -1942,7 +1942,7 @@ describe('Page', function() {
       expect(failedRequests.length).toBe(1);
       expect(failedRequests[0].url).toContain('one-style.css');
       expect(failedRequests[0].response()).toBe(null);
-      expect(failedRequests[0].resourceType).toBe('Stylesheet');
+      expect(failedRequests[0].resourceType).toBe('stylesheet');
     }));
     it('Page.Events.RequestFinished', SX(async function() {
       const requests = [];


### PR DESCRIPTION
This patch moves resourceType to be all small-caps. This aligns
with our convention that all string constants should be smallcaps.

BREAKING CHANGE: this patch changes the constants of the
request.resourceType to be all small-caps.