### PR TITLE
Feat(Page): introduce url at error message at goto.navigate

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -517,7 +517,7 @@ class Page extends EventEmitter {
     async function navigate(client, url, referrer) {
       try {
         const response = await client.send('Page.navigate', {url, referrer});
-        return response.errorText ? new Error(response.errorText) : null;
+        return response.errorText ? new Error(`${response.errorText} at ${url}`) : null;
       } catch (error) {
         return error;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -1420,6 +1420,16 @@ describe('Page', function() {
       expect(response.status()).toBe(200);
       expect(response.url()).toContain('self-request.html');
     });
+    it('should fail when navigating and show the url at the error message', async function({page, server, httpsServer}) {
+      const url = httpsServer.PREFIX + '/redirect/1.html';
+      let error = null;
+      try {
+        await page.goto(url);
+      } catch (e) {
+        error = e;
+      }
+      expect(error.message).toContain(url);
+    });
   });
 
   describe('Page.waitForNavigation', function() {


### PR DESCRIPTION
Now the error message will come with the url where the error was generated

Fixes: https://github.com/GoogleChrome/puppeteer/issues/2165