### PR TITLE
fix(page): fix "timeout: 0" to actually disable any navigation timeout

### DIFF
--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -63,7 +63,7 @@ class NavigatorWatcher {
    */
   _createTimeoutPromise() {
     if (!this._timeout)
-      return null;
+      return new Promise(() => {});
     const errorMessage = 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded';
     return new Promise(fulfill => this._maximumTimer = setTimeout(fulfill, this._timeout))
         .then(() => new Error(errorMessage));

--- a/test/test.js
+++ b/test/test.js
@@ -1014,8 +1014,11 @@ describe('Page', function() {
     }));
     it('should disable timeout when its set to 0', SX(async function() {
       let error = null;
-      await page.goto(PREFIX + '/grid.html', {timeout: 0}).catch(e => error = e);
+      let loaded = false;
+      page.once('load', () => loaded = true);
+      await page.goto(PREFIX + '/grid.html', {timeout: 0, waitUntil: ['load']}).catch(e => error = e);
       expect(error).toBe(null);
+      expect(loaded).toBe(true);
     }));
     it('should work when navigating to valid url', SX(async function() {
       const response = await page.goto(EMPTY_PAGE);


### PR DESCRIPTION
Since non-promise values always win the `Promise.race`, we shouldn't
return `null` for timeout promise in NavigationWatcher.

Instead, we can return a promise that never resolved. It should be
GC'd later with the navigation watcher itself.

Fixes #1417.