### PR TITLE
 Attribute network requests to frames (#1579)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -177,6 +177,7 @@
   * [request.abort([errorCode])](#requestaborterrorcode)
   * [request.continue([overrides])](#requestcontinueoverrides)
   * [request.failure()](#requestfailure)
+  * [request.frame()](#requestframe)
   * [request.headers()](#requestheaders)
   * [request.method()](#requestmethod)
   * [request.postData()](#requestpostdata)
@@ -2042,6 +2043,9 @@ page.on('requestfailed', request => {
   console.log(request.url + ' ' + request.failure().errorText);
 });
 ```
+
+#### request.frame()
+- returns: <?[Frame]> A matching [Frame] object, or `null` for offline mode or navigating to error pages.
 
 #### request.headers()
 - returns: <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2045,7 +2045,7 @@ page.on('requestfailed', request => {
 ```
 
 #### request.frame()
-- returns: <?[Frame]> A matching [Frame] object, or `null` for offline mode or navigating to error pages.
+- returns: <?[Frame]> A matching [Frame] object, or `null` if navigating to error pages.
 
 #### request.headers()
 - returns: <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -88,6 +88,14 @@ class FrameManager extends EventEmitter {
   }
 
   /**
+   * @param {!string} frameId
+   * @return {!Frame}
+   */
+  frame(frameId) {
+    return this._frames.get(frameId);
+  }
+
+  /**
    * @param {string} frameId
    * @param {?string} parentFrameId
    * @return {?Frame}

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -92,7 +92,7 @@ class FrameManager extends EventEmitter {
    * @return {?Frame}
    */
   frame(frameId) {
-    return this._frames.get(frameId);
+    return this._frames.get(frameId) || null;
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -89,7 +89,7 @@ class FrameManager extends EventEmitter {
 
   /**
    * @param {!string} frameId
-   * @return {!Frame}
+   * @return {?Frame}
    */
   frame(frameId) {
     return this._frames.get(frameId);

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -89,10 +89,10 @@ class FrameManager extends EventEmitter {
 
   /**
    * @param {!string} frameId
-   * @return {!Frame}
+   * @return {?Frame}
    */
   frame(frameId) {
-    return this._frames.get(frameId);
+    return this._frames.get(frameId) || null;
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -89,10 +89,10 @@ class FrameManager extends EventEmitter {
 
   /**
    * @param {!string} frameId
-   * @return {?Frame}
+   * @return {!Frame}
    */
   frame(frameId) {
-    return this._frames.get(frameId) || null;
+    return this._frames.get(frameId);
   }
 
   /**

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -285,7 +285,7 @@ class Request {
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} payload
-   * @param {Puppeteer.Frame} frame
+   * @param {?Puppeteer.Frame} frame
    */
   constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame) {
     this._client = client;

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -19,11 +19,13 @@ const Multimap = require('./Multimap');
 
 class NetworkManager extends EventEmitter {
   /**
-   * @param {Puppeteer.Session} client
+   * @param {!Puppeteer.Session} client
+   * @param {!Puppeteer.FrameManager} frameManager
    */
-  constructor(client) {
+  constructor(client, frameManager) {
     super();
     this._client = client;
+    this._frameManager = frameManager;
     /** @type {!Map<string, !Request>} */
     this._requestIdToRequest = new Map();
     /** @type {!Map<string, !Request>} */
@@ -189,7 +191,8 @@ class NetworkManager extends EventEmitter {
    * @param {string} frameId
    */
   _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId) {
-    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frameId);
+    const frame = this._frameManager._frames.get(frameId);
+    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);
     if (interceptionId)
@@ -282,9 +285,9 @@ class Request {
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} payload
-   * @param {string} frameId
+   * @param {!Puppeteer.Frame} frame
    */
-  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frameId) {
+  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame) {
     this._client = client;
     this._requestId = requestId;
     this._interceptionId = interceptionId;
@@ -301,8 +304,7 @@ class Request {
     this._method = payload.method;
     this._postData = payload.postData;
     this._headers = {};
-    this._frameId = frameId;
-    this._frame = null;
+    this._frame = frame;
     for (const key of Object.keys(payload.headers))
       this._headers[key.toLowerCase()] = payload.headers[key];
   }

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -285,7 +285,7 @@ class Request {
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} payload
-   * @param {!Puppeteer.Frame} frame
+   * @param {Puppeteer.Frame} frame
    */
   constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame) {
     this._client = client;

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -191,7 +191,7 @@ class NetworkManager extends EventEmitter {
    * @param {string} frameId
    */
   _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId) {
-    const frame = this._frameManager._frames.get(frameId);
+    const frame = this._frameManager.frame(frameId);
     const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -151,17 +151,17 @@ class NetworkManager extends EventEmitter {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
       console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
       this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders);
-      this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request);
+      this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId);
       return;
     }
     const requestHash = generateRequestHash(event.request);
     const requestId = this._requestHashToRequestIds.firstValue(requestHash);
     if (requestId) {
       this._requestHashToRequestIds.delete(requestHash, requestId);
-      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request);
+      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId);
     } else {
       this._requestHashToInterceptionIds.set(requestHash, event.interceptionId);
-      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request);
+      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId);
     }
   }
 
@@ -186,9 +186,10 @@ class NetworkManager extends EventEmitter {
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} requestPayload
+   * @param {string} frameId
    */
-  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload) {
-    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload);
+  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId) {
+    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frameId);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);
     if (interceptionId)
@@ -222,7 +223,7 @@ class NetworkManager extends EventEmitter {
       if (request)
         this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
     }
-    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request);
+    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request, event.frameId);
   }
 
   /**
@@ -281,8 +282,9 @@ class Request {
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} payload
+   * @param {string} frameId
    */
-  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload) {
+  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frameId) {
     this._client = client;
     this._requestId = requestId;
     this._interceptionId = interceptionId;
@@ -299,6 +301,8 @@ class Request {
     this._method = payload.method;
     this._postData = payload.postData;
     this._headers = {};
+    this._frameId = frameId;
+    this._frame = null;
     for (const key of Object.keys(payload.headers))
       this._headers[key.toLowerCase()] = payload.headers[key];
   }
@@ -343,6 +347,13 @@ class Request {
    */
   response() {
     return this._response;
+  }
+
+  /**
+   * @return {?Puppeteer.Frame}
+   */
+  frame() {
+    return this._frame;
   }
 
   /**

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -188,10 +188,12 @@ class NetworkManager extends EventEmitter {
    * @param {string} url
    * @param {string} resourceType
    * @param {!Object} requestPayload
-   * @param {string} frameId
+   * @param {?string} frameId
    */
   _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId) {
-    const frame = this._frameManager.frame(frameId);
+    let frame = null;
+    if (frameId)
+      frame = this._frameManager.frame(frameId);
     const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -84,10 +84,12 @@ class Page extends EventEmitter {
     this._frameManager.on(FrameManager.Events.FrameDetached, event => this.emit(Page.Events.FrameDetached, event));
     this._frameManager.on(FrameManager.Events.FrameNavigated, event => this.emit(Page.Events.FrameNavigated, event));
 
-    this._networkManager.on(NetworkManager.Events.Request, event => this.emit(Page.Events.Request, event));
     this._networkManager.on(NetworkManager.Events.Response, event => this.emit(Page.Events.Response, event));
-    this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(Page.Events.RequestFailed, event));
-    this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(Page.Events.RequestFinished, event));
+
+    this._networkManager.on(NetworkManager.Events.Request, event => this._handleRequest(Page.Events.Request, event));
+    this._networkManager.on(NetworkManager.Events.RequestFailed, event => this._handleRequest(Page.Events.RequestFailed, event));
+    this._networkManager.on(NetworkManager.Events.RequestFinished, event => this._handleRequest(Page.Events.RequestFinished, event));
+
 
     client.on('Page.loadEventFired', event => this.emit(Page.Events.Load));
     client.on('Runtime.consoleAPICalled', event => this._onConsoleAPI(event));
@@ -96,6 +98,16 @@ class Page extends EventEmitter {
     client.on('Security.certificateError', event => this._onCertificateError(event));
     client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
     client.on('Performance.metrics', event => this._emitMetrics(event));
+  }
+
+  /**
+   * @param {!string} eventName
+   * @param {!Object} event
+   */
+  _handleRequest(eventName, event) {
+    const frame = this._frameManager._frames.get(event._frameId);
+    event._frame = frame;
+    this.emit(eventName, event);
   }
 
   _onTargetCrashed() {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -71,7 +71,7 @@ class Page extends EventEmitter {
     this._mouse = new Mouse(client, this._keyboard);
     this._touchscreen = new Touchscreen(client, this._keyboard);
     this._frameManager = new FrameManager(client, frameTree, this);
-    this._networkManager = new NetworkManager(client);
+    this._networkManager = new NetworkManager(client, this._frameManager);
     this._emulationManager = new EmulationManager(client);
     this._tracing = new Tracing(client);
     /** @type {!Map<string, Function>} */
@@ -84,12 +84,10 @@ class Page extends EventEmitter {
     this._frameManager.on(FrameManager.Events.FrameDetached, event => this.emit(Page.Events.FrameDetached, event));
     this._frameManager.on(FrameManager.Events.FrameNavigated, event => this.emit(Page.Events.FrameNavigated, event));
 
+    this._networkManager.on(NetworkManager.Events.Request, event => this.emit(Page.Events.Request, event));
     this._networkManager.on(NetworkManager.Events.Response, event => this.emit(Page.Events.Response, event));
-
-    this._networkManager.on(NetworkManager.Events.Request, event => this._handleRequest(Page.Events.Request, event));
-    this._networkManager.on(NetworkManager.Events.RequestFailed, event => this._handleRequest(Page.Events.RequestFailed, event));
-    this._networkManager.on(NetworkManager.Events.RequestFinished, event => this._handleRequest(Page.Events.RequestFinished, event));
-
+    this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(Page.Events.RequestFailed, event));
+    this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(Page.Events.RequestFinished, event));
 
     client.on('Page.loadEventFired', event => this.emit(Page.Events.Load));
     client.on('Runtime.consoleAPICalled', event => this._onConsoleAPI(event));
@@ -98,16 +96,6 @@ class Page extends EventEmitter {
     client.on('Security.certificateError', event => this._onCertificateError(event));
     client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
     client.on('Performance.metrics', event => this._emitMetrics(event));
-  }
-
-  /**
-   * @param {!string} eventName
-   * @param {!Object} event
-   */
-  _handleRequest(eventName, event) {
-    const frame = this._frameManager._frames.get(event._frameId);
-    event._frame = frame;
-    this.emit(eventName, event);
   }
 
   _onTargetCrashed() {

--- a/test/test.js
+++ b/test/test.js
@@ -1573,25 +1573,18 @@ describe('Page', function() {
   });
 
   describe('Page.Events.Request', function() {
-    it('should fire on main frame', async({page, server}) => {
+    it('should fire', async({page, server}) => {
       const requests = [];
       page.on('request', request => requests.push(request));
       await page.goto(server.EMPTY_PAGE);
-      expect(requests.length).toBe(1);
+      await FrameUtils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      expect(requests.length).toBe(2);
       expect(requests[0].url()).toBe(server.EMPTY_PAGE);
       expect(requests[0].frame() === page.mainFrame()).toBe(true);
       expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
-    });
-
-    it('should fire on child frames', async({page, server}) => {
-      await page.goto(server.EMPTY_PAGE);
-      const requests = [];
-      page.on('request', request => requests.push(request));
-      await FrameUtils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
-      expect(requests.length).toBe(1);
-      expect(requests[0].url()).toBe(server.EMPTY_PAGE);
-      expect(requests[0].frame() === page.mainFrame()).toBe(false);
-      expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
+      expect(requests[1].url()).toBe(server.EMPTY_PAGE);
+      expect(requests[1].frame() === page.mainFrame()).toBe(false);
+      expect(requests[1].frame().url()).toBe(server.EMPTY_PAGE);
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1276,7 +1276,8 @@ describe('Page', function() {
         expect(request.method()).toBe('GET');
         expect(request.postData()).toBe(undefined);
         expect(request.resourceType()).toBe('document');
-        expect(request.frame()).toBeTruthy();
+        expect(request.frame() === page.mainFrame()).toBe(true);
+        expect(request.frame().url()).toBe('about:blank');
         request.continue();
       });
       const response = await page.goto(server.EMPTY_PAGE);
@@ -1581,8 +1582,9 @@ describe('Page', function() {
       page.on('request', request => requests.push(request));
       await page.goto(server.EMPTY_PAGE);
       expect(requests.length).toBe(1);
-      expect(requests[0].url()).toContain('empty.html');
-      expect(requests[0].frame()).toBeTruthy();
+      expect(requests[0].url()).toBe(server.EMPTY_PAGE);
+      expect(requests[0].frame() === page.mainFrame()).toBe(true);
+      expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
     });
   });
 
@@ -1606,7 +1608,7 @@ describe('Page', function() {
       page.on('framenavigated', frame => navigatedFrames.push(frame));
       await FrameUtils.navigateFrame(page, 'frame1', './empty.html');
       expect(navigatedFrames.length).toBe(1);
-      expect(navigatedFrames[0].url()).toContain('/empty.html');
+      expect(navigatedFrames[0].url()).toBe(server.EMPTY_PAGE);
 
       // validate framedetached events
       const detachedFrames = [];
@@ -2457,7 +2459,8 @@ describe('Page', function() {
       expect(requests[0].resourceType()).toBe('document');
       expect(requests[0].method()).toBe('GET');
       expect(requests[0].response()).toBeTruthy();
-      expect(requests[0].frame()).toBeTruthy();
+      expect(requests[0].frame() === page.mainFrame()).toBe(true);
+      expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
     });
     it('Page.Events.Request should report post data', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
@@ -2542,7 +2545,8 @@ describe('Page', function() {
       expect(requests.length).toBe(1);
       expect(requests[0].url()).toBe(server.EMPTY_PAGE);
       expect(requests[0].response()).toBeTruthy();
-      expect(requests[0].frame()).toBeTruthy();
+      expect(requests[0].frame() === page.mainFrame()).toBe(true);
+      expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
     });
     it('should fire events in proper order', async({page, server}) => {
       const events = [];

--- a/test/test.js
+++ b/test/test.js
@@ -1583,7 +1583,7 @@ describe('Page', function() {
       expect(requests[0].frame() === page.mainFrame()).toBe(true);
       expect(requests[0].frame().url()).toBe(server.EMPTY_PAGE);
       expect(requests[1].url()).toBe(server.EMPTY_PAGE);
-      expect(requests[1].frame() === page.mainFrame()).toBe(false);
+      expect(requests[1].frame() === page.frames()[1]).toBe(true);
       expect(requests[1].frame().url()).toBe(server.EMPTY_PAGE);
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1276,6 +1276,7 @@ describe('Page', function() {
         expect(request.method()).toBe('GET');
         expect(request.postData()).toBe(undefined);
         expect(request.resourceType()).toBe('document');
+        expect(request.frame()).toBeTruthy();
         request.continue();
       });
       const response = await page.goto(server.EMPTY_PAGE);
@@ -1581,6 +1582,7 @@ describe('Page', function() {
       await page.goto(server.EMPTY_PAGE);
       expect(requests.length).toBe(1);
       expect(requests[0].url()).toContain('empty.html');
+      expect(requests[0].frame()).toBeTruthy();
     });
   });
 
@@ -2455,6 +2457,7 @@ describe('Page', function() {
       expect(requests[0].resourceType()).toBe('document');
       expect(requests[0].method()).toBe('GET');
       expect(requests[0].response()).toBeTruthy();
+      expect(requests[0].frame()).toBeTruthy();
     });
     it('Page.Events.Request should report post data', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
@@ -2530,6 +2533,7 @@ describe('Page', function() {
       expect(failedRequests[0].response()).toBe(null);
       expect(failedRequests[0].resourceType()).toBe('stylesheet');
       expect(failedRequests[0].failure().errorText).toBe('net::ERR_FAILED');
+      expect(failedRequests[0].frame()).toBeTruthy();
     });
     it('Page.Events.RequestFinished', async({page, server}) => {
       const requests = [];
@@ -2538,6 +2542,7 @@ describe('Page', function() {
       expect(requests.length).toBe(1);
       expect(requests[0].url()).toBe(server.EMPTY_PAGE);
       expect(requests[0].response()).toBeTruthy();
+      expect(requests[0].frame()).toBeTruthy();
     });
     it('should fire events in proper order', async({page, server}) => {
       const events = [];


### PR DESCRIPTION
I think it's not only convenient for requests to have frame properties, but it's consistent with Chrome DevTool Protocol because [Network.requestWillBeSent](https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSent) event has frameId property.

One problem I faced is that the frameId is optional, so the frame cannot always be accessed from request. I noticed that the property is empty for offline mode and when navigating to bad SSL pages.

Fixes: https://github.com/GoogleChrome/puppeteer/issues/1579

@aslushnikov 