### PR TITLE
Improved XPath Detection

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1313,7 +1313,7 @@ This is a shortcut for [page.mainFrame().url()](#frameurl)
 - returns: <[Promise]<[JSHandle]>> Promise which resolves to a JSHandle of the success value
 
 This method behaves differently with respect to the type of the first parameter:
-- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with '//', and the method is a shortcut for
+- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with XPath prefixes (`/`, `//` or `./`) or common [node set functions](https://www.w3.org/TR/xpath/#section-Node-Set-Functions), and the method is a shortcut for
   [page.waitForSelector](#pagewaitforselectorselector-options) or [page.waitForXPath](#pagewaitforxpathxpath-options)
 - if `selectorOrFunctionOrTimeout` is a `function`, then the first argument is treated as a predicate to wait for and the method is a shortcut for [page.waitForFunction()](#pagewaitforfunctionpagefunction-options-args).
 - if `selectorOrFunctionOrTimeout` is a `number`, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
@@ -1894,7 +1894,7 @@ Returns frame's url.
 - returns: <[Promise]<[JSHandle]>> Promise which resolves to a JSHandle of the success value
 
 This method behaves differently with respect to the type of the first parameter:
-- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with '//', and the method is a shortcut for
+- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with XPath prefixes (`/`, `//` or `./`) or common [node set functions](https://www.w3.org/TR/xpath/#section-Node-Set-Functions), and the method is a shortcut for
   [frame.waitForSelector](#framewaitforselectorselector-options) or [frame.waitForXPath](#framewaitforsxpathxpath-options)
 - if `selectorOrFunctionOrTimeout` is a `function`, then the first argument is treated as a predicate to wait for and the method is a shortcut for [frame.waitForFunction()](#framewaitforfunctionpagefunction-options-args).
 - if `selectorOrFunctionOrTimeout` is a `number`, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout

--- a/docs/api.md
+++ b/docs/api.md
@@ -1313,7 +1313,7 @@ This is a shortcut for [page.mainFrame().url()](#frameurl)
 - returns: <[Promise]<[JSHandle]>> Promise which resolves to a JSHandle of the success value
 
 This method behaves differently with respect to the type of the first parameter:
-- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with XPath prefixes (`/`, `//` or `./`) or common [node set functions](https://www.w3.org/TR/xpath/#section-Node-Set-Functions), and the method is a shortcut for
+- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with XPath prefixes (`/`, `//` or `./`) or [`id` function](https://www.w3.org/TR/xpath/#function-id), and the method is a shortcut for
   [page.waitForSelector](#pagewaitforselectorselector-options) or [page.waitForXPath](#pagewaitforxpathxpath-options)
 - if `selectorOrFunctionOrTimeout` is a `function`, then the first argument is treated as a predicate to wait for and the method is a shortcut for [page.waitForFunction()](#pagewaitforfunctionpagefunction-options-args).
 - if `selectorOrFunctionOrTimeout` is a `number`, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout
@@ -1894,7 +1894,7 @@ Returns frame's url.
 - returns: <[Promise]<[JSHandle]>> Promise which resolves to a JSHandle of the success value
 
 This method behaves differently with respect to the type of the first parameter:
-- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with XPath prefixes (`/`, `//` or `./`) or common [node set functions](https://www.w3.org/TR/xpath/#section-Node-Set-Functions), and the method is a shortcut for
+- if `selectorOrFunctionOrTimeout` is a `string`, then the first argument is treated as a [selector] or [xpath], depending on whether or not it starts with XPath prefixes (`/`, `//` or `./`) or [`id()` function](https://www.w3.org/TR/xpath/#function-id), and the method is a shortcut for
   [frame.waitForSelector](#framewaitforselectorselector-options) or [frame.waitForXPath](#framewaitforsxpathxpath-options)
 - if `selectorOrFunctionOrTimeout` is a `function`, then the first argument is treated as a predicate to wait for and the method is a shortcut for [frame.waitForFunction()](#framewaitforfunctionpagefunction-options-args).
 - if `selectorOrFunctionOrTimeout` is a `number`, then the first argument is treated as a timeout in milliseconds and the method returns a promise which resolves after the timeout

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -631,11 +631,11 @@ class Frame {
    * @return {!Promise}
    */
   waitFor(selectorOrFunctionOrTimeout, options = {}, ...args) {
-    const xPathPattern = '//';
+    const xPathPattern = /^(?:[.][/]|[/][/]?|(?:count|id|last|name|position)[(])/i;
 
     if (helper.isString(selectorOrFunctionOrTimeout)) {
       const string = /** @type {string} */ (selectorOrFunctionOrTimeout);
-      if (string.startsWith(xPathPattern))
+      if (xPathPattern.test(string))
         return this.waitForXPath(string, options);
       return this.waitForSelector(string, options);
     }

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -631,7 +631,7 @@ class Frame {
    * @return {!Promise}
    */
   waitFor(selectorOrFunctionOrTimeout, options = {}, ...args) {
-    const xPathPattern = /^(?:[.][/]|[/][/]?|(?:count|id|last|name|position)[(])/i;
+    const xPathPattern = /^[(]?(?:[.][/]|[/][/]?|(?:count|id|last|name|position)[(])/i;
 
     if (helper.isString(selectorOrFunctionOrTimeout)) {
       const string = /** @type {string} */ (selectorOrFunctionOrTimeout);

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -631,7 +631,7 @@ class Frame {
    * @return {!Promise}
    */
   waitFor(selectorOrFunctionOrTimeout, options = {}, ...args) {
-    const xPathPattern = /^[(]?(?:[.][/]|[/][/]?|(?:count|id|last|name|position)[(])/i;
+    const xPathPattern = /^[(]?(?:[.][/]|[/][/]?|id[(])/i;
 
     if (helper.isString(selectorOrFunctionOrTimeout)) {
       const string = /** @type {string} */ (selectorOrFunctionOrTimeout);

--- a/test/test.js
+++ b/test/test.js
@@ -1044,11 +1044,25 @@ describe('Page', function() {
       await waitFor;
       expect(found).toBe(true);
     });
-    it('should not allow you to select an element with single slash xpath', async({page, server}) => {
+    it('should wait for an absolute xpath', async({page, server}) => {
+      let found = false;
       await page.setContent(`<div>some text</div>`);
-      let error = null;
-      await page.waitFor('/html/body/div').catch(e => error = e);
-      expect(error).toBeTruthy();
+      await page.waitFor('/html/body/div').then(() => found = true);
+      expect(found).toBe(true);
+    });
+    it('should wait for an xpath group', async({page, server}) => {
+      let found = false;
+      await page.setContent(`<div>some text</div><div>more text</div>`);
+      await page.waitFor('(//div)[1]').then(() => found = true).catch(() => found = false);
+      expect(found).toBe(true);
+      await page.waitFor('(//div)[2]').then(() => found = true).catch(() => found = false);
+      expect(found).toBe(true);
+    });
+    it('should wait for the xpath id function', async({page, server}) => {
+      let found = false;
+      await page.setContent(`<div id="foo">some text</div>`);
+      await page.waitFor('id("foo")').then(() => found = true);
+      expect(found).toBe(true);
     });
     it('should timeout', async({page, server}) => {
       const startTime = Date.now();


### PR DESCRIPTION
This patch extends the XPath detection from the basic prefix of `//` to the following prefix axis:

- `/` Root
- `//` Anywhere
- `./` Relative

It also detects the following [XPath node set functions](https://www.w3.org/TR/xpath/#section-Node-Set-Functions):

- `count(`
- `id(`
- `last(`
- `name(`
- `position(`

This is important because an XPath can look something like:

```
id("user-links")
count(//*)
```