### PR TITLE
test: add server/run.js that runs SimpleServer

### DIFF
--- a/test/server/run.js
+++ b/test/server/run.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const path = require('path');
+const SimpleServer = require('./SimpleServer');
+
+const port = 8907;
+const httpsPort = 8908;
+const assetsPath = path.join(__dirname, '..', 'assets');
+Promise.all([
+  SimpleServer.create(assetsPath, port),
+  SimpleServer.createHTTPS(assetsPath, httpsPort)
+]).then(([server, httpsServer]) => {
+  console.log(`HTTP: server is running on http://localhost:${port}`);
+  console.log(`HTTPS: server is running on https://localhost:${httpsPort}`);
+});


### PR DESCRIPTION
This comes handy when implementing new SimpleServer features.