### PR TITLE
chore: fix appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,11 +9,10 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - yarn install
   - if "%nodejs_version%" == "7" (
-      yarn run lint &
-      yarn run coverage  &
+      yarn run lint &&
+      yarn run coverage  &&
       yarn run test-doclint
     ) else (
-      yarn run test-node6-transformer  &
-      yarn run build  &
-      yarn run unit-node6  
+      yarn run build  &&
+      yarn run unit-node6
     )


### PR DESCRIPTION
This patch:
- starts using '&&' instead of '&' so that any failed commands results
  in build failure
- removes test-node6-transformer step from the node6 target