### PR TITLE
docs(api.md): fix minor spelling errors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -723,7 +723,7 @@ Brings page to front (activates tab).
 This method fetches an element with `selector`, scrolls it into view if needed, and then uses [page.mouse](#pagemouse) to click in the center of the element.
 If there's no element matching `selector`, the method throws an error.
 
-Bare in mind that if `click()` triggers a navigation event and there's a separate `page.waitForNavigation()` promise to be resolved, you may end up with a race condition that yields unexpected results. The correct pattern for click and wait for navigation is the following:
+Bear in mind that if `click()` triggers a navigation event and there's a separate `page.waitForNavigation()` promise to be resolved, you may end up with a race condition that yields unexpected results. The correct pattern for click and wait for navigation is the following:
 
 ```javascript
 const [response] = await Promise.all([
@@ -1757,7 +1757,7 @@ Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<s
 This method fetches an element with `selector`, scrolls it into view if needed, and then uses [page.mouse](#pagemouse) to click in the center of the element.
 If there's no element matching `selector`, the method throws an error.
 
-Bare in mind that if `click()` triggers a navigation event and there's a separate `page.waitForNavigation()` promise to be resolved, you may end up with a race condition that yields unexpected results. The correct pattern for click and wait for navigation is the following:
+Bear in mind that if `click()` triggers a navigation event and there's a separate `page.waitForNavigation()` promise to be resolved, you may end up with a race condition that yields unexpected results. The correct pattern for click and wait for navigation is the following:
 
 ```javascript
 const [response] = await Promise.all([


### PR DESCRIPTION
Small spelling error in docs: "Bare in mind" -> "Bear in mind" 

🐻