### PR TITLE
fix(touch): requestAnimationFrame before sending tap

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -215,6 +215,14 @@ class Touchscreen {
    * @param {number} y
    */
   async tap(x, y) {
+    // Touches appear to be lost during the first frame after navigation.
+    // This waits a frame before sending the tap.
+    // @see https://crbug.com/613219
+    await this._client.send('Runtime.evaluate', {
+      expression: 'new Promise(x => requestAnimationFrame(() => requestAnimationFrame(x)))',
+      awaitPromise: true
+    });
+
     const touchPoints = [{x: Math.round(x), y: Math.round(y)}];
     await this._client.send('Input.dispatchTouchEvent', {
       type: 'touchStart',


### PR DESCRIPTION
Until https://crbug.com/764122 is fixed upstream, this fixes the flakiness of `touchscreen.tap`.

Fixes #673