### PR TITLE
CLI support on install.js

### DIFF
--- a/install.js
+++ b/install.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const ProgressBar = require('progress');
+const mri = require('mri');
 
 buildNode6IfNecessary();
 
@@ -28,9 +30,11 @@ if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_c
 const Downloader = require('./lib/Downloader');
 const downloader = Downloader.createDefault();
 
-const platform = downloader.currentPlatform();
-const revision = Downloader.defaultRevision();
-const ProgressBar = require('progress');
+const {
+  platform = downloader.currentPlatform(),
+  revision = Downloader.defaultRevision()
+} = mri(process.argv.slice(2));
+
 
 const revisionInfo = downloader.revisionInfo(platform, revision);
 // Do nothing if the revision is already downloaded.
@@ -79,7 +83,7 @@ function onError(error) {
 let progressBar = null;
 function onProgress(bytesTotal, delta) {
   if (!progressBar) {
-    progressBar = new ProgressBar(`Downloading Chromium r${revision} - ${toMegabytes(bytesTotal)} [:bar] :percent :etas `, {
+    progressBar = new ProgressBar(`Downloading Chromium r${revision} for ${platform} - ${toMegabytes(bytesTotal)} [:bar] :percent :etas `, {
       complete: '=',
       incomplete: ' ',
       width: 20,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "esprima": "^4.0.0",
     "markdown-toc": "^1.1.0",
     "minimist": "^1.2.0",
+    "mri": "~1.1.0",
     "ncp": "^2.0.0",
     "pdfjs-dist": "^1.8.595",
     "pixelmatch": "^4.0.2",


### PR DESCRIPTION
Hello,

In this PR I added the functionality for being possible to download a chromium version specifying `platform` and `revision`:

```bash
$ node install.js --platform=linux 
```

This is helpful when you need to provision production machines that normally are a different architecture than a development environment.