### PR TITLE
 docs(api.md): iframe load event

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1637,29 +1637,29 @@ Waiting for a frame to be loaded is done in two steps:
 1. Wait for Frame to be attached - needed because looking for a specific frame on a page (using [`page.frames()`](#pageframes)) might be too early, before the frame is actually attached.
 2. Wait for Frame to be loaded - needed because both `frameattached` and `framenavigated` events will happen before frame's `window.onLoad` event.
 
-  An example for such implementation:
+    An example for such implementation:
 
-  ```js
-  function waitForFrame(page) {
-    let fulfill;
-    const promise = new Promise(x => fulfill = x);
-    checkFrame();
-    return promise;
+    ```js
+    function waitForFrame(page) {
+      let fulfill;
+      const promise = new Promise(x => fulfill = x);
+      checkFrame();
+      return promise;
 
-    function checkFrame() {
-      const frame = page.frames().find(f => f.name() === 'ifrw');
-      if (frame)
-        fulfill(frame);
-      else
-        page.once('frameattached', checkFrame);
+      function checkFrame() {
+        const frame = page.frames().find(f => f.name() === 'ifrw');
+        if (frame)
+          fulfill(frame);
+        else
+          page.once('frameattached', checkFrame);
+      }
     }
-  }
 
-  // 1. waiting for frame with name 'ifrw' to get attached
-  const frame = await waitForFrame(page);
-  // 2. waiting for the frame to contain the necessary selector
-  await frame.waitForSelector('#selector');
-  ```
+    // 1. waiting for frame with name 'ifrw' to get attached
+    const frame = await waitForFrame(page);
+    // 2. waiting for the frame to contain the necessary selector
+    await frame.waitForSelector('#selector');
+    ```
 
 
 An example of dumping frame tree:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1633,6 +1633,41 @@ At every point of time, page exposes its current frame tree via the [page.mainFr
 - ['framenavigated'](#event-framenavigated) - fired when the frame commits navigation to a different URL.
 - ['framedetached'](#event-framedetached) - fired when the frame gets detached from the page.  A Frame can be detached from the page only once.
 
+Waiting for a frame to be loaded
+
+Waiting for a frame to be loaded is done in two steps:
+1. Frame is attached.
+2. Frame is loaded.
+
+Step 1 is needed because looking for a specific frame on a page (using [`page.frames`](#pageframes)) might be too early, before the frame is actually attached.
+
+Step 2 in important because both `frameattached` and `framenavigated` events will happen before frame's `window.onLoad` event.
+
+An example for such implementation:
+
+```js
+function waitForFrame(page) {
+  let fulfill;
+  const promise = new Promise(x => fulfill = x);
+  checkFrame();
+  return promise;
+
+  function checkFrame() {
+    const frame = page.frames().find(f => f.name() === 'ifrw');
+    if (frame)
+      fulfill(frame);
+    else
+      page.once('frameattached', checkFrame);
+  }
+}
+
+// 1. waiting for frame with name 'ifrw' to get attached
+const frame = await waitForFrame(page);
+// 2. waiting for the frame to contain the necessary selector
+await frame.waitForSelector('#selector');
+```
+
+
 An example of dumping frame tree:
 
 ```js


### PR DESCRIPTION
Fixes #1413 

After playing around with frames, I figured out that execution order is:
1. `frameattached`
2. `framenavigated`
3.  Frame's `window.onLoad`

This means that the two steps are needed:
1. Wait for Frame to be attached
2. Wait for Frame to be loaded

I added a section in `Frame` docs: `Waiting for a frame to be loaded`, explaining this concept with the example from #1361.

I think that we might need a better built-in solution for that,  something like: `page.waitForFrameAttached(frameName)`

WDYT?