### PR TITLE
fix(Launcher): force-kill chrome on process exit and interruption

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -125,9 +125,9 @@ class Launcher {
       });
     });
 
-    const listeners = [ helper.addEventListener(process, 'exit', killChrome) ];
+    const listeners = [ helper.addEventListener(process, 'exit', forceKillChrome) ];
     if (options.handleSIGINT !== false)
-      listeners.push(helper.addEventListener(process, 'SIGINT', killChrome));
+      listeners.push(helper.addEventListener(process, 'SIGINT', forceKillChrome));
     /** @type {?Connection} */
     let connection = null;
     try {
@@ -146,22 +146,27 @@ class Launcher {
     function killChrome() {
       helper.removeEventListeners(listeners);
       if (temporaryUserDataDir) {
-        if (chromeProcess.pid && !chromeProcess.killed && !chromeClosed) {
-          // Force kill chrome.
-          if (process.platform === 'win32')
-            childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
-          else
-            process.kill(-chromeProcess.pid, 'SIGKILL');
-        }
-        // Attempt to remove temporary profile directory to avoid littering.
-        try {
-          removeFolder.sync(temporaryUserDataDir);
-        } catch (e) { }
+        forceKillChrome();
       } else if (connection) {
         // Attempt to close chrome gracefully
         connection.send('Browser.close');
       }
       return waitForChromeToClose;
+    }
+
+    function forceKillChrome() {
+      helper.removeEventListeners(listeners);
+      if (chromeProcess.pid && !chromeProcess.killed && !chromeClosed) {
+        // Force kill chrome.
+        if (process.platform === 'win32')
+          childProcess.execSync(`taskkill /pid ${chromeProcess.pid} /T /F`);
+        else
+          process.kill(-chromeProcess.pid, 'SIGKILL');
+      }
+      // Attempt to remove temporary profile directory to avoid littering.
+      try {
+        removeFolder.sync(temporaryUserDataDir);
+      } catch (e) { }
     }
   }
 


### PR DESCRIPTION
This patch starts force-killing chromium regardless of custom userdata
directory when the node process exits.

References #1047