### PR TITLE
Revert "feat(Page): teach Page.setContent to wait for resources to lo…

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -71,7 +71,7 @@
   * [page.reload(options)](#pagereloadoptions)
   * [page.screenshot([options])](#pagescreenshotoptions)
   * [page.select(selector, ...values)](#pageselectselector-values)
-  * [page.setContent(html, options)](#pagesetcontenthtml-options)
+  * [page.setContent(html)](#pagesetcontenthtml)
   * [page.setCookie(...cookies)](#pagesetcookiecookies)
   * [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
@@ -947,16 +947,9 @@ page.select('select#colors', 'red', 'green', 'blue'); // multiple selections
 
 Shortcut for [page.mainFrame.select()](#frameselectselector-values)
 
-#### page.setContent(html, options)
+#### page.setContent(html)
 - `html` <[string]> HTML markup to assign to the page.
-- `options` <[Object]> Navigation parameters which might have the following properties:
-  - `timeout` <[number]> Maximum navigation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout.
-  - `waitUntil` <[string]|[Array]<[string]>> When to consider setting content complete, defaults to `load`. Given an array of event strings, setting content is considered to be successful after all events have been fired. Events can be either:
-    - `load` - consider setting content to be finished when the `load` event is fired.
-    - `domcontentloaded` - consider setting content to be finished when the `DOMContentLoaded` event is fired.
-    - `networkidle0` - consider setting content to be finished when there are no more than 0 network connections for at least `500` ms.
-    - `networkidle2` - consider setting content to be finished when there are no more than 2 network connections for at least `500` ms.
-- returns: <[Promise]> Promise which resolves when content is set and all events are triggered.
+- returns: <[Promise]>
 
 #### page.setCookie(...cookies)
 - `...cookies` <...[Object]>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -438,17 +438,13 @@ class Page extends EventEmitter {
 
   /**
    * @param {string} html
-   * @param {!Object=} options
    */
-  async setContent(html, options) {
-    await Promise.all([
-      this.evaluate(html => {
-        document.open();
-        document.write(html);
-        document.close();
-      }, html),
-      this.waitForNavigation(options),
-    ]);
+  async setContent(html) {
+    await this.evaluate(html => {
+      document.open();
+      document.write(html);
+      document.close();
+    }, html);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -2253,17 +2253,6 @@ describe('Page', function() {
       const result = await page.content();
       expect(result).toBe(`${doctype}${expectedOutput}`);
     }));
-    it('should await resources to load', SX(async function() {
-      const imgPath = '/img.png';
-      let imgResponse = null;
-      server.setRoute(imgPath, (req, res) => imgResponse = res);
-      let loaded = false;
-      const contentPromise = page.setContent(`<img src="${PREFIX + imgPath}"></img>`).then(() => loaded = true);
-      await server.waitForRequest(imgPath);
-      expect(loaded).toBe(false);
-      imgResponse.end();
-      await contentPromise;
-    }));
   });
 
   describe('Network Events', function() {


### PR DESCRIPTION
…ad (#1152)"

This reverts commit 80ee46942908054dea3bc14e6505bc12718e0b2d.

Lifecycle events are not ready yet to support the setContent scenario.
The prerequisite for this is
https://chromium-review.googlesource.com/c/chromium/src/+/747805 that
might not land soon due to technical concerns.