### PR TITLE
fix(Connection): do not assert that methods always have callbacks.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -102,15 +102,17 @@ class Connection extends EventEmitter {
       await new Promise(f => setTimeout(f, this._delay));
     debugProtocol('◀ RECV ' + message);
     const object = JSON.parse(message);
-    if (object.id && this._callbacks.has(object.id)) {
+    if (object.id) {
       const callback = this._callbacks.get(object.id);
-      this._callbacks.delete(object.id);
-      if (object.error)
-        callback.reject(rewriteError(callback.error, `Protocol error (${callback.method}): ${object.error.message} ${object.error.data}`));
-      else
-        callback.resolve(object.result);
+      // Callbacks could be all rejected if someone has called `.dispose()`.
+      if (callback) {
+        this._callbacks.delete(object.id);
+        if (object.error)
+          callback.reject(rewriteError(callback.error, `Protocol error (${callback.method}): ${object.error.message} ${object.error.data}`));
+        else
+          callback.resolve(object.result);
+      }
     } else {
-      console.assert(!object.id);
       if (object.method === 'Target.receivedMessageFromTarget') {
         const session = this._sessions.get(object.params.sessionId);
         if (session)


### PR DESCRIPTION
In certain cases, all callbacks could be rejected before we get a
response from transport. This is easily reproducible with `slowMo`
option.

Fixes #563.