### PR TITLE
feat(Chromium): Roll chromium to r511134

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -75,7 +75,7 @@
   * [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
   * [page.setOfflineMode(enabled)](#pagesetofflinemodeenabled)
-  * [page.setRequestInterceptionEnabled(value)](#pagesetrequestinterceptionenabledvalue)
+  * [page.setRequestInterception(value)](#pagesetrequestinterceptionvalue)
   * [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
   * [page.setViewport(viewport)](#pagesetviewportviewport)
   * [page.tap(selector)](#pagetapselector)
@@ -416,7 +416,7 @@ Emitted when an uncaught exception happens within the page.
 - <[Request]>
 
 Emitted when a page issues a request. The [request] object is read-only.
-In order to intercept and mutate requests, see `page.setRequestInterceptionEnabled`.
+In order to intercept and mutate requests, see `page.setRequestInterception`.
 
 #### event: 'requestfailed'
 - <[Request]>
@@ -979,7 +979,7 @@ The extra HTTP headers will be sent with every request the page initiates.
 - `enabled` <[boolean]> When `true`, enables offline mode for the page.
 - returns: <[Promise]>
 
-#### page.setRequestInterceptionEnabled(value)
+#### page.setRequestInterception(value)
 - `value` <[boolean]> Whether to enable request interception.
 - returns: <[Promise]>
 
@@ -992,7 +992,7 @@ const puppeteer = require('puppeteer');
 
 puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
-  await page.setRequestInterceptionEnabled(true);
+  await page.setRequestInterception(true);
   page.on('request', interceptedRequest => {
     if (interceptedRequest.url.endsWith('.png') || interceptedRequest.url.endsWith('.jpg'))
       interceptedRequest.abort();
@@ -1864,7 +1864,7 @@ If request gets a 'redirect' response, the request is successfully finished with
   - `failed` - A generic failure occurred.
 - returns: <[Promise]>
 
-Aborts request. To use this, request interception should be enabled with `page.setRequestInterceptionEnabled`.
+Aborts request. To use this, request interception should be enabled with `page.setRequestInterception`.
 Exception is immediately thrown if the request interception is not enabled.
 
 #### request.continue([overrides])
@@ -1875,7 +1875,7 @@ Exception is immediately thrown if the request interception is not enabled.
   - `headers` <[Object]> If set changes the request HTTP headers
 - returns: <[Promise]>
 
-Continues request with optional request overrides. To use this, request interception should be enabled with `page.setRequestInterceptionEnabled`.
+Continues request with optional request overrides. To use this, request interception should be enabled with `page.setRequestInterception`.
 Exception is immediately thrown if the request interception is not enabled.
 
 #### request.failure()
@@ -1921,13 +1921,13 @@ ResourceType will be one of the following: `document`, `stylesheet`, `image`, `m
 - returns: <[Promise]>
 
 Fulfills request with given response. To use this, request interception should
-be enabled with `page.setRequestInterceptionEnabled`. Exception is thrown if
+be enabled with `page.setRequestInterception`. Exception is thrown if
 request interception is not enabled.
 
 An example of fulfilling all requests with 404 responses:
 
 ```js
-await page.setRequestInterceptionEnabled(true);
+await page.setRequestInterception(true);
 page.on('request', request => {
   request.respond({
     status: 404,

--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -22,7 +22,7 @@ const puppeteer = require('puppeteer');
 
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
-await page.setRequestInterceptionEnabled(true);
+await page.setRequestInterception(true);
 page.on('request', request => {
   if (request.resourceType === 'image')
     request.abort();

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -106,7 +106,7 @@ class NetworkManager extends EventEmitter {
   /**
    * @param {boolean} value
    */
-  async setRequestInterceptionEnabled(value) {
+  async setRequestInterception(value) {
     this._userRequestInterceptionEnabled = value;
     await this._updateProtocolRequestInterception();
   }
@@ -116,7 +116,8 @@ class NetworkManager extends EventEmitter {
     if (enabled === this._protocolRequestInterceptionEnabled)
       return;
     this._protocolRequestInterceptionEnabled = enabled;
-    await this._client.send('Network.setRequestInterceptionEnabled', {enabled});
+    const patterns = enabled ? [{urlPattern: '*'}] : [];
+    await this._client.send('Network.setRequestInterception', {patterns});
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -149,8 +149,8 @@ class Page extends EventEmitter {
   /**
    * @param {boolean} value
    */
-  async setRequestInterceptionEnabled(value) {
-    return this._networkManager.setRequestInterceptionEnabled(value);
+  async setRequestInterception(value) {
+    return this._networkManager.setRequestInterception(value);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "510398"
+    "chromium_revision": "511134"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll includes:
- crrev.com/510651 that changes request interception methods in protocol

The patch also renames an API method:
- s/Page.setRequestInterceptionEnabled/Page.setRequestInterception

BREAKING CHANGE

Page.setRequestInterceptionEnabled is renamed into
Page.setRequestInterception.