### PR TITLE
 feat: Implement JavaScript Coverage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,7 @@
   * [page.close()](#pageclose)
   * [page.content()](#pagecontent)
   * [page.cookies(...urls)](#pagecookiesurls)
+  * [page.coverage](#pagecoverage)
   * [page.deleteCookie(...cookies)](#pagedeletecookiecookies)
   * [page.emulate(options)](#pageemulateoptions)
   * [page.emulateMedia(mediaType)](#pageemulatemediamediatype)
@@ -197,6 +198,9 @@
   * [target.page()](#targetpage)
   * [target.type()](#targettype)
   * [target.url()](#targeturl)
+- [class: Coverage](#class-coverage)
+  * [coverage.startJSCoverage(options)](#coveragestartjscoverageoptions)
+  * [coverage.stopJSCoverage()](#coveragestopjscoverage)
 
 <!-- tocstop -->
 
@@ -599,6 +603,10 @@ Gets the full HTML contents of the page, including the doctype.
 
 If no URLs are specified, this method returns cookies for the current page URL.
 If URLs are specified, only cookies for those URLs are returned.
+
+#### page.coverage
+
+- returns: <[Coverage]>
 
 #### page.deleteCookie(...cookies)
 - `...cookies` <...[Object]>
@@ -2144,6 +2152,41 @@ Identifies what kind of target this is. Can be `"page"`, `"service_worker"`, or 
 #### target.url()
 - returns: <[string]>
 
+### class: Coverage
+
+#### coverage.startJSCoverage(options)
+- `options` <[Object]>  Set of configurable options for coverage
+  - `resetOnNavigation` <[boolean]> Whether to reset coverage on every navigation. Defaults to `true`.
+- returns: <[Promise]> Promise that resolves when coverage is started
+
+#### coverage.stopJSCoverage()
+- returns: <[Promise]<[Array]<[Object]>>> Promise that resolves to the array of coverage reports for all non-anonymous scripts
+  - `url` <[string]> Script URL
+  - `text` <[string]> Script content
+  - `ranges` <[Array]<[Object]>> Script ranges that were executed. Ranges are sorted and non-overlapping.
+    - `startOffset` <[number]>
+    - `endOffset` <[number]>
+
+> **NOTE** JavaScript Coverage doesn't include anonymous scripts; however, scripts with sourceURLs are
+reported.
+
+An example of using JavaScript coverage to get percentage of executed
+code:
+
+```js
+await page.startJSCoverage();
+await page.goto('https://example.com');
+const coverage = await page.stopJSCoverage();
+let totalBytes = 0;
+let usedBytes = 0;
+for (const entry of coverage) {
+  totalBytes += entry.text.length;
+  for (const range of entry.ranges)
+    usedBytes += range.endOffset - range.startOffset - 1;
+}
+console.log(`Coverage is ${usedBytes / totalBytes * 100}%`);
+```
+
 [Array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array "Array"
 [boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type "Boolean"
 [Buffer]: https://nodejs.org/api/buffer.html#buffer_class_buffer "Buffer"
@@ -2158,6 +2201,7 @@ Identifies what kind of target this is. Can be `"page"`, `"service_worker"`, or 
 [Frame]: #class-frame "Frame"
 [ConsoleMessage]: #class-consolemessage "ConsoleMessage"
 [ChildProcess]: https://nodejs.org/api/child_process.html "ChildProcess"
+[Coverage]: #class-coverage "Coverage"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [Response]: #class-response  "Response"
 [Request]: #class-request  "Request"

--- a/docs/api.md
+++ b/docs/api.md
@@ -2164,8 +2164,8 @@ Identifies what kind of target this is. Can be `"page"`, `"service_worker"`, or 
   - `url` <[string]> Script URL
   - `text` <[string]> Script content
   - `ranges` <[Array]<[Object]>> Script ranges that were executed. Ranges are sorted and non-overlapping.
-    - `startOffset` <[number]>
-    - `endOffset` <[number]>
+    - `start` <[number]> A start offset in text, inclusive
+    - `end` <[number]> An end offset in text, exclusive
 
 > **NOTE** JavaScript Coverage doesn't include anonymous scripts; however, scripts with sourceURLs are
 reported.
@@ -2182,7 +2182,7 @@ let usedBytes = 0;
 for (const entry of coverage) {
   totalBytes += entry.text.length;
   for (const range of entry.ranges)
-    usedBytes += range.endOffset - range.startOffset - 1;
+    usedBytes += range.end - range.start - 1;
 }
 console.log(`Coverage is ${usedBytes / totalBytes * 100}%`);
 ```

--- a/lib/Coverage.js
+++ b/lib/Coverage.js
@@ -98,7 +98,7 @@ class JSCoverage {
   }
 
   /**
-   * @return {!Promise<!Array<!{url:string, text:string, ranges:!Array<!{startOffset:number, endOffset:number}>}>>}
+   * @return {!Promise<!Array<!{url:string, text:string, ranges:!Array<!{start:number, end:number}>}>>}
    */
   async stop() {
     console.assert(this._enabled, 'JSCoverage is not enabled');
@@ -129,7 +129,7 @@ class JSCoverage {
 
 /**
  * @param {!Array<!{startOffset:number, endOffset:number, count:number}>} nestedRanges
- * @return {!Array<!{startOffset:number, endOffset:number}>}
+ * @return {!Array<!{start:number, end:number}>}
  */
 function convertToDisjointRanges(nestedRanges) {
   const points = [];
@@ -161,10 +161,10 @@ function convertToDisjointRanges(nestedRanges) {
   for (const point of points) {
     if (hitCountStack.length && lastOffset < point.offset && hitCountStack[hitCountStack.length - 1] > 0) {
       const lastResult = results.length ? results[results.length - 1] : null;
-      if (lastResult && lastResult.endOffset === lastOffset)
-        lastResult.endOffset = point.offset;
+      if (lastResult && lastResult.end === lastOffset)
+        lastResult.end = point.offset;
       else
-        results.push({startOffset: lastOffset, endOffset: point.offset});
+        results.push({start: lastOffset, end: point.offset});
     }
     lastOffset = point.offset;
     if (point.type === 0)
@@ -173,6 +173,6 @@ function convertToDisjointRanges(nestedRanges) {
       hitCountStack.pop();
   }
   // Filter out empty ranges.
-  return results.filter(range => range.endOffset - range.startOffset > 1);
+  return results.filter(range => range.end - range.start > 1);
 }
 

--- a/lib/Coverage.js
+++ b/lib/Coverage.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {helper, debugError} = require('./helper');
+
+class Coverage {
+  /**
+   * @param {!Puppeteer.Session} client
+   */
+  constructor(client) {
+    this._jsCoverage = new JSCoverage(client);
+  }
+
+  /**
+   * @param {!Object} options
+   */
+  async startJSCoverage(options) {
+    return await this._jsCoverage.start(options);
+  }
+
+  async stopJSCoverage() {
+    return await this._jsCoverage.stop();
+  }
+}
+
+module.exports = {Coverage};
+helper.tracePublicAPI(Coverage);
+
+class JSCoverage {
+  /**
+   * @param {!Puppeteer.Session} client
+   */
+  constructor(client) {
+    this._client = client;
+    this._enabled = false;
+    this._scriptURLs = new Map();
+    this._scriptSources = new Map();
+    this._eventListeners = [];
+    this._resetOnNavigation = false;
+  }
+
+  /**
+   * @param {!Object} options
+   */
+  async start(options = {}) {
+    console.assert(!this._enabled, 'JSCoverage is already enabled');
+    this._resetOnNavigation = options.resetOnNavigation === undefined ? true : !!options.resetOnNavigation;
+    this._enabled = true;
+    this._scriptURLs.clear();
+    this._scriptSources.clear();
+    this._eventListeners = [
+      helper.addEventListener(this._client, 'Debugger.scriptParsed', this._onScriptParsed.bind(this)),
+      helper.addEventListener(this._client, 'Runtime.executionContextsCleared', this._onExecutionContextsCleared.bind(this)),
+    ];
+    await Promise.all([
+      this._client.send('Profiler.enable'),
+      this._client.send('Profiler.startPreciseCoverage', {callCount: false, detailed: true}),
+      this._client.send('Debugger.enable'),
+      this._client.send('Debugger.setSkipAllPauses', {skip: true})
+    ]);
+  }
+
+  _onExecutionContextsCleared() {
+    if (!this._resetOnNavigation)
+      return;
+    this._scriptURLs.clear();
+    this._scriptSources.clear();
+  }
+
+  /**
+   * @param {!Object} event
+   */
+  async _onScriptParsed(event) {
+    // Ignore anonymous scripts
+    if (!event.url)
+      return;
+    try {
+      const response = await this._client.send('Debugger.getScriptSource', {scriptId: event.scriptId});
+      this._scriptURLs.set(event.scriptId, event.url);
+      this._scriptSources.set(event.scriptId, response.scriptSource);
+    } catch (e) {
+      // This might happen if the page has already navigated away.
+      debugError(e);
+    }
+  }
+
+  /**
+   * @return {!Promise<!Array<!{url:string, text:string, ranges:!Array<!{startOffset:number, endOffset:number}>}>>}
+   */
+  async stop() {
+    console.assert(this._enabled, 'JSCoverage is not enabled');
+    this._enabled = false;
+    const [profileResponse] = await Promise.all([
+      this._client.send('Profiler.takePreciseCoverage'),
+      this._client.send('Profiler.stopPreciseCoverage'),
+      this._client.send('Profiler.disable'),
+      this._client.send('Debugger.disable'),
+    ]);
+    helper.removeEventListeners(this._eventListeners);
+
+    const coverage = [];
+    for (const entry of profileResponse.result) {
+      const url = this._scriptURLs.get(entry.scriptId);
+      const text = this._scriptSources.get(entry.scriptId);
+      if (text === undefined || url === undefined)
+        continue;
+      const flattenRanges = [];
+      for (const func of entry.functions)
+        flattenRanges.push(...func.ranges);
+      const ranges = convertToDisjointRanges(flattenRanges);
+      coverage.push({url, ranges, text});
+    }
+    return coverage;
+  }
+}
+
+/**
+ * @param {!Array<!{startOffset:number, endOffset:number, count:number}>} nestedRanges
+ * @return {!Array<!{startOffset:number, endOffset:number}>}
+ */
+function convertToDisjointRanges(nestedRanges) {
+  const points = [];
+  for (const range of nestedRanges) {
+    points.push({ offset: range.startOffset, type: 0, range });
+    points.push({ offset: range.endOffset, type: 1, range });
+  }
+  // Sort points to form a valid parenthesis sequence.
+  points.sort((a, b) => {
+    // Sort with increasing offsets.
+    if (a.offset !== b.offset)
+      return a.offset - b.offset;
+    // All "end" points should go before "start" points.
+    if (a.type !== b.type)
+      return b.type - a.type;
+    const aLength = a.range.endOffset - a.range.startOffset;
+    const bLength = b.range.endOffset - b.range.startOffset;
+    // For two "start" points, the one with longer range goes first.
+    if (a.type === 0)
+      return bLength - aLength;
+    // For two "end" points, the one with shorter range goes first.
+    return aLength - bLength;
+  });
+
+  const hitCountStack = [];
+  const results = [];
+  let lastOffset = 0;
+  // Run scanning line to intersect all ranges.
+  for (const point of points) {
+    if (hitCountStack.length && lastOffset < point.offset && hitCountStack[hitCountStack.length - 1] > 0) {
+      const lastResult = results.length ? results[results.length - 1] : null;
+      if (lastResult && lastResult.endOffset === lastOffset)
+        lastResult.endOffset = point.offset;
+      else
+        results.push({startOffset: lastOffset, endOffset: point.offset});
+    }
+    lastOffset = point.offset;
+    if (point.type === 0)
+      hitCountStack.push(point.range.count);
+    else
+      hitCountStack.pop();
+  }
+  // Filter out empty ranges.
+  return results.filter(range => range.endOffset - range.startOffset > 1);
+}
+

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -25,6 +25,7 @@ const {FrameManager} = require('./FrameManager');
 const {Keyboard, Mouse, Touchscreen} = require('./Input');
 const Tracing = require('./Tracing');
 const {helper, debugError} = require('./helper');
+const {Coverage} = require('./Coverage');
 
 const writeFileAsync = helper.promisify(fs.writeFile);
 
@@ -77,6 +78,7 @@ class Page extends EventEmitter {
     /** @type {!Map<string, Function>} */
     this._pageBindings = new Map();
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
+    this._coverage = new Coverage(client);
 
     this._screenshotTaskQueue = screenshotTaskQueue;
 
@@ -121,6 +123,13 @@ class Page extends EventEmitter {
    */
   get touchscreen() {
     return this._touchscreen;
+  }
+
+  /**
+   * @return {!Coverage}
+   */
+  get coverage() {
+    return this._coverage;
   }
 
   /**

--- a/test/assets/jscoverage/involved.html
+++ b/test/assets/jscoverage/involved.html
@@ -1,0 +1,15 @@
+<script>
+function foo() {
+  if (1 > 2)
+    console.log(1);
+  if (1 < 2)
+    console.log(2);
+  let x = 1 > 2 ? 'foo' : 'bar';
+  let y = 1 < 2 ? 'foo' : 'bar';
+  let z = () => {};
+  let q = () => {};
+  q();
+}
+
+foo();
+</script>

--- a/test/assets/jscoverage/multiple.html
+++ b/test/assets/jscoverage/multiple.html
@@ -1,0 +1,2 @@
+<script src='script1.js'></script>
+<script src='script2.js'></script>

--- a/test/assets/jscoverage/ranges.html
+++ b/test/assets/jscoverage/ranges.html
@@ -1,0 +1,2 @@
+<script>
+function unused(){}console.log('used!');</script>

--- a/test/assets/jscoverage/script1.js
+++ b/test/assets/jscoverage/script1.js
@@ -1,0 +1,1 @@
+console.log(3);

--- a/test/assets/jscoverage/script2.js
+++ b/test/assets/jscoverage/script2.js
@@ -1,0 +1,1 @@
+console.log(3);

--- a/test/assets/jscoverage/simple.html
+++ b/test/assets/jscoverage/simple.html
@@ -1,0 +1,2 @@
+<script>
+function foo() {function bar() { } console.log(1); } foo(); </script>

--- a/test/assets/jscoverage/sourceurl.html
+++ b/test/assets/jscoverage/sourceurl.html
@@ -1,0 +1,4 @@
+<script>
+console.log(1);
+//# sourceURL=nicename.js
+</script>

--- a/test/assets/jscoverage/unused.html
+++ b/test/assets/jscoverage/unused.html
@@ -1,0 +1,1 @@
+<script>function foo() { }</script>

--- a/test/golden/jscoverage-involved.txt
+++ b/test/golden/jscoverage-involved.txt
@@ -3,24 +3,24 @@
     "url": "http://localhost:8907/jscoverage/involved.html",
     "ranges": [
       {
-        "startOffset": 0,
-        "endOffset": 35
+        "start": 0,
+        "end": 35
       },
       {
-        "startOffset": 50,
-        "endOffset": 100
+        "start": 50,
+        "end": 100
       },
       {
-        "startOffset": 107,
-        "endOffset": 141
+        "start": 107,
+        "end": 141
       },
       {
-        "startOffset": 148,
-        "endOffset": 160
+        "start": 148,
+        "end": 160
       },
       {
-        "startOffset": 168,
-        "endOffset": 207
+        "start": 168,
+        "end": 207
       }
     ],
     "text": "\nfunction foo() {\n  if (1 > 2)\n    console.log(1);\n  if (1 < 2)\n    console.log(2);\n  let x = 1 > 2 ? 'foo' : 'bar';\n  let y = 1 < 2 ? 'foo' : 'bar';\n  let z = () => {};\n  let q = () => {};\n  q();\n}\n\nfoo();\n"

--- a/test/golden/jscoverage-involved.txt
+++ b/test/golden/jscoverage-involved.txt
@@ -1,0 +1,28 @@
+[
+  {
+    "url": "http://localhost:8907/jscoverage/involved.html",
+    "ranges": [
+      {
+        "startOffset": 0,
+        "endOffset": 35
+      },
+      {
+        "startOffset": 50,
+        "endOffset": 100
+      },
+      {
+        "startOffset": 107,
+        "endOffset": 141
+      },
+      {
+        "startOffset": 148,
+        "endOffset": 160
+      },
+      {
+        "startOffset": 168,
+        "endOffset": 207
+      }
+    ],
+    "text": "\nfunction foo() {\n  if (1 > 2)\n    console.log(1);\n  if (1 < 2)\n    console.log(2);\n  let x = 1 > 2 ? 'foo' : 'bar';\n  let y = 1 < 2 ? 'foo' : 'bar';\n  let z = () => {};\n  let q = () => {};\n  q();\n}\n\nfoo();\n"
+  }
+]

--- a/test/test.js
+++ b/test/test.js
@@ -3420,8 +3420,8 @@ describe('Page', function() {
       expect(coverage.length).toBe(1);
       expect(coverage[0].url).toContain('/jscoverage/simple.html');
       expect(coverage[0].ranges).toEqual([
-        { startOffset: 0, endOffset: 17 },
-        { startOffset: 35, endOffset: 61 },
+        { start: 0, end: 17 },
+        { start: 35, end: 61 },
       ]);
     });
     it('should report sourceURLs', async function({page, server}) {
@@ -3455,7 +3455,7 @@ describe('Page', function() {
       const entry = coverage[0];
       expect(entry.ranges.length).toBe(1);
       const range = entry.ranges[0];
-      expect(entry.text.substring(range.startOffset, range.endOffset)).toBe(`console.log('used!');`);
+      expect(entry.text.substring(range.start, range.end)).toBe(`console.log('used!');`);
     });
     it('should report scripts that have no coverage', async function({page, server}) {
       await page.coverage.startJSCoverage();

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -24,6 +24,7 @@ const EXCLUDE_CLASSES = new Set([
   'Downloader',
   'EmulationManager',
   'FrameManager',
+  'JSCoverage',
   'Helper',
   'Launcher',
   'Multimap',


### PR DESCRIPTION
This patch introduces a new `page.coverage` namespace with two methods:
- `page.coverage.startJSCoverage` to initiate JavaScript coverage
  recording
- `page.coverage.stopJSCoverage` to stop JavaScript coverage and get
  results