### PR TITLE
pageerror event passes Error, not string

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -479,7 +479,7 @@ Emitted when the JavaScript code makes a call to `console.timeStamp`. For the li
 of metrics see `page.metrics`.
 
 #### event: 'pageerror'
-- <[string]> The exception message
+- <[Error]> The exception message
 
 Emitted when an uncaught exception happens within the page.
 


### PR DESCRIPTION
Source: personal experience, and also because of

https://github.com/GoogleChrome/puppeteer/blob/cb684ebbc4de271c7f2187f4e52c0b3a83cc0122/lib/Page.js#L419