### PR TITLE
Explain how to run examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,12 @@
+# Running the examples
+
+(The follow assumes you have checked out the complete puppeteer repository, and installed puppeteer's dependencies via `yarn`.)
+
+```sh
+# creates example.png
+$ env NODE_PATH=../.. node screenshot.js
+```
+
 # Other resources
 
 > Other useful tools, articles, and projects that use Puppeteer.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,9 @@
 # Running the examples
 
-(The follow assumes you have checked out the complete puppeteer repository, and installed puppeteer's dependencies via `yarn`.)
+Assuming you have a checked out the puppeteer repo and run yarn (or `npm i`) to install the dependencies, the examples can be run from the root folder like so:
 
 ```sh
-# creates example.png
-$ env NODE_PATH=../.. node screenshot.js
+NODE_PATH=../ node examples/search.js
 ```
 
 # Other resources

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Running the examples
 
-Assuming you have a checked out the puppeteer repo and run yarn (or `npm i`) to install the dependencies, the examples can be run from the root folder like so:
+Assuming you have a checkout of the Puppeteer repo and have run yarn (or npm i) to install the dependencies, the examples can be run from the root folder like so:
 
 ```sh
 NODE_PATH=../ node examples/search.js


### PR DESCRIPTION
The examples in the examples directory are not directly runnable--`node example.js` just fails on `require('puppeteer')`. Maybe there's a better way of doing this, but this worked for me.