### PR TITLE
Close #1492, fix screenshot mimetype definition when type and path are provided

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -614,19 +614,18 @@ class Page extends EventEmitter {
    */
   async screenshot(options = {}) {
     let screenshotType = null;
-    // try to define screenshotType from options.path if options.type isn't provided
-    if (!options.type) {
-      console.assert(options.path, 'Expected options.path or options.type to define screenshot type');
+    // options.type takes precedence over inferring the type from options.path
+    // because it may be a 0-length file with no extension created beforehand (i.e. as a temp file).
+    if (options.type) {
+      console.assert(options.type === 'png' || options.type === 'jpeg', 'Unknown options.type value: ' + options.type);
+      screenshotType = options.type;
+    } else if (options.path) {
       const mimeType = mime.lookup(options.path);
       if (mimeType === 'image/png')
         screenshotType = 'png';
       else if (mimeType === 'image/jpeg')
         screenshotType = 'jpeg';
       console.assert(screenshotType, 'Unsupported screenshot mime type: ' + mimeType);
-    } else {
-      console.assert(!screenshotType || options.type === screenshotType, `Passed screenshot type '${options.type}' does not match the type inferred from the file path: '${screenshotType}'`);
-      console.assert(options.type === 'png' || options.type === 'jpeg', 'Unknown options.type value: ' + options.type);
-      screenshotType = options.type;
     }
 
     if (!screenshotType)

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -614,19 +614,21 @@ class Page extends EventEmitter {
    */
   async screenshot(options = {}) {
     let screenshotType = null;
-    if (options.path) {
+    // try to define screenshotType from options.path if options.type isn't provided
+    if (!options.type) {
+      console.assert(options.path, 'Expected options.path or options.type to define screenshot type');
       const mimeType = mime.lookup(options.path);
       if (mimeType === 'image/png')
         screenshotType = 'png';
       else if (mimeType === 'image/jpeg')
         screenshotType = 'jpeg';
       console.assert(screenshotType, 'Unsupported screenshot mime type: ' + mimeType);
-    }
-    if (options.type) {
+    } else {
       console.assert(!screenshotType || options.type === screenshotType, `Passed screenshot type '${options.type}' does not match the type inferred from the file path: '${screenshotType}'`);
       console.assert(options.type === 'png' || options.type === 'jpeg', 'Unknown options.type value: ' + options.type);
       screenshotType = options.type;
     }
+
     if (!screenshotType)
       screenshotType = 'png';
 


### PR DESCRIPTION
This fixes https://github.com/GoogleChrome/puppeteer/issues/1492 by only trying to define the mimetype from the `options.path` value if the `options.type` is not provided.

This is useful, for example, in situation where `options.path` and `options.type` are provided and `options.path` exists but is an empty file, with no extension. With the current code, the mimetype deduced is `application/octet-stream` and this raises an error. With this fix, the `options.type` value is used, removing the need to deduce the mimetype from the file path.

Now the screenshot's mime-type is defined using : 

1. `options.type` if it is provided, whether or not `options.path` is provided (**this is what this PR introduces**)
2. `options.path` if `options.type` is not provided, by inferring the mime-type using `mime.lookup` (_this was not changed_)
3. `png` as a default value if neither `options.type` nor `options.path` is provided (_this was not changed_)
