### PR TITLE
Fix: Remove key codes from _pressedKeys Set after keyboard.up() is called

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -132,8 +132,8 @@ class Keyboard {
   async up(key) {
     const description = this._keyDescriptionForString(key);
 
-    this._modifiers &= ~this._modifierBit(description.code);
-    this._pressedKeys.delete(description.key);
+    this._modifiers &= ~this._modifierBit(description.key);
+    this._pressedKeys.delete(description.code);
     await this._client.send('Input.dispatchKeyEvent', {
       type: 'keyUp',
       modifiers: this._modifiers,

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -132,7 +132,7 @@ class Keyboard {
   async up(key) {
     const description = this._keyDescriptionForString(key);
 
-    this._modifiers &= ~this._modifierBit(description.key);
+    this._modifiers &= ~this._modifierBit(description.code);
     this._pressedKeys.delete(description.key);
     await this._client.send('Input.dispatchKeyEvent', {
       type: 'keyUp',

--- a/test/test.js
+++ b/test/test.js
@@ -2301,6 +2301,18 @@ describe('Page', function() {
       await page.keyboard.type('Hello World!');
       expect(await page.evaluate(() => textarea.value)).toBe('He Wrd!');
     });
+    it('should remove keys from _pressedKeys after keyboard.up()', async({page, server}) => {
+      await page.goto(server.PREFIX + '/input/textarea.html');
+      await page.focus('textarea');
+      await page.keyboard.down('w');
+      expect(await page.keyboard._pressedKeys.size).toEqual(1);
+      await page.keyboard.down('1');
+      expect(await page.keyboard._pressedKeys.size).toEqual(2);
+      await page.keyboard.up('w');
+      expect(await page.keyboard._pressedKeys.size).toEqual(1);
+      await page.keyboard.up('1');
+      expect(await page.keyboard._pressedKeys.size).toEqual(0);
+    });
     it('keyboard.modifiers()', async({page, server}) => {
       const keyboard = page.keyboard;
       expect(keyboard._modifiers).toBe(0);


### PR DESCRIPTION
This is a one line change to resolve an issue where once a key has been utilized in keyboard.down(), the repeat property on keydown events using the same key will always be set to true. See https://github.com/GoogleChrome/puppeteer/issues/1901 for full details.

keyboard.down() and keyboard.up() both use the _pressedKeys Set, however keyboard.down() adds and searches for the key code, whereas keyboard.up() attempts to delete based on the key rather than the key code.