### PR TITLE
feat(Chromium): roll chromium to r513435.

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -43,10 +43,11 @@ class Page extends EventEmitter {
     const page = new Page(client, frameTree, ignoreHTTPSErrors, screenshotTaskQueue);
 
     await Promise.all([
+      client.send('Page.setLifecycleEventsEnabled', { enabled: true }),
       client.send('Network.enable', {}),
       client.send('Runtime.enable', {}),
       client.send('Security.enable', {}),
-      client.send('Performance.enable', {})
+      client.send('Performance.enable', {}),
     ]);
     if (ignoreHTTPSErrors)
       await client.send('Security.setOverrideCertificateErrors', {override: true});

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "511134"
+    "chromium_revision": "513435"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll brings in a bunch of important patches:
- crrev.com/512647 Changed headless browser profile dir to use Default profile path
- crrev.com/512760 DevTools: stop idleness detector when pending navigation commits
- crrev.com/512905 DevTools: introduce Page.getFrameTree
- crrev.com/513373 DevTools: report loaderId in the lifecycle events
- crrev.com/513419 DevTools: introduce Page.setLifecycleEventsEnabled
- crrev.com/513422 DevTools: return loaderId from Page.navigate

Fixes #921 

BREAKING CHANGE:

Headless user profile structure is changing. Custom profiles set with --user-data-dir flag will no longer be read in Chrome 63 and will have to be recreated.

Alternatively, you can migrate old headless profile to a new structure. if you stored your profile in `<profile>` folder, you would run the following bash commands:

```bash
cd <profile>
mkdir Default
mv * Default
```

Full headless-dev PSA announcement: https://groups.google.com/a/chromium.org/forum/#!msg/headless-dev/asX8WgktXIE/zTUfmHDcAQAJ
