### PR TITLE
fix(ElementHandle): throw when trying to focus non-focusable element

### DIFF
--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -96,7 +96,11 @@ class ElementHandle extends JSHandle {
   }
 
   async focus() {
-    await this.executionContext().evaluate(element => element.focus(), this);
+    await this.executionContext().evaluate(element => {
+      element.focus();
+      if (element.ownerDocument.activeElement !== element)
+        throw new Error('Failed to focus: element is not focusable!');
+    }, this);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1998,6 +1998,13 @@ describe('Page', function() {
       await textarea.press('a', {text: 'y'});
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('f');
     }));
+    it('should not focus non-focusable elements', SX(async function() {
+      await page.setContent('<input disabled></input>');
+      const input = await page.$('input');
+      let error = null;
+      await input.focus().catch(e => error = e);
+      expect(error.message).toContain('not focusable');
+    }));
     it('should send a character with sendCharacter', SX(async function() {
       await page.goto(PREFIX + '/input/textarea.html');
       await page.focus('textarea');


### PR DESCRIPTION
This patch starts throwing errors when trying to focus non-focusable
element.

Fixes #1486