### PR TITLE
feat(Chromium): roll Chromium to r549031

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "548921"
+    "chromium_revision": "549031"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -145,8 +145,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         await browser2.close();
         rm(userDataDir);
       });
-      // @see https://github.com/GoogleChrome/puppeteer/issues/1537
-      xit('userDataDir option should restore cookies', async({server}) => {
+      it('userDataDir option should restore cookies', async({server}) => {
         const userDataDir = await mkdtempAsync(TMP_FOLDER);
         const options = Object.assign({userDataDir}, defaultBrowserOptions);
         const browser = await puppeteer.launch(options);


### PR DESCRIPTION
This roll includes:
- https://crrev.com/549003 - DevTools: make pptr tests pass with DCHECKs.

The patch fixes a browser crash that happens during browser close.
As a result, cookies were not saved properly (and thus the flaky test we
had).

Fixes #1537.