### PR TITLE
Add new buildpack url that adds additional fonts

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -158,3 +158,5 @@ Running Puppeteer on Heroku requires some additional dependencies that aren't in
 The url for the buildpack is https://github.com/jontewks/puppeteer-heroku-buildpack
 
 When you click add buildpack, simply paste that url into the input, and click save. On the next deploy, your app will also install the dependencies that Puppeteer needs to run.
+
+If you need to render Chinese, Japanese, or Korean characters you may need to use a buildpack with additional font files like https://github.com/CoffeeAndCode/puppeteer-heroku-buildpack


### PR DESCRIPTION
The jontewks buildpack worked great for running Chrome headless, but it did not include support for Chinese characters and the PDF rendering I was attempting was not usable. This fix brings in a few custom fonts to allow PDF generation to utilize the fonts.

The idea came from https://github.com/dscout/wkhtmltopdf-buildpack/pull/14/files