### PR TITLE
fix: scrub port from coverage golden files

### DIFF
--- a/test/golden/csscoverage-involved.txt
+++ b/test/golden/csscoverage-involved.txt
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://localhost:8907/csscoverage/involved.html",
+    "url": "http://localhost:<PORT>/csscoverage/involved.html",
     "ranges": [
       {
         "start": 149,

--- a/test/golden/jscoverage-involved.txt
+++ b/test/golden/jscoverage-involved.txt
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://localhost:8907/jscoverage/involved.html",
+    "url": "http://localhost:<PORT>/jscoverage/involved.html",
     "ranges": [
       {
         "start": 0,

--- a/test/test.js
+++ b/test/test.js
@@ -3476,7 +3476,7 @@ describe('Page', function() {
       await page.coverage.startJSCoverage();
       await page.goto(server.PREFIX + '/jscoverage/involved.html');
       const coverage = await page.coverage.stopJSCoverage();
-      expect(JSON.stringify(coverage, null, 2)).toBeGolden('jscoverage-involved.txt');
+      expect(JSON.stringify(coverage, null, 2).replace(/:\d{4}\//g, ':<PORT>/')).toBeGolden('jscoverage-involved.txt');
     });
     describe('resetOnNavigation', function() {
       it('should report scripts across navigations when disabled', async function({page, server}) {
@@ -3546,7 +3546,7 @@ describe('Page', function() {
       await page.coverage.startCSSCoverage();
       await page.goto(server.PREFIX + '/csscoverage/involved.html');
       const coverage = await page.coverage.stopCSSCoverage();
-      expect(JSON.stringify(coverage, null, 2)).toBeGolden('csscoverage-involved.txt');
+      expect(JSON.stringify(coverage, null, 2).replace(/:\d{4}\//g, ':<PORT>/')).toBeGolden('csscoverage-involved.txt');
     });
     it('should ignore injected stylesheets', async function({page, server}) {
       await page.coverage.startCSSCoverage();


### PR DESCRIPTION
These tests were flaky in parallel.