### PR TITLE
fix(Network): be prepared to miss requestWillBeSent events

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -218,7 +218,9 @@ class NetworkManager extends EventEmitter {
     }
     if (event.redirectResponse) {
       const request = this._requestIdToRequest.get(event.requestId);
-      this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
+      // If we connect late to the target, we could have missed the requestWillBeSent event.
+      if (request)
+        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
     }
     this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -73,7 +73,6 @@ jasmine.getEnv().addReporter({
 
 // Setup unhandledRejectionHandlers
 let hasUnhandledRejection = false;
-const unhandledRejectionHandler = () => hasUnhandledRejection = true;
 process.on('unhandledRejection', error => {
   hasUnhandledRejection = true;
   const textLines = [


### PR DESCRIPTION
With the addition of `browser.targets()` api, we now can connect to
in-flight targets.

For Puppeteer, it means that it can "miss" certain events happenning
while it wasn't attached to the target.

This patch:
- fixes this problem with NetworkManager, preparing it for the
  missed `requestWillBeSent` event.
- adds a new test to ensure that not a single unhandled promise
  rejection has happened during test execution.

Fixes #1363.