### PR TITLE
fix(Page): teach Page.waitFor* function to work with strict CSP

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -810,7 +810,11 @@ class WaitTask {
     let success = null;
     let error = null;
     try {
-      success = await (await this._frame.executionContext()).evaluateHandle(waitForPredicatePageFunction, this._predicateBody, this._polling, this._timeout, ...this._args);
+      // Do surgery over evaluation string to insert predicate body and make WaitTask work with strict CSP.
+      let evalFunctionText = waitForPredicatePageFunction.toString();
+      evalFunctionText = evalFunctionText.replace('// _PUPPETEER_PREDICATE_BODY_', this._predicateBody);
+      const evalFunction = eval('var x = ' + evalFunctionText + ';x');
+      success = await (await this._frame.executionContext()).evaluateHandle(evalFunction, this._polling, this._timeout, ...this._args);
     } catch (e) {
       error = e;
     }
@@ -858,8 +862,10 @@ class WaitTask {
  * @param {number} timeout
  * @return {!Promise<*>}
  */
-async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...args) {
-  const predicate = new Function('...args', predicateBody);
+async function waitForPredicatePageFunction(polling, timeout, ...args) {
+  const predicate = function (...args) {
+    // _PUPPETEER_PREDICATE_BODY_
+  };
   let timedOut = false;
   setTimeout(() => timedOut = true, timeout);
   if (polling === 'raf')

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -857,13 +857,12 @@ class WaitTask {
 }
 
 /**
- * @param {string} predicateBody
  * @param {string} polling
  * @param {number} timeout
  * @return {!Promise<*>}
  */
 async function waitForPredicatePageFunction(polling, timeout, ...args) {
-  const predicate = function (...args) {
+  const predicate = function(...args) {
     // _PUPPETEER_PREDICATE_BODY_
   };
   let timedOut = false;

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -110,6 +110,13 @@ module.exports.addTests = function({testRunner, expect}) {
       await page.evaluate(() => window.__FOO = 'hit');
       await watchdog;
     });
+    it('should work with strict CSP policy', async({page, server}) => {
+      server.setCSP('/empty.html', 'script-src ' + server.PREFIX);
+      await page.goto(server.EMPTY_PAGE);
+      const watchdog = page.waitForFunction(() => window.__FOO === 'hit', {polling: 'raf'});
+      await page.evaluate(() => window.__FOO = 'hit');
+      await watchdog;
+    });
     it('should throw on bad polling value', async({page, server}) => {
       let error = null;
       try {

--- a/test/server/SimpleServer.js
+++ b/test/server/SimpleServer.js
@@ -78,6 +78,8 @@ class SimpleServer {
     this._routes = new Map();
     /** @type {!Map<string, !{username:string, password:string}>} */
     this._auths = new Map();
+    /** @type {!Map<string, string>} */
+    this._csp = new Map();
     /** @type {!Map<string, !Promise>} */
     this._requestSubscribers = new Map();
   }
@@ -107,6 +109,14 @@ class SimpleServer {
    */
   setAuth(path, username, password) {
     this._auths.set(path, {username, password});
+  }
+
+  /**
+   * @param {string} path
+   * @param {string} csp
+   */
+  setCSP(path, csp) {
+    this._csp.set(path, csp);
   }
 
   async stop() {
@@ -158,6 +168,7 @@ class SimpleServer {
   reset() {
     this._routes.clear();
     this._auths.clear();
+    this._csp.clear();
     const error = new Error('Static Server has been reset');
     for (const subscriber of this._requestSubscribers.values())
       subscriber[rejectSymbol].call(null, error);
@@ -214,6 +225,8 @@ class SimpleServer {
     } else {
       response.setHeader('Cache-Control', 'no-cache, no-store');
     }
+    if (this._csp.has(pathName))
+      response.setHeader('Content-Security-Policy', this._csp.get(pathName));
 
     fs.readFile(filePath, function(err, data) {
       if (err) {


### PR DESCRIPTION
This patch removes function creation from WaitTask, making the
following methods work with strict CSP policy:
- frame.waitForFunction
- frame.waitForSelector
- frame.waitForXPath

Page counterparts of the methods work as well.

References #1229.