### PR TITLE
Throw exception when set cookie in 'about:blank' page

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -255,11 +255,13 @@ class Page extends EventEmitter {
    * @param {Array<Network.CookieParam>} cookies
    */
   async setCookie(...cookies) {
+    const pageURL = this.url();
+    const startsWithHTTP = pageURL.startsWith('http');
     const items = cookies.map(cookie => {
       const item = Object.assign({}, cookie);
-      const pageURL = this.url();
-      if (!item.url && pageURL.startsWith('http'))
-        item.url = this.url();
+      if (!item.url && startsWithHTTP)
+        item.url = pageURL;
+      console.assert(item.url !== 'about:blank', `Blank page can not have cookie "${item.name}"`);
       return item;
     });
     await this.deleteCookie(...items);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -261,7 +261,14 @@ class Page extends EventEmitter {
       const item = Object.assign({}, cookie);
       if (!item.url && startsWithHTTP)
         item.url = pageURL;
-      console.assert(item.url !== 'about:blank', `Blank page can not have cookie "${item.name}"`);
+      console.assert(
+          item.url !== 'about:blank',
+          `Blank page can not have cookie "${item.name}"`
+      );
+      console.assert(
+          !String.prototype.startsWith.call(item.url || '', 'data:'),
+          `Data URL page can not have cookie "${item.name}"`
+      );
       return item;
     });
     await this.deleteCookie(...items);

--- a/test/test.js
+++ b/test/test.js
@@ -3126,6 +3126,30 @@ describe('Page', function() {
       expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie3=3');
     });
 
+    it('should not set a cookie on a blank page', async function({page}) {
+      let error = null;
+      await page.goto('about:blank');
+      try {
+        await page.setCookie({name: 'example-cookie', value: 'best'});
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+      expect(error.message).toEqual('Protocol error (Network.deleteCookies): At least one of the url and domain needs to be specified undefined');
+    });
+
+    it('should not set a cookie with blank page URL', async function({page, server}) {
+      let error = null;
+      await page.goto(server.PREFIX + '/grid.html');
+      try {
+        await page.setCookie({name: 'example-cookie', value: 'best'}, {url: 'about:blank', name: 'example-cookie-blank', value: 'best'});
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+      expect(error.message).toEqual(`Blank page can not have cookie "example-cookie-blank"`);
+    });
+
     it('should set a cookie on a different domain', async({page, server}) => {
       await page.goto(server.PREFIX + '/grid.html');
       await page.setCookie({name: 'example-cookie', value: 'best',  url: 'https://www.example.com'});

--- a/test/test.js
+++ b/test/test.js
@@ -3137,7 +3137,7 @@ describe('Page', function() {
       expect(error).toBeTruthy();
       expect(error.message).toEqual('Protocol error (Network.deleteCookies): At least one of the url and domain needs to be specified undefined');
     });
-    
+
     it('should not set a cookie with blank page URL', async function({page, server}) {
       let error = null;
       await page.goto(server.PREFIX + '/grid.html');
@@ -3154,7 +3154,7 @@ describe('Page', function() {
           `Blank page can not have cookie "example-cookie-blank"`
       );
     });
-    
+
     it('should not set a cookie on a data URL page', async function({page}) {
       let error = null;
       await page.goto('data:,Hello%2C%20World!');

--- a/test/test.js
+++ b/test/test.js
@@ -3137,6 +3137,37 @@ describe('Page', function() {
       expect(error).toBeTruthy();
       expect(error.message).toEqual('Protocol error (Network.deleteCookies): At least one of the url and domain needs to be specified undefined');
     });
+    
+    it('should not set a cookie with blank page URL', async function({page, server}) {
+      let error = null;
+      await page.goto(server.PREFIX + '/grid.html');
+      try {
+        await page.setCookie(
+            {name: 'example-cookie', value: 'best'},
+            {url: 'about:blank', name: 'example-cookie-blank', value: 'best'}
+        );
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+      expect(error.message).toEqual(
+          `Blank page can not have cookie "example-cookie-blank"`
+      );
+    });
+    
+    it('should not set a cookie on a data URL page', async function({page}) {
+      let error = null;
+      await page.goto('data:,Hello%2C%20World!');
+      try {
+        await page.setCookie({name: 'example-cookie', value: 'best'});
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
+      expect(error.message).toEqual(
+          'Protocol error (Network.deleteCookies): At least one of the url and domain needs to be specified undefined'
+      );
+    });
 
     it('should not set a cookie with blank page URL', async function({page, server}) {
       let error = null;


### PR DESCRIPTION
Original from https://github.com/GoogleChrome/puppeteer/pull/1411#issuecomment-345423707

When you set cookie in 'about:blank' page, you'll get following exception:

```
AssertionError [ERR_ASSERTION]: Blank page can not have cookie "<cookie_name>"
```
