### PR TITLE
PR to ask question about this fork and startScreencast is not a function error

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,7 @@
     + [event: 'requestfailed'](#event-requestfailed)
     + [event: 'requestfinished'](#event-requestfinished)
     + [event: 'response'](#event-response)
+    + [event: 'screencastframe'](#event-screencastframe)
     + [page.$(selector)](#pageselector)
     + [page.$$(selector)](#pageselector)
     + [page.addScriptTag(url)](#pageaddscripttagurl)
@@ -55,6 +56,7 @@
     + [page.plainText()](#pageplaintext)
     + [page.press(key[, options])](#pagepresskey-options)
     + [page.reload(options)](#pagereloadoptions)
+    + [page.screencastFrameAck(sessionId)](#pagescreencastframeacksessionid)
     + [page.screenshot([options])](#pagescreenshotoptions)
     + [page.setContent(html)](#pagesetcontenthtml)
     + [page.setCookie(...cookies)](#pagesetcookiecookies)
@@ -63,6 +65,8 @@
     + [page.setRequestInterceptionEnabled(value)](#pagesetrequestinterceptionenabledvalue)
     + [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
     + [page.setViewport(viewport)](#pagesetviewportviewport)
+    + [page.startScreencast([options])](#pagestartscreencastoptions)
+    + [page.stopScreencast()](#pagestopscreencast)
     + [page.title()](#pagetitle)
     + [page.tracing](#pagetracing)
     + [page.type(text, options)](#pagetypetext-options)
@@ -294,6 +298,21 @@ Emitted when a request finishes successfully.
 
 #### event: 'response'
 - <[Response]>
+
+Emitted when a [response] is received.
+
+#### event: 'screencastframe'
+- <[object]>
+    - `data` <[string]> Base64 encoded frame data.
+    - `metadata` <[object]>
+        - `offsetTop` <[number]>
+        - `pageScaleFactor` <[number]>
+        - `deviceWidth` <[number]>
+        - `deviceHeight` <[number]>
+        - `scrollOffsetX` <[number]>
+        - `scrollOffsetY` <[number]>
+        - `timestamp` <[number]>
+    - `sessionId` <[number]> The ID of the session this frame is from.
 
 Emitted when a [response] is received.
 
@@ -661,6 +680,10 @@ Shortcut for [`keyboard.down`](#keyboarddownkey-options) and [`keyboard.up`](#ke
   - `networkIdleTimeout` <[number]> A timeout to wait before completing navigation. Takes effect only with `waitUntil: 'networkidle'` parameter.
 - returns: <[Promise]<[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
+#### page.screencastFrameAck(sessionId)
+- `sessionId` <[number]> The sessionId of the frame that is being acknowledge. Provided in the `screencastframe` event.
+- returns: <[Promise]>
+
 #### page.screenshot([options])
 - `options` <[Object]> Options object which might have the following properties:
     - `path` <[string]> The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the image won't be saved to the disk.
@@ -747,6 +770,18 @@ puppeteer.launch().then(async browser => {
 > **NOTE** in certain cases, setting viewport will reload the page in order to set the `isMobile` or `hasTouch` properties.
 
 In the case of multiple pages in a single browser, each page can have its own viewport size.
+
+#### page.startScreencast([options])
+- `options` <[Object]> Options object which might have the following properties:
+    - `format` <[string]> Specify screencast frame format, could be either `jpeg` or `png`. Defaults to 'png'.
+    - `quality` <[number]> The quality of the image, between 0-100. Not applicable to `png` images.
+    - `maxWidth` <[number]> The maximum width of the screencast frame.
+    - `maxHeight` <[number]> The maximum height of the screencast frame.
+    - `everyNthFrame` <[number]> Defines which frames to send.
+- returns: <[Promise]>
+
+#### page.stopScreencast()
+- returns: <[Promise]>
 
 #### page.title()
 - returns: <[Promise]<[string]>> Returns page's title.

--- a/examples/screencast.js
+++ b/examples/screencast.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const puppeteer = require('../index.js');
+const fs = require('fs');
+
+(async() => {
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+await page.goto('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+
+let frameCount = 0;
+page.on('screencastframe', async frame => {
+  await page.screencastFrameAck(frame.sessionId);
+
+  fs.writeFileSync('frame' + frameCount + '.jpg', frame.data, 'base64');
+  frameCount++;
+
+  if (frameCount > 25)
+    await browser.close();
+});
+
+await page.startScreencast({format: 'jpeg', everyNthFrame: 1});
+
+})();

--- a/examples/screencast.js
+++ b/examples/screencast.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-const puppeteer = require('../index.js');
+const puppeteer = require('puppeteer');
 const fs = require('fs');
 
 (async() => {
@@ -28,9 +28,6 @@ await page.goto('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 let frameCount = 0;
 page.on('screencastframe', async frame => {
   await page.screencastFrameAck(frame.sessionId);
-
-  console.log(Object.keys(frame.metadata));
-  console.log(frame.metadata);
 
   fs.writeFileSync('frame' + frameCount + '.jpg', frame.data, 'base64');
   frameCount++;

--- a/examples/screencast.js
+++ b/examples/screencast.js
@@ -29,6 +29,9 @@ let frameCount = 0;
 page.on('screencastframe', async frame => {
   await page.screencastFrameAck(frame.sessionId);
 
+  console.log(Object.keys(frame.metadata));
+  console.log(frame.metadata);
+
   fs.writeFileSync('frame' + frameCount + '.jpg', frame.data, 'base64');
   frameCount++;
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -85,6 +85,7 @@ class Page extends EventEmitter {
     client.on('Runtime.exceptionThrown', exception => this._handleException(exception.exceptionDetails));
     client.on('Security.certificateError', event => this._onCertificateError(event));
     client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
+    client.on('Page.screencastFrame', event => this.emit(Page.Events.ScreencastFrame, event));
   }
 
   _onTargetCrashed() {
@@ -479,6 +480,54 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
+   * @return {!Promise}
+   */
+  async startScreencast(options = {}) {
+    if (options.format)
+      console.assert(options.format === 'png' || options.format === 'jpeg', 'Unknown options.format value: ' + options.format);
+
+    if (options.quality) {
+      console.assert(screenshotType === 'jpeg', 'options.quality is unsupported for the ' + screenshotType + ' screenshots');
+      console.assert(typeof options.quality === 'number', 'Expected options.quality to be a number but found ' + (typeof options.quality));
+      console.assert(Number.isInteger(options.quality), 'Expected options.quality to be an integer');
+      console.assert(options.quality >= 0 && options.quality <= 100, 'Expected options.quality to be between 0 and 100 (inclusive), got ' + options.quality);
+    }
+    if (options.maxWidth) {
+      console.assert(typeof options.maxWidth === 'number', 'Expected options.maxWidth to be a number but found ' + (typeof options.maxWidth));
+      console.assert(Number.isInteger(options.maxWidth), 'Expected options.maxWidth to be an integer');
+      console.assert(options.maxHeight >= 0, 'Expected options.maxWidth to be greater than 0, got ' + options.maxWidth);
+    }
+    if (options.maxHeight) {
+      console.assert(typeof options.maxHeight === 'number', 'Expected options.maxHeight to be a number but found ' + (typeof options.maxHeight));
+      console.assert(Number.isInteger(options.maxHeight), 'Expected options.maxHeight to be an integer');
+      console.assert(options.maxHeight >= 0, 'Expected options.maxHeight to be greater than 0, got ' + options.maxHeight);
+    }
+    if (options.everyNthFrame) {
+      console.assert(typeof options.everyNthFrame === 'number', 'Expected options.everyNthFrame to be a number but found ' + (typeof options.everyNthFrame));
+      console.assert(Number.isInteger(options.everyNthFrame), 'Expected options.everyNthFrame to be an integer');
+      console.assert(options.everyNthFrame >= 0, 'Expected options.everyNthFrame to be greater than 0, got ' + options.everyNthFrame);
+    }
+    await this._client.send('Page.startScreencast', options);
+  }
+
+  /**
+   * @param {!string} sessionId
+   * @return {!Promise}
+   */
+  async screencastFrameAck(sessionId) {
+    console.assert(sessionId, 'Expected sessionId');
+    await this._client.send('Page.screencastFrameAck', { sessionId });
+  }
+
+  /**
+   * @return {!Promise}
+   */
+  async stopScreencast() {
+    await this._client.send('Page.stopScreencast');
+  }
+
+  /**
+   * @param {!Object=} options
    * @return {!Promise<!Buffer>}
    */
   async screenshot(options = {}) {
@@ -792,6 +841,7 @@ Page.Events = {
   FrameDetached: 'framedetached',
   FrameNavigated: 'framenavigated',
   Load: 'load',
+  ScreencastFrame: 'screencastframe'
 };
 
 /** @typedef {{width: number, height: number, deviceScaleFactor: number|undefined, isMobile: boolean|undefined, isLandscape: boolean, hasTouch: boolean|undefined}} */

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -511,7 +511,7 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {!string} sessionId
+   * @param {!number} sessionId
    * @return {!Promise}
    */
   async screencastFrameAck(sessionId) {


### PR DESCRIPTION
Hello @michaelshiel

I tried the screencast.js like following
```
~$ node screencast.js
(node:13449) UnhandledPromiseRejectionWarning: TypeError: page.startScreencast is not a function
    at /home/bitnami/screencast.js:39:12
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:118:7)
(node:13449) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:13449) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

```
But it did not worked, Can you help me please ?
Why startScreencast is not found ? I did cloned this version and did a node install