### PR TITLE
Add `opacity: 0` to `waitForSelector`’s hidden element check

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1165,8 +1165,8 @@ Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]
 #### page.waitForSelector(selector[, options])
 - `selector` <[string]> A [selector] of an element to wait for,
 - `options` <[Object]> Optional waiting parameters
-  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
-  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none`, `opacity: 0` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none`, `opacity: 0` or `visibility: hidden` CSS properties. Defaults to `false`.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds).
 - returns: <[Promise]> Promise which resolves when element specified by selector string is added to DOM.
 
@@ -1616,8 +1616,8 @@ puppeteer.launch().then(async browser => {
 #### frame.waitForSelector(selector[, options])
 - `selector` <[string]> A [selector] of an element to wait for,
 - `options` <[Object]> Optional waiting parameters
-  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
-  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `visible` <[boolean]> wait for element to be present in DOM and to be visible, i.e. to not have `display: none`, `opacity: 0` or `visibility: hidden` CSS properties. Defaults to `false`.
+  - `hidden` <[boolean]> wait for element to not be found in the DOM or to be hidden, i.e. have `display: none`, `opacity: 0` or `visibility: hidden` CSS properties. Defaults to `false`.
   - `timeout` <[number]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds).
 - returns: <[Promise]> Promise which resolves when element specified by selector string is added to DOM.
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -577,7 +577,7 @@ class Frame {
       if (!waitForVisible && !waitForHidden)
         return true;
       const style = window.getComputedStyle(node);
-      const isVisible = style && style.visibility !== 'hidden' && hasVisibleBoundingBox();
+      const isVisible = style && style.visibility !== 'hidden' && style.display !== 'none' && style.opacity !== '0' && hasVisibleBoundingBox();
       return (waitForVisible === isVisible || waitForHidden === !isVisible);
 
       /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -577,7 +577,7 @@ class Frame {
       if (!waitForVisible && !waitForHidden)
         return true;
       const style = window.getComputedStyle(node);
-      const isVisible = style && style.visibility !== 'hidden' && style.display !== 'none' && style.opacity !== '0' && hasVisibleBoundingBox();
+      const isVisible = style && style.visibility !== 'hidden' && style.opacity !== '0' && hasVisibleBoundingBox();
       return (waitForVisible === isVisible || waitForHidden === !isVisible);
 
       /**

--- a/test/test.js
+++ b/test/test.js
@@ -809,6 +809,16 @@ describe('Page', function() {
       expect(await waitForSelector).toBe(true);
       expect(divHidden).toBe(true);
     }));
+    it('hidden should wait for opacity: 0', SX(async function() {
+      let divHidden = false;
+      await page.setContent(`<div style='opacity: 1;'></div>`);
+      const waitForSelector = page.waitForSelector('div', {hidden: true}).then(() => divHidden = true);
+      await page.waitForSelector('div'); // do a round trip
+      expect(divHidden).toBe(false);
+      await page.evaluate(() => document.querySelector('div').style.setProperty('display', '0'));
+      expect(await waitForSelector).toBe(true);
+      expect(divHidden).toBe(true);
+    }));
     it('hidden should wait for removal', SX(async function() {
       await page.setContent(`<div></div>`);
       let divRemoved = false;


### PR DESCRIPTION
There are many, many ways someone can hide an element from view, but it seems odd that the only stylistic check done here is on the `visibility` property. 

This change adds checks for `display: none` and `opacity: 0;`. We're very likely to see these methods of hiding something from view in plenty of codebases. 

Ideally, this code would follow whatever it is that selenium does for 'visibility checks', but I'd rather not start bike shedding that on this PR. 