### PR TITLE
feat: add target.targetId() method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -236,6 +236,7 @@
 - [class: Target](#class-target)
   * [target.createCDPSession()](#targetcreatecdpsession)
   * [target.page()](#targetpage)
+  * [target.targetId()](#targettargetid)
   * [target.type()](#targettype)
   * [target.url()](#targeturl)
 - [class: CDPSession](#class-cdpsession)
@@ -2545,6 +2546,9 @@ Creates a Chrome Devtools Protocol session attached to the target.
 - returns: <[Promise]<?[Page]>>
 
 If the target is not of type `"page"`, returns `null`.
+
+#### target.targetId()
+- returns: <[string]>
 
 #### target.type()
 - returns: <[string]>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -706,7 +706,7 @@ class Page extends EventEmitter {
    * @return {!Promise<!Buffer>}
    */
   async _screenshotTask(format, options) {
-    await this._client.send('Target.activateTarget', {targetId: this._target._targetId});
+    await this._client.send('Target.activateTarget', {targetId: this._target.targetId()});
     let clip = options.clip ? Object.assign({}, options['clip']) : undefined;
     if (clip)
       clip.scale = 1;
@@ -801,7 +801,7 @@ class Page extends EventEmitter {
 
   async close() {
     console.assert(!!this._client._connection, 'Protocol error: Connection closed. Most likely the page has been closed.');
-    await this._client._connection.send('Target.closeTarget', { targetId: this._target._targetId });
+    await this._client._connection.send('Target.closeTarget', { targetId: this._target.targetId() });
     await this._target._isClosedPromise;
   }
 

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -11,7 +11,6 @@ class Target {
    */
   constructor(targetInfo, sessionFactory, ignoreHTTPSErrors, appMode, screenshotTaskQueue) {
     this._targetInfo = targetInfo;
-    this._targetId = targetInfo.targetId;
     this._sessionFactory = sessionFactory;
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
     this._appMode = appMode;
@@ -58,6 +57,13 @@ class Target {
     if (type === 'page' || type === 'service_worker' || type === 'browser')
       return type;
     return 'other';
+  }
+
+  /**
+   * @return {string}
+   */
+  targetId() {
+    return this._targetInfo.targetId;
   }
 
   /**


### PR DESCRIPTION
This is the last piece that I needed to be able to support the use case from #1978

With this change, I can create 'incognito pages' using the (public) puppeteer api. [gist](https://gist.github.com/haroldhues/645a7d85d6686dab7f3fe81492d1e608)

There are also `TargetInfo`'s `title` and `attached` properties that aren't exposed. I considered exposing those as well, but I didn't have a use case for them, so I didn't. However, I am happy to do that as well if maintainers think that is a good idea?

PS: I have been unable to get the all the tests to pass on Windows. Is that a known issue?