### PR TITLE
feat(Page): introduce Page.queryObjects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,7 @@
     + [page.mainFrame()](#pagemainframe)
     + [page.mouse](#pagemouse)
     + [page.pdf(options)](#pagepdfoptions)
+    + [page.queryObjects(prototypeHandle)](#pagequeryobjectsprototypehandle)
     + [page.reload(options)](#pagereloadoptions)
     + [page.screenshot([options])](#pagescreenshotoptions)
     + [page.select(selector, ...values)](#pageselectselector-values)
@@ -128,6 +129,7 @@
   * [class: ExecutionContext](#class-executioncontext)
     + [executionContext.evaluate(pageFunction, ...args)](#executioncontextevaluatepagefunction-args)
     + [executionContext.evaluateHandle(pageFunction, ...args)](#executioncontextevaluatehandlepagefunction-args)
+    + [executionContext.queryObjects(prototypeHandle)](#executioncontextqueryobjectsprototypehandle)
   * [class: JSHandle](#class-jshandle)
     + [jsHandle.asElement()](#jshandleaselement)
     + [jsHandle.dispose()](#jshandledispose)
@@ -791,6 +793,27 @@ The `format` options are:
 - `A3`: 11.7in x 16.5in
 - `A4`: 8.27in x 11.7in
 - `A5`: 5.83in x 8.27in
+
+#### page.queryObjects(prototypeHandle)
+- `prototypeHandle` <[JSHandle]> A handle to the object prototype.
+- returns: <[JSHandle]> A handle to an array of objects with this prototype
+
+The method iterates javascript heap and finds all the objects with the given prototype.
+
+```js
+// Create a Map object 
+await page.evaluate(() => window.map = new Map());
+// Get a handle to the Map object prototype
+const mapPrototype = await page.evaluateHandle(() => Map.prototype);
+// Query all map instances into an array
+const mapInstances = await page.queryObjects(mapPrototype);
+// Count amount of map objects in heap
+const count = await page.evaluate(maps => maps.length, mapInstances);
+await mapInstances.dispose();
+await mapPrototype.dispose();
+```
+
+Shortcut for [page.mainFrame().executionContext().queryObjects(prototypeHandle)](#executioncontextqueryobjectsprototypehandle).
 
 #### page.reload(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:
@@ -1477,6 +1500,25 @@ const resultHandle = await context.evaluateHandle(body => body.innerHTML, aHandl
 console.log(await resultHandle.jsonValue()); // prints body's innerHTML
 await aHandle.dispose();
 await resultHandle.dispose();
+```
+
+#### executionContext.queryObjects(prototypeHandle)
+- `prototypeHandle` <[JSHandle]> A handle to the object prototype.
+- returns: <[JSHandle]> A handle to an array of objects with this prototype
+
+The method iterates javascript heap and finds all the objects with the given prototype.
+
+```js
+// Create a Map object 
+await page.evaluate(() => window.map = new Map());
+// Get a handle to the Map object prototype
+const mapPrototype = await page.evaluateHandle(() => Map.prototype);
+// Query all map instances into an array
+const mapInstances = await page.queryObjects(mapPrototype);
+// Count amount of map objects in heap
+const count = await page.evaluate(maps => maps.length, mapInstances);
+await mapInstances.dispose();
+await mapPrototype.dispose();
 ```
 
 ### class: JSHandle

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -95,6 +95,19 @@ class ExecutionContext {
       return { value: arg };
     }
   }
+
+  /**
+   * @param {!JSHandle} prototypeHandle
+   * @return {!Promise<!JSHandle>}
+   */
+  async queryObjects(prototypeHandle) {
+    console.assert(!prototypeHandle._disposed, 'Prototype JSHandle is disposed!');
+    console.assert(prototypeHandle._remoteObject.objectId, 'Prototype JSHandle must not be referencing primitive value');
+    const response = await this._client.send('Runtime.queryObjects', {
+      prototypeObjectId: prototypeHandle._remoteObject.objectId
+    });
+    return this._objectHandleFactory(response.objects);
+  }
 }
 
 class JSHandle {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -177,6 +177,14 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {!JSHandle} prototypeHandle
+   * @return {!Promise<!JSHandle>}
+   */
+  async queryObjects(prototypeHandle) {
+    return this.mainFrame().executionContext().queryObjects(prototypeHandle);
+  }
+
+  /**
    * @param {string} selector
    * @param {function()|string} pageFunction
    * @param {!Array<*>} args

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -177,8 +177,8 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {!JSHandle} prototypeHandle
-   * @return {!Promise<!JSHandle>}
+   * @param {!Puppeteer.JSHandle} prototypeHandle
+   * @return {!Promise<!Puppeteer.JSHandle>}
    */
   async queryObjects(prototypeHandle) {
     return this.mainFrame().executionContext().queryObjects(prototypeHandle);

--- a/test/test.js
+++ b/test/test.js
@@ -333,11 +333,13 @@ describe('Page', function() {
   describe('ExecutionContext.queryObjects', function() {
     it('should work', SX(async function() {
       // Instantiate an object
-      await page.evaluate(() => window.map = new Map());
-      const prototypeHandle = await page.evaluateHandle(() => Map.prototype);
+      await page.evaluate(() => window.set = new Set(['hello', 'world']));
+      const prototypeHandle = await page.evaluateHandle(() => Set.prototype);
       const objectsHandle = await page.queryObjects(prototypeHandle);
       const count = await page.evaluate(objects => objects.length, objectsHandle);
       expect(count).toBe(1);
+      const values = await page.evaluate(objects => Array.from(objects[0].values()), objectsHandle);
+      expect(values).toEqual(['hello', 'world']);
     }));
     it('should fail for disposed handles', SX(async function() {
       const prototypeHandle = await page.evaluateHandle(() => HTMLBodyElement.prototype);


### PR DESCRIPTION
This patch introduces `Page.queryObjects` and
`ExecutionContext.queryObjects` methods to query JavaScript heap
for objects with a certain prototype.

Fixes #304.
