### PR TITLE
test(BrokenTest): Fix broken Tracing unit tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3000,7 +3000,7 @@ describe('Page', function() {
 
   describe('Tracing', function() {
     beforeEach(function(state) {
-      state.outputFile = path.join(__dirname, 'assets', `trace-${state.parallel}.json`);
+      state.outputFile = path.join(__dirname, 'assets', `trace-${state.parallelIndex}.json`);
     });
     afterEach(function(state) {
       fs.unlinkSync(state.outputFile);


### PR DESCRIPTION
This patch fixes broken Tracing tests which are failing since the `state.parallel` -> `state.parallelIndex` modification of #1531