### PR TITLE
feat(elementHandle): add boxModel method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2206,7 +2206,7 @@ This method returns the bounding box of the element (relative to the main frame)
   - width <[number]> Element's width.
   - height <[number]> Element's height.
 
-This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of quad vertices, x immediately followed by y for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details
+This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of quad vertices, x immediately followed by y for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details.
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2199,14 +2199,14 @@ This method returns the bounding box of the element (relative to the main frame)
 
 #### elementHandle.boxModel()
 - returns: <[Promise]<?[Object]>>
-  - content <[Array]<[number]>> Content box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
-  - padding <[Array]<[number]>> Padding box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
-  - border <[Array]<[number]>> Border box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
-  - margin <[Array]<[number]>> Margin box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
+  - content <[Array]<[Object]>> Content box, represented as an array of {x, y} points.
+  - padding <[Array]<[Object]>> Padding box, represented as an array of {x, y} points.
+  - border <[Array]<[Object]>> Border box, represented as an array of {x, y} points.
+  - margin <[Array]<[Object]>> Margin box, represented as an array of {x, y} points.
   - width <[number]> Element's width.
   - height <[number]> Element's height.
 
-This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of quad vertices, x immediately followed by y for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details.
+This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of quad objects, {x, y} for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details.
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2206,7 +2206,7 @@ This method returns the bounding box of the element (relative to the main frame)
   - width <[number]> Element's width.
   - height <[number]> Element's height.
 
-This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as An array of quad vertices, x immediately followed by y for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details
+This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of quad vertices, x immediately followed by y for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -186,6 +186,7 @@
   * [elementHandle.$x(expression)](#elementhandlexexpression)
   * [elementHandle.asElement()](#elementhandleaselement)
   * [elementHandle.boundingBox()](#elementhandleboundingbox)
+  * [elementHandle.boxModel()](#elementhandleboxmodel)
   * [elementHandle.click([options])](#elementhandleclickoptions)
   * [elementHandle.contentFrame()](#elementhandlecontentframe)
   * [elementHandle.dispose()](#elementhandledispose)
@@ -2195,6 +2196,17 @@ The method evaluates the XPath expression relative to the elementHandle. If ther
   - height <[number]> the height of the element in pixels.
 
 This method returns the bounding box of the element (relative to the main frame), or `null` if the element is not visible.
+
+#### elementHandle.boxModel()
+- returns: <[Promise]<?[Object]>>
+  - content <[Array]<[number]>> Content box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
+  - padding <[Array]<[number]>> Padding box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
+  - border <[Array]<[number]>> Border box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
+  - margin <[Array]<[number]>> Margin box, represented as a [quad](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad).
+  - width <[number]> Element's width.
+  - height <[number]> Element's height.
+
+This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as An array of quad vertices, x immediately followed by y for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2206,7 +2206,7 @@ This method returns the bounding box of the element (relative to the main frame)
   - width <[number]> Element's width.
   - height <[number]> Element's height.
 
-This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of quad objects, {x, y} for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details.
+This method returns boxes of the element, or `null` if the element is not visible. Boxes are represented as an array of objects, {x, y} for each point, points clock-wise. See [getBoxModel](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getBoxModel) for more details.
 
 #### elementHandle.click([options])
 - `options` <[Object]>

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -79,6 +79,15 @@ class ElementHandle extends JSHandle {
     };
   }
 
+  /**
+   * @return {!Promise<?{model: object}>}
+   */
+  _getBoxModel() {
+    return this._client.send('DOM.getBoxModel', {
+      objectId: this._remoteObject.objectId
+    }).catch(error => debugError(error));
+  }
+
   async hover() {
     const {x, y} = await this._visibleCenter();
     await this._page.mouse.move(x, y);
@@ -133,9 +142,7 @@ class ElementHandle extends JSHandle {
    * @return {!Promise<?{x: number, y: number, width: number, height: number}>}
    */
   async boundingBox() {
-    const result = await this._client.send('DOM.getBoxModel', {
-      objectId: this._remoteObject.objectId
-    }).catch(error => void debugError(error));
+    const result = await this._getBoxModel();
 
     if (!result)
       return null;
@@ -153,9 +160,7 @@ class ElementHandle extends JSHandle {
    * @return {!Promise<?object>}
    */
   async boxModel() {
-    const result = await this._client.send('DOM.getBoxModel', {
-      objectId: this._remoteObject.objectId
-    }).catch(error => debugError(error));
+    const result = await this._getBoxModel();
 
     if (!result)
       return null;

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -165,7 +165,19 @@ class ElementHandle extends JSHandle {
     if (!result)
       return null;
 
-    return result.model;
+    return Object.keys(result.model).reduce((prev, key) => {
+      if (['width', 'height'].includes(key))
+        return Object.assign({}, prev, {[key]: result.model[key]});
+
+      const quad = result.model[key];
+      return Object.assign({}, prev,
+          {[key]: [
+            {x: quad[0], y: quad[1]},
+            {x: quad[2], y: quad[3]},
+            {x: quad[4], y: quad[5]},
+            {x: quad[6], y: quad[7]}
+          ]});
+    }, {});
   }
 
   /**

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -88,6 +88,19 @@ class ElementHandle extends JSHandle {
     }).catch(error => debugError(error));
   }
 
+  /**
+   * @param {!Array<number>} quad
+   * @return {!Array<object>}
+   */
+  _fromProtocolQuad(quad) {
+    return [
+      {x: quad[0], y: quad[1]},
+      {x: quad[2], y: quad[3]},
+      {x: quad[4], y: quad[5]},
+      {x: quad[6], y: quad[7]}
+    ];
+  }
+
   async hover() {
     const {x, y} = await this._visibleCenter();
     await this._page.mouse.move(x, y);
@@ -165,19 +178,15 @@ class ElementHandle extends JSHandle {
     if (!result)
       return null;
 
-    return Object.keys(result.model).reduce((prev, key) => {
-      if (['width', 'height'].includes(key))
-        return Object.assign({}, prev, {[key]: result.model[key]});
-
-      const quad = result.model[key];
-      return Object.assign({}, prev,
-          {[key]: [
-            {x: quad[0], y: quad[1]},
-            {x: quad[2], y: quad[3]},
-            {x: quad[4], y: quad[5]},
-            {x: quad[6], y: quad[7]}
-          ]});
-    }, {});
+    const {content, padding, border, margin, width, height} = result.model;
+    return {
+      content: this._fromProtocolQuad(content),
+      padding: this._fromProtocolQuad(padding),
+      border: this._fromProtocolQuad(border),
+      margin: this._fromProtocolQuad(margin),
+      width,
+      height
+    };
   }
 
   /**

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -150,6 +150,20 @@ class ElementHandle extends JSHandle {
   }
 
   /**
+   * @return {!Promise<?object>}
+   */
+  async boxModel() {
+    const result = await this._client.send('DOM.getBoxModel', {
+      objectId: this._remoteObject.objectId
+    }).catch(error => debugError(error));
+
+    if (!result)
+      return null;
+
+    return result.model;
+  }
+
+  /**
    * @return {!Promise<?{x: number, y: number, width: number, height: number}>}
    */
   async _assertBoundingBox() {

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -59,10 +59,10 @@ module.exports.addTests = function({testRunner, expect}) {
       const elementHandle = await page.$('div');
       const box = await elementHandle.boxModel();
 
-      expect(box.content).toEqual([10, 10, 110, 10, 110, 110, 10, 110]);
-      expect(box.padding).toEqual([6, 6, 114, 6, 114, 114, 6, 114]);
-      expect(box.border).toEqual([5, 5, 115, 5, 115, 115, 5, 115]);
-      expect(box.margin).toEqual([0, 0, 120, 0, 120, 120, 0, 120]);
+      expect(box.content).toEqual([{x: 10, y: 10}, {x: 110, y: 10}, {x: 110, y: 110}, {x: 10, y: 110}]);
+      expect(box.padding).toEqual([{x: 6, y: 6}, {x: 114, y: 6}, {x: 114, y: 114}, {x: 6, y: 114}]);
+      expect(box.border).toEqual([{x: 5, y: 5}, {x: 115, y: 5}, {x: 115, y: 115}, {x: 5, y: 115}]);
+      expect(box.margin).toEqual([{x: 0, y: 0}, {x: 120, y: 0}, {x: 120, y: 120}, {x: 0, y: 120}]);
       expect(box.height).toBe(110);
       expect(box.width).toBe(110);
     });

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -52,6 +52,28 @@ module.exports.addTests = function({testRunner, expect}) {
     });
   });
 
+  describe('ElementHandle.boxModel', function() {
+    it('should work', async({page, server}) => {
+      await page.setViewport({width: 500, height: 500});
+      await page.setContent('<div style="width: 100px; height: 100px; margin: 5px; padding: 4px; border: 1px solid black;top: 0; left: 0; position: absolute;"></div>');
+      const elementHandle = await page.$('div');
+      const box = await elementHandle.boxModel();
+
+      expect(box.content).toEqual([10, 10, 110, 10, 110, 110, 10, 110]);
+      expect(box.padding).toEqual([6, 6, 114, 6, 114, 114, 6, 114]);
+      expect(box.border).toEqual([5, 5, 115, 5, 115, 115, 5, 115]);
+      expect(box.margin).toEqual([0, 0, 120, 0, 120, 120, 0, 120]);
+      expect(box.height).toBe(110);
+      expect(box.width).toBe(110);
+    });
+
+    it('should return null for invisible elements', async({page, server}) => {
+      await page.setContent('<div style="display:none">hi</div>');
+      const element = await page.$('div');
+      expect(await element.boxModel()).toBe(null);
+    });
+  });
+
   describe('ElementHandle.contentFrame', function() {
     it('should work', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -54,17 +54,22 @@ module.exports.addTests = function({testRunner, expect}) {
 
   describe('ElementHandle.boxModel', function() {
     it('should work', async({page, server}) => {
-      await page.setViewport({width: 500, height: 500});
-      await page.setContent('<div style="width: 100px; height: 100px; margin: 5px; padding: 4px; border: 1px solid black;top: 0; left: 0; position: absolute;"></div>');
-      const elementHandle = await page.$('div');
-      const box = await elementHandle.boxModel();
+      const leftTop = {x: 28, y: 260};
+      const rightTop = {x: 292, y: 260};
+      const rightBottom = {x: 292, y: 278};
+      const leftBottom = {x: 28, y: 278};
 
-      expect(box.content).toEqual([{x: 10, y: 10}, {x: 110, y: 10}, {x: 110, y: 110}, {x: 10, y: 110}]);
-      expect(box.padding).toEqual([{x: 6, y: 6}, {x: 114, y: 6}, {x: 114, y: 114}, {x: 6, y: 114}]);
-      expect(box.border).toEqual([{x: 5, y: 5}, {x: 115, y: 5}, {x: 115, y: 115}, {x: 5, y: 115}]);
-      expect(box.margin).toEqual([{x: 0, y: 0}, {x: 120, y: 0}, {x: 120, y: 120}, {x: 0, y: 120}]);
-      expect(box.height).toBe(110);
-      expect(box.width).toBe(110);
+      await page.setViewport({width: 500, height: 500});
+      await page.goto(server.PREFIX + '/frames/nested-frames.html');
+      const nestedFrame = page.frames()[1].childFrames()[1];
+      const elementHandle = await nestedFrame.$('div');
+      const box = await elementHandle.boxModel();
+      expect(box.content).toEqual([leftTop, rightTop, rightBottom, leftBottom]);
+      expect(box.padding).toEqual([leftTop, rightTop, rightBottom, leftBottom]);
+      expect(box.border).toEqual([leftTop, rightTop, rightBottom, leftBottom]);
+      expect(box.margin).toEqual([leftTop, rightTop, rightBottom, leftBottom]);
+      expect(box.height).toBe(18);
+      expect(box.width).toBe(264);
     });
 
     it('should return null for invisible elements', async({page, server}) => {


### PR DESCRIPTION
Fixes #1357 - expose element's boxModel. 

I wasn't sure how exactly do we want to represent `boxmodel` data, so I just represented it "as is": an object containing [quads](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-Quad), exactly as it is represented in [chromedevtools](https://chromedevtools.github.io/devtools-protocol/tot/DOM#type-BoxModel)