### PR TITLE
fix: setRequestInterception and setExtraHTTPHeaders not working together (#1729)

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -569,16 +569,14 @@ function generateRequestHash(request) {
   };
 
   if (!normalizedURL.startsWith('data:')) {
-    const headers = {};
-    for (const key of Object.keys(request.headers))
-      // Need to consider uncapitalized headers. See https://github.com/GoogleChrome/puppeteer/issues/1729
-      headers[key.toLowerCase()] = request.headers[key];
-    const headerKeys = Object.keys(headers);
-    headerKeys.sort();
-    for (const key of headerKeys) {
-      if (key === 'accept' || key === 'referer' || key === 'x-devtools-emulate-network-conditions-client-id')
+    const headers = Object.keys(request.headers);
+    headers.sort();
+    for (let header of headers) {
+      const headerValue = request.headers[header];
+      header = header.toLowerCase();
+      if (header === 'accept' || header === 'referer' || header === 'x-devtools-emulate-network-conditions-client-id')
         continue;
-      hash.headers[key] = headers[key];
+      hash.headers[header] = headerValue;
     }
   }
   return JSON.stringify(hash);

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -569,12 +569,16 @@ function generateRequestHash(request) {
   };
 
   if (!normalizedURL.startsWith('data:')) {
-    const headers = Object.keys(request.headers);
-    headers.sort();
-    for (const header of headers) {
-      if (header === 'Accept' || header === 'Referer' || header === 'X-DevTools-Emulate-Network-Conditions-Client-Id')
+    const headers = {};
+    for (const key of Object.keys(request.headers))
+      // Need to consider uncapitalized headers. See https://github.com/GoogleChrome/puppeteer/issues/1729
+      headers[key.toLowerCase()] = request.headers[key];
+    const headerKeys = Object.keys(headers);
+    headerKeys.sort();
+    for (const key of headerKeys) {
+      if (key === 'accept' || key === 'referer' || key === 'x-devtools-emulate-network-conditions-client-id')
         continue;
-      hash.headers[header] = request.headers[header];
+      hash.headers[key] = headers[key];
     }
   }
   return JSON.stringify(hash);

--- a/test/test.js
+++ b/test/test.js
@@ -1321,6 +1321,16 @@ describe('Page', function() {
       const response = await page.goto(server.EMPTY_PAGE);
       expect(response.ok()).toBe(true);
     });
+    it('should works with customizing referer headers', async({page, server}) => {
+      await page.setExtraHTTPHeaders({ 'referer': server.EMPTY_PAGE });
+      await page.setRequestInterception(true);
+      page.on('request', request => {
+        expect(request.headers()['referer']).toBe(server.EMPTY_PAGE);
+        request.continue();
+      });
+      const response = await page.goto(server.EMPTY_PAGE);
+      expect(response.ok()).toBe(true);
+    });
     it('should be abortable', async({page, server}) => {
       await page.setRequestInterception(true);
       page.on('request', request => {


### PR DESCRIPTION
This is just a fix to the problem that `page.goto` resolves to `null`.
Setting referer does not work properly, but that should be discussed [here](https://github.com/GoogleChrome/puppeteer/issues/469).

Fixes: https://github.com/GoogleChrome/puppeteer/issues/1729
  