### PR TITLE
feat(Page): Page.addScriptTag should throw when blocked by CSP

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -543,7 +543,7 @@ class Frame {
 
     /**
      * @param {string} content
-     * @return {!HTMLElement}
+     * @return {!Promise<!HTMLElement>}
      */
     function addStyleContent(content) {
       const style = document.createElement('style');

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -470,12 +470,12 @@ class Frame {
       script.src = url;
       if (type)
         script.type = type;
-      document.head.appendChild(script);
-      await new Promise((res, rej) => {
-        script.onload = res;
+      const promise = new Promise((res, rej) => {
+        script.onload = res.bind(null, script);
         script.onerror = rej;
       });
-      return script;
+      document.head.appendChild(script);
+      return promise;
     }
 
     /**
@@ -487,7 +487,11 @@ class Frame {
       const script = document.createElement('script');
       script.type = type;
       script.text = content;
+      let error = null;
+      script.onerror = e => error = e;
       document.head.appendChild(script);
+      if (error)
+        throw error;
       return script;
     }
   }
@@ -529,12 +533,12 @@ class Frame {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
       link.href = url;
-      document.head.appendChild(link);
-      await new Promise((res, rej) => {
-        link.onload = res;
+      const promise = new Promise((res, rej) => {
+        link.onload = res.bind(null, link);
         link.onerror = rej;
       });
-      return link;
+      document.head.appendChild(link);
+      return promise;
     }
 
     /**
@@ -545,8 +549,12 @@ class Frame {
       const style = document.createElement('style');
       style.type = 'text/css';
       style.appendChild(document.createTextNode(content));
+      const promise = new Promise((res, rej) => {
+        style.onload = res.bind(null, style);
+        style.onerror = rej;
+      });
       document.head.appendChild(style);
-      return style;
+      return promise;
     }
   }
 

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -471,11 +471,12 @@ class Frame {
       if (type)
         script.type = type;
       const promise = new Promise((res, rej) => {
-        script.onload = res.bind(null, script);
+        script.onload = res;
         script.onerror = rej;
       });
       document.head.appendChild(script);
-      return promise;
+      await promise;
+      return script;
     }
 
     /**
@@ -534,27 +535,29 @@ class Frame {
       link.rel = 'stylesheet';
       link.href = url;
       const promise = new Promise((res, rej) => {
-        link.onload = res.bind(null, link);
+        link.onload = res;
         link.onerror = rej;
       });
       document.head.appendChild(link);
-      return promise;
+      await promise;
+      return link;
     }
 
     /**
      * @param {string} content
      * @return {!Promise<!HTMLElement>}
      */
-    function addStyleContent(content) {
+    async function addStyleContent(content) {
       const style = document.createElement('style');
       style.type = 'text/css';
       style.appendChild(document.createTextNode(content));
       const promise = new Promise((res, rej) => {
-        style.onload = res.bind(null, style);
+        style.onload = res;
         style.onerror = rej;
       });
       document.head.appendChild(style);
-      return promise;
+      await promise;
+      return style;
     }
   }
 

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1336,6 +1336,20 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         expect(scriptHandle.asElement()).not.toBeNull();
         expect(await page.evaluate(() => __injected)).toBe(35);
       });
+
+      it('should throw when added with content to the CSP page', async({page, server}) => {
+        await page.goto(server.PREFIX + '/csp.html');
+        let error = null;
+        await page.addScriptTag({ content: 'window.__injected = 35;' }).catch(e => error = e);
+        expect(error).toBeTruthy();
+      });
+
+      it('should throw when added with URL to the CSP page', async({page, server}) => {
+        await page.goto(server.PREFIX + '/csp.html');
+        let error = null;
+        await page.addScriptTag({ url: server.CROSS_PROCESS_PREFIX + '/injectedfile.js' }).catch(e => error = e);
+        expect(error).toBeTruthy();
+      });
     });
 
     describe('Page.addStyleTag', function() {
@@ -1387,6 +1401,20 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         const styleHandle = await page.addStyleTag({ content: 'body { background-color: green; }' });
         expect(styleHandle.asElement()).not.toBeNull();
         expect(await page.evaluate(`window.getComputedStyle(document.querySelector('body')).getPropertyValue('background-color')`)).toBe('rgb(0, 128, 0)');
+      });
+
+      it('should throw when added with content to the CSP page', async({page, server}) => {
+        await page.goto(server.PREFIX + '/csp.html');
+        let error = null;
+        await page.addStyleTag({ content: 'body { background-color: green; }' }).catch(e => error = e);
+        expect(error).toBeTruthy();
+      });
+
+      it('should throw when added with URL to the CSP page', async({page, server}) => {
+        await page.goto(server.PREFIX + '/csp.html');
+        let error = null;
+        await page.addStyleTag({ url: server.CROSS_PROCESS_PREFIX + '/injectedstyle.css' }).catch(e => error = e);
+        expect(error).toBeTruthy();
       });
     });
 


### PR DESCRIPTION
This patch teaches Page.addScriptTag and Page.addStyleTag to throw
an error when blocked by CSP.

References #1229.