### PR TITLE
fix(Page.goto): check navigation completeness on frame detachment

### DIFF
--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -43,7 +43,8 @@ class NavigatorWatcher {
     this._initialLoaderId = frame._loaderId;
     this._timeout = typeof options.timeout === 'number' ? options.timeout : 30000;
     this._eventListeners = [
-      helper.addEventListener(this._frameManager, FrameManager.Events.LifecycleEvent, this._checkLifecycleComplete.bind(this))
+      helper.addEventListener(this._frameManager, FrameManager.Events.LifecycleEvent, this._checkLifecycleComplete.bind(this)),
+      helper.addEventListener(this._frameManager, FrameManager.Events.FrameDetached, this._checkLifecycleComplete.bind(this))
     ];
 
     const lifecycleCompletePromise = new Promise(fulfill => {


### PR DESCRIPTION
Currently, the NavigatorWatcher ensures that all the frames in the
frame subtree reach the desired lifecycle events state.

For this to be fully correct, NavigatorWatcher should also check
navigation status whenever frames are detached.