### PR TITLE
fix: fixed select() behavior to be on par with docs

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -542,17 +542,20 @@ class Frame {
   * @param {!Array<string>} values
   * @return {!Promise<!Array<string>>}
   */
-  async select(selector, ...values){
+  select(selector, ...values){
     for (const value of values)
       console.assert(helper.isString(value), 'Values must be strings. Found value "' + value + '" of type "' + (typeof value) + '"');
-    return await this.$eval(selector, (element, values) => {
+    return this.$eval(selector, (element, values) => {
       if (element.nodeName.toLowerCase() !== 'select')
         throw new Error('Element is not a <select> element.');
 
       const options = Array.from(element.options);
       element.value = undefined;
-      for (const option of options)
+      for (const option of options) {
         option.selected = values.includes(option.value);
+        if (option.selected && !element.multiple)
+          break;
+      }
       element.dispatchEvent(new Event('input', { 'bubbles': true }));
       element.dispatchEvent(new Event('change', { 'bubbles': true }));
       return options.filter(option => option.selected).map(option => option.value);

--- a/test/test.js
+++ b/test/test.js
@@ -3142,6 +3142,12 @@ describe('Page', function() {
       expect(await page.evaluate(() => result.onInput)).toEqual(['blue']);
       expect(await page.evaluate(() => result.onChange)).toEqual(['blue']);
     });
+    it('should select only first option', async({page, server}) => {
+      await page.goto(server.PREFIX + '/input/select.html');
+      await page.select('select', 'blue', 'green', 'red');
+      expect(await page.evaluate(() => result.onInput)).toEqual(['blue']);
+      expect(await page.evaluate(() => result.onChange)).toEqual(['blue']);
+    });
     it('should select multiple options', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/select.html');
       await page.evaluate(() => makeMultiple());


### PR DESCRIPTION
This PR fixes lost functionality that is no longer on-par with the documentation for `Page.select`, namely:

> `...values` <...string> Values of options to select. If the `<select>` has the `multiple` attribute, all values are considered, **otherwise only the first one is taken into account**.

I've also added an accompanying test for this use case.