### PR TITLE
chore(testrunner): support first-class test debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "unit": "node test/test.js",
-    "debug-unit": "cross-env DEBUG_TEST=true node --inspect-brk test/test.js",
+    "debug-unit": "node --inspect-brk test/test.js",
     "test-doclint": "node utils/doclint/check_public_api/test/test.js && node utils/doclint/preprocessor/test.js",
     "test": "npm run lint --silent && npm run coverage && npm run test-doclint && npm run test-node6-transformer",
     "install": "node install.js",

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ const defaultBrowserOptions = {
   args: ['--no-sandbox']
 };
 
-const timeout = process.env.DEBUG_TEST || slowMo ?  0 : 10 * 1000;
+const timeout = slowMo ?  0 : 10 * 1000;
 let parallel = 1;
 if (process.env.PPTR_PARALLEL_TESTS)
   parallel = parseInt(process.env.PPTR_PARALLEL_TESTS.trim(), 10);

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-const inspector = require('inspector');
 const path = require('path');
 const EventEmitter = require('events');
 const Multimap = require('./Multimap');
 
 const TimeoutError = new Error('Timeout');
 const TerminatedError = new Error('Terminated');
+
+const MAJOR_NODEJS_VERSION = parseInt(process.version.substring(1).split('.')[0], 10);
 
 class UserCallback {
   constructor(callback, timeout) {
@@ -270,12 +271,15 @@ class TestRunner extends EventEmitter {
 
     this._hasFocusedTestsOrSuites = false;
 
-    if (inspector.url()) {
-      console.log('TestRunner detected inspector; overriding certain properties to be debugger-friendly');
-      console.log('  - timeout = 0 (Infinite)');
-      console.log('  - parallel = 1');
-      this._timeout = 2147483647;
-      this._parallel = 1;
+    if (MAJOR_NODEJS_VERSION >= 8) {
+      const inspector = require('inspector');
+      if (inspector.url()) {
+        console.log('TestRunner detected inspector; overriding certain properties to be debugger-friendly');
+        console.log('  - timeout = 0 (Infinite)');
+        console.log('  - parallel = 1');
+        this._timeout = 2147483647;
+        this._parallel = 1;
+      }
     }
 
     // bind methods so that they can be used as a DSL.

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -276,7 +276,6 @@ class TestRunner extends EventEmitter {
       if (inspector.url()) {
         console.log('TestRunner detected inspector; overriding certain properties to be debugger-friendly');
         console.log('  - timeout = 0 (Infinite)');
-        console.log('  - parallel = 1');
         this._timeout = 2147483647;
         this._parallel = 1;
       }

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+const inspector = require('inspector');
 const path = require('path');
 const EventEmitter = require('events');
 const Multimap = require('./Multimap');
@@ -268,6 +269,14 @@ class TestRunner extends EventEmitter {
     this._retryFailures = !!options.retryFailures;
 
     this._hasFocusedTestsOrSuites = false;
+
+    if (inspector.url()) {
+      console.log('TestRunner detected inspector; overriding certain properties to be debugger-friendly');
+      console.log('  - timeout = 0 (Infinite)');
+      console.log('  - parallel = 1');
+      this._timeout = 2147483647;
+      this._parallel = 1;
+    }
 
     // bind methods so that they can be used as a DSL.
     this.describe = this._addSuite.bind(this, TestMode.Run);


### PR DESCRIPTION
This patch teaches testrunner to override both timeout and
parallel execution option if there's attached inspector.