### PR TITLE
feat(Page): add timestamp to Request and Response events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -207,12 +207,12 @@
   * [request.frame()](#requestframe)
   * [request.headers()](#requestheaders)
   * [request.method()](#requestmethod)
+  * [request.monotonicTimeEnd()](#requestmonotonictimeend)
+  * [request.monotonicTimeStart()](#requestmonotonictimestart)
   * [request.postData()](#requestpostdata)
   * [request.resourceType()](#requestresourcetype)
   * [request.respond(response)](#requestrespondresponse)
   * [request.response()](#requestresponse)
-  * [request.monotonicTimestampStart()](#requestmonotonictimestampstart)
-  * [request.monotonicTimestampEnd()](#requestmonotonictimestampend)
   * [request.url()](#requesturl)
 - [class: Response](#class-response)
   * [response.buffer()](#responsebuffer)
@@ -220,12 +220,12 @@
   * [response.fromServiceWorker()](#responsefromserviceworker)
   * [response.headers()](#responseheaders)
   * [response.json()](#responsejson)
+  * [response.monotonicTimeEnd()](#responsemonotonictimeend)
   * [response.ok()](#responseok)
   * [response.request()](#responserequest)
   * [response.securityDetails()](#responsesecuritydetails)
   * [response.status()](#responsestatus)
   * [response.text()](#responsetext)
-  * [response.monotonicTimestampEnd()](#responsemonotonictimestampend)
   * [response.url()](#responseurl)
 - [class: SecurityDetails](#class-securitydetails)
   * [securityDetails.issuer()](#securitydetailsissuer)
@@ -2364,6 +2364,12 @@ page.on('requestfailed', request => {
 #### request.method()
 - returns: <[string]> Request's method (GET, POST, etc.)
 
+#### request.monotonicTimeEnd()
+- returns: <[number]> The monotonic timestamp when this request finished or failed.
+
+#### request.monotonicTimeStart()
+- returns: <[number]> The monotonic timestamp when this request started.
+
 #### request.postData()
 - returns: <[string]> Request's post body, if any.
 
@@ -2404,12 +2410,6 @@ page.on('request', request => {
 #### request.response()
 - returns: <?[Response]> A matching [Response] object, or `null` if the response has not been received yet.
 
-#### request.monotonicTimestampStart()
-- returns: <[number]> The monotonic timestamp when this request started.
-
-#### request.monotonicTimestampEnd()
-- returns: <[number]> The monotonic timestamp when this request finished or failed.
-
 #### request.url()
 - returns: <[string]> URL of the request.
 
@@ -2438,6 +2438,9 @@ True if the response was served by a service worker.
 
 This method will throw if the response body is not parsable via `JSON.parse`.
 
+#### response.monotonicTimeEnd()
+- returns: <[number]> The MonotonicTime timestamp when this response happened.
+
 #### response.ok()
 - returns: <[boolean]>
 
@@ -2456,9 +2459,6 @@ Contains the status code of the response (e.g., 200 for a success).
 
 #### response.text()
 - returns: <[Promise]<[string]>> Promise which resolves to a text representation of response body.
-
-#### response.monotonicTimestampEnd()
-- returns: <[number]> The MonotonicTime timestamp when this response happened.
 
 #### response.url()
 - returns: <[string]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -211,7 +211,8 @@
   * [request.resourceType()](#requestresourcetype)
   * [request.respond(response)](#requestrespondresponse)
   * [request.response()](#requestresponse)
-  * [request.timestamp()](#requesttimestamp)
+  * [request.monotonicTimestampStart()](#requestmonotonictimestampstart)
+  * [request.monotonicTimestampEnd()](#requestmonotonictimestampend)
   * [request.url()](#requesturl)
 - [class: Response](#class-response)
   * [response.buffer()](#responsebuffer)
@@ -224,7 +225,7 @@
   * [response.securityDetails()](#responsesecuritydetails)
   * [response.status()](#responsestatus)
   * [response.text()](#responsetext)
-  * [response.timestamp()](#responsetimestamp)
+  * [response.monotonicTimestampEnd()](#responsemonotonictimestampend)
   * [response.url()](#responseurl)
 - [class: SecurityDetails](#class-securitydetails)
   * [securityDetails.issuer()](#securitydetailsissuer)
@@ -2403,8 +2404,11 @@ page.on('request', request => {
 #### request.response()
 - returns: <?[Response]> A matching [Response] object, or `null` if the response has not been received yet.
 
-#### request.timestamp()
-- returns: <[number]> The MonotonicTime timestamp when this request happened.
+#### request.monotonicTimestampStart()
+- returns: <[number]> The monotonic timestamp when this request started.
+
+#### request.monotonicTimestampEnd()
+- returns: <[number]> The monotonic timestamp when this request finished or failed.
 
 #### request.url()
 - returns: <[string]> URL of the request.
@@ -2453,7 +2457,7 @@ Contains the status code of the response (e.g., 200 for a success).
 #### response.text()
 - returns: <[Promise]<[string]>> Promise which resolves to a text representation of response body.
 
-#### response.timestamp()
+#### response.monotonicTimestampEnd()
 - returns: <[number]> The MonotonicTime timestamp when this response happened.
 
 #### response.url()

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,6 +206,7 @@
   * [request.resourceType()](#requestresourcetype)
   * [request.respond(response)](#requestrespondresponse)
   * [request.response()](#requestresponse)
+  * [request.timestamp()](#requesttimestamp)
   * [request.url()](#requesturl)
 - [class: Response](#class-response)
   * [response.buffer()](#responsebuffer)
@@ -217,6 +218,7 @@
   * [response.request()](#responserequest)
   * [response.status()](#responsestatus)
   * [response.text()](#responsetext)
+  * [response.timestamp()](#responsetimestamp)
   * [response.url()](#responseurl)
 - [class: Target](#class-target)
   * [target.createCDPSession()](#targetcreatecdpsession)
@@ -2384,6 +2386,9 @@ page.on('request', request => {
 #### request.response()
 - returns: <?[Response]> A matching [Response] object, or `null` if the response has not been received yet.
 
+#### request.timestamp()
+- returns: <[number]> The MonotonicTime timestamp when this request happened.
+
 #### request.url()
 - returns: <[string]> URL of the request.
 
@@ -2427,6 +2432,9 @@ Contains the status code of the response (e.g., 200 for a success).
 
 #### response.text()
 - returns: <[Promise]<[string]>> Promise which resolves to a text representation of response body.
+
+#### response.timestamp()
+- returns: <[number]> The MonotonicTime timestamp when this response happened.
 
 #### response.url()
 - returns: <[string]>

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -327,6 +327,7 @@ class Request {
     this._headers = {};
     this._frame = frame;
     this._monotonicTimeStart = monotonicTimestamp;
+    this._monotonicTimeEnd = null;
     for (const key of Object.keys(payload.headers))
       this._headers[key.toLowerCase()] = payload.headers[key];
 
@@ -388,7 +389,7 @@ class Request {
   monotonicTimeStart() {
     return this._monotonicTimeStart;
   }
-  
+
   /**
    * Timestamp for when a request finished or failed.
    * @return {?number}
@@ -583,7 +584,7 @@ class Response {
   monotonicTimeEnd() {
     return this._monotonicTimeEnd;
   }
-  
+
   /**
    * @return {?SecurityDetails}
    */

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -153,8 +153,8 @@ class NetworkManager extends EventEmitter {
     if (event.redirectUrl) {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
       if (request) {
-        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders, false /* fromDiskCache */, false /* fromServiceWorker */);
-        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId);
+        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders, false /* fromDiskCache */, false /* fromServiceWorker */, null /* timestamp */);
+        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId, null);
       }
       return;
     }
@@ -162,10 +162,10 @@ class NetworkManager extends EventEmitter {
     const requestId = this._requestHashToRequestIds.firstValue(requestHash);
     if (requestId) {
       this._requestHashToRequestIds.delete(requestHash, requestId);
-      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId);
+      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId, event.timestamp);
     } else {
       this._requestHashToInterceptionIds.set(requestHash, event.interceptionId);
-      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId);
+      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId, null);
     }
   }
 
@@ -184,9 +184,10 @@ class NetworkManager extends EventEmitter {
    * @param {!Object} redirectHeaders
    * @param {boolean} fromDiskCache
    * @param {boolean} fromServiceWorker
+   * @param {?number} timestamp
    */
-  _handleRequestRedirect(request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker) {
-    const response = new Response(this._client, request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker);
+  _handleRequestRedirect(request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, timestamp) {
+    const response = new Response(this._client, request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, timestamp);
     request._response = response;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
@@ -203,11 +204,11 @@ class NetworkManager extends EventEmitter {
    * @param {!Object} requestPayload
    * @param {?string} frameId
    */
-  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId) {
+  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId, timestamp) {
     let frame = null;
     if (frameId)
       frame = this._frameManager.frame(frameId);
-    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame);
+    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame, timestamp);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);
     if (interceptionId)
@@ -239,9 +240,9 @@ class NetworkManager extends EventEmitter {
       const request = this._requestIdToRequest.get(event.requestId);
       // If we connect late to the target, we could have missed the requestWillBeSent event.
       if (request)
-        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers, event.redirectResponse.fromDiskCache, event.redirectResponse.fromServiceWorker);
+        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers, event.redirectResponse.fromDiskCache, event.redirectResponse.fromServiceWorker, event.timestamp);
     }
-    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request, event.frameId);
+    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request, event.frameId, event.timestamp);
   }
 
   /**
@@ -252,8 +253,7 @@ class NetworkManager extends EventEmitter {
     // FileUpload sends a response without a matching request.
     if (!request)
       return;
-    const response = new Response(this._client, request, event.response.status, event.response.headers,
-        event.response.fromDiskCache, event.response.fromServiceWorker);
+    const response = new Response(this._client, request, event.response.status, event.response.headers, event.response.fromDiskCache, event.response.fromServiceWorker, event.timestamp);
     request._response = response;
     this.emit(NetworkManager.Events.Response, response);
   }
@@ -268,6 +268,8 @@ class NetworkManager extends EventEmitter {
     if (!request)
       return;
     request._completePromiseFulfill.call(null);
+    // save loading finished timestamp and not loading started timestamp
+    request._timestamp = event.timestamp;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
     this._attemptedAuthentications.delete(request._interceptionId);
@@ -285,6 +287,8 @@ class NetworkManager extends EventEmitter {
       return;
     request._failureText = event.errorText;
     request._completePromiseFulfill.call(null);
+    // save loading finished timestamp and not loading started timestamp
+    request._timestamp = event.timestamp;
     this._requestIdToRequest.delete(request._requestId);
     this._interceptionIdToRequest.delete(request._interceptionId);
     this._attemptedAuthentications.delete(request._interceptionId);
@@ -302,8 +306,9 @@ class Request {
    * @param {string} resourceType
    * @param {!Object} payload
    * @param {?Puppeteer.Frame} frame
+   * @param {?number} timestamp
    */
-  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame) {
+  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame, timestamp) {
     this._client = client;
     this._requestId = requestId;
     this._interceptionId = interceptionId;
@@ -321,6 +326,7 @@ class Request {
     this._postData = payload.postData;
     this._headers = {};
     this._frame = frame;
+    this._timestamp = timestamp;
     for (const key of Object.keys(payload.headers))
       this._headers[key.toLowerCase()] = payload.headers[key];
 
@@ -374,6 +380,13 @@ class Request {
    */
   frame() {
     return this._frame;
+  }
+
+  /**
+   * @return {?number}
+   */
+  timestamp() {
+    return this._timestamp;
   }
 
   /**
@@ -500,8 +513,9 @@ class Response {
    * @param {!Object} headers
    * @param {boolean} fromDiskCache
    * @param {boolean} fromServiceWorker
+   * @param {?number} timestamp
    */
-  constructor(client, request, status, headers, fromDiskCache, fromServiceWorker) {
+  constructor(client, request, status, headers, fromDiskCache, fromServiceWorker, timestamp) {
     this._client = client;
     this._request = request;
     this._contentPromise = null;
@@ -511,6 +525,7 @@ class Response {
     this._fromDiskCache = fromDiskCache;
     this._fromServiceWorker = fromServiceWorker;
     this._headers = {};
+    this._timestamp = timestamp;
     for (const key of Object.keys(headers))
       this._headers[key.toLowerCase()] = headers[key];
   }
@@ -541,6 +556,13 @@ class Response {
    */
   headers() {
     return this._headers;
+  }
+
+  /**
+   * @return {?number}
+   */
+  timestamp() {
+    return this._timestamp;
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1452,10 +1452,12 @@ describe('Page', function() {
         expect(request.resourceType()).toBe('document');
         expect(request.frame() === page.mainFrame()).toBe(true);
         expect(request.frame().url()).toBe('about:blank');
+        expect(request.timestamp()).toBe(null);
         request.continue();
       });
       const response = await page.goto(server.EMPTY_PAGE);
       expect(response.ok()).toBe(true);
+      expect(response.timestamp()).not.toBeNull();
     });
     it('should stop intercepting', async({page, server}) => {
       await page.setRequestInterception(true);

--- a/test/test.js
+++ b/test/test.js
@@ -1483,13 +1483,13 @@ describe('Page', function() {
         expect(request.resourceType()).toBe('document');
         expect(request.frame() === page.mainFrame()).toBe(true);
         expect(request.frame().url()).toBe('about:blank');
-        expect(request.monotonicTimestampStart()).not.toBeNull();
-        expect(request.monotonicTimestampEnd()).not.toBeNull();
+        expect(request.monotonicTimeStart()).toBeNull();
+        expect(request.monotonicTimeEnd()).toBeNull();
         request.continue();
       });
       const response = await page.goto(server.EMPTY_PAGE);
       expect(response.ok()).toBe(true);
-      expect(response.monotonicTimestampEnd()).not.toBeNull();
+      expect(response.monotonicTimeEnd()).not.toBeNull();
     });
     it('should stop intercepting', async({page, server}) => {
       await page.setRequestInterception(true);

--- a/test/test.js
+++ b/test/test.js
@@ -1483,12 +1483,13 @@ describe('Page', function() {
         expect(request.resourceType()).toBe('document');
         expect(request.frame() === page.mainFrame()).toBe(true);
         expect(request.frame().url()).toBe('about:blank');
-        expect(request.timestamp()).toBe(null);
+        expect(request.monotonicTimestampStart()).not.toBeNull();
+        expect(request.monotonicTimestampEnd()).not.toBeNull();
         request.continue();
       });
       const response = await page.goto(server.EMPTY_PAGE);
       expect(response.ok()).toBe(true);
-      expect(response.timestamp()).not.toBeNull();
+      expect(response.monotonicTimestampEnd()).not.toBeNull();
     });
     it('should stop intercepting', async({page, server}) => {
       await page.setRequestInterception(true);


### PR DESCRIPTION
To be able to know when requests exactly have happened during the network timeline you need a timestamp. Here it is. Timestamp is null when intercepted, this is not available in the Devtools protocol.