### PR TITLE
feat(Tracing): add support for tracing without saving to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 *.swp
 *.pyc
+.idea
 .vscode
 package-lock.json
 /node6

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,6 +106,7 @@
 - [class: Touchscreen](#class-touchscreen)
   * [touchscreen.tap(x, y)](#touchscreentapx-y)
 - [class: Tracing](#class-tracing)
+  * [tracing.getResult()](#tracinggetresult)
   * [tracing.start(options)](#tracingstartoptions)
   * [tracing.stop()](#tracingstop)
 - [class: Dialog](#class-dialog)
@@ -1346,15 +1347,27 @@ Dispatches a `touchstart` and `touchend` event.
 
 You can use [`tracing.start`](#tracingstartoptions) and [`tracing.stop`](#tracingstop) to create a trace file which can be opened in Chrome DevTools or [timeline viewer](https://chromedevtools.github.io/timeline-viewer/).
 
+Save trace result to file:
 ```js
 await page.tracing.start({path: 'trace.json'});
 await page.goto('https://www.google.com');
 await page.tracing.stop();
 ```
 
+Read the trace result:
+```js
+await page.tracing.start();
+await page.goto('https://www.google.com');
+await page.tracing.stop();
+let tracingResult = await page.tracing.getResult();
+```
+
+#### tracing.getResult()
+- returns: <[string]> The trace result in JSON format.
+
 #### tracing.start(options)
 - `options` <[Object]>
-  - `path` <[string]> A path to write the trace file to. **required**
+  - `path` <[string]> A path to write the trace file to.
   - `screenshots` <[boolean]> captures screenshots in the trace.
   - `categories` <[Array]<[string]>> specify custom categories to use instead of default.
 - returns: <[Promise]>

--- a/lib/Tracing.js
+++ b/lib/Tracing.js
@@ -27,15 +27,24 @@ class Tracing {
   constructor(client) {
     this._client = client;
     this._recording = false;
+    this._result = '';
     this._path = '';
+  }
+
+  /**
+   * @return {string} The trace result.
+   */
+  getResult() {
+    if (this._recording)
+      throw new Error('Tracing is still in progress!');
+    return this._result;
   }
 
   /**
    * @param {!Object} options
    */
-  async start(options) {
+  async start(options = {}) {
     console.assert(!this._recording, 'Cannot start recording trace while already recording trace.');
-    console.assert(options.path, 'Must specify a path to write trace file to.');
 
     const defaultCategories = [
       '-*', 'devtools.timeline', 'v8.execute', 'disabled-by-default-devtools.timeline',
@@ -50,6 +59,7 @@ class Tracing {
 
     this._path = options.path;
     this._recording = true;
+    this._result = '';
     await this._client.send('Tracing.start', {
       transferMode: 'ReturnAsStream',
       categories: categoriesArray.join(',')
@@ -59,8 +69,11 @@ class Tracing {
   async stop() {
     let fulfill;
     const contentPromise = new Promise(x => fulfill = x);
-    this._client.once('Tracing.tracingComplete', event => {
-      this._readStream(event.stream, this._path).then(fulfill);
+    this._client.once('Tracing.tracingComplete', async event => {
+      await this._readResultFromStream(event.stream);
+      if (this._path)
+        await this._writeResultToFile(this._path);
+      fulfill();
     });
     await this._client.send('Tracing.end');
     this._recording = false;
@@ -69,19 +82,25 @@ class Tracing {
 
   /**
    * @param {string} handle
-   * @param {string} path
    */
-  async _readStream(handle, path) {
+  async _readResultFromStream(handle) {
     let eof = false;
-    const file = await openAsync(path, 'w');
+    this._result = '';
     while (!eof) {
       const response = await this._client.send('IO.read', {handle});
       eof = response.eof;
-      if (path)
-        await writeAsync(file, response.data);
+      this._result += response.data;
     }
-    await closeAsync(file);
     await this._client.send('IO.close', {handle});
+  }
+
+  /**
+   * @param {string} path
+   */
+  async _writeResultToFile(path) {
+    const file = await openAsync(path, 'w');
+    await writeAsync(file, this._result);
+    await closeAsync(file);
   }
 }
 helper.tracePublicAPI(Tracing);

--- a/test/test.js
+++ b/test/test.js
@@ -3003,10 +3003,11 @@ describe('Page', function() {
       state.outputFile = path.join(__dirname, 'assets', `trace-${state.parallel}.json`);
     });
     afterEach(function(state) {
-      fs.unlinkSync(state.outputFile);
+      if (fs.existsSync(state.outputFile))
+        fs.unlinkSync(state.outputFile);
       state.outputFile = null;
     });
-    it('should output a trace', async({page, server, outputFile}) => {
+    it('should write a trace to file if path specified', async({page, server, outputFile}) => {
       await page.tracing.start({screenshots: true, path: outputFile});
       await page.goto(server.PREFIX + '/grid.html');
       await page.tracing.stop();
@@ -3027,6 +3028,26 @@ describe('Page', function() {
       await newPage.close();
       expect(error).toBeTruthy();
       await page.tracing.stop();
+    });
+    it('should return the tracing result', async({page, server}) => {
+      await page.tracing.start();
+      await page.goto(server.PREFIX + '/grid.html');
+      await page.tracing.stop();
+
+      const result = await page.tracing.getResult();
+      expect(result.length).toBeGreaterThan(0);
+    });
+    it('should throw if calling .getResult() while tracing is in progress', async({page, server}) => {
+      let error = null;
+      await page.tracing.start();
+      await page.goto(server.PREFIX + '/grid.html');
+
+      try {
+        page.tracing.getResult();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
This patch adds support for using tracing without necessarily saving the result to a file. This allows consumers to process the tracing result without any unnecessary file operations.