### PR TITLE
feat(Chromium): roll to r533271

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "526987"
+    "chromium_revision": "533271"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",

--- a/test/test.js
+++ b/test/test.js
@@ -1477,6 +1477,18 @@ describe('Page', function() {
       expect(failedRequest).toBeTruthy();
       expect(failedRequest.failure().errorText).toBe('net::ERR_INTERNET_DISCONNECTED');
     });
+    it('should send referer', async({page, server}) => {
+      await page.setExtraHTTPHeaders({
+        referer: 'http://google.com/'
+      });
+      await page.setRequestInterception(true);
+      page.on('request', request => request.continue());
+      const [request] = await Promise.all([
+        server.waitForRequest('/grid.html'),
+        page.goto(server.PREFIX + '/grid.html'),
+      ]);
+      expect(request.headers['referer']).toBe('http://google.com/');
+    });
     it('should amend HTTP headers', async({page, server}) => {
       await page.setRequestInterception(true);
       page.on('request', request => {
@@ -2130,6 +2142,7 @@ describe('Page', function() {
         'mousedown',
         'mouseup',
         'click',
+        'input',
         'change',
       ]);
       await page.click('input#agree');
@@ -2143,6 +2156,7 @@ describe('Page', function() {
       expect(await page.evaluate(() => result.check)).toBe(true);
       expect(await page.evaluate(() => result.events)).toEqual([
         'click',
+        'input',
         'change',
       ]);
       await page.click('label[for="agree"]');


### PR DESCRIPTION
This roll includes:
- https://crrev.com/530961 DevTools: fix Referer header handling in
  net interceptor

The patch adds a test to cover the referrer functionality.

References #469.