### PR TITLE
Added assertion to page.type()

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -795,6 +795,7 @@ class Page extends EventEmitter {
    */
   async type(selector, text, options) {
     const handle = await this.$(selector);
+    console.assert(handle, 'No node found for selector: ' + selector);
     await handle.type(text, options);
     await handle.dispose();
   }


### PR DESCRIPTION
To make it match the other event shortcuts but mostly because I got confused by the ` TypeError: Cannot read property 'type' of null` exception i kept getting.