### PR TITLE
fix(Launcher): handle SIGTERM by default

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -251,6 +251,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
   - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
   - `args` <[Array]<[string]>> Additional arguments to pass to the Chromium instance. List of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `handleSIGINT` <[boolean]> Close chrome process on Ctrl-C. Defaults to `true`.
+  - `handleSIGTERM` <[boolean]> Close chrome process on SIGTERM. Defaults to `true`.
   - `timeout` <[number]> Maximum time in milliseconds to wait for the Chrome instance to start. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
   - `dumpio` <[boolean]> Whether to pipe browser process stdout and stderr into `process.stdout` and `process.stderr`. Defaults to `false`.
   - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md).

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -126,6 +126,8 @@ class Launcher {
     const listeners = [ helper.addEventListener(process, 'exit', forceKillChrome) ];
     if (options.handleSIGINT !== false)
       listeners.push(helper.addEventListener(process, 'SIGINT', forceKillChrome));
+    if (options.handleSIGTERM !== false)
+      listeners.push(helper.addEventListener(process, 'SIGTERM', killChrome));
     /** @type {?Connection} */
     let connection = null;
     try {
@@ -134,7 +136,7 @@ class Launcher {
       connection = await Connection.create(browserWSEndpoint, connectionDelay);
       return Browser.create(connection, options, killChrome);
     } catch (e) {
-      killChrome();
+      forceKillChrome();
       throw e;
     }
 


### PR DESCRIPTION
This patch starts listening to SIGTERM event to gracefully shutdown
chromium instance.

References #1047.