### PR TITLE
fix: page.goto should resolve to response for self request (#1391)

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -476,7 +476,10 @@ class Page extends EventEmitter {
 
     const requests = new Map();
     const eventListeners = [
-      helper.addEventListener(this._networkManager, NetworkManager.Events.Request, request => requests.set(request.url(), request))
+      helper.addEventListener(this._networkManager, NetworkManager.Events.Request, request => {
+        if (!requests.get(request.url()))
+          requests.set(request.url(), request);
+      })
     ];
 
     const mainFrame = this._frameManager.mainFrame();

--- a/test/assets/self-request.html
+++ b/test/assets/self-request.html
@@ -1,0 +1,5 @@
+<script>
+var req = new XMLHttpRequest();
+req.open('GET', '/self-request.html');
+req.send(null);
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -1189,6 +1189,11 @@ describe('Page', function() {
       expect(requests.length).toBe(1);
       expect(requests[0].url()).toBe(server.EMPTY_PAGE);
     });
+    it('should work with self requesting page', async({page, server}) => {
+      const response = await page.goto(server.PREFIX + '/self-request.html');
+      expect(response.status()).toBe(200);
+      expect(response.url()).toContain('self-request.html');
+    });
   });
 
   describe('Page.waitForNavigation', function() {
@@ -1397,7 +1402,6 @@ describe('Page', function() {
       expect(requests.length).toBe(5);
       expect(requests[2].resourceType()).toBe('document');
     });
-
     it('should work with self requesting page', async({page, server}) => {
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
@@ -1405,7 +1409,6 @@ describe('Page', function() {
       expect(response.status()).toBe(200);
       expect(response.url()).toContain('self-request.html');
     });
-
     it('should be able to abort redirects', async({page, server}) => {
       await page.setRequestInterception(true);
       server.setRedirect('/non-existing.json', '/non-existing-2.json');

--- a/test/test.js
+++ b/test/test.js
@@ -1397,6 +1397,15 @@ describe('Page', function() {
       expect(requests.length).toBe(5);
       expect(requests[2].resourceType()).toBe('document');
     });
+
+    it('should work with self requesting page', async({page, server}) => {
+      await page.setRequestInterception(true);
+      page.on('request', request => request.continue());
+      const response = await page.goto(server.PREFIX + '/self-request.html');
+      expect(response.status()).toBe(200);
+      expect(response.url()).toContain('self-request.html');
+    });
+
     it('should be able to abort redirects', async({page, server}) => {
       await page.setRequestInterception(true);
       server.setRedirect('/non-existing.json', '/non-existing-2.json');

--- a/test/test.js
+++ b/test/test.js
@@ -1402,13 +1402,6 @@ describe('Page', function() {
       expect(requests.length).toBe(5);
       expect(requests[2].resourceType()).toBe('document');
     });
-    it('should work with self requesting page', async({page, server}) => {
-      await page.setRequestInterception(true);
-      page.on('request', request => request.continue());
-      const response = await page.goto(server.PREFIX + '/self-request.html');
-      expect(response.status()).toBe(200);
-      expect(response.url()).toContain('self-request.html');
-    });
     it('should be able to abort redirects', async({page, server}) => {
       await page.setRequestInterception(true);
       server.setRedirect('/non-existing.json', '/non-existing-2.json');


### PR DESCRIPTION
I confirmed that the following URLs will start resolving responses by this fix:

- http://giffysk8s.blogspot.com/
- http://lemaninignesinden.blogspot.com/2015/02/vitaminenzimklorofilsifa.html
- http://henke-s.blogspot.com/
- http://www.qh119.com/10022/
- http://corralitopiraeus.blogspot.com/2017/07/malma-con-piezas-de-ordenador-y.html
- http://kedm.org/

I cannot repro for the following URLs:

- http://www.cometogetherkids.com/2011/03/fleece-flower-petal-pillows.html
- http://www.wildstar-online.com/uk/drops/1/strain/
- https://www.vanityfair.com/culture/photos/2010/06/world-cup-portfolio-201006
- http://www.sportsnet.ca/baseball/mlb/blue-jays-exploring-trade-options-before-free-agency/
- http://www.fc-weisweil.de/
- https://www.lovedignity.com/ex-back-experts-review/
- http://www.hainanrra.com/bjbw/
- http://www.manlexi.com/rqfp/
- http://www.12011.org/ljnn/
- http://www.grgds.com/jbs/

But these may have been fixed already like https://github.com/GoogleChrome/puppeteer/issues/631 .

Fixes: https://github.com/GoogleChrome/puppeteer/issues/1391

@aslushnikov 