### PR TITLE
feat(ElementHandle): boxModel method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -161,6 +161,7 @@
   * [elementHandle.$x(expression)](#elementhandlexexpression)
   * [elementHandle.asElement()](#elementhandleaselement)
   * [elementHandle.boundingBox()](#elementhandleboundingbox)
+  * [elementHandle.boxModel()](#elementhandleboxmodel)
   * [elementHandle.click([options])](#elementhandleclickoptions)
   * [elementHandle.dispose()](#elementhandledispose)
   * [elementHandle.executionContext()](#elementhandleexecutioncontext)
@@ -1886,6 +1887,11 @@ The method evluates the XPath expression relative to the elementHandle. If there
     - height <[number]> the height of the element in pixels.
 
 This method returns the bounding box of the element (relative to the main frame), or `null` if the element is not visible.
+
+#### elementHandle.boxModel()
+- returns: <[Promise]<?[Object]>>
+
+This method returns the [box model](https://chromedevtools.github.io/devtools-protocol/tot/DOM/#type-BoxModel) for the given element, or `null` if the element is not visible.
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1891,7 +1891,8 @@ This method returns the bounding box of the element (relative to the main frame)
 #### elementHandle.boxModel()
 - returns: <[Promise]<?[Object]>>
 
-This method returns the [box model](https://chromedevtools.github.io/devtools-protocol/tot/DOM/#type-BoxModel) for the given element, or `null` if the element is not visible.
+This method returns the [box model](https://chromedevtools.github.io/devtools-protocol/tot/DOM/#type-BoxModel) for the given element with calculated quads, or `null` if the element is not visible.
+Each box from model contains `x` and `y` values of the element box.
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -138,6 +138,20 @@ class ElementHandle extends JSHandle {
   }
 
   /**
+   * @return {!Promise<?object>}
+   */
+  async boxModel() {
+    const result = await this._client.send('DOM.getBoxModel', {
+      objectId: this._remoteObject.objectId
+    }).catch(error => void debugError(error));
+
+    if (!result)
+      return null;
+
+    return result.model;
+  }
+
+  /**
    *
    * @param {!Object=} options
    * @returns {!Promise<Object>}

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -148,6 +148,17 @@ class ElementHandle extends JSHandle {
     if (!result)
       return null;
 
+    const calculatePos = function(quad)  {
+      return {
+        x: Math.min(quad[0], quad[2], quad[4], quad[6]),
+        y: Math.min(quad[1], quad[3], quad[5], quad[7])
+      };
+    };
+
+    ['content', 'padding', 'border', 'margin'].map(function(name) {
+      result.model[name] = calculatePos(result.model[name]);
+    });
+
     return result.model;
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1777,6 +1777,16 @@ describe('Page', function() {
     });
   });
 
+  describe('ElementHandle.boxModel', function() {
+    it('should work', async({page, server}) => {
+      await page.setViewport({width: 500, height: 500});
+      await page.goto(server.PREFIX + '/grid.html');
+      const elementHandle = await page.$('.box:nth-of-type(13)');
+      const box = await elementHandle.boxModel();
+      expect(box).not.toBe(null);
+    });
+  });
+
   describe('ElementHandle.boundingBox', function() {
     it('should work', async({page, server}) => {
       await page.setViewport({width: 500, height: 500});

--- a/test/test.js
+++ b/test/test.js
@@ -1783,7 +1783,14 @@ describe('Page', function() {
       await page.goto(server.PREFIX + '/grid.html');
       const elementHandle = await page.$('.box:nth-of-type(13)');
       const box = await elementHandle.boxModel();
+
       expect(box).not.toBe(null);
+      expect(box.content).not.toBe(null);
+      expect(box.padding).not.toBe(null);
+      expect(box.border).not.toBe(null);
+      expect(box.margin).not.toBe(null);
+      expect(box.width).not.toBe(null);
+      expect(box.height).not.toBe(null);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/puppeteer/issues/1357

Now we can get `getBoundingClientRect`-like box of the element and the full model from devtools.