### PR TITLE
feat(Request): expose request failure reason

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1798,7 +1798,7 @@ Exception is immediately thrown if the request interception is not enabled.
 
 #### request.failure()
 - returns: <[Object]> Object describing request failure, if any
-  - `errorText` <[string]> Human-readable error message
+  - `errorText` <[string]> Human-readable error message, e.g. `'net::ERR_FAILED'`.
 
 The method returns null unless this request was failed, as reported by
 `requestfailed` event.

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,7 @@
 - [class: Request](#class-request)
   * [request.abort()](#requestabort)
   * [request.continue([overrides])](#requestcontinueoverrides)
+  * [request.failure()](#requestfailure)
   * [request.headers](#requestheaders)
   * [request.method](#requestmethod)
   * [request.postData](#requestpostdata)
@@ -1794,6 +1795,13 @@ Exception is immediately thrown if the request interception is not enabled.
 
 Continues request with optional request overrides. To use this, request interception should be enabled with `page.setRequestInterceptionEnabled`.
 Exception is immediately thrown if the request interception is not enabled.
+
+#### request.failure()
+- returns: <[Object]> Object describing request failure, if any
+  - `errorText` <[string]> Human-readable error message
+
+The method returns null unless this request was failed, as reported by
+`requestfailed` event.
 
 #### request.headers
 - <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1803,6 +1803,14 @@ Exception is immediately thrown if the request interception is not enabled.
 The method returns null unless this request was failed, as reported by
 `requestfailed` event.
 
+Example of logging all failed requests:
+
+```js
+page.on('requestfailed', request => {
+  console.log(request.url + ' ' + request.failure().errorText);
+});
+```
+
 #### request.headers
 - <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.
 

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -259,6 +259,7 @@ class NetworkManager extends EventEmitter {
     // @see https://crbug.com/750469
     if (!request)
       return;
+    request._failureText = event.errorText;
     request._completePromiseFulfill.call(null);
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
@@ -284,6 +285,7 @@ class Request {
     this._allowInterception = allowInterception;
     this._interceptionHandled = false;
     this._response = null;
+    this._failureText = null;
     this._completePromise = new Promise(fulfill => {
       this._completePromiseFulfill = fulfill;
     });
@@ -302,6 +304,17 @@ class Request {
    */
   response() {
     return this._response;
+  }
+
+  /**
+   * @return {?{errorText: string}}
+   */
+  failure() {
+    if (!this._failureText)
+      return null;
+    return {
+      errorText: this._failureText
+    };
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -2100,6 +2100,7 @@ describe('Page', function() {
       expect(failedRequests[0].url).toContain('one-style.css');
       expect(failedRequests[0].response()).toBe(null);
       expect(failedRequests[0].resourceType).toBe('stylesheet');
+      expect(failedRequests[0].failure().errorText).toBe('net::ERR_FAILED');
     }));
     it('Page.Events.RequestFinished', SX(async function() {
       const requests = [];


### PR DESCRIPTION
Similarly to the `request.response()` method, this patch adds
`request.failure()` method that returns error details for the failed
requests.

Fixes #901.