### PR TITLE
fix(NavigationWatcher):correct closure annotation

### DIFF
--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -60,7 +60,7 @@ class NavigatorWatcher {
   }
 
   /**
-   * @return {?Promise<?Error>}
+   * @return {!Promise<?Error>}
    */
   _createTimeoutPromise() {
     if (!this._timeout)


### PR DESCRIPTION
`_createTimeoutPromise()` always returns a promise.

It changed [here](https://github.com/GoogleChrome/puppeteer/pull/1435).