### PR TITLE
feat(Page): add monotonic timestamp to Request and Response events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -188,6 +188,7 @@
   * [request.resourceType()](#requestresourcetype)
   * [request.respond(response)](#requestrespondresponse)
   * [request.response()](#requestresponse)
+  * [request.timestamp()](#requesttimestamp)
   * [request.url()](#requesturl)
 - [class: Response](#class-response)
   * [response.buffer()](#responsebuffer)
@@ -197,6 +198,7 @@
   * [response.request()](#responserequest)
   * [response.status()](#responsestatus)
   * [response.text()](#responsetext)
+  * [response.timestamp()](#responsetimestamp)
   * [response.url()](#responseurl)
 - [class: Target](#class-target)
   * [target.createCDPSession()](#targetcreatecdpsession)
@@ -2142,6 +2144,9 @@ page.on('request', request => {
 #### request.response()
 - returns: <?[Response]> A matching [Response] object, or `null` if the response has not been received yet.
 
+#### request.timestamp()
+- returns: <[number]> The MonotonicTime timestamp when this request happened.
+ 
 #### request.url()
 - returns: <[string]> URL of the request.
 
@@ -2175,6 +2180,9 @@ Contains the status code of the response (e.g., 200 for a success).
 
 #### response.text()
 - returns: <[Promise]<[string]>> Promise which resolves to a text representation of response body.
+
+#### response.timestamp()
+- returns: <[number]> The MonotonicTime timestamp when this response happened.
 
 #### response.url()
 - returns: <[string]>

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -152,8 +152,8 @@ class NetworkManager extends EventEmitter {
     if (event.redirectUrl) {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
       if (request) {
-        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders);
-        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId);
+        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders, null);
+        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId, null);
       }
       return;
     }
@@ -161,10 +161,10 @@ class NetworkManager extends EventEmitter {
     const requestId = this._requestHashToRequestIds.firstValue(requestHash);
     if (requestId) {
       this._requestHashToRequestIds.delete(requestHash, requestId);
-      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId);
+      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId, event.timestamp);
     } else {
       this._requestHashToInterceptionIds.set(requestHash, event.interceptionId);
-      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId);
+      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId, null);
     }
   }
 
@@ -172,9 +172,10 @@ class NetworkManager extends EventEmitter {
    * @param {!Request} request
    * @param {number} redirectStatus
    * @param {!Object} redirectHeaders
+   * @param {?number} timestamp
    */
-  _handleRequestRedirect(request, redirectStatus, redirectHeaders) {
-    const response = new Response(this._client, request, redirectStatus, redirectHeaders);
+  _handleRequestRedirect(request, redirectStatus, redirectHeaders, timestamp) {
+    const response = new Response(this._client, request, redirectStatus, redirectHeaders, timestamp);
     request._response = response;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
@@ -190,12 +191,13 @@ class NetworkManager extends EventEmitter {
    * @param {string} resourceType
    * @param {!Object} requestPayload
    * @param {?string} frameId
+   * @param {?number} timestamp
    */
-  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId) {
+  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId, timestamp) {
     let frame = null;
     if (frameId)
       frame = this._frameManager.frame(frameId);
-    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame);
+    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame, timestamp);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);
     if (interceptionId)
@@ -227,9 +229,9 @@ class NetworkManager extends EventEmitter {
       const request = this._requestIdToRequest.get(event.requestId);
       // If we connect late to the target, we could have missed the requestWillBeSent event.
       if (request)
-        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers);
+        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers, event.timestamp);
     }
-    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request, event.frameId);
+    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request, event.frameId, event.timestamp);
   }
 
   /**
@@ -240,7 +242,7 @@ class NetworkManager extends EventEmitter {
     // FileUpload sends a response without a matching request.
     if (!request)
       return;
-    const response = new Response(this._client, request, event.response.status, event.response.headers);
+    const response = new Response(this._client, request, event.response.status, event.response.headers, event.timestamp);
     request._response = response;
     this.emit(NetworkManager.Events.Response, response);
   }
@@ -255,6 +257,8 @@ class NetworkManager extends EventEmitter {
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
+    // save loading finished timestamp and not loading started timestamp
+    request._timestamp = event.timestamp;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
     this._attemptedAuthentications.delete(request._interceptionId);
@@ -272,6 +276,8 @@ class NetworkManager extends EventEmitter {
       return;
     request._failureText = event.errorText;
     request._completePromiseFulfill.call(null);
+    // save loading finished timestamp and not loading started timestamp
+    request._timestamp = event.timestamp;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
     this._attemptedAuthentications.delete(request._interceptionId);
@@ -289,8 +295,9 @@ class Request {
    * @param {string} resourceType
    * @param {!Object} payload
    * @param {?Puppeteer.Frame} frame
+   * @param {?number} timestamp
    */
-  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame) {
+  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame, timestamp) {
     this._client = client;
     this._requestId = requestId;
     this._interceptionId = interceptionId;
@@ -308,6 +315,7 @@ class Request {
     this._postData = payload.postData;
     this._headers = {};
     this._frame = frame;
+    this._timestamp = timestamp;
     for (const key of Object.keys(payload.headers))
       this._headers[key.toLowerCase()] = payload.headers[key];
   }
@@ -359,6 +367,13 @@ class Request {
    */
   frame() {
     return this._frame;
+  }
+
+  /**
+   * @return {?number}
+   */
+  timestamp() {
+    return this._timestamp;
   }
 
   /**
@@ -483,8 +498,9 @@ class Response {
    * @param {!Request} request
    * @param {number} status
    * @param {!Object} headers
+   * @param {?number} timestamp
    */
-  constructor(client, request, status, headers) {
+  constructor(client, request, status, headers, timestamp) {
     this._client = client;
     this._request = request;
     this._contentPromise = null;
@@ -492,6 +508,7 @@ class Response {
     this._status = status;
     this._url = request.url();
     this._headers = {};
+    this._timestamp = timestamp;
     for (const key of Object.keys(headers))
       this._headers[key.toLowerCase()] = headers[key];
   }
@@ -522,6 +539,13 @@ class Response {
    */
   headers() {
     return this._headers;
+  }
+
+  /**
+   * @return {?number}
+   */
+  timestamp() {
+    return this._timestamp;
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1319,10 +1319,12 @@ describe('Page', function() {
         expect(request.resourceType()).toBe('document');
         expect(request.frame() === page.mainFrame()).toBe(true);
         expect(request.frame().url()).toBe('about:blank');
+        expect(request.timestamp()).toBe(null);
         request.continue();
       });
       const response = await page.goto(server.EMPTY_PAGE);
       expect(response.ok()).toBe(true);
+      expect(response.timestamp()).not.toBeNull();
     });
     it('should stop intercepting', async({page, server}) => {
       await page.setRequestInterception(true);


### PR DESCRIPTION
To be able to know when requests exactly have happened during the network timeline you need a timestamp. Here it is. Timestamp is null when intercepted, this is not available in the Devtools protocol.