### PR TITLE
docs(api): document appMode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -288,6 +288,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
   - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md).
   - `env` <[Object]> Specify environment variables that will be visible to browser. Defaults to `process.env`.
   - `devtools` <[boolean]> Whether to auto-open DevTools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
+  - `appMode` <[boolean]> If this option is set to `true`, the browser opens in headful mode and Puppeteer does not set a default viewport of 800x600 for new pages. Overrides the `headless` option if both options are used together.
 - returns: <[Promise]<[Browser]>> Promise which resolves to browser instance.
 
 The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed.


### PR DESCRIPTION
I've found `appMode` useful when using pptr with lighthouse. 

Background:
Both Lighthouse and Puppeteer emulate a viewport when you run the tools, but they use different sizes. This causes lighthouse's perf audits to fail because screenshots end up changing sizes during an audit. During an audit session, Lighthouse reloads the page several times.

example  - inject a stylesheet into the page before each lighthouse runs.

```js
const {URL} = require('url');
const puppeteer = require('puppeteer');
const lighthouse = require('lighthouse');

(async() => {

const url = 'https://www.chromestatus.com/features';

const browser = await puppeteer.launch({
  appMode: true, // sets headless: true and does not set a viewport size. Let ligthhouse do that.
});

browser.on('targetchanged', async target => {
  const page = await target.page();
  if (page && page.url() === url) {
  await page.addStyleTag({content: 'body {color: red}'});
  }
});

const lhr = await lighthouse(url, {
  port: (new URL(browser.wsEndpoint())).port,
  output: 'json',
  logLevel: 'info',
  // disableDeviceEmulation: true,
});

console.log(`Lighthouse score: ${lhr.score}`);

await browser.close();

})();
```