### PR TITLE
Cirrus CI

### DIFF
--- a/.ci/node6/Dockerfile.linux
+++ b/.ci/node6/Dockerfile.linux
@@ -1,0 +1,9 @@
+FROM node:6.12.3
+
+RUN apt-get update && \
+    apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
+      libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+      libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+      libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
+      libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \
+    rm -rf /var/lib/apt/lists/*

--- a/.ci/node6/Dockerfile.windows
+++ b/.ci/node6/Dockerfile.windows
@@ -1,0 +1,15 @@
+FROM microsoft/windowsservercore:1709
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 6.12.3
+
+RUN netsh interface ipv4 set subinterface 'vEthernet (Ethernet)' mtu=1460 store=persistent
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+SHELL ["cmd", "/S", "/C"]
+
+RUN setx /m PATH "%PATH%;C:\nodejs"

--- a/.ci/node7/Dockerfile.linux
+++ b/.ci/node7/Dockerfile.linux
@@ -1,0 +1,9 @@
+FROM node:7.10.1
+
+RUN apt-get update && \
+    apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
+      libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+      libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+      libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
+      libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \
+    rm -rf /var/lib/apt/lists/*

--- a/.ci/node7/Dockerfile.windows
+++ b/.ci/node7/Dockerfile.windows
@@ -1,0 +1,15 @@
+FROM microsoft/windowsservercore:1709
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 7.10.1
+
+RUN netsh interface ipv4 set subinterface 'vEthernet (Ethernet)' mtu=1460 store=persistent
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+SHELL ["cmd", "/S", "/C"]
+
+RUN setx /m PATH "%PATH%;C:\nodejs"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,28 @@
+env:
+  DISPLAY: :99.0
+
+task:
+  matrix:
+    - name: node6 (windows)
+      windows_container:
+        dockerfile: .ci/node6/Dockerfile.windows
+    - name: node6 (linux)
+      container:
+        dockerfile: .ci/node6/Dockerfile.linux
+      xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
+  install_script: npm install --unsafe-perm
+  test_script: npm run unit-node6
+
+task:
+  matrix:
+    - name: node7 (windows)
+      windows_container:
+        dockerfile: .ci/node7/Dockerfile.windows
+    - name: node7 (linux)
+      container:
+        dockerfile: .ci/node7/Dockerfile.linux
+      xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
+  install_script: npm install --unsafe-perm
+  lint_script: npm run lint
+  coverage_script: npm run coverage
+  test_doclint_script: npm run test-doclint

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Puppeteer
 
 <!-- [START badges] -->
-[![Linux Build Status](https://img.shields.io/travis/GoogleChrome/puppeteer/master.svg)](https://travis-ci.org/GoogleChrome/puppeteer) [![Windows Build Status](https://img.shields.io/appveyor/ci/aslushnikov/puppeteer/master.svg?logo=appveyor)](https://ci.appveyor.com/project/aslushnikov/puppeteer/branch/master) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
+[![Linux Build Status](https://img.shields.io/travis/GoogleChrome/puppeteer/master.svg)](https://travis-ci.org/GoogleChrome/puppeteer) [![Windows Build Status](https://img.shields.io/appveyor/ci/aslushnikov/puppeteer/master.svg?logo=appveyor)](https://ci.appveyor.com/project/aslushnikov/puppeteer/branch/master) [![Build Status](https://api.cirrus-ci.com/github/GoogleChrome/puppeteer.svg)](https://cirrus-ci.com/github/GoogleChrome/puppeteer) [![NPM puppeteer package](https://img.shields.io/npm/v/puppeteer.svg)](https://npmjs.org/package/puppeteer)
 <!-- [END badges] -->
 
 <img src="https://user-images.githubusercontent.com/10379601/29446482-04f7036a-841f-11e7-9872-91d1fc2ea683.png" height="200" align="right">


### PR DESCRIPTION
As opposite to #2178, this change configures Cirrus CI to run Puppeteer in both Windows and Linux containers.

Here is a link to a [corresponding Cirrus CI build](https://cirrus-ci.com/build/5079208896233472):

![image](https://user-images.githubusercontent.com/989066/37307247-ab65cc3e-2610-11e8-8c6f-d05abcdfa310.png)

As you can see there are 4 auto-generate Docker Builder tasks to build custom Linux and Windows Docker containers. And 4 tasks to actually run tests in the cached containers. If interested read more about Cirrus CI's container builds in [this blog post](https://medium.com/cirruslabs/introducing-container-builder-for-cirrus-ci-80b9234f007).
