### PR TITLE
Allow Timeouts of 0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,9 +37,7 @@ module.exports = {
         "spaced-comment": [2, "always", {
             "markers": ["*"]
         }],
-        "eqeqeq": [2, "always", {
-          "null": "ignore"
-        }],
+        "eqeqeq": [2],
         "arrow-body-style": [2, "as-needed"],
         "accessor-pairs": [2, {
             "getWithoutSet": false,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,9 @@ module.exports = {
         "spaced-comment": [2, "always", {
             "markers": ["*"]
         }],
-        "eqeqeq": [2],
+        "eqeqeq": [2, "always", {
+          "null": "ignore"
+        }],
         "arrow-body-style": [2, "as-needed"],
         "accessor-pairs": [2, {
             "getWithoutSet": false,

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -618,7 +618,7 @@ class Frame {
    * @return {!Promise}
    */
   waitForFunction(pageFunction, options = {}, ...args) {
-    const timeout = (options.timeout != null) ? options.timeout : 30000;
+    const timeout = helper.isNumber(options.timeout) ? options.timeout : 30000;
     const polling = options.polling || 'raf';
     return new WaitTask(this, pageFunction, polling, timeout, ...args).promise;
   }

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -618,7 +618,7 @@ class Frame {
    * @return {!Promise}
    */
   waitForFunction(pageFunction, options = {}, ...args) {
-    const timeout = options.timeout || 30000;
+    const timeout = (options.timeout != null) ? options.timeout : 30000;
     const polling = options.polling || 'raf';
     return new WaitTask(this, pageFunction, polling, timeout, ...args).promise;
   }
@@ -637,11 +637,10 @@ class Frame {
    * @return {!Promise}
    */
   _waitForSelectorOrXPath(selectorOrXPath, isXPath, options = {}) {
-    const timeout = options.timeout || 30000;
     const waitForVisible = !!options.visible;
     const waitForHidden = !!options.hidden;
     const polling = waitForVisible || waitForHidden ? 'raf' : 'mutation';
-    return this.waitForFunction(predicate, {timeout, polling}, selectorOrXPath, isXPath, waitForVisible, waitForHidden);
+    return this.waitForFunction(predicate, {timeout: options.timeout, polling}, selectorOrXPath, isXPath, waitForVisible, waitForHidden);
 
     /**
      * @param {string} selectorOrXPath

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -136,8 +136,9 @@ class Launcher {
     /** @type {?Connection} */
     let connection = null;
     try {
+      const timeout = (options.timeout != null) ? options.timeout : 30000;
       const connectionDelay = options.slowMo || 0;
-      const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, options.timeout || 30 * 1000);
+      const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, timeout);
       connection = await Connection.create(browserWSEndpoint, connectionDelay);
       return Browser.create(connection, options, chromeProcess, killChrome);
     } catch (e) {

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -136,7 +136,7 @@ class Launcher {
     /** @type {?Connection} */
     let connection = null;
     try {
-      const timeout = (options.timeout != null) ? options.timeout : 30000;
+      const timeout = helper.isNumber(options.timeout) ? options.timeout : 30000;
       const connectionDelay = options.slowMo || 0;
       const browserWSEndpoint = await waitForWSEndpoint(chromeProcess, timeout);
       connection = await Connection.create(browserWSEndpoint, connectionDelay);

--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ const defaultBrowserOptions = {
   args: ['--no-sandbox', '--disable-dev-shm-usage']
 };
 
-const timeout = slowMo ?  0 : 10 * 1000;
+const timeout = slowMo ? 0 : 15 * 1000;
 let parallel = 1;
 if (process.env.PPTR_PARALLEL_TESTS)
   parallel = parseInt(process.env.PPTR_PARALLEL_TESTS.trim(), 10);

--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ const defaultBrowserOptions = {
   args: ['--no-sandbox', '--disable-dev-shm-usage']
 };
 
-const timeout = slowMo ? 0 : 15 * 1000;
+const timeout = slowMo ? 0 : 10 * 1000;
 let parallel = 1;
 if (process.env.PPTR_PARALLEL_TESTS)
   parallel = parseInt(process.env.PPTR_PARALLEL_TESTS.trim(), 10);

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -264,8 +264,8 @@ class TestRunner extends EventEmitter {
     this._rootSuite = new Suite(null, '', TestMode.Run);
     this._currentSuite = this._rootSuite;
     this._tests = [];
-    // Default timeout is 10 seconds.
-    this._timeout = options.timeout === 0 ? 2147483647 : options.timeout ||  10 * 1000;
+    // Default timeout is 15 seconds.
+    this._timeout = options.timeout === 0 ? 2147483647 : options.timeout || 15 * 1000;
     this._parallel = options.parallel || 1;
     this._retryFailures = !!options.retryFailures;
 

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -264,8 +264,8 @@ class TestRunner extends EventEmitter {
     this._rootSuite = new Suite(null, '', TestMode.Run);
     this._currentSuite = this._rootSuite;
     this._tests = [];
-    // Default timeout is 15 seconds.
-    this._timeout = options.timeout === 0 ? 2147483647 : options.timeout || 15 * 1000;
+    // Default timeout is 10 seconds.
+    this._timeout = options.timeout === 0 ? 2147483647 : options.timeout || 10 * 1000;
     this._parallel = options.parallel || 1;
     this._retryFailures = !!options.retryFailures;
 


### PR DESCRIPTION
Closes #1960 .

It also addresses the timeout in `Puppeteer.launch()`, as [per the docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions):

> `timeout` <number> Maximum time in milliseconds to wait for the browser instance to start.
> Defaults to `30000` (30 seconds). **Pass `0` to disable timeout.**