### PR TITLE
fix(Navigation): wait for lifecycle events for the frame subtree

### DIFF
--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -94,6 +94,10 @@ class NavigatorWatcher {
         if (!frame._lifecycleEvents.has(event))
           return false;
       }
+      for (const child of frame.childFrames()) {
+        if (!checkLifecycle(child, expectedLifecycle))
+          return false;
+      }
       return true;
     }
   }


### PR DESCRIPTION
Currently, we wait only for the main frame to reach the desired
lifecycle state.

This patch starts waiting until all the frames reach the desired
lifecycle state.

Fixes #1173.