### PR TITLE
fix(Launcher): handle SIGHUP signal

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -252,6 +252,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
   - `args` <[Array]<[string]>> Additional arguments to pass to the Chromium instance. List of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `handleSIGINT` <[boolean]> Close chrome process on Ctrl-C. Defaults to `true`.
   - `handleSIGTERM` <[boolean]> Close chrome process on SIGTERM. Defaults to `true`.
+  - `handleSIGHUP` <[boolean]> Close chrome process on SIGHUP. Defaults to `true`.
   - `timeout` <[number]> Maximum time in milliseconds to wait for the Chrome instance to start. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
   - `dumpio` <[boolean]> Whether to pipe browser process stdout and stderr into `process.stdout` and `process.stderr`. Defaults to `false`.
   - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md).

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -128,6 +128,8 @@ class Launcher {
       listeners.push(helper.addEventListener(process, 'SIGINT', forceKillChrome));
     if (options.handleSIGTERM !== false)
       listeners.push(helper.addEventListener(process, 'SIGTERM', killChrome));
+    if (options.handleSIGHUP !== false)
+      listeners.push(helper.addEventListener(process, 'SIGHUP', killChrome));
     /** @type {?Connection} */
     let connection = null;
     try {


### PR DESCRIPTION
The SIGHUP signal is sent whenever the controlling terminal is closed.

On Windows, SIGHUP is emulated by libuv, and will be the only signal we
receive before the application will be terminated.

This patch starts handling SIGHUP in the same way we handle SIGTERM.

Fixes #1367.