### PR TITLE
Add the ability to specify padding for elementHandle.screenshot()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1937,7 +1937,13 @@ If `key` is a single character and no modifier keys besides `Shift` are being he
 > **NOTE** Modifier keys DO effect `elementHandle.press`. Holding down `Shift` will type the text in upper case.
 
 #### elementHandle.screenshot([options])
-- `options` <[Object]> Same options as in [page.screenshot](#pagescreenshotoptions).
+- `options` <[Object]> Options object which might have the following properties:
+    - `path` <[string]> The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the image won't be saved to the disk.
+    - `type` <[string]> Specify screenshot type, can be either `jpeg` or `png`. Defaults to 'png'.
+    - `quality` <[number]> The quality of the image, between 0-100. Not applicable to `png` images.
+    - `fullPage` <[boolean]> When true, takes a screenshot of the full scrollable page. Defaults to `false`.
+    - `padding` <[Array<[number]>]> The amount of pixels we need to pad to the element, if possible, using [CSS shorthand](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases) style notation.
+    - `omitBackground` <[boolean]> Hides default white background and allows capturing screenshots with transparency. Defaults to `false`.
 - returns: <[Promise]<[Buffer]>> Promise which resolves to buffer with captured screenshot.
 
 This method scrolls element into view if needed, and then uses [page.screenshot](#pagescreenshotoptions) to take a screenshot of the element.

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -152,6 +152,38 @@ class ElementHandle extends JSHandle {
     const clip = Object.assign({}, boundingBox);
     clip.x += pageX;
     clip.y += pageY;
+
+    if (options.padding) {
+      if(options.padding.constructor !== Array || options.padding.length > 4) {
+          throw Error('Invalid padding parameter (should be [top, right, bottom, left])')
+      }
+      switch (options.padding.length){
+          case 1:
+              clip.x -= options.padding[0];
+              clip.y -= options.padding[0];
+              clip.width += options.padding[0];
+              clip.height += options.padding[0];
+              break;
+          case 2:
+              clip.x -= options.padding[1];
+              clip.y -= options.padding[0];
+              clip.width += options.padding[1];
+              clip.height += options.padding[0];
+              break;
+          case 3:
+              clip.x -= options.padding[1];
+              clip.y -= options.padding[0];
+              clip.width += options.padding[1];
+              clip.height += options.padding[2];
+              break;
+          case 4:
+              clip.x -= options.padding[3];
+              clip.y -= options.padding[0];
+              clip.width += options.padding[1];
+              clip.height += options.padding[2];
+              break;
+      }
+    }
     return await this._page.screenshot(Object.assign({}, {
       clip
     }, options));

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -160,26 +160,26 @@ class ElementHandle extends JSHandle {
         case 1:
           clip.x -= options.padding[0];
           clip.y -= options.padding[0];
-          clip.width += options.padding[0];
-          clip.height += options.padding[0];
+          clip.width += options.padding[0] * 2;
+          clip.height += options.padding[0] * 2;
           break;
         case 2:
           clip.x -= options.padding[1];
           clip.y -= options.padding[0];
-          clip.width += options.padding[1];
-          clip.height += options.padding[0];
+          clip.width += options.padding[1] * 2;
+          clip.height += options.padding[0] * 2;
           break;
         case 3:
           clip.x -= options.padding[1];
           clip.y -= options.padding[0];
-          clip.width += options.padding[1];
-          clip.height += options.padding[2];
+          clip.width += options.padding[1] * 2;
+          clip.height += options.padding[2] + options.padding[0];
           break;
         case 4:
           clip.x -= options.padding[3];
           clip.y -= options.padding[0];
-          clip.width += options.padding[1];
-          clip.height += options.padding[2];
+          clip.width += options.padding[1] + options.padding[3];
+          clip.height += options.padding[2] + options.padding[0];;
           break;
       }
     }

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -154,34 +154,33 @@ class ElementHandle extends JSHandle {
     clip.y += pageY;
 
     if (options.padding) {
-      if(options.padding.constructor !== Array || options.padding.length > 4) {
-          throw Error('Invalid padding parameter (should be [top, right, bottom, left])')
-      }
+      if (options.padding.constructor !== Array || options.padding.length > 4)
+          throw Error('Invalid padding parameter (should be [top, right, bottom, left])');     
       switch (options.padding.length){
-          case 1:
-              clip.x -= options.padding[0];
-              clip.y -= options.padding[0];
-              clip.width += options.padding[0];
-              clip.height += options.padding[0];
-              break;
-          case 2:
-              clip.x -= options.padding[1];
-              clip.y -= options.padding[0];
-              clip.width += options.padding[1];
-              clip.height += options.padding[0];
-              break;
-          case 3:
-              clip.x -= options.padding[1];
-              clip.y -= options.padding[0];
-              clip.width += options.padding[1];
-              clip.height += options.padding[2];
-              break;
-          case 4:
-              clip.x -= options.padding[3];
-              clip.y -= options.padding[0];
-              clip.width += options.padding[1];
-              clip.height += options.padding[2];
-              break;
+        case 1:
+          clip.x -= options.padding[0];
+          clip.y -= options.padding[0];
+          clip.width += options.padding[0];
+          clip.height += options.padding[0];
+          break;
+        case 2:
+          clip.x -= options.padding[1];
+          clip.y -= options.padding[0];
+          clip.width += options.padding[1];
+          clip.height += options.padding[0];
+          break;
+        case 3:
+          clip.x -= options.padding[1];
+          clip.y -= options.padding[0];
+          clip.width += options.padding[1];
+          clip.height += options.padding[2];
+          break;
+        case 4:
+          clip.x -= options.padding[3];
+          clip.y -= options.padding[0];
+          clip.width += options.padding[1];
+          clip.height += options.padding[2];
+          break;
       }
     }
     return await this._page.screenshot(Object.assign({}, {


### PR DESCRIPTION
Proposal to add an easy option to add padding to the elementHandle.screenshot() function. I'm not quite sure yet how the api interface should look, but this is a first working proposal.