### PR TITLE
feat(Page): add Page.wsEndpoint, for monitoring / debugging.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -96,6 +96,7 @@
   * [page.waitForFunction(pageFunction[, options[, ...args]])](#pagewaitforfunctionpagefunction-options-args)
   * [page.waitForNavigation(options)](#pagewaitfornavigationoptions)
   * [page.waitForSelector(selector[, options])](#pagewaitforselectorselector-options)
+  * [page.wsEndpoint()](#pagewsendpoint)
 - [class: Keyboard](#class-keyboard)
   * [keyboard.down(key[, options])](#keyboarddownkey-options)
   * [keyboard.press(key[, options])](#keyboardpresskey-options)
@@ -1242,6 +1243,12 @@ puppeteer.launch().then(async browser => {
 ```
 Shortcut for [page.mainFrame().waitForSelector(selector[, options])](#framewaitforselectorselector-options).
 
+#### page.wsEndpoint()
+- returns: <[string]> Page websocket url.
+
+The websocket endpoint used to drive the browser tab via the devtools protocol.
+The format is `ws://${host}:${port}/devtools/page/<id>`. Learn more about the
+[devtools protocol](https://chromedevtools.github.io/devtools-protocol).
 
 ### class: Keyboard
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -169,6 +169,13 @@ class Session extends EventEmitter {
   }
 
   /**
+   * @return {!Connection}
+   */
+  connection() {
+    return this._connection;
+  }
+
+  /**
    * @param {string} method
    * @param {!Object=} params
    * @return {!Promise<?Object>}

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -112,6 +112,17 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @return {!string}
+   */
+  wsEndpoint() {
+    const connection = this._client.connection();
+    if (!connection)
+      return null;
+    const targetId = this._client.targetId();
+    return connection.url().replace(/\/browser\/.*$/, `/page/${targetId}`);
+  }
+
+  /**
    * @return {!Keyboard}
    */
   get keyboard() {

--- a/test/test.js
+++ b/test/test.js
@@ -292,6 +292,12 @@ describe('Page', function() {
     });
   });
 
+  describe('Browser.wsEndpont', function() {
+    it('should return a devtools browser WebSocket URL', async({browser}) => {
+      expect(/^ws?:\/\/.*\/devtools\/browser\//.test(browser.wsEndpoint())).toBe(true);
+    });
+  });
+
   describe('Browser.Events.disconnected', function() {
     it('should emitted when: browser gets closed, disconnected or underlying websocket gets closed', async() => {
       const originalBrowser = await puppeteer.launch(defaultBrowserOptions);
@@ -3083,6 +3089,12 @@ describe('Page', function() {
         error = e;
       }
       expect(error.message).toContain('Values must be strings');
+    });
+  });
+
+  describe('Page.wsEndpont', function() {
+    it('should return a devtools page WebSocket URL', async({page}) => {
+      expect(/^ws?:\/\/.*\/devtools\/page\//.test(page.wsEndpoint())).toBe(true);
     });
   });
 


### PR DESCRIPTION
I'm using Puppeteer for parallel scraping in a personal project. I have one master connected to 25 Chrome instances running on separate worker machines, each of which might have multiple tabs open.

I've been using a hack that pokes into the private fields of Page and Session to get the equivalent of this PR, for monitoring purposes. I have a scheduler that keeps track of available pages, and assigns pages to tasks. When a task errors out, having the /devtools/page URL allows me to connect directly to the tab and see what happened.

I'm submitting this PR hoping that others will find the feature useful, and that I won't have to maintain my hack :smile: 