### PR TITLE
Add the ability to end navigation using a console message

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -764,8 +764,10 @@ If there's no element matching `selector`, the method throws an error.
   - `waitUntil` <[string]> When to consider a navigation finished, defaults to `load`. Can be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
+    - `consolemessage` - consider navigation to be finished when a specific message is received on console, defined by `consoleMessage`.
   - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter.
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter.
+  - `consoleMessage` <[string]> Console message that will end navigation. Takes effect only with `waitUntil: 'consolemessage'` parameter. Default value: `'puppeteerClosePage'`
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If
 can not go back, resolves to null.
 
@@ -777,8 +779,10 @@ Navigate to the previous page in history.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Can be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
+    - `consolemessage` - consider navigation to be finished when a specific message is received on console, defined by `consoleMessage`.
   - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter.
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter.
+  - `consoleMessage` <[string]> Console message that will end navigation. Takes effect only with `waitUntil: 'consolemessage'` parameter. Default value: `'puppeteerClosePage'`
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If
 can not go back, resolves to null.
 
@@ -791,8 +795,10 @@ Navigate to the next page in history.
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Can be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
+    - `consolemessage` - consider navigation to be finished when a specific message is received on console, defined by `consoleMessage`.
   - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter. Defaults to 2.
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter. Defaults to 1000 ms.
+  - `consoleMessage` <[string]> Console message that will end navigation. Takes effect only with `waitUntil: 'consolemessage'` parameter. Default value: `'puppeteerClosePage'`
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
 The `page.goto` will throw an error if:
@@ -906,8 +912,10 @@ Shortcut for [page.mainFrame().executionContext().queryObjects(prototypeHandle)]
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Can be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
+    - `consolemessage` - consider navigation to be finished when a specific message is received on console, defined by `consoleMessage`.
   - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter.
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter.
+  - `consoleMessage` <[string]> Console message that will end navigation. Takes effect only with `waitUntil: 'consolemessage'` parameter. Default value: `'puppeteerClosePage'`
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
 #### page.screenshot([options])
@@ -1110,8 +1118,10 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
   - `waitUntil` <[string]> When to consider navigation succeeded, defaults to `load`. Can be either:
     - `load` - consider navigation to be finished when the `load` event is fired.
     - `networkidle` - consider navigation to be finished when the network activity stays "idle" for at least `networkIdleTimeout` ms.
+    - `consolemessage` - consider navigation to be finished when a specific message is received on console, defined by `consoleMessage`.
   - `networkIdleInflight` <[number]> Maximum amount of inflight requests which are considered "idle". Takes effect only with `waitUntil: 'networkidle'` parameter.
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter.
+  - `consoleMessage` <[string]> Console message that will end navigation. Takes effect only with `waitUntil: 'consolemessage'` parameter. Default value: `'puppeteerClosePage'`
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
 #### page.waitForSelector(selector[, options])

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -29,7 +29,8 @@ class NavigatorWatcher {
     this._idleTime = typeof options['networkIdleTimeout'] === 'number' ? options['networkIdleTimeout'] : 1000;
     this._idleInflight = typeof options['networkIdleInflight'] === 'number' ? options['networkIdleInflight'] : 2;
     this._waitUntil = typeof options['waitUntil'] === 'string' ? options['waitUntil'] : 'load';
-    console.assert(this._waitUntil === 'load' || this._waitUntil === 'networkidle', 'Unknown value for options.waitUntil: ' + this._waitUntil);
+    this._consoleMessage = typeof options['consoleMessage'] === 'string' ? options['consoleMessage'] : 'puppeteerClosePage';
+    console.assert(this._waitUntil === 'load' || this._waitUntil === 'networkidle' || this._waitUntil === 'consolemessage', 'Unknown value for options.waitUntil: ' + this._waitUntil);
   }
 
   /**
@@ -59,6 +60,10 @@ class NavigatorWatcher {
         this._eventListeners.push(helper.addEventListener(this._client, 'Page.loadEventFired', fulfill));
       }).then(() => null);
       navigationPromises.push(loadEventFired);
+    } else if (this._waitUntil === 'consolemessage') {
+      helper.addEventListener(this._client, 'Runtime.consoleAPICalled', this._onConsoleMessageReceived.bind(this));
+      const consoleMessage = new Promise(fulfill => this._consoleMessageCallback = fulfill).then(() => null);
+      navigationPromises.push(consoleMessage);
     } else {
       this._eventListeners.push(...[
         helper.addEventListener(this._client, 'Network.requestWillBeSent', this._onLoadingStarted.bind(this)),
@@ -78,6 +83,14 @@ class NavigatorWatcher {
 
   cancel() {
     this._cleanup();
+  }
+
+  /**
+   * @param {!Object} event
+   */
+  _onConsoleMessageReceived(event) {
+    if (event.args[0].value === this._consoleMessage)
+      this._consoleMessageCallback();
   }
 
   /**

--- a/test/assets/consolemessage.html
+++ b/test/assets/consolemessage.html
@@ -1,0 +1,8 @@
+<script>
+  async function main() {
+    setTimeout (() => {
+      console.log('puppeteerClosePage');
+    }, 5000);
+  }
+  main();
+</script>

--- a/test/assets/customconsolemessage.html
+++ b/test/assets/customconsolemessage.html
@@ -1,0 +1,8 @@
+<script>
+  async function main() {
+    setTimeout (() => {
+      console.log('customConsoleMessage');
+    }, 5000);
+  }
+  main();
+</script>


### PR DESCRIPTION
This PR allows puppeteer to set a special log message that will determine when the navigation is done. Is particularly useful when you need to load a page that takes a long time to render and network activity has ended long time before page is ready.