### PR TITLE
throw an error upon page.select option not present

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -925,11 +925,10 @@ Shortcut for [page.mainFrame().executionContext().queryObjects(prototypeHandle)]
 #### page.select(selector, ...values)
 - `selector` <[string]> A [selector] to query page for
 - `...values` <...[string]> Values of options to select. If the `<select>` has the `multiple` attribute, all values are considered, otherwise only the first one is taken into account.
-- returns: <[Promise]>
+- returns: <[Promise]<[Array]<[string]>>> Returns an array of option values that have been successfully selected.
 
 Triggers a `change` and `input` event once all the provided options have been selected.
-If there's no `<select>` element matching `selector`, the method throws an error.
-If no value in the provided values array matches any `<option>` element, the method throws an error. 
+If there's no `<select>` element matching `selector`, the method throws an error. 
 
 ```js
 page.select('select#colors', 'blue'); // single selection

--- a/docs/api.md
+++ b/docs/api.md
@@ -929,6 +929,7 @@ Shortcut for [page.mainFrame().executionContext().queryObjects(prototypeHandle)]
 
 Triggers a `change` and `input` event once all the provided options have been selected.
 If there's no `<select>` element matching `selector`, the method throws an error.
+If no value in the provided values array matches any `<option>` element, the method throws an error. 
 
 ```js
 page.select('select#colors', 'blue'); // single selection

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -775,20 +775,21 @@ class Page extends EventEmitter {
    * @param {!Array<string>} values
    */
   async select(selector, ...values) {
-    await this.$eval(selector, (element, values) => {
+    return await this.$eval(selector, (element, values) => {
       if (element.nodeName.toLowerCase() !== 'select')
         throw new Error('Element is not a <select> element.');
       const options = Array.from(element.options);
-      if (!values.some(value => options.some(option => option.value === value)))
-        throw new Error('Option does not exist.');
+      const filteredValues = values.filter(value => options.some(option => option.value === value));
       if (element.multiple) {
         for (const option of options)
           option.selected = values.includes(option.value);
       } else {
-        element.value = values.shift();
+        filteredValues.splice(1);
+        element.value = filteredValues[0];
       }
       element.dispatchEvent(new Event('input', { 'bubbles': true }));
       element.dispatchEvent(new Event('change', { 'bubbles': true }));
+      return Promise.all(filteredValues);
     }, values);
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -780,7 +780,9 @@ class Page extends EventEmitter {
         throw new Error('Element is not a <select> element.');
 
       const options = Array.from(element.options);
-
+      if (!options.some(function (v) {return values.indexOf(v.value) >= 0;})){
+        throw new Error('Option does not exist');
+      }
       if (element.multiple) {
         for (const option of options)
           option.selected = values.includes(option.value);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -779,13 +779,9 @@ class Page extends EventEmitter {
       if (element.nodeName.toLowerCase() !== 'select')
         throw new Error('Element is not a <select> element.');
       const options = Array.from(element.options);
-      const filteredValues = values.filter(value => options.some(option => option.value === value));
-      if (element.multiple) {
-        for (const option of options)
-          option.selected = filteredValues.includes(option.value);
-      } else {
-        element.value = filteredValues[0];
-      }
+      element.value = undefined;
+      for (const option of options)
+        option.selected = values.includes(option.value);
       element.dispatchEvent(new Event('input', { 'bubbles': true }));
       element.dispatchEvent(new Event('change', { 'bubbles': true }));
       return options.filter(option => option.selected).map(option => option.value);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -778,10 +778,9 @@ class Page extends EventEmitter {
     await this.$eval(selector, (element, values) => {
       if (element.nodeName.toLowerCase() !== 'select')
         throw new Error('Element is not a <select> element.');
-
       const options = Array.from(element.options);
-      if (!options.some(function(v) {return values.indexOf(v.value) >= 0;})) throw new Error('Option does not exist.');
-      
+      if (!values.some(value => options.some(option => option.value === value)))
+        throw new Error('Option does not exist.');
       if (element.multiple) {
         for (const option of options)
           option.selected = values.includes(option.value);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -782,14 +782,13 @@ class Page extends EventEmitter {
       const filteredValues = values.filter(value => options.some(option => option.value === value));
       if (element.multiple) {
         for (const option of options)
-          option.selected = values.includes(option.value);
+          option.selected = filteredValues.includes(option.value);
       } else {
-        filteredValues.splice(1);
         element.value = filteredValues[0];
       }
       element.dispatchEvent(new Event('input', { 'bubbles': true }));
       element.dispatchEvent(new Event('change', { 'bubbles': true }));
-      return Promise.all(filteredValues);
+      return options.filter(option => option.selected).map(option => option.value);
     }, values);
   }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -773,7 +773,7 @@ class Page extends EventEmitter {
   /**
    * @param {string} selector
    * @param {!Array<string>} values
-   * @return {!Promise<!Array<string>>} selected values
+   * @return {!Promise<!Array<string>>}
    */
   async select(selector, ...values) {
     return await this.$eval(selector, (element, values) => {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -780,9 +780,8 @@ class Page extends EventEmitter {
         throw new Error('Element is not a <select> element.');
 
       const options = Array.from(element.options);
-      if (!options.some(function (v) {return values.indexOf(v.value) >= 0;})){
-        throw new Error('Option does not exist');
-      }
+      if (!options.some(function(v) {return values.indexOf(v.value) >= 0;})) throw new Error('Option does not exist.');
+      
       if (element.multiple) {
         for (const option of options)
           option.selected = values.includes(option.value);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -773,6 +773,7 @@ class Page extends EventEmitter {
   /**
    * @param {string} selector
    * @param {!Array<string>} values
+   * @return {!Promise<!Array<string>>} selected values
    */
   async select(selector, ...values) {
     return await this.$eval(selector, (element, values) => {

--- a/test/test.js
+++ b/test/test.js
@@ -2556,21 +2556,6 @@ describe('Page', function() {
       expect(await page.evaluate(() => result.onBubblingChange)).toEqual(['blue']);
     }));
 
-    it('should work with no options', SX(async function() {
-      await page.goto(PREFIX + '/input/select.html');
-      await page.evaluate(() => makeEmpty());
-      await page.select('select', '42');
-      expect(await page.evaluate(() => result.onInput)).toEqual([]);
-      expect(await page.evaluate(() => result.onChange)).toEqual([]);
-    }));
-
-    it('should not select a non-existent option', SX(async function() {
-      await page.goto(PREFIX + '/input/select.html');
-      await page.select('select', '42');
-      expect(await page.evaluate(() => result.onInput)).toEqual([]);
-      expect(await page.evaluate(() => result.onChange)).toEqual([]);
-    }));
-
     it('should throw', SX(async function() {
       let error = null;
       await page.goto(PREFIX + '/input/select.html');
@@ -2578,9 +2563,7 @@ describe('Page', function() {
       expect(error.message).toContain('Element is not a <select> element.');
     }));
 
-
-
-     it('should throw on selecting non existent option', SX(async function() {
+    it('should throw on selecting non existent option', SX(async function() {
       let error = null;
       await page.goto(PREFIX + '/input/select.html');
       await page.select('select', '42').catch(e => error = e);

--- a/test/test.js
+++ b/test/test.js
@@ -2556,7 +2556,7 @@ describe('Page', function() {
       expect(await page.evaluate(() => result.onBubblingChange)).toEqual(['blue']);
     }));
 
-    it('should throw', SX(async function() {
+    it('should throw when element is not a <select>', SX(async function() {
       let error = null;
       await page.goto(PREFIX + '/input/select.html');
       await page.select('body', '').catch(e => error = e);
@@ -2573,7 +2573,7 @@ describe('Page', function() {
       await page.goto(PREFIX + '/input/select.html');
       await page.evaluate(() => makeMultiple());
       const result = await page.select('select','blue','black','magenta');
-      expect(result).toEqual(['blue','black','magenta']);
+      expect(result.reduce((accumulator,current) => ['blue', 'black', 'magenta'].includes(current) && accumulator, true)).toEqual(true);
     }));
 
     it('should return an array of one element when multiple is not set', SX(async function() {
@@ -2586,6 +2586,21 @@ describe('Page', function() {
       await page.goto(PREFIX + '/input/select.html');
       const result = await page.select('select');
       expect(result).toEqual([]);
+    }));
+
+    it('should deselect all options when passed no values for a multiple select',SX(async function() {
+      await page.goto(PREFIX + '/input/select.html');
+      await page.evaluate(() => makeMultiple());
+      await page.select('select','blue','black','magenta');
+      await page.select('select');
+      expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
+    }));
+
+    it('should deselect all options when passed no values for a select without multiple',SX(async function() {
+      await page.goto(PREFIX + '/input/select.html');
+      await page.select('select','blue','black','magenta');
+      await page.select('select');
+      expect(await page.$eval('select', select => Array.from(select.options).every(option => !option.selected))).toEqual(true);
     }));
 
   });

--- a/test/test.js
+++ b/test/test.js
@@ -2579,7 +2579,7 @@ describe('Page', function() {
     it('should return an array of one element when multiple is not set', SX(async function() {
       await page.goto(PREFIX + '/input/select.html');
       const result = await page.select('select','42','blue','black','magenta');
-      expect(result).toEqual(['blue']);
+      expect(result.length).toEqual(1);
     }));
 
     it('should return [] on no values',SX(async function() {

--- a/test/test.js
+++ b/test/test.js
@@ -2577,6 +2577,16 @@ describe('Page', function() {
       await page.select('body', '').catch(e => error = e);
       expect(error.message).toContain('Element is not a <select> element.');
     }));
+
+
+
+     it('should throw on selecting non existent option', SX(async function() {
+      let error = null;
+      await page.goto(PREFIX + '/input/select.html');
+      await page.select('select', '42').catch(e => error = e);
+      expect(error.message).toContain('Option does not exist.');
+    }));
+
   });
 
   describe('Tracing', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -2563,11 +2563,29 @@ describe('Page', function() {
       expect(error.message).toContain('Element is not a <select> element.');
     }));
 
-    it('should throw on selecting non existent option', SX(async function() {
-      let error = null;
+    it('should return [] on no matched values', SX(async function() {
       await page.goto(PREFIX + '/input/select.html');
-      await page.select('select', '42').catch(e => error = e);
-      expect(error.message).toContain('Option does not exist.');
+      const result = await page.select('select','42','abc');
+      expect(result).toEqual([]);
+    }));
+
+    it('should return an array of matched values', SX(async function() {
+      await page.goto(PREFIX + '/input/select.html');
+      await page.evaluate(() => makeMultiple());
+      const result = await page.select('select','blue','black','magenta');
+      expect(result).toEqual(['blue','black','magenta']);
+    }));
+
+    it('should return an array of one element when multiple is not set', SX(async function() {
+      await page.goto(PREFIX + '/input/select.html');
+      const result = await page.select('select','42','blue','black','magenta');
+      expect(result).toEqual(['blue']);
+    }));
+
+    it('should return [] on no values',SX(async function() {
+      await page.goto(PREFIX + '/input/select.html');
+      const result = await page.select('select');
+      expect(result).toEqual([]);
     }));
 
   });


### PR DESCRIPTION
For my use case, I needed to know when page.select succeeded to alter the form vs when page.select failed. A case where page.select fails is when the option is not present. I think this use case may be common and it could be a good addition to puppeteer! This solution may be too case specific though as page.select may fail under other conditions. 