### PR TITLE
refactor: move ChromiumDownloader under lib/

### DIFF
--- a/install.js
+++ b/install.js
@@ -28,7 +28,7 @@ const Downloader = require('./lib/Downloader');
 const downloader = Downloader.createDefault();
 
 const platform = downloader.currentPlatform();
-const revision = helper.packageJSON().puppeteer.chromium_revision;
+const revision = Downloader.defaultRevision();
 const ProgressBar = require('progress');
 
 const revisionInfo = downloader.revisionInfo(platform, revision);

--- a/install.js
+++ b/install.js
@@ -30,7 +30,7 @@ try {
   asyncawait = false;
 }
 
-const Downloader = asyncawait ? require('./lib/Downloader') : require('./node6/Downloader');
+const Downloader = require('./lib/Downloader');
 const downloader = Downloader.createDefault();
 
 const platform = downloader.currentPlatform();

--- a/install.js
+++ b/install.js
@@ -23,8 +23,14 @@ if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_c
   return;
 }
 
-const {helper} = require('./lib/helper');
-const Downloader = require('./lib/Downloader');
+let asyncawait = true;
+try {
+  new Function('async function test(){await 1}');
+} catch (error) {
+  asyncawait = false;
+}
+
+const Downloader = asyncawait ? require('./lib/Downloader') : require('./node6/Downloader');
 const downloader = Downloader.createDefault();
 
 const platform = downloader.currentPlatform();

--- a/install.js
+++ b/install.js
@@ -23,13 +23,6 @@ if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_c
   return;
 }
 
-let asyncawait = true;
-try {
-  new Function('async function test(){await 1}');
-} catch (error) {
-  asyncawait = false;
-}
-
 const Downloader = require('./lib/Downloader');
 const downloader = Downloader.createDefault();
 

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -192,7 +192,7 @@ class Downloader {
   _getFolderPath(platform, revision) {
     return path.join(this._downloadsFolder, platform + '-' + revision);
   }
-};
+}
 
 module.exports = Downloader;
 

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -21,14 +21,13 @@ const extract = require('extract-zip');
 const util = require('util');
 const URL = require('url');
 const removeRecursive = require('rimraf');
+const {helper} = require('./helper');
 // @ts-ignore
 const ProxyAgent = require('https-proxy-agent');
 // @ts-ignore
 const getProxyForUrl = require('proxy-from-env').getProxyForUrl;
 
-const DOWNLOADS_FOLDER = path.join(__dirname, '..', '.local-chromium');
 const DEFAULT_DOWNLOAD_HOST = 'https://storage.googleapis.com';
-
 const downloadURLs = {
   linux: '%s/chromium-browser-snapshots/Linux_x64/%d/chrome-linux.zip',
   mac: '%s/chromium-browser-snapshots/Mac/%d/chrome-mac.zip',
@@ -36,18 +35,38 @@ const downloadURLs = {
   win64: '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win32.zip',
 };
 
-module.exports = {
+class Downloader {
+  constructor(downloadsFolder) {
+    this._downloadsFolder = downloadsFolder;
+    this._downloadHost = DEFAULT_DOWNLOAD_HOST;
+  }
+
+  /**
+   * @return {!Downloader}
+   */
+  static createDefault() {
+    const downloadsFolder = path.join(helper.projectRoot(), '.local-chromium');
+    return new Downloader(downloadsFolder);
+  }
+
+  /**
+   * @param {string} downloadHost
+   */
+  setDownloadHost(downloadHost) {
+    this._downloadHost = downloadHost;
+  }
+
   /**
    * @return {!Array<string>}
    */
-  supportedPlatforms: function() {
+  supportedPlatforms() {
     return Object.keys(downloadURLs);
-  },
+  }
 
   /**
    * @return {string}
    */
-  currentPlatform: function() {
+  currentPlatform() {
     const platform = os.platform();
     if (platform === 'darwin')
       return 'mac';
@@ -56,17 +75,17 @@ module.exports = {
     if (platform === 'win32')
       return os.arch() === 'x64' ? 'win64' : 'win32';
     return '';
-  },
+  }
 
   /**
    * @param {string} platform
    * @param {string} revision
    * @return {!Promise<boolean>}
    */
-  canDownloadRevision: function(platform, revision) {
+  canDownloadRevision(platform, revision) {
     console.assert(downloadURLs[platform], 'Unknown platform: ' + platform);
 
-    const url = util.format(downloadURLs[platform], DEFAULT_DOWNLOAD_HOST, revision);
+    const url = util.format(downloadURLs[platform], this._downloadHost, revision);
 
     let resolve;
     const promise = new Promise(x => resolve = x);
@@ -78,25 +97,24 @@ module.exports = {
       resolve(false);
     });
     return promise;
-  },
+  }
 
   /**
    * @param {string} platform
    * @param {string} revision
-   * @param {string} [downloadHost=DEFAULT_DOWNLOAD_HOST]
    * @param {?function(number, number)} progressCallback
    * @return {!Promise}
    */
-  downloadRevision: function(platform, revision, downloadHost = DEFAULT_DOWNLOAD_HOST, progressCallback) {
+  downloadRevision(platform, revision, progressCallback) {
     let url = downloadURLs[platform];
     console.assert(url, `Unsupported platform: ${platform}`);
-    url = util.format(url, downloadHost, revision);
-    const zipPath = path.join(DOWNLOADS_FOLDER, `download-${platform}-${revision}.zip`);
-    const folderPath = getFolderPath(platform, revision);
+    url = util.format(url, this._downloadHost, revision);
+    const zipPath = path.join(this._downloadsFolder, `download-${platform}-${revision}.zip`);
+    const folderPath = this._getFolderPath(platform, revision);
     if (fs.existsSync(folderPath))
       return;
-    if (!fs.existsSync(DOWNLOADS_FOLDER))
-      fs.mkdirSync(DOWNLOADS_FOLDER);
+    if (!fs.existsSync(this._downloadsFolder))
+      fs.mkdirSync(this._downloadsFolder);
     return downloadFile(url, zipPath, progressCallback)
         .then(() => extractZip(zipPath, folderPath))
         .catch(err => err)
@@ -106,38 +124,38 @@ module.exports = {
           if (err)
             throw err;
         });
-  },
+  }
 
   /**
    * @return {!Array<!{platform:string, revision: string}>}
    */
-  downloadedRevisions: function() {
-    if (!fs.existsSync(DOWNLOADS_FOLDER))
+  downloadedRevisions() {
+    if (!fs.existsSync(this._downloadsFolder))
       return [];
-    const fileNames = fs.readdirSync(DOWNLOADS_FOLDER);
+    const fileNames = fs.readdirSync(this._downloadsFolder);
     return fileNames.map(fileName => parseFolderPath(fileName)).filter(revision => !!revision);
-  },
+  }
 
   /**
    * @param {string} platform
    * @param {string} revision
    * @return {!Promise}
    */
-  removeRevision: function(platform, revision) {
+  removeRevision(platform, revision) {
     console.assert(downloadURLs[platform], `Unsupported platform: ${platform}`);
-    const folderPath = getFolderPath(platform, revision);
+    const folderPath = this._getFolderPath(platform, revision);
     console.assert(fs.existsSync(folderPath));
     return new Promise(fulfill => removeRecursive(folderPath, fulfill));
-  },
+  }
 
   /**
    * @param {string} platform
    * @param {string} revision
-   * @return {!{folderPath: string, executablePath: string, downloaded: boolean}}
+   * @return {!{revision: string, folderPath: string, executablePath: string, downloaded: boolean}}
    */
-  revisionInfo: function(platform, revision) {
+  revisionInfo(platform, revision) {
     console.assert(downloadURLs[platform], `Unsupported platform: ${platform}`);
-    const folderPath = getFolderPath(platform, revision);
+    const folderPath = this._getFolderPath(platform, revision);
     let executablePath = '';
     if (platform === 'mac')
       executablePath = path.join(folderPath, 'chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium');
@@ -148,21 +166,24 @@ module.exports = {
     else
       throw 'Unsupported platform: ' + platform;
     return {
+      revision,
       executablePath,
       folderPath,
       downloaded: fs.existsSync(folderPath)
     };
-  },
+  }
+
+  /**
+   * @param {string} platform
+   * @param {string} revision
+   * @return {string}
+   */
+  _getFolderPath(platform, revision) {
+    return path.join(this._downloadsFolder, platform + '-' + revision);
+  }
 };
 
-/**
- * @param {string} platform
- * @param {string} revision
- * @return {string}
- */
-function getFolderPath(platform, revision) {
-  return path.join(DOWNLOADS_FOLDER, platform + '-' + revision);
-}
+module.exports = Downloader;
 
 /**
  * @param {string} folderPath

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -21,7 +21,6 @@ const extract = require('extract-zip');
 const util = require('util');
 const URL = require('url');
 const removeRecursive = require('rimraf');
-const {helper} = require('./helper');
 // @ts-ignore
 const ProxyAgent = require('https-proxy-agent');
 // @ts-ignore
@@ -35,17 +34,29 @@ const downloadURLs = {
   win64: '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win32.zip',
 };
 
+const PROJECT_ROOT = path.join(__dirname, '..');
+
 class Downloader {
+  /**
+   * @param {string} downloadsFolder
+   */
   constructor(downloadsFolder) {
     this._downloadsFolder = downloadsFolder;
     this._downloadHost = DEFAULT_DOWNLOAD_HOST;
   }
 
   /**
+   * @return {string}
+   */
+  static defaultRevision() {
+    return require(path.join(PROJECT_ROOT, 'package.json')).puppeteer.chromium_revision;
+  }
+
+  /**
    * @return {!Downloader}
    */
   static createDefault() {
-    const downloadsFolder = path.join(helper.projectRoot(), '.local-chromium');
+    const downloadsFolder = path.join(PROJECT_ROOT, '.local-chromium');
     return new Downloader(downloadsFolder);
   }
 

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -23,7 +23,6 @@ const {Browser} = require('./Browser');
 const readline = require('readline');
 const fs = require('fs');
 const {helper} = require('./helper');
-// @ts-ignore
 const ChromiumRevision = Downloader.defaultRevision();
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -24,7 +24,7 @@ const readline = require('readline');
 const fs = require('fs');
 const {helper} = require('./helper');
 // @ts-ignore
-const ChromiumRevision = helper.packageJSON().puppeteer.chromium_revision;
+const ChromiumRevision = Downloader.defaultRevision();
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -17,14 +17,14 @@ const os = require('os');
 const path = require('path');
 const removeFolder = require('rimraf');
 const childProcess = require('child_process');
-const Downloader = require('../utils/ChromiumDownloader');
+const Downloader = require('./Downloader');
 const {Connection} = require('./Connection');
 const {Browser} = require('./Browser');
 const readline = require('readline');
 const fs = require('fs');
 const {helper} = require('./helper');
 // @ts-ignore
-const ChromiumRevision = require('../package.json').puppeteer.chromium_revision;
+const ChromiumRevision = helper.packageJSON().puppeteer.chromium_revision;
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);
@@ -88,7 +88,8 @@ class Launcher {
     }
     let chromeExecutable = options.executablePath;
     if (typeof chromeExecutable !== 'string') {
-      const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
+      const downloader = Downloader.createDefault();
+      const revisionInfo = downloader.revisionInfo(downloader.currentPlatform(), ChromiumRevision);
       console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "npm install"`);
       chromeExecutable = revisionInfo.executablePath;
     }
@@ -176,7 +177,8 @@ class Launcher {
    * @return {string}
    */
   static executablePath() {
-    const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
+    const downloader = Downloader.createDefault();
+    const revisionInfo = downloader.revisionInfo(downloader.currentPlatform(), ChromiumRevision);
     return revisionInfo.executablePath;
   }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const path = require('path');
+
 const debugError = require('debug')(`puppeteer:error`);
 /** @type {?Map<string, boolean>} */
 let apiCoverage = null;
@@ -224,6 +226,20 @@ class Helper {
       });
     }
     return promisified;
+  }
+
+  /**
+   * @return {string}
+   */
+  static projectRoot() {
+    return path.join(__dirname, '..');
+  }
+
+  /**
+   * @return {*}
+   */
+  static packageJSON() {
+    return require(path.join(Helper.projectRoot(), 'package.json'));
   }
 }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-const path = require('path');
-
 const debugError = require('debug')(`puppeteer:error`);
 /** @type {?Map<string, boolean>} */
 let apiCoverage = null;
@@ -226,20 +224,6 @@ class Helper {
       });
     }
     return promisified;
-  }
-
-  /**
-   * @return {string}
-   */
-  static projectRoot() {
-    return path.join(__dirname, '..');
-  }
-
-  /**
-   * @return {*}
-   */
-  static packageJSON() {
-    return require(path.join(Helper.projectRoot(), 'package.json'));
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ const {helper} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
 console.log('Testing on Node', process.version);
-const puppeteer = require('..');
+const puppeteer = require(helper.projectRoot());
 const SimpleServer = require('./server/SimpleServer');
 const GoldenUtils = require('./golden-utils');
 
@@ -51,12 +51,7 @@ const defaultBrowserOptions = {
 };
 
 // Make sure the `npm install` was run after the chromium roll.
-{
-  const Downloader = require('../utils/ChromiumDownloader');
-  const chromiumRevision = require('../package.json').puppeteer.chromium_revision;
-  const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), chromiumRevision);
-  console.assert(revisionInfo.downloaded, `Chromium r${chromiumRevision} is not downloaded. Run 'npm install' and try to re-run tests.`);
-}
+console.assert(fs.existsSync(puppeteer.executablePath()), `Chromium is not Downloaded. Run 'npm install' and try to re-run tests`);
 
 const timeout = process.env.DEBUG_TEST || slowMo ?  0 : 10 * 1000;
 

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ const {helper} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
 console.log('Testing on Node', process.version);
-const puppeteer = require(helper.projectRoot());
+const puppeteer = require('../lib/Puppeteer');
 const SimpleServer = require('./server/SimpleServer');
 const GoldenUtils = require('./golden-utils');
 

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ const {helper} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
 console.log('Testing on Node', process.version);
-const puppeteer = require('../lib/Puppeteer');
+const puppeteer = require('..');
 const SimpleServer = require('./server/SimpleServer');
 const GoldenUtils = require('./golden-utils');
 

--- a/utils/check_availability.js
+++ b/utils/check_availability.js
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-const Downloader = require('./ChromiumDownloader');
+const Downloader = require('../lib/Downloader');
 const https = require('https');
 const OMAHA_PROXY = 'https://omahaproxy.appspot.com/all.json';
+
+const downloader = Downloader.createDefault();
 
 const colors = {
   reset: '\x1b[0m',
@@ -71,7 +73,7 @@ async function checkOmahaProxyAvailability() {
     return;
   }
   const table = new Table([27, 7, 7, 7, 7]);
-  table.drawRow([''].concat(Downloader.supportedPlatforms()));
+  table.drawRow([''].concat(downloader.supportedPlatforms()));
   for (const platform of platforms) {
     // Trust only to the main platforms.
     if (platform.os !== 'mac' && platform.os !== 'win' && platform.os !== 'win64' && platform.os !== 'linux')
@@ -93,7 +95,7 @@ async function checkOmahaProxyAvailability() {
  */
 async function checkRangeAvailability(fromRevision, toRevision) {
   const table = new Table([10, 7, 7, 7, 7]);
-  table.drawRow([''].concat(Downloader.supportedPlatforms()));
+  table.drawRow([''].concat(downloader.supportedPlatforms()));
   const inc = fromRevision < toRevision ? 1 : -1;
   for (let revision = fromRevision; revision !== toRevision; revision += inc)
     await checkAndDrawRevisionAvailability(table, '', revision);
@@ -106,8 +108,8 @@ async function checkRangeAvailability(fromRevision, toRevision) {
  */
 async function checkAndDrawRevisionAvailability(table, name, revision) {
   const promises = [];
-  for (const platform of Downloader.supportedPlatforms())
-    promises.push(Downloader.canDownloadRevision(platform, revision));
+  for (const platform of downloader.supportedPlatforms())
+    promises.push(downloader.canDownloadRevision(platform, revision));
   const availability = await Promise.all(promises);
   const allAvailable = availability.every(e => !!e);
   const values = [name + ' ' + (allAvailable ? colors.green + revision + colors.reset : revision)];

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -21,6 +21,7 @@ const Message = require('../Message');
 
 const EXCLUDE_CLASSES = new Set([
   'Connection',
+  'Downloader',
   'EmulationManager',
   'FrameManager',
   'Helper',


### PR DESCRIPTION
This patch:
- renames `ChromiumDownloader` into `Downloader` (this is in
  preparation for different products download)
- moves `Downloader` from `utils/` to `lib/`. This unifies all of the
  production-critical code in the `lib/` and would make our node6
  transpilation easier.

Drive-by: make `Downloader` a regular class.