### PR TITLE
Add test for #750 - Throw error with stack trace when launching with …

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -102,6 +102,12 @@ describe('Puppeteer', function() {
       await neverResolves;
       expect(error.message).toContain('Protocol error');
     }));
+    it('should reject if executable path is invalid', SX(async function() {
+      let waitError = null;
+      const options = Object.assign({}, defaultBrowserOptions, {executablePath: 'random-invalid-path'});
+      await puppeteer.launch(options).catch(e => waitError = e);
+      expect(waitError.message.startsWith('Failed to launch chrome! spawn random-invalid-path ENOENT')).toBe(true);
+    }));
     it('userDataDir option', SX(async function() {
       const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
       const options = Object.assign({userDataDir}, defaultBrowserOptions);


### PR DESCRIPTION
…an invalid executablePath option.

When https://github.com/GoogleChrome/puppeteer/pull/863 was opened as opposed to my original PR (https://github.com/GoogleChrome/puppeteer/pull/751), the test was not carried over.

/cc @aslushnikov @JoelEinbinder 