### PR TITLE
feat(Chromium): roll Chromium to r546920

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "543305"
+    "chromium_revision": "546920"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll includes the following important CLs:
- https://crrev.com/545955 - DevTools: Update page scale immediately in InputHandler
- https://crrev.com/544446 - Make HeadlessWebContentsImpl::Close wait for the renderer to go
- https://crrev.com/546865 - DevTools(Headless): close WebContents when closed via
  'window.close'
- https://crrev.com/546685 - Headless: Add support for the --remote-debugging-pipe flag

This should drastically reduce flakiness for pptr input events.