### PR TITLE
test(UnitTest): Adding support to run tests in concurrent mode based on number of CPUs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,10 @@ HEADLESS=false SLOW_MO=500 npm run unit
 ```
 npm run debug-unit
 ```
+- To run tests in concurrent mode:
+```
+npm run unit-concurrent
+```
 
 ## Public API Coverage
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "unit": "node test/test.js",
+    "unit-concurrent": "node test/test.js -- -j MAX",
     "debug-unit": "node --inspect-brk test/test.js",
     "test-doclint": "node utils/doclint/check_public_api/test/test.js && node utils/doclint/preprocessor/test.js",
     "test": "npm run lint --silent && npm run coverage && npm run test-doclint && npm run test-node6-transformer",

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const rm = require('rimraf').sync;
 const path = require('path');
+const os = require('os');
 const {helper} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
@@ -54,12 +55,23 @@ const defaultBrowserOptions = {
 };
 
 const timeout = slowMo ?  0 : 10 * 1000;
-let parallel = 1;
-if (process.env.PPTR_PARALLEL_TESTS)
-  parallel = parseInt(process.env.PPTR_PARALLEL_TESTS.trim(), 10);
-const parallelArgIndex = process.argv.indexOf('-j');
-if (parallelArgIndex !== -1)
-  parallel = parseInt(process.argv[parallelArgIndex + 1], 10);
+const getThreadCount = () => {
+  const parallelArgIndex = process.argv.indexOf('-j');
+  let value;
+
+  if (process.env.PPTR_PARALLEL_TESTS)
+    value = process.env.PPTR_PARALLEL_TESTS;
+  if (parallelArgIndex !== -1)
+    value = process.argv[parallelArgIndex + 1];
+
+  if (value === 'MAX')
+    return os.cpus().length;
+  else if (value)
+    return parseInt(value.trim(), 10);
+  else
+    return 1;
+};
+const parallel = getThreadCount();
 
 const {TestRunner, Reporter, Matchers}  = require('../utils/testrunner/');
 const runner = new TestRunner({timeout, parallel});


### PR DESCRIPTION
This patch adds support for defining thread count in concurrent unit test execution by using `MAX` as value. This will result in running tests based on number of CPUs dynamically.