### PR TITLE
Expose Page.setGeolocationOverride

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,7 @@
   * [page.setContent(html, options)](#pagesetcontenthtml-options)
   * [page.setCookie(...cookies)](#pagesetcookiecookies)
   * [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
+  * [page.setGeolocationOverride(options)](#pagesetgeolocationoverrideoptions)
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
   * [page.setOfflineMode(enabled)](#pagesetofflinemodeenabled)
   * [page.setRequestInterception(value)](#pagesetrequestinterceptionvalue)
@@ -979,11 +980,17 @@ The extra HTTP headers will be sent with every request the page initiates.
 
 > **NOTE** page.setExtraHTTPHeaders does not guarantee the order of headers in the outgoing requests.
 
+#### page.setGeolocationOverride(options)
+- `options` <[Object]> Contains latitude, longitude and accuracy numbers.
+- returns: <[Promise]>
+
 #### page.setJavaScriptEnabled(enabled)
 - `enabled` <[boolean]> Whether or not to enable JavaScript on the page.
 - returns: <[Promise]>
 
 > **NOTE** changing this value won't affect scripts that have already been run. It will take full effect on the next [navigation](#pagegotourl-options).
+
+
 
 #### page.setOfflineMode(enabled)
 - `enabled` <[boolean]> When `true`, enables offline mode for the page.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -562,6 +562,16 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {?Object} options
+   */
+  async setGeolocationOverride(options) {
+    if (options !== null)
+      console.assert(typeof options.latitude === 'number' && typeof options.longitude === 'number' && typeof options.accuracy === 'number', 'Must pass in latitude, longitude and accuracy numbers in options');
+
+    await this._client.send('Emulation.setGeolocationOverride', options);
+  }
+
+  /**
    * @param {?string} mediaType
    */
   async emulateMedia(mediaType) {

--- a/test/test.js
+++ b/test/test.js
@@ -2571,6 +2571,25 @@ describe('Page', function() {
     }));
   });
 
+  describe('Page.setGeolocationOverride', function() {
+    fit('should work', SX(async function() {
+      await page.goto(EMPTY_PAGE);
+      let error = null;
+      await page.setGeolocationOverride({longitude: 0, accuracy: 1}).catch(e => error = e);
+      expect(error.message).toContain('Must pass in');
+
+      await page.setGeolocationOverride({latitude: 10, longitude: 12, accuracy: 1})
+      const result = await page.evaluate(() => {
+        return new Promise(callback => navigator.geolocation.getCurrentPosition(result => {
+          // do something with result
+          callback('');
+        }));
+      });
+
+      expect(result).toBe(null);
+    }));
+  });
+
   describe('Page.evaluateOnNewDocument', function() {
     it('should evaluate before anything else on the page', SX(async function() {
       await page.evaluateOnNewDocument(function(){


### PR DESCRIPTION
The test in this fails due to permissions and should not be merged yet.

Fixes #1077 