### PR TITLE
feat(ExecutionContext): introduce ExecutionContext.frame()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -167,6 +167,7 @@
 - [class: ExecutionContext](#class-executioncontext)
   * [executionContext.evaluate(pageFunction, ...args)](#executioncontextevaluatepagefunction-args)
   * [executionContext.evaluateHandle(pageFunction, ...args)](#executioncontextevaluatehandlepagefunction-args)
+  * [executionContext.frame()](#executioncontextframe)
   * [executionContext.queryObjects(prototypeHandle)](#executioncontextqueryobjectsprototypehandle)
 - [class: JSHandle](#class-jshandle)
   * [jsHandle.asElement()](#jshandleaselement)
@@ -2040,6 +2041,11 @@ console.log(await resultHandle.jsonValue()); // prints body's innerHTML
 await aHandle.dispose();
 await resultHandle.dispose();
 ```
+
+#### executionContext.frame()
+- returns: <?[Frame]> Frame associated with this execution context.
+
+> **NOTE** Not every execution context is associated with a frame. For example, workers and extensions have execution contexts that are not associated with frames.
 
 #### executionContext.queryObjects(prototypeHandle)
 - `prototypeHandle` <[JSHandle]> A handle to the object prototype.

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -21,15 +21,20 @@ class ExecutionContext {
    * @param {!Puppeteer.CDPSession} client
    * @param {!Object} contextPayload
    * @param {function(*):!JSHandle} objectHandleFactory
+   * @param {?Puppeteer.Frame} frame
    */
-  constructor(client, contextPayload, objectHandleFactory) {
+  constructor(client, contextPayload, objectHandleFactory, frame) {
     this._client = client;
+    this._frame = frame;
     this._contextId = contextPayload.id;
-
-    const auxData = contextPayload.auxData || {isDefault: true};
-    this._frameId = auxData.frameId || null;
-    this._isDefault = !!auxData.isDefault;
     this._objectHandleFactory = objectHandleFactory;
+  }
+
+  /**
+   * @return {?Puppeteer.Frame}
+   */
+  frame() {
+    return this._frame;
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -154,11 +154,11 @@ class FrameManager extends EventEmitter {
   }
 
   _onExecutionContextCreated(contextPayload) {
-    const context = new ExecutionContext(this._client, contextPayload, this.createJSHandle.bind(this, contextPayload.id));
+    const frameId = contextPayload.auxData && contextPayload.auxData.isDefault ? contextPayload.auxData.frameId : null;
+    const frame = frameId ? this._frames.get(frameId) : null;
+    const context = new ExecutionContext(this._client, contextPayload, this.createJSHandle.bind(this, contextPayload.id), frame);
     this._contextIdToContext.set(contextPayload.id, context);
-
-    const frame = context._frameId ? this._frames.get(context._frameId) : null;
-    if (frame && context._isDefault)
+    if (frame)
       frame._setDefaultContext(context);
   }
 
@@ -166,9 +166,8 @@ class FrameManager extends EventEmitter {
    * @param {!ExecutionContext} context
    */
   _removeContext(context) {
-    const frame = context._frameId ? this._frames.get(context._frameId) : null;
-    if (frame && context._isDefault)
-      frame._setDefaultContext(null);
+    if (context.frame())
+      context.frame()._setDefaultContext(null);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -152,7 +152,8 @@ describe('Puppeteer', function() {
       expect(response.ok()).toBe(true);
       expect(response.securityDetails()).toBeTruthy();
       expect(response.securityDetails().protocol()).toBe('TLS 1.2');
-      browser.close();
+      await page.close();
+      await browser.close();
     });
     it('should reject all promises when browser is closed', async() => {
       const browser = await puppeteer.launch(defaultBrowserOptions);
@@ -647,6 +648,8 @@ describe('Page', function() {
       expect(context1).toBeTruthy();
       expect(context2).toBeTruthy();
       expect(context1 !== context2).toBeTruthy();
+      expect(context1.frame()).toBe(frame1);
+      expect(context2.frame()).toBe(frame2);
 
       await Promise.all([
         context1.evaluate(() => window.a = 1),


### PR DESCRIPTION
This patch introduces ExecutionContext.frame() that returns Frame
associated with this Execution Context.

This allows to associate console messages with the originating frame,
if any.