### PR TITLE
demo(search) - search d.g.c for "Headess Chrome" articles

### DIFF
--- a/examples/search.js
+++ b/examples/search.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Search developers.google.com/web for articles tagged
+ * "Headless Chrome" and scrape results from the results page.
+ */
+
+'use strict';
+
+const puppeteer = require('puppeteer');
+
+(async() => {
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+
+await page.goto('https://developers.google.com/web/');
+
+// Type into search box.
+await page.type('#searchbox input', 'Headless Chrome');
+
+// Wait for suggest overlay to appear and click "show all results".
+const allResultsSelector = '.devsite-suggest-all-results';
+await page.waitForSelector(allResultsSelector);
+await page.click(allResultsSelector);
+
+// Wait for the results page to load and display the results.
+const resultsSelector = '.gsc-results .gsc-thumbnail-inside a.gs-title';
+await page.waitForSelector(resultsSelector);
+
+// Extract the results from the page.
+const links = await page.evaluate(resultsSelector => {
+  const anchors = Array.from(document.querySelectorAll(resultsSelector));
+  return anchors.map(anchor => {
+    const title = anchor.textContent.split('|')[0].trim();
+    return `${title} - ${anchor.href}`;
+  });
+}, resultsSelector);
+console.log(links.join('\n'));
+
+await browser.close();
+
+})();


### PR DESCRIPTION
Adds back a search demo. I chose d.g.c. b/c the protocol viewer uses shadow dom. Gets a bit confusing.

Fixes https://github.com/GoogleChrome/puppeteer/issues/1578