### PR TITLE
Add a6 page size

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -809,6 +809,7 @@ The `format` options are:
 - `A3`: 11.7in x 16.5in
 - `A4`: 8.27in x 11.7in
 - `A5`: 5.83in x 8.27in
+- `A6`: 4.13in x 5.83in
 
 #### page.reload(options)
 - `options` <[Object]> Navigation parameters which might have the following properties:

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -850,6 +850,7 @@ Page.PaperFormats = {
   a3: {width: 11.7, height: 16.5 },
   a4: {width: 8.27, height: 11.7 },
   a5: {width: 5.83, height: 8.27 },
+  a6: {width: 4.13, height: 5.83 },
 };
 
 const unitToPixels = {


### PR DESCRIPTION
Adds the a6 format, perhaps not as useful for website pdf's, but useful for ticket/barcode generation etc.