### PR TITLE
Adding in browserless to troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -251,3 +251,7 @@ AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) de
 - https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (tracks the latest Chromium snapshots)
 - https://github.com/sambaiz/puppeteer-lambda-starter-kit (uses an old version of Chromium)
 - https://github.com/universalbasket/aws-lambda-chrome
+
+## Running Puppeteer on browserless
+
+browserless is a third-party service that has built-in support for [running puppeteer](https://docs.browserless.io/libraries/puppeteer/). browserless is a paid-for service, but has open-sourced their work which can be found on [GitHub](https://github.com/joelgriffith/browserless) as well as [docker](https://hub.docker.com/r/browserless/chrome/).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -251,7 +251,3 @@ AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) de
 - https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (tracks the latest Chromium snapshots)
 - https://github.com/sambaiz/puppeteer-lambda-starter-kit (uses an old version of Chromium)
 - https://github.com/universalbasket/aws-lambda-chrome
-
-## Running Puppeteer on browserless
-
-browserless is a third-party service that has built-in support for [running puppeteer](https://docs.browserless.io/libraries/puppeteer/). browserless is a paid-for service, but has open-sourced their work which can be found on [GitHub](https://github.com/joelgriffith/browserless) as well as [docker](https://hub.docker.com/r/browserless/chrome/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,7 @@ const browser = await puppeteer.launch({
 - [pupperender](https://github.com/LasaleFamine/pupperender) - Express middleware that checks the User-Agent header of incoming requests, and if it matches one of a configurable set of bots, render the page using Puppeteer. Useful for PWA rendering.
 - [headless-chrome-crawler](https://github.com/yujiosaka/headless-chrome-crawler) - Crawler that provides simple APIs to manipulate Headless Chrome and allows you to crawl dynamic websites.
 - [puppeteer-examples](https://github.com/checkly/puppeteer-examples) - Puppeteer Headless Chrome examples for real life use cases such as getting useful info from the web pages or common login scenarios.
+- [browserless](https://github.com/joelgriffith/browserless) - Headless Chrome as a service letting you execute Puppeteer scripts remotely. Provides a docker image with configuration for concurrency, launch arguments and more.
 
 ## Testing
 - [angular-puppeteer-demo](https://github.com/Quramy/angular-puppeteer-demo) - Demo repository explaining how to use Puppeteer in Karma.


### PR DESCRIPTION
Hey folks,

Full-disclosure for those not familiar -- I am the maintainer/author of browserless. I'm opening up this PR to discuss adding in a reference to that service from the troublehsooting doc. I believe there's a lot of issues/discussions that can be moved over to libraries like browserless since it's not the core problem that puppeteer is trying to solve. I, of course, am biased by being the creator.

I'd love to hear feedback and am open to moving this elsewhere. Maybe we should start a `providers.md` file or similar where we can enumerate services and how to use puppeteer on them?

Thanks for taking time to read over this and review it. Looking forward to hearing your thoughts!