### PR TITLE
feat(Chromium): roll chromium to 524617

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "522446"
+    "chromium_revision": "524617"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This patch rolls chromium to r524617. This roll includes:
- http://crrev.com/523674 - Headless printing: refactor print template
  to allow header/footer customization.

References #373