### PR TITLE
Proposal: flexible chromium revisions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -269,6 +269,7 @@ Puppeteer looks for certain [environment variables](https://en.wikipedia.org/wik
 - `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` - defines HTTP proxy settings that are used to download and run Chromium.
 - `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` - do not download bundled Chromium during installation step.
 - `PUPPETEER_DOWNLOAD_HOST` - overwrite host part of URL that is used to download Chromium
+- `PUPPETEER_CHROMIUM_REVISION` - specify a certain version of chrome you'd like puppeteer to use during the installation step.
 
 ### class: Puppeteer
 

--- a/install.js
+++ b/install.js
@@ -30,7 +30,7 @@ const downloadHost = process.env.PUPPETEER_DOWNLOAD_HOST || process.env.npm_conf
 const puppeteer = require('./index');
 const browserFetcher = puppeteer.createBrowserFetcher({ host: downloadHost });
 
-const revision = require('./package.json').puppeteer.chromium_revision;
+const revision = process.env.PUPPETEER_CHROMIUM_REVISION || require('./package.json').puppeteer.chromium_revision;
 const revisionInfo = browserFetcher.revisionInfo(revision);
 
 // Do nothing if the revision is already downloaded.


### PR DESCRIPTION
Often we want to test changes on new chromium versions. At the moment we would have to switch from the default downloader to specifying our own executable and downloading that etc. 

Exposing this to an environment variable would make it easy to test against different chromium versions in CI environments.