### PR TITLE
feat(Page.select) Throwing an error when select option is not found

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -527,6 +527,12 @@ class Frame {
         throw new Error('Element is not a <select> element.');
 
       const options = Array.from(element.options);
+      const optionValues = options.map(option => option.value);
+      const unknownValues = values.filter(value => !optionValues.includes(value));
+
+      if (unknownValues.length)
+        throw new Error(`Option(s) not found: ${unknownValues.join(', ')}`);
+
       element.value = undefined;
       for (const option of options)
         option.selected = values.includes(option.value);

--- a/test/test.js
+++ b/test/test.js
@@ -2996,6 +2996,12 @@ describe('Page', function() {
       }
       expect(error.message).toContain('Values must be strings');
     });
+    it('should throw if select doesn\'t contain a given value', async function({page}) {
+      let error;
+      await page.setContent('<select><option value="foo">Foo</option></select>');
+      await page.select('select', 'bar', 'foo', 'pptr').catch(e => error = e);
+      expect(error.message).toContain('Option(s) not found: bar, pptr');
+    });
   });
 
   describe('Tracing', function() {


### PR DESCRIPTION
This patch adds support for throwing an error when passing an option to `Page.select()` which is not found in the given select.

Fixes #1384

BREAKING CHANGE: `Page.select()` now throws an error if an invalid option was passed.