### PR TITLE
feat(Frame): implement frame.content and frame.setContent methods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -125,12 +125,14 @@
   * [frame.addScriptTag(options)](#frameaddscripttagoptions)
   * [frame.addStyleTag(options)](#frameaddstyletagoptions)
   * [frame.childFrames()](#framechildframes)
+  * [frame.content()](#framecontent)
   * [frame.evaluate(pageFunction, ...args)](#frameevaluatepagefunction-args)
   * [frame.executionContext()](#frameexecutioncontext)
   * [frame.isDetached()](#frameisdetached)
   * [frame.name()](#framename)
   * [frame.parentFrame()](#frameparentframe)
   * [frame.select(selector, ...values)](#frameselectselector-values)
+  * [frame.setContent(html)](#framesetcontenthtml)
   * [frame.title()](#frametitle)
   * [frame.url()](#frameurl)
   * [frame.waitFor(selectorOrFunctionOrTimeout[, options[, ...args]])](#framewaitforselectororfunctionortimeout-options-args)
@@ -1484,6 +1486,11 @@ Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<s
 #### frame.childFrames()
 - returns: <[Array]<[Frame]>>
 
+#### frame.content()
+- returns: <[Promise]<[String]>>
+
+Gets the full HTML contents of the frame, including the doctype.
+
 #### frame.evaluate(pageFunction, ...args)
 - `pageFunction` <[function]|[string]> Function to be evaluated in browser context
 - `...args` <...[Serializable]|[ElementHandle]> Arguments to pass to  `pageFunction`
@@ -1545,6 +1552,10 @@ If there's no `<select>` element matching `selector`, the method throws an error
 frame.select('select#colors', 'blue'); // single selection
 frame.select('select#colors', 'red', 'green', 'blue'); // multiple selections
 ```
+
+#### frame.setContent(html)
+- `html` <[string]> HTML markup to assign to the page.
+- returns: <[Promise]>
 
 #### frame.title()
 - returns: <[Promise]<[string]>> Returns page's title.

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -340,6 +340,31 @@ class Frame {
   }
 
   /**
+   * @return {!Promise<String>}
+   */
+  async content() {
+    return await this.evaluate(() => {
+      let retVal = '';
+      if (document.doctype)
+        retVal = new XMLSerializer().serializeToString(document.doctype);
+      if (document.documentElement)
+        retVal += document.documentElement.outerHTML;
+      return retVal;
+    });
+  }
+
+  /**
+   * @param {string} html
+   */
+  async setContent(html) {
+    await this.evaluate(html => {
+      document.open();
+      document.write(html);
+      document.close();
+    }, html);
+  }
+
+  /**
    * @return {string}
    */
   name() {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -428,25 +428,14 @@ class Page extends EventEmitter {
    * @return {!Promise<String>}
    */
   async content() {
-    return await this.evaluate(() => {
-      let retVal = '';
-      if (document.doctype)
-        retVal = new XMLSerializer().serializeToString(document.doctype);
-      if (document.documentElement)
-        retVal += document.documentElement.outerHTML;
-      return retVal;
-    });
+    return await this._frameManager.mainFrame().content();
   }
 
   /**
    * @param {string} html
    */
   async setContent(html) {
-    await this.evaluate(html => {
-      document.open();
-      document.write(html);
-      document.close();
-    }, html);
+    await this._frameManager.mainFrame().setContent(html);
   }
 
   /**


### PR DESCRIPTION
This refactors the page.content and page.setContent methods to be defined on the Frame class. This allows access from the Page still but also on all frames.

Fixes #754