### PR TITLE
feat(prefs): add ability to launch browser with desired preferences

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -275,6 +275,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
   - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. List of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
+  - `prefs` <[Object]> Additional browser preferences. List of Chromium preferences can be found [here](https://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/pref_names.cc?view=markup). Can't be used in headless mode or with `userDataDir` option/argument.
   - `ignoreDefaultArgs` <[boolean]> Do not use [`puppeteer.defaultArgs()`](#puppeteerdefaultargs). Dangerous option; use with care. Defaults to `false`.
   - `handleSIGINT` <[boolean]> Close browser process on Ctrl-C. Defaults to `true`.
   - `handleSIGTERM` <[boolean]> Close browser process on SIGTERM. Defaults to `true`.

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -26,6 +26,8 @@ const {helper} = require('./helper');
 const ChromiumRevision = Downloader.defaultRevision();
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
+const mkdirAsync = helper.promisify(fs.mkdir);
+const writeFileAsync = helper.promisify(fs.writeFile);
 const removeFolderAsync = helper.promisify(removeFolder);
 
 const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile-');
@@ -75,6 +77,13 @@ class Launcher {
         temporaryUserDataDir = await mkdtempAsync(CHROME_PROFILE_PATH);
 
       chromeArguments.push(`--user-data-dir=${options.userDataDir || temporaryUserDataDir}`);
+    }
+    if (options.prefs) {
+      console.assert(!options.headless, `Custom preferences can't be used in headless mode`);
+      console.assert(temporaryUserDataDir, `Custom preferences can't be used with custom userDataDir`);
+      const profileDefaultDir = temporaryUserDataDir + '/Default';
+      await mkdirAsync(profileDefaultDir);
+      await writeFileAsync(profileDefaultDir + '/Preferences', JSON.stringify(options.prefs));
     }
     if (options.devtools === true) {
       chromeArguments.push('--auto-open-devtools-for-tabs');

--- a/test/test.js
+++ b/test/test.js
@@ -208,6 +208,59 @@ describe('Puppeteer', function() {
       const args = puppeteer.defaultArgs();
       expect(args).toContain('--no-first-run');
     });
+    describe('prefs option', () => {
+      it('should reject if prefs used in headless mode', async() => {
+        let waitError = null;
+        const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
+        const options = Object.assign({}, defaultBrowserOptions, {
+          headless: true,
+          userDataDir,
+          prefs: {},
+        });
+        await puppeteer.launch(options).catch(e => waitError = e);
+        expect(waitError.message).toBe(`Custom preferences can't be used in headless mode`);
+      });
+      it('should reject if prefs used in conjunction with userDataDir option', async() => {
+        let waitError = null;
+        const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
+        const options = Object.assign({}, defaultBrowserOptions, {
+          headless: false,
+          userDataDir,
+          prefs: {},
+        });
+        await puppeteer.launch(options).catch(e => waitError = e);
+        expect(waitError.message).toBe(`Custom preferences can't be used with custom userDataDir`);
+      });
+      it('should reject if prefs used in conjunction with userDataDir argument', async() => {
+        let waitError = null;
+        const userDataDir = fs.mkdtempSync(path.join(__dirname, 'test-user-data-dir'));
+        const options = Object.assign({}, defaultBrowserOptions, {
+          headless: false,
+          prefs: {},
+        });
+        options.args = [`--user-data-dir=${userDataDir}`].concat(options.args);
+        await puppeteer.launch(options).catch(e => waitError = e);
+        expect(waitError.message).toBe(`Custom preferences can't be used with custom userDataDir`);
+      });
+      it('should apply custom prefs', async() => {
+        const customDefaultFontSize = 10;
+        const options = Object.assign({}, defaultBrowserOptions, {
+          headless: false,
+          prefs: {
+            webkit: {
+              webprefs: {
+                default_font_size: customDefaultFontSize,
+              },
+            },
+          },
+        });
+        const browser = await puppeteer.launch(options);
+        const [page] = await browser.pages();
+        const pageFontSize = await page.evaluate(() => window.getComputedStyle(document.documentElement)['font-size']);
+        expect(pageFontSize).toBe(`${customDefaultFontSize}px`);
+        await browser.close();
+      });
+    });
   });
   describe('Puppeteer.connect', function() {
     it('should be able to connect multiple times to the same browser', async({server}) => {


### PR DESCRIPTION
The ability to start browser with desired [preferences](https://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/pref_names.cc?view=markup).
[Related issue](https://github.com/GoogleChrome/puppeteer/issues/1693#issuecomment-356181997)

The easier way to kickoff was to allow to set `prefs` for the cases when there is no preconfigured `userDataDir` / `--user-data-dir` and to see the feedback from the maintainers.
What's done:
- [x] implementation
- [x] write tests
- [x] update documentation

What could be done as a separate feature:
- allow setting `prefs` in conjunction with `userDataDir` / `--user-data-dir`
- add ability to set ["local state" prefs](https://src.chromium.org/viewvc/chrome/trunk/src/chrome/common/pref_names.cc?view=markup#l1255)

@aslushnikov WDYT?