### PR TITLE
feat: Add windows build status(appveyor)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "7"
+
+build: off
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - yarn install
+  - if "%nodejs_version%" == "7" (
+      yarn run lint &
+      yarn run coverage  &
+      yarn run test-doclint
+    ) else (
+      yarn run test-node6-transformer  &
+      yarn run build  &
+      yarn run unit-node6  
+    )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Puppeteer [![Build Status](https://travis-ci.org/GoogleChrome/puppeteer.svg?branch=master)](https://travis-ci.org/GoogleChrome/puppeteer) [![App Veyor build status](https://ci.appveyor.com/api/projects/status/github/GoogleChrome/puppeteer)](https://ci.appveyor.com/project/GoogleChrome/puppeteer) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
+# Puppeteer [![Build Status](https://travis-ci.org/GoogleChrome/puppeteer.svg?branch=master)](https://travis-ci.org/GoogleChrome/puppeteer) [![App Veyor build status](https://ci.appveyor.com/api/projects/status/github/aslushnikov/puppeteer)](https://ci.appveyor.com/project/aslushnikov/puppeteer) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
 
 <img src="https://user-images.githubusercontent.com/10379601/29446482-04f7036a-841f-11e7-9872-91d1fc2ea683.png" height="200" align="right">
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Puppeteer [![Build Status](https://travis-ci.org/GoogleChrome/puppeteer.svg?branch=master)](https://travis-ci.org/GoogleChrome/puppeteer) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
+# Puppeteer [![Build Status](https://travis-ci.org/GoogleChrome/puppeteer.svg?branch=master)](https://travis-ci.org/GoogleChrome/puppeteer) [![App Veyor build status](https://ci.appveyor.com/api/projects/status/github/GoogleChrome/puppeteer)](https://ci.appveyor.com/project/GoogleChrome/puppeteer) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
 
 <img src="https://user-images.githubusercontent.com/10379601/29446482-04f7036a-841f-11e7-9872-91d1fc2ea683.png" height="200" align="right">
 


### PR DESCRIPTION
This patch:
  -  add .appveyor.yml to configure appveyor Continuous Integration on windows platform.
  -  add badge (appveyor build status) beside travis build status

Leaving process:
  -  [x]  registration on [appveyor](https://www.appveyor.com/)
  -  [x]  authorization to puppeteer repository

Since #992 is merge, with this should kill #955 
