### PR TITLE
feat(Chromium): roll chromium to r515411

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "514418"
+    "chromium_revision": "515411"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll includes the following revisions:
- crrev.com/515281 DevTools: fix crash on intercepting request that
  posts a blob
- crrev.com/515368 DevTools: wait for navigation to be committed
  upon Page.navigate on the browser side.

Fixes #894, References #1218