### PR TITLE
docs(api.md): Fixing two minor anchor issues

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@
   * [event: 'requestfinished'](#event-requestfinished)
   * [event: 'response'](#event-response)
   * [page.$(selector)](#pageselector)
-  * [page.$$(selector)](#pageselector)
+  * [page.$$(selector)](#pageselector-1)
   * [page.$$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
   * [page.$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
   * [page.$x(expression)](#pagexexpression)
@@ -561,7 +561,7 @@ Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector
 
 The method evaluates the XPath expression.
 
-Shortcut for [page.mainFrame().$x(expression)](#frameexpression)
+Shortcut for [page.mainFrame().$x(expression)](#framexexpression)
 
 #### page.addScriptTag(options)
 - `options` <[Object]>


### PR DESCRIPTION
- Menu item "page.$$(selector)" now pointing to the right anchor: "pageselector-1" instead of "pageselector"
- Within "page.$x(expression)", shortcut link now pointing to "framexexpression" instead of "frameexpression"