### PR TITLE
fix(examples): add missing argument

### DIFF
--- a/examples/search.js
+++ b/examples/search.js
@@ -24,7 +24,7 @@ const browser = await puppeteer.launch();
 const page = await browser.newPage();
 await page.goto('https://google.com', {waitUntil: 'networkidle'});
 // Type our query into the search bar
-await page.type('puppeteer');
+await page.type('input[name=q]', 'puppeteer');
 
 await page.click('input[type="submit"]');
 


### PR DESCRIPTION
I tried to do it as follows, but I encountered an error.

```
$ node examples/search.js
(node:95394) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'type' of null
(node:95394) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

page.type requires selector of argument.