### PR TITLE
docs: add missing session property to api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -594,6 +594,7 @@ Gets the full HTML contents of the page, including the doctype.
   - `expires` <[number]> Unix time in seconds.
   - `httpOnly` <[boolean]>
   - `secure` <[boolean]>
+  - `session` <[boolean]>
   - `sameSite` <[string]> `"Strict"` or `"Lax"`.
 
 If no URLs are specified, this method returns cookies for the current page URL.


### PR DESCRIPTION
The `session` value is returned from the protocol, but not accepted as a cookie parameter.
See: https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Session
fixes #980