### PR TITLE
Fix README.md runnable code to respect current API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ const puppeteer = require('puppeteer');
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  await page.goto('https://news.ycombinator.com', {waitUntil: 'networkidle2'});
+  await page.goto('https://news.ycombinator.com');
+  page.waitForNavigation({ options: { waitUntil: 'networkidle2' } });
+
   await page.pdf({path: 'hn.pdf', format: 'A4'});
 
   await browser.close();


### PR DESCRIPTION
Puppeteer README.md has options as second argument to page.goto, however, page.goto does not allow options.
