### PR TITLE
Use the save Node versions in Travis and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ build: off
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
-  - if "%nodejs_version%" == "7" (
+  - if "%nodejs_version%" == "7.10.1" (
       npm run lint &&
       npm run coverage  &&
       npm run test-doclint

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "7"
+    - nodejs_version: "6.12.3"
+    - nodejs_version: "7.10.1"
 
 build: off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ script:
   - 'if [ "$NODE6" = "true" ]; then npm run unit-node6; fi'
 jobs:
   include:
-    - node_js: "7.6.0"
+    - node_js: "7.10.1"
       env: NODE7=true
-    - node_js: "6.4.0"
+    - node_js: "6.12.3"
       env: NODE6=true
 before_deploy: "npm run apply-next-version"
 deploy:


### PR DESCRIPTION
AppVeyour was configured to use the latest versions of Node for major releases. To make builds more reproducible I've changed both Travis and AppVeyor to use the same fixed versions of Node 6 and Node 7 that AppVeyor is using at the moment.