### PR TITLE
feat(Browser): add remoteDebuggingPort method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,7 @@
   * [browser.disconnect()](#browserdisconnect)
   * [browser.newPage()](#browsernewpage)
   * [browser.pages()](#browserpages)
+  * [browser.remoteDebuggingPort()](#browserremotedebuggingport)
   * [browser.targets()](#browsertargets)
   * [browser.version()](#browserversion)
   * [browser.wsEndpoint()](#browserwsendpoint)
@@ -327,6 +328,9 @@ Disconnects Puppeteer from the browser, but leaves the Chromium process running.
 
 #### browser.pages()
 - returns: <[Promise]<[Array]<[Page]>>> Promise which resolves to an array of all open pages.
+
+#### browser.remoteDebuggingPort()
+- returns: <[number]> Browser remote debugging port.
 
 #### browser.targets()
 - returns: <[Array]<[Target]>> An array of all active targets.

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -17,6 +17,7 @@
 const {helper} = require('./helper');
 const Page = require('./Page');
 const EventEmitter = require('events');
+const Url = require('url');
 
 class Browser extends EventEmitter {
   /**
@@ -30,6 +31,7 @@ class Browser extends EventEmitter {
     this._appMode = !!options.appMode;
     this._screenshotTaskQueue = new TaskQueue();
     this._connection = connection;
+    this._remoteDebuggingPort = parseInt(Url.parse(connection.url()).port, 10);
     this._closeCallback = closeCallback || new Function();
     /** @type {Map<string, Target>} */
     this._targets = new Map();
@@ -89,6 +91,13 @@ class Browser extends EventEmitter {
    */
   wsEndpoint() {
     return this._connection.url();
+  }
+
+  /**
+   * @return {number}
+   */
+  remoteDebuggingPort() {
+    return this._remoteDebuggingPort;
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,7 @@
 const fs = require('fs');
 const rm = require('rimraf').sync;
 const path = require('path');
+const url = require('url');
 const {helper} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
@@ -278,6 +279,15 @@ describe('Page', function() {
       expect(disconnectedOriginal).toBe(1);
       expect(disconnectedRemote1).toBe(1);
       expect(disconnectedRemote2).toBe(1);
+    }));
+  });
+
+  describe('Browser.remoteDebuggingPort', function() {
+    it('should return the same port as in wsEndpoint', SX(async function() {
+      const wsEndpoint = browser.wsEndpoint();
+      const endpointPort = parseInt(url.parse(wsEndpoint).port, 10);
+      const remoteDebuggingPort = browser.remoteDebuggingPort();
+      expect(remoteDebuggingPort).toBe(endpointPort);
     }));
   });
 


### PR DESCRIPTION
It is sometimes useful to have the remote debugging port which is used by the browser. To get some debugging information, or to use other tools like lighthouse.

This PR adds a method to the `Browser` class returning the port based on the wsEndpoint. The same thing could be achieved on the user side, but I feel it is a convenient helper method to have.