### PR TITLE
Document that jsonValue might return error/blank

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1686,7 +1686,7 @@ Returns a JSON representation of the object. If the object has a
 [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior)
 function, it **will not be called**.
 
-> **NOTE** The method will throw if the referenced object is not stringifiable.
+> **NOTE** The method will return an empty JSON if the referenced object is not stringifiable. It will throw an error if the object has circular references.
 
 ### class: ElementHandle
 


### PR DESCRIPTION
In some cases `jsHandle.jsonValue` might error
an error or an empty JSON value.

Please refer to https://github.com/GoogleChrome/puppeteer/blob/9603bab0c731e6bd914b4b083537a20f7ae0a4da/test/test.js#L426-L443 .