### PR TITLE
fix: force layout in bounding box

### DIFF
--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -119,6 +119,8 @@ class ElementHandle extends JSHandle {
    * @return {!Promise<?{x: number, y: number, width: number, height: number}>}
    */
   async boundingBox() {
+    // force a layout
+    await this.executionContext().evaluate(element => element.getBoundingClientRect(), this);
     const result = await this._client.send('DOM.getBoxModel', {
       objectId: this._remoteObject.objectId
     }).catch(error => void debugError(error));


### PR DESCRIPTION
Some tests were flaky because `DOM.getBoxModel` doesn't force a layout. Maybe it should on the backend?