### PR TITLE
fix: recommend yarn install than npm install in the error message

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -92,7 +92,7 @@ class Launcher {
     if (typeof chromeExecutable !== 'string') {
       const downloader = Downloader.createDefault();
       const revisionInfo = downloader.revisionInfo(downloader.currentPlatform(), ChromiumRevision);
-      console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "npm install"`);
+      console.assert(revisionInfo.downloaded, `Chromium revision is not downloaded. Run "yarn install" or "npm install"`);
       chromeExecutable = revisionInfo.executablePath;
     }
     if (Array.isArray(options.args))


### PR DESCRIPTION
Small fix.

<img width="1280" alt="2018-01-10 12 27 25" src="https://user-images.githubusercontent.com/2261067/34754517-a8ea854c-f601-11e7-9299-77a51040a405.png">

I think the error message should recommend "yarn install" than "npm install".