### PR TITLE
Support global proxy env vars as backup

### DIFF
--- a/install.js
+++ b/install.js
@@ -34,16 +34,16 @@ if (revisionInfo.downloaded)
   return;
 
 // Override current environment proxy settings with npm configuration, if any.
-const NPM_HTTPS_PROXY = process.env.npm_config_https_proxy || process.env.npm_config_proxy;
-const NPM_HTTP_PROXY = process.env.npm_config_http_proxy || process.env.npm_config_proxy;
-const NPM_NO_PROXY = process.env.npm_config_no_proxy;
+const HTTPS_PROXY = process.env.npm_config_https_proxy || process.env.npm_config_proxy || process.env.HTTPS_PROXY;
+const HTTP_PROXY = process.env.npm_config_http_proxy || process.env.npm_config_proxy || process.env.HTTP_PROXY;
+const NO_PROXY = process.env.npm_config_no_proxy || process.env.no_proxy || process.env.NO_PROXY;
 
-if (NPM_HTTPS_PROXY)
-  process.env.HTTPS_PROXY = NPM_HTTPS_PROXY;
-if (NPM_HTTP_PROXY)
-  process.env.HTTP_PROXY = NPM_HTTP_PROXY;
-if (NPM_NO_PROXY)
-  process.env.NO_PROXY = NPM_NO_PROXY;
+if (HTTPS_PROXY)
+  process.env.HTTPS_PROXY = HTTPS_PROXY;
+if (HTTP_PROXY)
+  process.env.HTTP_PROXY = HTTP_PROXY;
+if (NO_PROXY)
+  process.env.NO_PROXY = NO_PROXY;
 
 const allRevisions = Downloader.downloadedRevisions();
 const DOWNLOAD_HOST = process.env.PUPPETEER_DOWNLOAD_HOST || process.env.npm_config_puppeteer_download_host;


### PR DESCRIPTION
Right now I'm using an older version of npm (3.10.8), where I have global environment variables for `HTTP_PROXY` and `HTTPS_PROXY` and `no_proxy` and they work just fine installing other modules. This module in particular doesn't support it. It just so happens when I add in the `http-proxy`, `https-proxy` and `no-proxy` settings to the NPM config so that puppeteer can pick them up, my `no-proxy` is unrecognized (as global or npm config). So I am stuck. There's no harm in supporting the global proxy settings also as a fallback if the npm ones aren't set.