### PR TITLE
chore: generalize node6 transpilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@
 .vscode
 package-lock.json
 /node6
-/node6-test
-/node6-testrunner

--- a/.npmignore
+++ b/.npmignore
@@ -11,4 +11,9 @@ node_modules
 *.pyc
 .vscode
 package-lock.json
-/node6-test
+/node6/test
+/node6/utils
+/test
+/utils
+/docs
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -25,4 +25,4 @@ try {
 if (asyncawait)
   module.exports = require('./lib/Puppeteer');
 else
-  module.exports = require('./node6/Puppeteer');
+  module.exports = require('./node6/lib/Puppeteer');

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -34,7 +34,8 @@ const downloadURLs = {
   win64: '%s/chromium-browser-snapshots/Win_x64/%d/chrome-win32.zip',
 };
 
-const PROJECT_ROOT = path.join(__dirname, '..');
+// Project root will be different for node6-transpiled code.
+const PROJECT_ROOT = fs.existsSync(path.join(__dirname, '..', 'package.json')) ? path.join(__dirname, '..') : path.join(__dirname, '..', '..');
 
 class Downloader {
   /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage": "cross-env COVERAGE=true npm run unit",
     "test-node6-transformer": "node utils/node6-transform/test/test.js",
     "build": "node utils/node6-transform/index.js",
-    "unit-node6": "node node6-test/test.js",
+    "unit-node6": "node node6/test/test.js",
     "tsc": "tsc -p ."
   },
   "author": "The Chromium Authors",

--- a/test/test.js
+++ b/test/test.js
@@ -19,8 +19,12 @@ const path = require('path');
 const {helper} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
-console.log('Testing on Node', process.version);
-const puppeteer = require('..');
+
+const PROJECT_ROOT = fs.existsSync(path.join(__dirname, '..', 'package.json')) ? path.join(__dirname, '..') : path.join(__dirname, '..', '..');
+
+const puppeteer = require(PROJECT_ROOT);
+const DeviceDescriptors = require(path.join(PROJECT_ROOT, 'DeviceDescriptors'));
+
 const SimpleServer = require('./server/SimpleServer');
 const GoldenUtils = require('./golden-utils');
 
@@ -40,8 +44,12 @@ const HTTPS_PREFIX = 'https://localhost:' + HTTPS_PORT;
 const headless = (process.env.HEADLESS || 'true').trim().toLowerCase() === 'true';
 const slowMo = parseInt((process.env.SLOW_MO || '0').trim(), 10);
 const executablePath = process.env.CHROME;
+
+console.log('Testing on Node', process.version);
 if (executablePath)
   console.warn(`${YELLOW_COLOR}WARN: running tests with ${executablePath}${RESET_COLOR}`);
+// Make sure the `npm install` was run after the chromium roll.
+console.assert(fs.existsSync(puppeteer.executablePath()), `Chromium is not Downloaded. Run 'npm install' and try to re-run tests`);
 
 const defaultBrowserOptions = {
   executablePath,
@@ -49,9 +57,6 @@ const defaultBrowserOptions = {
   headless,
   args: ['--no-sandbox']
 };
-
-// Make sure the `npm install` was run after the chromium roll.
-console.assert(fs.existsSync(puppeteer.executablePath()), `Chromium is not Downloaded. Run 'npm install' and try to re-run tests`);
 
 const timeout = process.env.DEBUG_TEST || slowMo ?  0 : 10 * 1000;
 
@@ -228,8 +233,8 @@ describe('Puppeteer', function() {
 });
 
 describe('Page', function() {
-  const iPhone = require('../DeviceDescriptors')['iPhone 6'];
-  const iPhoneLandscape = require('../DeviceDescriptors')['iPhone 6 landscape'];
+  const iPhone = DeviceDescriptors['iPhone 6'];
+  const iPhoneLandscape = DeviceDescriptors['iPhone 6 landscape'];
 
   let browser;
   let page;

--- a/utils/node6-transform/index.js
+++ b/utils/node6-transform/index.js
@@ -51,7 +51,7 @@ function copyFile(from, to) {
   if (from.endsWith('.js')) {
     text = text.toString();
     const prefix = text.startsWith('#!') ? text.substring(0, text.indexOf('\n')) : '';
-    text = prefix + transformAsyncFunctions(text.substring(prefix.length))
+    text = prefix + transformAsyncFunctions(text.substring(prefix.length));
   }
   fs.writeFileSync(to, text);
 }

--- a/utils/node6-transform/index.js
+++ b/utils/node6-transform/index.js
@@ -19,9 +19,17 @@ const path = require('path');
 const removeRecursive = require('rimraf').sync;
 const transformAsyncFunctions = require('./TransformAsyncFunctions');
 
-copyFolder(path.join(__dirname, '..', '..', 'lib'), path.join(__dirname, '..', '..', 'node6'));
-copyFolder(path.join(__dirname, '..', '..', 'test'), path.join(__dirname, '..', '..', 'node6-test'));
-copyFolder(path.join(__dirname, '..', '..', 'utils', 'testrunner'), path.join(__dirname, '..', '..', 'node6-testrunner'));
+const root = path.join(__dirname, '..', '..');
+const dest = path.join(__dirname, '..', '..', 'node6');
+
+if (fs.existsSync(dest))
+  removeRecursive(dest);
+fs.mkdirSync(dest);
+fs.mkdirSync(path.join(dest, 'utils'));
+
+copyFolder(path.join(root, 'lib'), path.join(dest, 'lib'));
+copyFolder(path.join(root, 'test'), path.join(dest, 'test'));
+copyFolder(path.join(root, 'utils'), path.join(dest, 'utils'));
 
 function copyFolder(source, target) {
   if (fs.existsSync(target))
@@ -31,16 +39,18 @@ function copyFolder(source, target) {
   fs.readdirSync(source).forEach(file => {
     const from = path.join(source, file);
     const to = path.join(target, file);
-    if (fs.lstatSync(from).isDirectory()) {
+    if (fs.lstatSync(from).isDirectory())
       copyFolder(from, to);
-    } else {
-      let text = fs.readFileSync(from);
-      if (file.endsWith('.js')) {
-        text = transformAsyncFunctions(text.toString());
-        text = text.replace(/require\('\.\.\/lib\//g, `require('../node6/`);
-        text = text.replace(/require\('\.\.\/utils\/testrunner\//g, `require('../node6-testrunner/`);
-      }
-      fs.writeFileSync(to, text);
-    }
+    else
+      copyFile(from, to);
   });
+}
+
+function copyFile(from, to) {
+  let text = fs.readFileSync(from, 'utf8');
+  if (from.endsWith('.js')) {
+    const prefix = text.startsWith('#!') ? text.substring(0, text.indexOf('\n')) : '';
+    text = prefix + transformAsyncFunctions(text.substring(prefix.length))
+  }
+  fs.writeFileSync(to, text);
 }

--- a/utils/node6-transform/index.js
+++ b/utils/node6-transform/index.js
@@ -47,8 +47,9 @@ function copyFolder(source, target) {
 }
 
 function copyFile(from, to) {
-  let text = fs.readFileSync(from, 'utf8');
+  let text = fs.readFileSync(from);
   if (from.endsWith('.js')) {
+    text = text.toString();
     const prefix = text.startsWith('#!') ? text.substring(0, text.indexOf('\n')) : '';
     text = prefix + transformAsyncFunctions(text.substring(prefix.length))
   }


### PR DESCRIPTION
This patch unifies node6 transpilation:
- instead of generating multiple top-level directories, prefixed with
  `node6-`, all transpiled code gets placed under single `node6/` folder
- transpilation doesn't change require paths of transpiled modules any
  more