### PR TITLE
test: add test on Page.evaluateOnNewDocument with CSP

### DIFF
--- a/test/assets/csp.html
+++ b/test/assets/csp.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'">

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1509,11 +1509,16 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         expect(await page.evaluate(() => window.result)).toBe(123);
       });
       it('should work with CSP', async({page, server}) => {
+        server.setCSP('/empty.html', 'script-src ' + server.PREFIX);
         await page.evaluateOnNewDocument(function(){
           window.injected = 123;
         });
-        await page.goto(server.PREFIX + '/csp.html');
+        await page.goto(server.PREFIX + '/empty.html');
         expect(await page.evaluate(() => window.injected)).toBe(123);
+
+        // Make sure CSP works.
+        await page.addScriptTag({content: 'window.e = 10;'}).catch(e => void e);
+        expect(await page.evaluate(() => window.e)).toBe(undefined);
       });
     });
 

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1508,6 +1508,13 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         await page.goto(server.PREFIX + '/tamperable.html');
         expect(await page.evaluate(() => window.result)).toBe(123);
       });
+      it('should work with CSP', async({page, server}) => {
+        await page.evaluateOnNewDocument(function(){
+          window.injected = 123;
+        });
+        await page.goto(server.PREFIX + '/csp.html');
+        expect(await page.evaluate(() => window.injected)).toBe(123);
+      });
     });
 
     describe('Page.setCacheEnabled', function() {


### PR DESCRIPTION
This patch adds a test that Page.evaluateOnNewDocument works
with CSP: there's been some concerns on the bugtracker before.

References #1229