### PR TITLE
fix(Page.getMetrics): do not report a few metrics

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -663,9 +663,6 @@ If there's no element matching `selector`, the method throws an error.
   - `TaskDuration` <[number]> Combined duration of all tasks performed by the browser.
   - `JSHeapUsedSize` <[number]> Used JavaScript heap size.
   - `JSHeapTotalSize` <[number]> Total JavaScript heap size.
-  - `FirstMeaningfulPaint` <[number]> Timestamp of the first meaningful paint event.
-  - `DomContentLoaded` <[number]> Timestamp of the DOM content loaded event.
-  - `NavigationStart` <[number]> Timestamp of the navigation start event.
 
 > **NOTE** All timestamps are in monotonic time: monotonically increasing time in seconds since an arbitrary point in the past.
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -824,9 +824,6 @@ const supportedMetrics = new Set([
   'TaskDuration',
   'JSHeapUsedSize',
   'JSHeapTotalSize',
-  'FirstMeaningfulPaint',
-  'DomContentLoaded',
-  'NavigationStart',
 ]);
 
 /** @enum {string} */

--- a/test/test.js
+++ b/test/test.js
@@ -777,9 +777,6 @@ describe('Page', function() {
         'TaskDuration',
         'JSHeapUsedSize',
         'JSHeapTotalSize',
-        'FirstMeaningfulPaint',
-        'DomContentLoaded',
-        'NavigationStart',
       ]);
       for (const name in metrics) {
         expect(metricsToCheck.has(name)).toBeTruthy();


### PR DESCRIPTION
A few of the reported metrics in the Page.getMetrics are already
reported with lifecycle events.

This patch excludes these metrics for now.