### PR TITLE
When printing pdf, default to printing the background

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -830,7 +830,7 @@ Page is guaranteed to have a main frame which persists during navigations.
   - `path` <[string]> The file path to save the PDF to. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the PDF won't be saved to the disk.
   - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`.
   - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
-  - `printBackground` <[boolean]> Print background graphics. Defaults to `false`.
+  - `printBackground` <[boolean]> Print background graphics. Defaults to `true`.
   - `landscape` <[boolean]> Paper orientation. Defaults to `false`.
   - `pageRanges` <[string]> Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
   - `format` <[string]> Paper format. If set, takes priority over `width` or `height` options. Defaults to 'Letter'.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -686,7 +686,7 @@ class Page extends EventEmitter {
   async pdf(options = {}) {
     const scale = options.scale || 1;
     const displayHeaderFooter = !!options.displayHeaderFooter;
-    const printBackground = !!options.printBackground;
+    const printBackground = options.hasOwnProperty('printBackground') ? !!options.printBackground : true;
     const landscape = !!options.landscape;
     const pageRanges = options.pageRanges || '';
 

--- a/test/test.js
+++ b/test/test.js
@@ -2518,6 +2518,30 @@ describe('Page', function() {
       expect(pages[0].width).toBeCloseTo(8.5, 2);
       expect(pages[0].height).toBeCloseTo(11, 2);
     }));
+    it('should default to printing backgrounds', SX(async function() {
+      spyOn(page._client, 'send').and.callThrough();
+      await page.pdf();
+      const [/* ignored */, opts] = page._client.send.calls.argsFor(0);
+      expect(opts.printBackground).toBe(true);
+    }));
+    it('should allow printBackground to be set and coalesced to boolean', SX(async function() {
+      spyOn(page._client, 'send').and.callThrough();
+      await page.pdf({printBackground: false});
+      let [/* ignored */, opts] = page._client.send.calls.argsFor(0);
+      expect(opts.printBackground).toBe(false);
+
+      await page.pdf({printBackground: 0});
+      [/* ignored */, opts] = page._client.send.calls.argsFor(1);
+      expect(opts.printBackground).toBe(false);
+
+      await page.pdf({printBackground: 'true'});
+      [/* ignored */, opts] = page._client.send.calls.argsFor(2);
+      expect(opts.printBackground).toBe(true);
+
+      await page.pdf({printBackground: 1});
+      [/* ignored */, opts] = page._client.send.calls.argsFor(3);
+      expect(opts.printBackground).toBe(true);
+    }));
     it('should support setting custom format', SX(async function() {
       const pages = await getPDFPages(await page.pdf({
         format: 'a4'


### PR DESCRIPTION
Embarrassingly, I lost half a day to debugging why my backgrounds weren't appearing when printing pdfs.

Since chromium's --print-to-pdf feature defaults to printing the backgrounds, it would be good to match that default.

https://github.com/GoogleChrome/puppeteer/issues/301
https://bugs.chromium.org/p/chromium/issues/detail?id=771634