### PR TITLE
Throw exception when set cookie in 'about:blank' page

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -255,11 +255,13 @@ class Page extends EventEmitter {
    * @param {Array<Network.CookieParam>} cookies
    */
   async setCookie(...cookies) {
+    const pageURL = this.url();
+    const startsWithHTTP = pageURL.startsWith('http');
     const items = cookies.map(cookie => {
       const item = Object.assign({}, cookie);
-      const pageURL = this.url();
-      if (!item.url && pageURL.startsWith('http'))
-        item.url = this.url();
+      if (!item.url && startsWithHTTP)
+        item.url = pageURL;
+      console.assert(item.url !== 'about:blank', `Blank page can not have cookie "${item.name}"`);
       return item;
     });
     await this.deleteCookie(...items);

--- a/test/test.js
+++ b/test/test.js
@@ -3107,6 +3107,30 @@ describe('Page', function() {
       expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie3=3');
     }));
 
+    it('should not set a cookie on a blank page', SX(async function() {
+      let error = null;
+      await page.goto('about:blank');
+      try {
+        await page.setCookie({name: 'example-cookie', value: 'best'});
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+      expect(error.message).toEqual('Protocol error (Network.deleteCookies): At least one of the url and domain needs to be specified undefined');
+    }));
+
+    it('should not set a cookie with blank page URL', SX(async function() {
+      let error = null;
+      await page.goto(PREFIX + '/grid.html');
+      try {
+        await page.setCookie({name: 'example-cookie', value: 'best'}, {url: 'about:blank', name: 'example-cookie-blank', value: 'best'});
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+      expect(error.message).toEqual(`Blank page can not have cookie "example-cookie-blank"`);
+    }));
+
     it('should set a cookie on a different domain', SX(async function() {
       await page.goto(PREFIX + '/grid.html');
       await page.setCookie({name: 'example-cookie', value: 'best',  url: 'https://www.example.com'});


### PR DESCRIPTION
# DEPRECATED
Please refer to #1567 

---

Original from https://github.com/GoogleChrome/puppeteer/pull/1411#issuecomment-345423707

When you set cookie in 'about:blank' page, you'll get following exception:

```
AssertionError [ERR_ASSERTION]: Blank page can not have cookie "<cookie_name>"
```

