### PR TITLE
feat(Page): add `headerTemplate` and `footerTemplate` to PDF options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -888,6 +888,13 @@ Page is guaranteed to have a main frame which persists during navigations.
   - `path` <[string]> The file path to save the PDF to. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the PDF won't be saved to the disk.
   - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`.
   - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
+  - `headerTemplate` <[string]> HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
+    - `date` formatted print date
+    - `title` document title
+    - `url` document location
+    - `pageNumber` current page number
+    - `totalPages` total pages in the document
+  - `footerTemplate` <[string]> HTML template for the print footer. Should use the same format as the `headerTemplate`.
   - `printBackground` <[boolean]> Print background graphics. Defaults to `false`.
   - `landscape` <[boolean]> Paper orientation. Defaults to `false`.
   - `pageRanges` <[string]> Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -703,6 +703,8 @@ class Page extends EventEmitter {
   async pdf(options = {}) {
     const scale = options.scale || 1;
     const displayHeaderFooter = !!options.displayHeaderFooter;
+    const headerTemplate = options.headerTemplate || '';
+    const footerTemplate = options.footerTemplate || '';
     const printBackground = !!options.printBackground;
     const landscape = !!options.landscape;
     const pageRanges = options.pageRanges || '';
@@ -728,6 +730,8 @@ class Page extends EventEmitter {
     const result = await this._client.send('Page.printToPDF', {
       landscape: landscape,
       displayHeaderFooter: displayHeaderFooter,
+      headerTemplate: headerTemplate,
+      footerTemplate: footerTemplate,
       printBackground: printBackground,
       scale: scale,
       paperWidth: paperWidth,


### PR DESCRIPTION
The Stable RC (1.3) release of Chrome DevTools Protocol includes new options for providing a custom header and footer templates to `Page.printToPDF` method - https://github.com/ChromeDevTools/devtools-protocol/blob/0956b7c770c81c49682f0e50589652dd818655fc/changelog.md#page-modified-command
They are available in Chrome Canary so we can start using them today.