### PR TITLE
fix(Page): Prevent silently failing when addScriptTag and addStyleTag violate Content Security Policy (#1229)

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -457,9 +457,9 @@ class Frame {
      * @return {!Promise<!ElementHandle>}
      */
     async function evaluateScriptContent(content) {
-      content += `\nwindow.pptrCsp = true; //# Detect Content Security Policy`;
+      content += '\nwindow.pptrCsp = true; //# Detect Content Security Policy';
       const script = await context.evaluateHandle(addScriptContent, content);
-      const cspInactive = await context.evaluate(`window.pptrCsp`);
+      const cspInactive = await context.evaluate(() => window['pptrCsp']);
       if (!cspInactive) throw new Error('Refused to execute inline script because it violates the Content Security Policy');
       return script;
     }
@@ -536,9 +536,11 @@ class Frame {
      */
     async function evaluateStyleContent(content) {
       await context.evaluate(addCSPElement);
-      content += `\n#pptr-csp { font-family: csp-inactive; } /*# Detect Content Security Policy */`;
+      content += '\n#pptr-csp { font-family: csp-inactive; } /*# Detect Content Security Policy */';
       const style = await context.evaluateHandle(addStyleContent, content);
-      const fontFamily = await context.evaluate("window.getComputedStyle(document.getElementById('pptr-csp'), null).fontFamily");
+      const fontFamily = await context.evaluate(() => (
+        window.getComputedStyle(window.document.getElementById('pptr-csp'), null).fontFamily
+      ));
       const cspInactive = (fontFamily === 'csp-inactive');
       if (!cspInactive) throw new Error('Refused to execute inline style because it violates the Content Security Policy');
       return style;

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -404,10 +404,10 @@ class Frame {
    * @return {!Promise<!ElementHandle>}
    */
   async addScriptTag(options) {
+    const context = await this._contextPromise;
     if (typeof options.url === 'string') {
       const url = options.url;
       try {
-        const context = await this._contextPromise;
         return await context.evaluateHandle(addScriptUrl, url);
       } catch (error) {
         throw new Error(`Loading script from ${url} failed`);
@@ -417,14 +417,11 @@ class Frame {
     if (typeof options.path === 'string') {
       let contents = await readFileAsync(options.path, 'utf8');
       contents += '//# sourceURL=' + options.path.replace(/\n/g, '');
-      const context = await this._contextPromise;
-      return context.evaluateHandle(addScriptContent, contents);
+      return evaluateScriptContent(contents);
     }
 
-    if (typeof options.content === 'string') {
-      const context = await this._contextPromise;
-      return context.evaluateHandle(addScriptContent, options.content);
-    }
+    if (typeof options.content === 'string')
+      return evaluateScriptContent(options.content);
 
     throw new Error('Provide an object with a `url`, `path` or `content` property');
 
@@ -454,6 +451,18 @@ class Frame {
       document.head.appendChild(script);
       return script;
     }
+
+    /**
+     * @param {string} content
+     * @return {!Promise<!ElementHandle>}
+     */
+    async function evaluateScriptContent(content) {
+      content += `\nwindow.pptrCsp = true; //# Detect Content Security Policy`;
+      const script = await context.evaluateHandle(addScriptContent, content);
+      const cspInactive = await context.evaluate(`window.pptrCsp`);
+      if (!cspInactive) throw new Error('Refused to execute inline script because it violates the Content Security Policy');
+      return script;
+    }
   }
 
   /**
@@ -461,10 +470,10 @@ class Frame {
    * @return {!Promise<!ElementHandle>}
    */
   async addStyleTag(options) {
+    const context = await this._contextPromise;
     if (typeof options.url === 'string') {
       const url = options.url;
       try {
-        const context = await this._contextPromise;
         return await context.evaluateHandle(addStyleUrl, url);
       } catch (error) {
         throw new Error(`Loading style from ${url} failed`);
@@ -474,14 +483,11 @@ class Frame {
     if (typeof options.path === 'string') {
       let contents = await readFileAsync(options.path, 'utf8');
       contents += '/*# sourceURL=' + options.path.replace(/\n/g, '') + '*/';
-      const context = await this._contextPromise;
-      return await context.evaluateHandle(addStyleContent, contents);
+      return await evaluateStyleContent(contents);
     }
 
-    if (typeof options.content === 'string') {
-      const context = await this._contextPromise;
-      return await context.evaluateHandle(addStyleContent, options.content);
-    }
+    if (typeof options.content === 'string')
+      return await evaluateStyleContent(options.content);
 
     throw new Error('Provide an object with a `url`, `path` or `content` property');
 
@@ -510,6 +516,31 @@ class Frame {
       style.type = 'text/css';
       style.appendChild(document.createTextNode(content));
       document.head.appendChild(style);
+      return style;
+    }
+
+    /**
+     * @return {!HTMLElement}
+     */
+    function addCSPElement() {
+      const div = window.document.createElement('div');
+      div.id = 'pptr-csp';
+      div.style.display = 'none';
+      window.document.body.appendChild(div);
+      return div;
+    }
+
+    /**
+     * @param {string} content
+     * @return {!Promise<!ElementHandle>}
+     */
+    async function evaluateStyleContent(content) {
+      await context.evaluate(addCSPElement);
+      content += `\n#pptr-csp { font-family: csp-inactive; } /*# Detect Content Security Policy */`;
+      const style = await context.evaluateHandle(addStyleContent, content);
+      const fontFamily = await context.evaluate("window.getComputedStyle(document.getElementById('pptr-csp'), null).fontFamily");
+      const cspInactive = (fontFamily === 'csp-inactive');
+      if (!cspInactive) throw new Error('Refused to execute inline style because it violates the Content Security Policy');
       return style;
     }
   }

--- a/test/server/SimpleServer.js
+++ b/test/server/SimpleServer.js
@@ -77,6 +77,8 @@ class SimpleServer {
     this._auths = new Map();
     /** @type {!Map<string, !Promise>} */
     this._requestSubscribers = new Map();
+    /** @type {boolean} */
+    this._csp = false;
   }
 
   _onSocket(socket) {
@@ -97,6 +99,10 @@ class SimpleServer {
    */
   setAuth(path, username, password) {
     this._auths.set(path, {username, password});
+  }
+
+  setCSP() {
+    this._csp = true;
   }
 
   async stop() {
@@ -148,6 +154,7 @@ class SimpleServer {
   reset() {
     this._routes.clear();
     this._auths.clear();
+    this._csp = false;
     const error = new Error('Static Server has been reset');
     for (const subscriber of this._requestSubscribers.values())
       subscriber[rejectSymbol].call(null, error);
@@ -174,6 +181,10 @@ class SimpleServer {
     // Notify request subscriber.
     if (this._requestSubscribers.has(pathName))
       this._requestSubscribers.get(pathName)[fulfillSymbol].call(null, request);
+
+    if (this._csp)
+      response.setHeader('Content-Security-Policy', "default-src 'self'");
+
     const handler = this._routes.get(pathName);
     if (handler)
       handler.call(null, request, response);

--- a/test/test.js
+++ b/test/test.js
@@ -2577,6 +2577,18 @@ describe('Page', function() {
       expect(scriptHandle.asElement()).not.toBeNull();
       expect(await page.evaluate(() => __injected)).toBe(35);
     });
+
+    it('throw an error if content violates Content Security Policy', async({page, server}) => {
+      server.setCSP();
+      await page.goto(server.EMPTY_PAGE);
+      let error = null;
+      try {
+        await page.addScriptTag({ content: 'window.__injected = 36;' });
+      } catch (e) {
+        error = e;
+      }
+      expect(error.message).toBe('Refused to execute inline script because it violates the Content Security Policy');
+    });
   });
 
   describe('Page.addStyleTag', function() {
@@ -2628,6 +2640,18 @@ describe('Page', function() {
       const styleHandle = await page.addStyleTag({ content: 'body { background-color: green; }' });
       expect(styleHandle.asElement()).not.toBeNull();
       expect(await page.evaluate(`window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')`)).toBe('rgb(0, 128, 0)');
+    });
+
+    it('throw an error if content violates Content Security Policy', async({page, server}) => {
+      server.setCSP();
+      await page.goto(server.EMPTY_PAGE);
+      let error = null;
+      try {
+        await page.addStyleTag({ content: 'body { background-color: blue; }' });
+      } catch (e) {
+        error = e;
+      }
+      expect(error.message).toBe('Refused to execute inline style because it violates the Content Security Policy');
     });
   });
 


### PR DESCRIPTION
Both `page.addScriptTag()` and `page.addStyleTag()` silently fail when the requested page is protected by Content Security Policy.

Although it would be a nice feature to have an option to disable it, I think the default behavior should be failing gracefully.

I don't like my implementation of adding a global variable and an invisible element in the page, so I would like to hear better ideas and solutions.

Fixes: https://github.com/GoogleChrome/puppeteer/issues/1229