### PR TITLE
feat(Page): kill the page.plainText method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,7 +58,6 @@
     + [page.mainFrame()](#pagemainframe)
     + [page.mouse](#pagemouse)
     + [page.pdf(options)](#pagepdfoptions)
-    + [page.plainText()](#pageplaintext)
     + [page.reload(options)](#pagereloadoptions)
     + [page.screenshot([options])](#pagescreenshotoptions)
     + [page.select(selector, ...values)](#pageselectselector-values)
@@ -764,9 +763,6 @@ The `format` options are:
 - `A3`: 11.7in x 16.5in
 - `A4`: 8.27in x 11.7in
 - `A5`: 5.83in x 8.27in
-
-#### page.plainText()
-- returns:  <[Promise]<[string]>> Returns page's inner text.
 
 #### page.reload(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -660,13 +660,6 @@ class Page extends EventEmitter {
   /**
    * @return {!Promise<string>}
    */
-  async plainText() {
-    return this.evaluate(() =>  document.body.innerText);
-  }
-
-  /**
-   * @return {!Promise<string>}
-   */
   async title() {
     return this.mainFrame().title();
   }

--- a/test/test.js
+++ b/test/test.js
@@ -2184,13 +2184,6 @@ describe('Page', function() {
     }));
   });
 
-  describe('Page.plainText', function() {
-    it('should return the page text', SX(async function(){
-      await page.setContent('<div>the result text</div>');
-      expect(await page.plainText()).toBe('the result text');
-    }));
-  });
-
   describe('Page.title', function() {
     it('should return the page title', SX(async function(){
       await page.goto(PREFIX + '/input/button.html');


### PR DESCRIPTION
The page.plainText is confusing: it's unclear what kind of text it
returns, textContent or innerText. It's also easily polyfillable and
doesn't seem to be used.

BREAKING CHANGE: the page.plainText is not existing any more.
Instead, use `page.evaluate(() => document.body.innerText)`.