### PR TITLE
test: validate headless reading cookies written by headful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ cache:
   yarn: true
   directories:
     - node_modules
+# allow headful tests
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 install:
   - yarn install
   # puppeteer's install script downloads Chrome

--- a/test/test.js
+++ b/test/test.js
@@ -165,6 +165,26 @@ describe('Puppeteer', function() {
       await browser2.close();
       rm(userDataDir);
     }));
+    it('headless/headful should be able to read cookies of each other', SX(async function() {
+      const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
+      const options = Object.assign({userDataDir}, defaultBrowserOptions);
+      // Write a cookie in headful chrome
+      options.headless = false;
+      const headfulBrowser = await puppeteer.launch(options);
+      const headfulPage = await headfulBrowser.newPage();
+      await headfulPage.goto(EMPTY_PAGE);
+      await headfulPage.evaluate(() => document.cookie = 'foo=true; expires=Fri, 31 Dec 9999 23:59:59 GMT');
+      await headfulBrowser.close();
+      // Read the cookie from headless chrome
+      options.headless = true;
+      const headlessBrowser = await puppeteer.launch(options);
+      const headlessPage = await headlessBrowser.newPage();
+      await headlessPage.goto(EMPTY_PAGE);
+      const cookie = await headlessPage.evaluate(() => document.cookie);
+      await headlessBrowser.close();
+      rm(userDataDir);
+      expect(cookie).toBe('foo=true');
+    }));
   });
   describe('Puppeteer.connect', function() {
     it('should be able to connect multiple times to the same browser', SX(async function() {

--- a/test/test.js
+++ b/test/test.js
@@ -165,7 +165,7 @@ describe('Puppeteer', function() {
       await browser2.close();
       rm(userDataDir);
     }));
-    it('headless/headful should be able to read cookies of each other', SX(async function() {
+    xit('headless should be able to read cookies written by headful', SX(async function() {
       const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
       const options = Object.assign({userDataDir}, defaultBrowserOptions);
       // Write a cookie in headful chrome


### PR DESCRIPTION
This test ensures that Chrome Headless can successfully read cookies written
by Chrome Headful.

References #921