### PR TITLE
docs: add documentation referencing puppeteer-to-istanbul

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2557,6 +2557,9 @@ for (const entry of coverage) {
 console.log(`Bytes used: ${usedBytes / totalBytes * 100}%`);
 ```
 
+_To output coverage in a form consumable by [Istanbul](https://github.com/istanbuljs),
+  see [puppeteer-to-istanbul](https://github.com/istanbuljs/puppeteer-to-istanbul)._
+
 #### coverage.startCSSCoverage(options)
 - `options` <[Object]>  Set of configurable options for coverage
   - `resetOnNavigation` <[boolean]> Whether to reset coverage on every navigation. Defaults to `true`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,3 +40,4 @@ const browser = await puppeteer.launch({
 
 - [angular-puppeteer-demo](https://github.com/Quramy/angular-puppeteer-demo) - Demo repository explaining how to use Puppeteer in Karma.
 - [mocha-headless-chrome](https://github.com/direct-adv-interfaces/mocha-headless-chrome) - Tool which runs client-side **mocha** tests in the command line through headless Chrome.
+- [puppeteer-to-istanbul-example](https://github.com/bcoe/puppeteer-to-istanbul-example) - Demo repository demonstrating how to output Puppeteer coverage in Istanbul format.


### PR DESCRIPTION
add documentation pointing folks towards the [puppeteer-to-istanbul](https://github.com/istanbuljs/puppeteer-to-istanbul) connector.

CC: @vkoves, @rjaltman, @aslushnikov

see: #1768 