### PR TITLE
fix(interception): Disable newtork caching when intercepting

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1007,6 +1007,8 @@ puppeteer.launch().then(async browser => {
 > **NOTE** Request interception doesn't work with data URLs. Calling `abort`,
 > `continue` or `respond` on requests for data URLs is a noop.
 
+> **NOTE** Enabling request interception disables page caching.
+
 #### page.setUserAgent(userAgent)
 - `userAgent` <[string]> Specific user agent to use in this page
 - returns: <[Promise]> Promise which resolves when the user agent is set.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -117,7 +117,10 @@ class NetworkManager extends EventEmitter {
       return;
     this._protocolRequestInterceptionEnabled = enabled;
     const patterns = enabled ? [{urlPattern: '*'}] : [];
-    await this._client.send('Network.setRequestInterception', {patterns});
+    await Promise.all([
+      this._client.send('Network.setCacheDisabled', {cacheDisabled: enabled}),
+      this._client.send('Network.setRequestInterception', {patterns})
+    ]);
   }
 
   /**


### PR DESCRIPTION
Request interception might not work properly if caching is enabled.