### PR TITLE
chore: use unique version for puppeteer@next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
       env: NODE7=true
     - node_js: "6.4.0"
       env: NODE6=true
+before_deploy: "yarn run apply-next-version"
 deploy:
   provider: npm
   email: aslushnikov@gmail.com

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "node utils/node6-transform/index.js",
     "unit-node6": "node node6/test/test.js",
     "tsc": "tsc -p .",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "apply-next-version": "node utils/apply_next_version.js"
   },
   "author": "The Chromium Authors",
   "license": "Apache-2.0",

--- a/utils/apply_next_version.js
+++ b/utils/apply_next_version.js
@@ -1,7 +1,12 @@
-let version = require('../package.json').version;
+const path = require('path');
+const fs = require('fs');
+
+const package = require('../package.json');
+let version = package.version;
 const dashIndex = version.indexOf('-');
 if (dashIndex !== -1)
   version = version.substring(0, dashIndex);
 version += '-next.' + Date.now();
-console.log("Setting version to " + version);
-require('child_process').execSync('npm version ' + version);
+console.log('Setting version to ' + version);
+package.version = version;
+fs.writeFileSync(path.join(__dirname, '..', 'package.json'), JSON.stringify(package, undefined, 2) + '\n');

--- a/utils/apply_next_version.js
+++ b/utils/apply_next_version.js
@@ -1,0 +1,7 @@
+let version = require('../package.json').version;
+const dashIndex = version.indexOf('-');
+if (dashIndex !== -1)
+  version = version.substring(0, dashIndex);
+version += '-next.' + Date.now();
+console.log("Setting version to " + version);
+require('child_process').execSync('npm version ' + version);


### PR DESCRIPTION
The puppeteer@next deployment was failing because the version can only be used once. This changes the version before we deploy to something like `1.0.0-next.1514509666103`