### PR TITLE
Fix sample code in API doc

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1116,7 +1116,7 @@ puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
   await page.setRequestInterception(true);
   page.on('request', interceptedRequest => {
-    if (interceptedRequest.url.endsWith('.png') || interceptedRequest.url.endsWith('.jpg'))
+    if (interceptedRequest.url().endsWith('.png') || interceptedRequest.url().endsWith('.jpg'))
       interceptedRequest.abort();
     else
       interceptedRequest.continue();


### PR DESCRIPTION
Because `Request.url` is changed to `Request.url()`.