### PR TITLE
docs(api.md): fix return value of frame.select()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1510,7 +1510,7 @@ If the name is empty, returns the id attribute instead.
 #### frame.select(selector, ...values)
 - `selector` <[string]> A [selector] to query frame for
 - `...values` <...[string]> Values of options to select. If the `<select>` has the `multiple` attribute, all values are considered, otherwise only the first one is taken into account.
-- returns: <[Promise]<[string]>>
+- returns: <[Promise]<[Array]<[string]>>> Returns an array of option values that have been successfully selected.
 
 Triggers a `change` and `input` event once all the provided options have been selected.
 If there's no `<select>` element matching `selector`, the method throws an error.


### PR DESCRIPTION
It seems this should be in sync with [`page.select()`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageselectselector-values).