### PR TITLE
chore: fixate TypeScript to ~2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.2.0",
     "text-diff": "^1.0.1",
-    "typescript": "^2.6.0-rc"
+    "typescript": "~2.7.0"
   }
 }


### PR DESCRIPTION
This patch fixates TypeScript release to 2.7.X.
For some reason, tsc 2.8.X fails to lint our types.

References #2279