### PR TITLE
refactor: use Page.getFrameTree instead of Page.getResourceTree

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -39,7 +39,7 @@ class Page extends EventEmitter {
   static async create(client, ignoreHTTPSErrors, appMode, screenshotTaskQueue) {
 
     await client.send('Page.enable');
-    const {frameTree} = await client.send('Page.getResourceTree');
+    const {frameTree} = await client.send('Page.getFrameTree');
     const page = new Page(client, frameTree, ignoreHTTPSErrors, screenshotTaskQueue);
 
     await Promise.all([


### PR DESCRIPTION
This patch starts using Page.getFrameTree instead of
Page.getResourceTree.

The resource tree is experimental, whereas the frame tree is not.