### PR TITLE
fix(NetworkManager): add initiator property to Request object

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -183,6 +183,7 @@
   * [request.failure()](#requestfailure)
   * [request.frame()](#requestframe)
   * [request.headers()](#requestheaders)
+  * [request.initiator()](#requestinitiator)
   * [request.method()](#requestmethod)
   * [request.postData()](#requestpostdata)
   * [request.resourceType()](#requestresourcetype)
@@ -2098,6 +2099,9 @@ page.on('requestfailed', request => {
 
 #### request.headers()
 - returns: <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.
+
+#### request.initiator()
+- returns: <?[Object]> An object with request initiator data.
 
 #### request.method()
 - returns: <[string]> Request's method (GET, POST, etc.)

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -215,6 +215,7 @@ class NetworkManager extends EventEmitter {
       const interceptionId = this._requestHashToInterceptionIds.firstValue(requestHash);
       const request = interceptionId ? this._interceptionIdToRequest.get(interceptionId) : null;
       if (request) {
+        if (event.initiator) request._initiator = event.initiator;
         request._requestId = event.requestId;
         this._requestIdToRequest.set(event.requestId, request);
         this._requestHashToInterceptionIds.delete(requestHash, interceptionId);
@@ -308,6 +309,7 @@ class Request {
     this._postData = payload.postData;
     this._headers = {};
     this._frame = frame;
+    this._initiator = null;
     for (const key of Object.keys(payload.headers))
       this._headers[key.toLowerCase()] = payload.headers[key];
   }
@@ -359,6 +361,13 @@ class Request {
    */
   frame() {
     return this._frame;
+  }
+
+  /**
+   * @return {!Object}
+   */
+  initiator() {
+    return this._initiator;
   }
 
   /**


### PR DESCRIPTION
this change allows you to check the initiator of a request.

Fixes #1395 

note: does not add property in time for it to be available within interceptedRequest event. 