### PR TITLE
feat(Page): introduce Page.$$eval method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@
     + [event: 'response'](#event-response)
     + [page.$(selector)](#pageselector)
     + [page.$$(selector)](#pageselector)
+    + [page.$$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
     + [page.$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
     + [page.addStyleTag(url)](#pageaddstyletagurl)
@@ -110,6 +111,7 @@
   * [class: Frame](#class-frame)
     + [frame.$(selector)](#frameselector)
     + [frame.$$(selector)](#frameselector)
+    + [frame.$$eval(selector, pageFunction[, ...args])](#frameevalselector-pagefunction-args)
     + [frame.$eval(selector, pageFunction[, ...args])](#frameevalselector-pagefunction-args)
     + [frame.addScriptTag(url)](#frameaddscripttagurl)
     + [frame.addStyleTag(url)](#frameaddstyletagurl)
@@ -378,6 +380,22 @@ Shortcut for [page.mainFrame().$(selector)](#frameselector).
 The method runs `document.querySelectorAll` within the page. If no elements match the selector, the return value resolve to `[]`.
 
 Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
+
+
+#### page.$$eval(selector, pageFunction[, ...args])
+- `selector` <[string]> A [selector] to query frame for
+- `pageFunction` <[function]> Function to be evaluated in browser context
+- `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to `pageFunction`
+- returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
+
+This method runs `document.querySelectorAll` within the page and passes it as the first argument to `pageFunction`.
+
+If `pageFunction` returns a [Promise], then `page.$$eval` would wait for the promise to resolve and return its value.
+
+Examples:
+```js
+const divsCounts = await page.$$eval('div', divs => divs.length);
+```
 
 #### page.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> A [selector] to query page for
@@ -1259,6 +1277,21 @@ The method queries frame for the selector. If there's no such element within the
 - returns: <[Promise]<[Array]<[ElementHandle]>>> Promise which resolves to ElementHandles pointing to the frame elements.
 
 The method runs `document.querySelectorAll` within the frame. If no elements match the selector, the return value resolve to `[]`.
+
+#### frame.$$eval(selector, pageFunction[, ...args])
+- `selector` <[string]> A [selector] to query frame for
+- `pageFunction` <[function]> Function to be evaluated in browser context
+- `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to `pageFunction`
+- returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
+
+This method runs `document.querySelectorAll` within the frame and passes it as the first argument to `pageFunction`.
+
+If `pageFunction` returns a [Promise], then `frame.$$eval` would wait for the promise to resolve and return its value.
+
+Examples:
+```js
+const divsCounts = await frame.$$eval('div', divs => divs.length);
+```
 
 #### frame.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> A [selector] to query frame for

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -240,6 +240,20 @@ class Frame {
 
   /**
    * @param {string} selector
+   * @param {Function|string} pageFunction
+   * @param {!Array<*>} args
+   * @return {!Promise<(!Object|undefined)>}
+   */
+  async $$eval(selector, pageFunction, ...args) {
+    const arrayHandle = await this._context.evaluateHandle(selector => Array.from(document.querySelectorAll(selector)), selector);
+    args = [arrayHandle].concat(args);
+    const result = await this.evaluate(pageFunction, ...args);
+    await arrayHandle.dispose();
+    return result;
+  }
+
+  /**
+   * @param {string} selector
    * @return {!Promise<!Array<!ElementHandle>>}
    */
   async $$(selector) {

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -232,8 +232,7 @@ class Frame {
     const elementHandle = await this.$(selector);
     if (!elementHandle)
       throw new Error(`Error: failed to find element matching selector "${selector}"`);
-    args = [elementHandle].concat(args);
-    const result = await this.evaluate(pageFunction, ...args);
+    const result = await this.evaluate(pageFunction, elementHandle, ...args);
     await elementHandle.dispose();
     return result;
   }
@@ -246,8 +245,7 @@ class Frame {
    */
   async $$eval(selector, pageFunction, ...args) {
     const arrayHandle = await this._context.evaluateHandle(selector => Array.from(document.querySelectorAll(selector)), selector);
-    args = [arrayHandle].concat(args);
-    const result = await this.evaluate(pageFunction, ...args);
+    const result = await this.evaluate(pageFunction, arrayHandle, ...args);
     await arrayHandle.dispose();
     return result;
   }

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -188,6 +188,16 @@ class Page extends EventEmitter {
 
   /**
    * @param {string} selector
+   * @param {Function|string} pageFunction
+   * @param {!Array<*>} args
+   * @return {!Promise<(!Object|undefined)>}
+   */
+  async $$eval(selector, pageFunction, ...args) {
+    return this.mainFrame().$$eval(selector, pageFunction, ...args);
+  }
+
+  /**
+   * @param {string} selector
    * @return {!Promise<!Array<!Puppeteer.ElementHandle>>}
    */
   async $$(selector) {

--- a/test/test.js
+++ b/test/test.js
@@ -1392,6 +1392,14 @@ describe('Page', function() {
     }));
   });
 
+  describe('Page.$$eval', function() {
+    it('should work', SX(async function() {
+      await page.setContent('<div>hello</div><div>beautiful</div><div>world!</div>');
+      const divsCount = await page.$$eval('div', divs => divs.length);
+      expect(divsCount).toBe(3);
+    }));
+  });
+
   describe('Page.$', function() {
     it('should query existing element', SX(async function() {
       await page.setContent('<section>test</section>');


### PR DESCRIPTION
This patch adds a Page.$$eval method that runs document.querySelectorAll
and passes resulting array to the page function.

Fixes #625.