### PR TITLE
feat(Chromium): roll Chromium to r510141

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "509368"
+    "chromium_revision": "510141"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll includes the following important revisions:
- https://crrev.com/509990 - DevTools: Allow location to be specified in
  Input.dispatchKeyEvent
- https://crrev.com/509486 - DevTools: fix extra HTTP headers not sent
on browser navigation request

References #877, references #777