### PR TITLE
feat(Targets): expose browser target

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2483,7 +2483,7 @@ If the target is not of type `"page"`, returns `null`.
 #### target.type()
 - returns: <[string]>
 
-Identifies what kind of target this is. Can be `"page"`, `"service_worker"`, or `"other"`.
+Identifies what kind of target this is. Can be `"page"`, `"service_worker"`, `"browser"` or `"other"`.
 
 #### target.url()
 - returns: <[string]>

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -229,11 +229,11 @@ class Target {
   }
 
   /**
-   * @return {"page"|"service_worker"|"other"}
+   * @return {"page"|"service_worker"|"other"|"browser"}
    */
   type() {
     const type = this._targetInfo.type;
-    if (type === 'page' || type === 'service_worker')
+    if (type === 'page' || type === 'service_worker' || type === 'browser')
       return type;
     return 'other';
   }

--- a/test/test.js
+++ b/test/test.js
@@ -3618,6 +3618,11 @@ describe('Page', function() {
       expect(allPages).toContain(page);
       expect(allPages[0]).not.toBe(allPages[1]);
     });
+    it('should contain browser target', async({browser}) => {
+      const targets = browser.targets();
+      const browserTarget = targets.find(target => target.type() === 'browser');
+      expect(browserTarget).toBeTruthy();
+    });
     it('should be able to use the default page in the browser', async({page, server, browser}) => {
       // The pages will be the testing page and the original newtab page
       const allPages = await browser.pages();

--- a/test/test.js
+++ b/test/test.js
@@ -3608,8 +3608,7 @@ describe('Page', function() {
       const targets = browser.targets();
       expect(targets.some(target => target.type() === 'page' &&
         target.url() === 'about:blank')).toBeTruthy('Missing blank page');
-      expect(targets.some(target => target.type() === 'other' &&
-        target.url() === '')).toBeTruthy('Missing browser target');
+      expect(targets.some(target => target.type() === 'browser')).toBeTruthy('Missing browser target');
     });
     it('Browser.pages should return all of the pages', async({page, server, browser}) => {
       // The pages will be the testing page and the original newtab page


### PR DESCRIPTION
This patch exposes "browser" target to the list of targets.