### PR TITLE
fix: avoid calling jsonValue from waitFor

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -715,7 +715,7 @@ class WaitTask {
     }
 
     // Ignore timeouts in pageScript - we track timeouts ourselves.
-    if (!error && !(await success.jsonValue())) {
+    if (!error && await this._frame.evaluate(s => !s, success)) {
       await success.dispose();
       return;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -703,6 +703,9 @@ describe('Page', function() {
     it('should return the success value as a JSHandle', async({page}) => {
       expect(await (await page.waitForFunction(() => 5)).jsonValue()).toBe(5);
     });
+    it('should return the window as a success value', async({ page }) => {
+      expect(await page.waitForFunction(() => window)).toBeTruthy();
+    });
     it('should accept ElementHandle arguments', async({page}) => {
       await page.setContent('<div></div>');
       const div = await page.$('div');


### PR DESCRIPTION
If the success value of `waitForFunction` was not serializable, checking whether it was truthy with `.jsonValue()` might fail. Now I check whether it was truthy inside the page.

Fixes #1737