### PR TITLE
feat(install): build node6 support when installing from github

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,5 @@ install:
       yarn run coverage  &&
       yarn run test-doclint
     ) else (
-      yarn run build  &&
       yarn run unit-node6
     )

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ script:
   - 'if [ "$NODE7" = "true" ]; then yarn run lint; fi'
   - 'if [ "$NODE7" = "true" ]; then yarn run coverage; fi'
   - 'if [ "$NODE7" = "true" ]; then yarn run test-doclint; fi'
-  - 'if [ "$NODE6" = "true" ]; then yarn run build; fi'
   - 'if [ "$NODE6" = "true" ]; then yarn run unit-node6; fi'
 jobs:
   include:

--- a/install.js
+++ b/install.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+buildNode6IfNecessary();
+
 if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;
@@ -92,3 +94,24 @@ function toMegabytes(bytes) {
   return `${Math.round(mb * 10) / 10} Mb`;
 }
 
+function buildNode6IfNecessary() {
+  const fs = require('fs');
+  const path = require('path');
+
+  // if this package is installed from NPM, then it already has up-to-date node6
+  // folder.
+  if (!fs.existsSync(path.join('utils')))
+    return;
+  let asyncawait = true;
+  try {
+    new Function('async function test(){await 1}');
+  } catch (error) {
+    asyncawait = false;
+  }
+  // if async/await is supported, then node6 is not needed.
+  if (asyncawait)
+    return;
+  // Re-build node6/ folder.
+  console.log('Building Puppeteer for Node 6');
+  require(path.join(__dirname, 'utils', 'node6-transform'));
+}

--- a/install.js
+++ b/install.js
@@ -100,7 +100,7 @@ function buildNode6IfNecessary() {
 
   // if this package is installed from NPM, then it already has up-to-date node6
   // folder.
-  if (!fs.existsSync(path.join('utils')))
+  if (!fs.existsSync(path.join('utils', 'node6-transform')))
     return;
   let asyncawait = true;
   try {


### PR DESCRIPTION
This patch starts building node6 support if puppeteer is installed directly from
github and is run under Node 6.