### PR TITLE
chore(typescript): switch to 2.6-rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.2.0",
     "text-diff": "^1.0.1",
-    "typescript": "next"
+    "typescript": "^2.6.0-rc"
   }
 }


### PR DESCRIPTION
This moves us off of typescript@next to the slightly more stable release candidate version.