### PR TITLE
feat: Set default executablePath

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -215,7 +215,9 @@ Puppeteer looks for certain [environment variables](https://en.wikipedia.org/wik
 
 - `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` - defines HTTP proxy settings that are used to download and run Chromium.
 - `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` - do not download bundled Chromium during installation step.
-- `PUPPETEER_DOWNLOAD_HOST` - overwrite host part of URL that is used to download Chromium
+- `PUPPETEER_DOWNLOAD_HOST` - overwrite host part of URL that is used to download Chromium.
+- `PUPPETEER_EXECUTABLE_PATH` - change the default executablePath, useful when using bundled Chromium, in a package that's depended on Puppeteer.
+
 
 ### class: Puppeteer
 

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -179,8 +179,12 @@ class Launcher {
    * @return {string}
    */
   static executablePath() {
-    const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
-    return revisionInfo.executablePath;
+    let executablePath = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.npm_config_puppeteer_executable_path;
+
+    if (!executablePath)
+      executablePath = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision).executablePath;
+
+    return executablePath;
   }
 
   /**

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -86,7 +86,14 @@ class Launcher {
           '--mute-audio'
       );
     }
+
     let chromeExecutable = options.executablePath;
+
+    if (!options.executablePath) {
+      const EXECUTABLE_PATH = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.npm_config_puppeteer_executable_path;
+      if (EXECUTABLE_PATH)
+        chromeExecutable = EXECUTABLE_PATH;
+    }
     if (typeof chromeExecutable !== 'string') {
       const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
       console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "npm install"`);


### PR DESCRIPTION
Allows to set the default executablePath as the
`PUPPETEER_EXECUTABLE_PATH`  Environment Variable. Or with a npm config.

This is best used when you want to use a bundled chromium, in a third
party package where puppeteer is a dependency.

Fixes #1335