### PR TITLE
fix: response.ok should be true for file:// urls

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -538,7 +538,7 @@ class Response {
    * @return {boolean}
    */
   ok() {
-    return this._status >= 200 && this._status <= 299;
+    return this._status === 0 || (this._status >= 200 && this._status <= 299);
   }
 
   /**
@@ -773,4 +773,4 @@ const statusTexts = {
   '511': 'Network Authentication Required',
 };
 
-module.exports = NetworkManager;
+module.exports = {Request, Response, NetworkManager};

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -17,7 +17,7 @@
 const fs = require('fs');
 const EventEmitter = require('events');
 const mime = require('mime');
-const NetworkManager = require('./NetworkManager');
+const {NetworkManager} = require('./NetworkManager');
 const NavigatorWatcher = require('./NavigatorWatcher');
 const Dialog = require('./Dialog');
 const EmulationManager = require('./EmulationManager');
@@ -478,11 +478,12 @@ class Page extends EventEmitter {
   /**
    * @param {string} url
    * @param {!Object=} options
-   * @return {!Promise<?Response>}
+   * @return {!Promise<?Puppeteer.Response>}
    */
   async goto(url, options = {}) {
     const referrer = this._networkManager.extraHTTPHeaders()['referer'];
 
+    /** @type {Map<string, !Puppeteer.Request>} */
     const requests = new Map();
     const eventListeners = [
       helper.addEventListener(this._networkManager, NetworkManager.Events.Request, request => {
@@ -526,7 +527,7 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
-   * @return {!Promise<?Response>}
+   * @return {!Promise<?Puppeteer.Response>}
    */
   async reload(options) {
     const [response] = await Promise.all([
@@ -538,7 +539,7 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
-   * @return {!Promise<!Response>}
+   * @return {!Promise<!Puppeteer.Response>}
    */
   async waitForNavigation(options = {}) {
     const mainFrame = this._frameManager.mainFrame();
@@ -556,7 +557,7 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
-   * @return {!Promise<?Response>}
+   * @return {!Promise<?Puppeteer.Response>}
    */
   async goBack(options) {
     return this._go(-1, options);
@@ -564,7 +565,7 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
-   * @return {!Promise<?Response>}
+   * @return {!Promise<?Puppeteer.Response>}
    */
   async goForward(options) {
     return this._go(+1, options);
@@ -572,7 +573,7 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
-   * @return {!Promise<?Response>}
+   * @return {!Promise<?Puppeteer.Response>}
    */
   async _go(delta, options) {
     const history = await this._client.send('Page.getNavigationHistory');

--- a/lib/externs.d.ts
+++ b/lib/externs.d.ts
@@ -7,7 +7,7 @@ import {Mouse as RealMouse, Keyboard as RealKeyboard, Touchscreen as RealTouchsc
 import {Frame as RealFrame, FrameManager as RealFrameManager}  from './FrameManager.js';
 import {JSHandle as RealJSHandle, ExecutionContext as RealExecutionContext}  from './ExecutionContext.js';
 import * as RealElementHandle  from './ElementHandle.js';
-import * as RealNetworkManager from './NetworkManager.js';
+import { NetworkManager as RealNetworkManager, Request as RealRequest, Response as RealResponse } from './NetworkManager.js';
 import * as child_process from 'child_process';
 export as namespace Puppeteer;
 
@@ -25,7 +25,9 @@ export class NetworkManager extends RealNetworkManager {}
 export class ElementHandle extends RealElementHandle {}
 export class JSHandle extends RealJSHandle {}
 export class ExecutionContext extends RealExecutionContext {}
-export class Page extends RealPage {}
+export class Page extends RealPage { }
+export class Response extends RealResponse { }
+export class Request extends RealRequest { }
 
 export interface ConnectionTransport extends NodeJS.EventEmitter {
   send(string);


### PR DESCRIPTION
I tried to add a test, but we don't have a good way to load `file://` urls cross platform. I also found out that our type annotations for request and response were wrong.

Fixes #2116