### PR TITLE
feat: roll chromium to r543305

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "538022"
+    "chromium_revision": "543305"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",

--- a/test/test.js
+++ b/test/test.js
@@ -2068,6 +2068,14 @@ describe('Page', function() {
       const element = await page.$('div');
       expect(await element.boundingBox()).toBe(null);
     });
+    it('should force a layout', async({page, server}) => {
+      await page.setViewport({ width: 500, height: 500 });
+      await page.setContent('<div style="width: 100px; height: 100px">hello</div>');
+      const elementHandle = await page.$('div');
+      await page.evaluate(element => element.style.height = '200px', elementHandle);
+      const box = await elementHandle.boundingBox();
+      expect(box).toEqual({ x: 8, y: 8, width: 100, height: 200 });
+    });
   });
 
   describe('ElementHandle.contentFrame', function() {


### PR DESCRIPTION
This roll contains a [fix](https://chromium-review.googlesource.com/c/chromium/src/+/963302) for boundingBox not forcing a layout, and the patch contains a corresponding test.