### PR TITLE
Cirrus CI for Windows Builds

### DIFF
--- a/.ci/node6/Dockerfile.windows
+++ b/.ci/node6/Dockerfile.windows
@@ -1,0 +1,15 @@
+FROM microsoft/windowsservercore:1709
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 6.12.3
+
+RUN netsh interface ipv4 set subinterface 'vEthernet (Ethernet)' mtu=1460 store=persistent
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+SHELL ["cmd", "/S", "/C"]
+
+RUN setx /m PATH "%PATH%;C:\nodejs"

--- a/.ci/node7/Dockerfile.windows
+++ b/.ci/node7/Dockerfile.windows
@@ -1,0 +1,15 @@
+FROM microsoft/windowsservercore:1709
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 7.10.1
+
+RUN netsh interface ipv4 set subinterface 'vEthernet (Ethernet)' mtu=1460 store=persistent
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+SHELL ["cmd", "/S", "/C"]
+
+RUN setx /m PATH "%PATH%;C:\nodejs"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+environement:
+  DISPLAY: :99.0
+
+node6_task:
+  windows_container:
+    dockerfile: .ci/node6/Dockerfile.windows
+  install_script: npm install
+  test_script: npm run unit-node6
+
+node7_task:
+  windows_container:
+    dockerfile: .ci/node7/Dockerfile.windows
+  install_script: npm install
+  lint_script: npm run lint
+  coverage_script: npm run coverage
+  test_doclint_script: npm run test-doclint


### PR DESCRIPTION
Cirrus CI recently added support for Windows Docker containers. This change configures Cirrus CI so Puppeteer CI builds for Windows platform are executed in a controlled dockerized environment. 

Cirrus CI has a slightly faster build start time than the current CI thanks to light Docker containers. Build times itself are also comparable with the current VM-based CI. Another advantage could be in future to unify CI builds for Linux and Windows platforms since Cirrus CI supports both of them. 

Here is [a Cirrus CI build for this change](https://cirrus-ci.com/build/5645256259272704): 

![image](https://user-images.githubusercontent.com/989066/37299298-47cf6818-25f9-11e8-9728-78bf0c3f35aa.png)

I was testing Windows Docker support on this repository and decided to share the results. Feel free to close the PR if not interested in a better CI. Didn't want to waste my work 😅

In case you will merge the PR. Don't forget to [install Cirrus CI application from Github Marketplace](https://github.com/apps/cirrus-ci) as described in [Quick Start guide](https://cirrus-ci.org/guide/quick-start/).


