### PR TITLE
docs: document osx keyboard shortcuts not working

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1193,6 +1193,8 @@ await page.keyboard.press('KeyA');
 await page.keyboard.up('Shift');
 ```
 
+> **NOTE** On MacOS, keyboard shortcuts like `⌘ A` -> Select All do not work. See [#776](https://github.com/GoogleChrome/puppeteer/issues/776)
+
 #### keyboard.down(key[, options])
 - `key` <[string]> Name of key to press, such as `ArrowLeft`. See [USKeyboardLayout] for a list of all key names.
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1193,7 +1193,7 @@ await page.keyboard.press('KeyA');
 await page.keyboard.up('Shift');
 ```
 
-> **NOTE** On MacOS, keyboard shortcuts like `⌘ A` -> Select All do not work. See [#776](https://github.com/GoogleChrome/puppeteer/issues/776)
+> **NOTE** On MacOS, keyboard shortcuts like `⌘ A` -> Select All do not work. See [#1313](https://github.com/GoogleChrome/puppeteer/issues/1313)
 
 #### keyboard.down(key[, options])
 - `key` <[string]> Name of key to press, such as `ArrowLeft`. See [USKeyboardLayout] for a list of all key names.


### PR DESCRIPTION
Fixes #776