### PR TITLE
chore(types): upgrade to TypeScript 2.8.1

### DIFF
--- a/lib/Puppeteer.js
+++ b/lib/Puppeteer.js
@@ -17,7 +17,7 @@ const {helper} = require('./helper');
 const Launcher = require('./Launcher');
 const BrowserFetcher = require('./BrowserFetcher');
 
-class Puppeteer {
+module.exports = class {
   /**
    * @param {!Object=} options
    * @return {!Promise<!Puppeteer.Browser>}
@@ -55,7 +55,6 @@ class Puppeteer {
   static createBrowserFetcher(options) {
     return new BrowserFetcher(options);
   }
-}
+};
 
-module.exports = Puppeteer;
-helper.tracePublicAPI(Puppeteer);
+helper.tracePublicAPI(module.exports, 'Puppeteer');

--- a/lib/externs.d.ts
+++ b/lib/externs.d.ts
@@ -9,37 +9,40 @@ import {JSHandle as RealJSHandle, ExecutionContext as RealExecutionContext}  fro
 import * as RealElementHandle  from './ElementHandle.js';
 import { NetworkManager as RealNetworkManager, Request as RealRequest, Response as RealResponse } from './NetworkManager.js';
 import * as child_process from 'child_process';
-export as namespace Puppeteer;
+declare global {
+  module Puppeteer {
+    export class Connection extends RealConnection {}
+    export class CDPSession extends RealCDPSession {}
+    export class Mouse extends RealMouse {}
+    export class Keyboard extends RealKeyboard {}
+    export class Touchscreen extends RealTouchscreen {}
+    export class TaskQueue extends RealTaskQueue {}
+    export class Browser extends RealBrowser {}
+    export class Target extends RealTarget {}
+    export class Frame extends RealFrame {}
+    export class FrameManager extends RealFrameManager {}
+    export class NetworkManager extends RealNetworkManager {}
+    export class ElementHandle extends RealElementHandle {}
+    export class JSHandle extends RealJSHandle {}
+    export class ExecutionContext extends RealExecutionContext {}
+    export class Page extends RealPage { }
+    export class Response extends RealResponse { }
+    export class Request extends RealRequest { }
 
-export class Connection extends RealConnection {}
-export class CDPSession extends RealCDPSession {}
-export class Mouse extends RealMouse {}
-export class Keyboard extends RealKeyboard {}
-export class Touchscreen extends RealTouchscreen {}
-export class TaskQueue extends RealTaskQueue {}
-export class Browser extends RealBrowser {}
-export class Target extends RealTarget {}
-export class Frame extends RealFrame {}
-export class FrameManager extends RealFrameManager {}
-export class NetworkManager extends RealNetworkManager {}
-export class ElementHandle extends RealElementHandle {}
-export class JSHandle extends RealJSHandle {}
-export class ExecutionContext extends RealExecutionContext {}
-export class Page extends RealPage { }
-export class Response extends RealResponse { }
-export class Request extends RealRequest { }
+    export interface ConnectionTransport extends NodeJS.EventEmitter {
+      send(string);
+      close();
+    }
 
-export interface ConnectionTransport extends NodeJS.EventEmitter {
-  send(string);
-  close();
+    export interface TargetInfo {
+      type: string;
+      targetId: string;
+      title: string;
+      url: string;
+      attached: boolean;
+    }
+
+    export interface ChildProcess extends child_process.ChildProcess {}
+
+  }
 }
-
-export interface TargetInfo {
-  type: string;
-  targetId: string;
-  title: string;
-  url: string;
-  attached: boolean;
-}
-
-export interface ChildProcess extends child_process.ChildProcess {}

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -112,9 +112,10 @@ class Helper {
 
   /**
    * @param {!Object} classType
+   * @param {string=} exportedName
    */
-  static tracePublicAPI(classType) {
-    let className = classType.prototype.constructor.name;
+  static tracePublicAPI(classType, exportedName) {
+    let className = exportedName || classType.prototype.constructor.name;
     className = className.substring(0, 1).toLowerCase() + className.substring(1);
     const debug = require('debug')(`puppeteer:${className}`);
     if (!debug.enabled && !apiCoverage)

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -112,10 +112,10 @@ class Helper {
 
   /**
    * @param {!Object} classType
-   * @param {string=} exportedName
+   * @param {string=} publicName
    */
-  static tracePublicAPI(classType, exportedName) {
-    let className = exportedName || classType.prototype.constructor.name;
+  static tracePublicAPI(classType, publicName) {
+    let className = publicName || classType.prototype.constructor.name;
     className = className.substring(0, 1).toLowerCase() + className.substring(1);
     const debug = require('debug')(`puppeteer:${className}`);
     if (!debug.enabled && !apiCoverage)

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.2.0",
     "text-diff": "^1.0.1",
-    "typescript": "~2.7.0"
+    "typescript": "~2.8.1"
   }
 }

--- a/utils/doclint/check_public_api/JSBuilder.js
+++ b/utils/doclint/check_public_api/JSBuilder.js
@@ -19,7 +19,11 @@ const ESTreeWalker = require('../../ESTreeWalker');
 const Documentation = require('./Documentation');
 
 class JSOutline {
-  constructor(text) {
+  /**
+   * @param {string} text
+   * @param {string} name
+   */
+  constructor(text, name) {
     this.classes = [];
     /** @type {!Map<string, string>} */
     this.inheritance = new Map();
@@ -27,11 +31,12 @@ class JSOutline {
     this._eventsByClassName = new Map();
     this._currentClassName = null;
     this._currentClassMembers = [];
+    this._name = name;
 
     this._text = text;
     const ast = esprima.parseScript(this._text, {loc: true, range: true});
     const walker = new ESTreeWalker(node => {
-      if (node.type === 'ClassDeclaration')
+      if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression')
         this._onClassDeclaration(node);
       else if (node.type === 'MethodDefinition')
         this._onMethodDefinition(node);
@@ -46,6 +51,8 @@ class JSOutline {
   _onClassDeclaration(node) {
     this._flushClassIfNeeded();
     this._currentClassName = this._extractText(node.id);
+    if (!this._currentClassName)
+      this._currentClassName = this._name.substring(0, this._name.indexOf('.'));
     const superClass = this._extractText(node.superClass);
     if (superClass)
       this.inheritance.set(this._currentClassName, superClass);
@@ -179,7 +186,7 @@ module.exports = async function(sources) {
   const errors = [];
   const inheritance = new Map();
   for (const source of sources) {
-    const outline = new JSOutline(source.text());
+    const outline = new JSOutline(source.text(), source.name());
     classes.push(...outline.classes);
     errors.push(...outline.errors);
     for (const entry of outline.inheritance)


### PR DESCRIPTION
This converts `externs.d.ts` to export a global namespace instead of a UMD global.

See: https://github.com/GoogleChrome/puppeteer/issues/2279 and https://github.com/Microsoft/TypeScript/issues/22969