### PR TITLE
test: add test for page.waitForFunction with script CSP

### DIFF
--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -110,6 +110,13 @@ module.exports.addTests = function({testRunner, expect}) {
       await page.evaluate(() => window.__FOO = 'hit');
       await watchdog;
     });
+    xit('should work with strict CSP policy', async({page, server}) => {
+      server.setCSP('/empty.html', 'script-src ' + server.PREFIX);
+      await page.goto(server.EMPTY_PAGE);
+      const watchdog = page.waitForFunction(() => window.__FOO === 'hit', {polling: 'raf'});
+      await page.evaluate(() => window.__FOO = 'hit');
+      await watchdog;
+    });
     it('should throw on bad polling value', async({page, server}) => {
       let error = null;
       try {

--- a/test/server/SimpleServer.js
+++ b/test/server/SimpleServer.js
@@ -78,6 +78,8 @@ class SimpleServer {
     this._routes = new Map();
     /** @type {!Map<string, !{username:string, password:string}>} */
     this._auths = new Map();
+    /** @type {!Map<string, string>} */
+    this._csp = new Map();
     /** @type {!Map<string, !Promise>} */
     this._requestSubscribers = new Map();
   }
@@ -107,6 +109,14 @@ class SimpleServer {
    */
   setAuth(path, username, password) {
     this._auths.set(path, {username, password});
+  }
+
+  /**
+   * @param {string} path
+   * @param {string} csp
+   */
+  setCSP(path, csp) {
+    this._csp.set(path, csp);
   }
 
   async stop() {
@@ -158,6 +168,7 @@ class SimpleServer {
   reset() {
     this._routes.clear();
     this._auths.clear();
+    this._csp.clear();
     const error = new Error('Static Server has been reset');
     for (const subscriber of this._requestSubscribers.values())
       subscriber[rejectSymbol].call(null, error);
@@ -214,6 +225,8 @@ class SimpleServer {
     } else {
       response.setHeader('Cache-Control', 'no-cache, no-store');
     }
+    if (this._csp.has(pathName))
+      response.setHeader('Content-Security-Policy', this._csp.get(pathName));
 
     fs.readFile(filePath, function(err, data) {
       if (err) {


### PR DESCRIPTION
This patch adds a test to fixate page.waitForFunction behavior
for pages with CSP.

References #1229.