### PR TITLE
feat(coverage): Support Node.js coverage instrumentation.

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -25,6 +25,7 @@ const {FrameManager} = require('./FrameManager');
 const {Keyboard, Mouse, Touchscreen} = require('./Input');
 const Tracing = require('./Tracing');
 const {helper, debugError} = require('./helper');
+const {createHash} = require('crypto');
 
 const writeFileAsync = helper.promisify(fs.writeFile);
 
@@ -51,6 +52,45 @@ class Page extends EventEmitter {
     // Initialize default page size.
     if (!appMode)
       await page.setViewport({width: 800, height: 600});
+
+    if (global.__coverage__) {
+      const cv_objects = {};
+      Object.keys(global.__coverage__).forEach(filename => {
+        const hash = createHash('sha1');
+        hash.update(filename);
+        const key = parseInt(hash.digest('hex').substr(0, 12), 16).toString(36);
+        cv_objects[key] = global.__coverage__[filename];
+      });
+      await page.exposeFunction('cv_proxy_add', async arr => {
+        arr = JSON.parse(arr);
+        let obj = cv_objects;
+        while (arr.length > 1)
+          obj = obj[arr.shift()];
+
+        obj[arr.shift()]++;
+      });
+      await page.evaluate(keys => {
+        const createProxy = parents => {
+          parents = parents.slice();
+          return new Proxy({}, {
+            get: (target, name) => 0,
+            set: (obj, prop, value) => {
+              const arr = parents.concat([prop]);
+              cv_proxy_add(JSON.stringify(arr));
+              return true;
+            }
+          });
+        };
+        keys.forEach(key => {
+          window[`cov_${key}`] = {
+            f: createProxy([key, 'f']),
+            s: createProxy([key, 's']),
+            b: createProxy([key, 'b'])
+          };
+        });
+      }, Object.keys(cv_objects));
+    }
+
     return page;
   }
 


### PR DESCRIPTION
This patch detects coverage and inserts proxy objects to handle coverage on instrumented evaluate calls.

This patch works great, I used a bunch of puppeteer tests I have locally to verify, but I'm not entirely sure how to write a unit test for puppeteer itself for it. 

Additionally, the typescript linter is failing on globals detection and I have no idea how to suppress them.