### PR TITLE
fix(test): add missing test for making sure chrome is closed

### DIFF
--- a/test/fixtures/closeme.js
+++ b/test/fixtures/closeme.js
@@ -1,0 +1,5 @@
+(async() => {
+  const [, , puppeteerRoot, options] = process.argv;
+  const browser = await require(puppeteerRoot).launch(JSON.parse(options));
+  console.log(browser.wsEndpoint());
+})();

--- a/test/test.js
+++ b/test/test.js
@@ -301,7 +301,7 @@ describe('Puppeteer', function() {
       if (process.platform === 'win32')
         execSync(`taskkill /pid ${res.pid} /T /F`);
       else
-        process.kill(-res.pid, 'SIGKILL');
+        process.kill(res.pid);
       await Promise.all(promises);
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -283,6 +283,27 @@ describe('Puppeteer', function() {
 
       expect(dumpioData).toContain(dumpioTextToLog);
     });
+    it('should close the browser when the node process closes', async({ server }) => {
+      const {spawn, execSync} = require('child_process');
+      const res = spawn('node', [path.join(__dirname, 'fixtures', 'closeme.js'), PROJECT_ROOT, JSON.stringify(defaultBrowserOptions)]);
+      let wsEndPointCallback;
+      const wsEndPointPromise = new Promise(x => wsEndPointCallback = x);
+      let output = '';
+      res.stdout.on('data', data => {
+        output += data;
+        if (output.indexOf('\n'))
+          wsEndPointCallback(output.substring(0, output.indexOf('\n')));
+      });
+      const browser = await puppeteer.connect({ browserWSEndpoint: await wsEndPointPromise });
+      const promises = [
+        new Promise(resolve => browser.once('disconnected', resolve)),
+        new Promise(resolve => res.on('close', resolve))];
+      if (process.platform === 'win32')
+        execSync(`taskkill /pid ${res.pid} /T /F`);
+      else
+        process.kill(-res.pid, 'SIGKILL');
+      await Promise.all(promises);
+    });
   });
   describe('Puppeteer.connect', function() {
     it('should be able to connect multiple times to the same browser', async({server}) => {


### PR DESCRIPTION
This should give some peace of mind that Puppeteer isn't leaving zombie Chromium processes everywhere as we make changes to the closing code.