### PR TITLE
Updated block-images.js to reflect updated setRequestInterception

### DIFF
--- a/examples/block-images.js
+++ b/examples/block-images.js
@@ -22,7 +22,7 @@ const puppeteer = require('puppeteer');
 
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
-await page.setRequestInterception(true);
+await page.setRequestInterceptionEnabled(true);
 page.on('request', request => {
   if (request.resourceType === 'image')
     request.abort();


### PR DESCRIPTION
The /examples didn't have the adjustment from:

`await page.setRequestInterception(true);` 
to
`await page.setRequestInterceptionEnabled(true);` 