### PR TITLE
feat: add Browser.newIsolatedPage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@
   * [event: 'targetdestroyed'](#event-targetdestroyed)
   * [browser.close()](#browserclose)
   * [browser.disconnect()](#browserdisconnect)
+  * [browser.newIsolatedPage()](#browsernewisolatedpage)
   * [browser.newPage()](#browsernewpage)
   * [browser.pages()](#browserpages)
   * [browser.process()](#browserprocess)
@@ -357,6 +358,11 @@ Closes Chromium and all of its pages (if any were opened). The browser object it
 #### browser.disconnect()
 
 Disconnects Puppeteer from the browser, but leaves the Chromium process running. After calling `disconnect`, the browser object is considered disposed and cannot be used anymore.
+
+#### browser.newIsolatedPage()
+- returns: <[Promise]<[Page]>> Promise which resolves to a new [Page] object. The page will be created in a new browser context. Like an incognito window but for each tab.
+
+> **NOTE** Browser contexts are only supported in Chrome headless.
 
 #### browser.newPage()
 - returns: <[Promise]<[Page]>> Promise which resolves to a new [Page] object.

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -113,6 +113,24 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @return {!Promise<!Page>}
+   */
+  async newIsolatedPage() {
+    const {browserContextId} = await this._connection.send('Target.createBrowserContext');
+    const {targetId} = await this._connection.send('Target.createTarget', {url: 'about:blank', browserContextId});
+    this._connection.on('Target.targetDestroyed', async function disposeBrowserContext(event) {
+      if (event.targetId === targetId) {
+        await this._connection.send('Target.disposeBrowserContext', {browserContextId});
+        this._connection.removeListener('Target.targetDestroyed', disposeBrowserContext);
+      }
+    }.bind(this));
+    const target = await this._targets.get(targetId);
+    console.assert(await target._initializedPromise, 'Failed to create target for page');
+    const page = await target.page();
+    return page;
+  }
+
+  /**
    * @return {!Array<!Target>}
    */
   targets() {

--- a/test/test.js
+++ b/test/test.js
@@ -318,6 +318,40 @@ describe('Page', function() {
     });
   });
 
+  describe('Browser.newIsolatedPage', function() {
+    beforeEach(async state => {
+      state.incognitoPage = await state.browser.newIsolatedPage();
+    });
+
+    afterEach(async state => {
+      await state.incognitoPage.close();
+      state.incognitoPage = null;
+    });
+
+    it('should use a separate browser context', async function({page, incognitoPage, server}) {
+      await page.goto(server.PREFIX + '/grid.html');
+      await incognitoPage.goto(server.PREFIX + '/grid.html');
+      expect(await page.cookies()).toEqual([]);
+      expect(await incognitoPage.cookies()).toEqual([]);
+      await incognitoPage.setCookie({
+        name: 'password',
+        value: '123456'
+      });
+      expect(await incognitoPage.cookies()).toEqual([{
+        name: 'password',
+        value: '123456',
+        domain: 'localhost',
+        path: '/',
+        expires: -1,
+        size: 14,
+        httpOnly: false,
+        secure: false,
+        session: true
+      }]);
+      expect(await page.cookies()).toEqual([]);
+    });
+  });
+
   describe('Page.close', function() {
     it('should reject all promises when page is closed', async({browser}) => {
       const newPage = await browser.newPage();


### PR DESCRIPTION
One use case for #85 is being able to open up many isolated pages. In our case, we needed each page to have its own auth cookie. I got the impression that the puppeteer team was holding off implementing something like this until it was available in headful chrome, but we found this to be very helpful even with that caveat so I figured I would give a PR a shot.