### PR TITLE
feat(Chromium): roll Chromium to r538022

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "536395"
+    "chromium_revision": "538022"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll includes:
- https://crrev.com/536535 - using HINTING_FULL by default in headless builds, added command line parameter to override it

Fixes #2028.