### PR TITLE
fix: requestInterception should play nicely with canceled redirects

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -151,9 +151,10 @@ class NetworkManager extends EventEmitter {
 
     if (event.redirectUrl) {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
-      console.assert(request, 'INTERNAL ERROR: failed to find request for interception redirect.');
-      this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders);
-      this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId);
+      if (request) {
+        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders);
+        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId);
+      }
       return;
     }
     const requestHash = generateRequestHash(event.request);


### PR DESCRIPTION
Since interception events and `loadingFailed` events come from
different processes and are not serialized, we might get `loadingFailed` event and a subsequent outdated `requestIntercepted`.

Short-term, this patch stops assuming that interception events are
aligned with `loadingFailed`.

Long-term, this will be resolved as @caseq completes network
servicification effort in chromium.

Fixes #880.