### PR TITLE
fix(Launcher): consume protocol errors when initiating browser.close()

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -140,13 +140,13 @@ class Launcher {
       });
     });
 
-    const listeners = [ helper.addEventListener(process, 'exit', forceKillChrome) ];
+    const listeners = [ helper.addEventListener(process, 'exit', killChrome) ];
     if (options.handleSIGINT !== false)
-      listeners.push(helper.addEventListener(process, 'SIGINT', forceKillChrome));
+      listeners.push(helper.addEventListener(process, 'SIGINT', killChrome));
     if (options.handleSIGTERM !== false)
-      listeners.push(helper.addEventListener(process, 'SIGTERM', killChrome));
+      listeners.push(helper.addEventListener(process, 'SIGTERM', gracefullyCloseChrome));
     if (options.handleSIGHUP !== false)
-      listeners.push(helper.addEventListener(process, 'SIGHUP', killChrome));
+      listeners.push(helper.addEventListener(process, 'SIGHUP', gracefullyCloseChrome));
     /** @type {?Connection} */
     let connection = null;
     try {
@@ -158,30 +158,31 @@ class Launcher {
       } else {
         connection = Connection.createForPipe(/** @type {!NodeJS.WritableStream} */(chromeProcess.stdio[3]), /** @type {!NodeJS.ReadableStream} */ (chromeProcess.stdio[4]), connectionDelay);
       }
-      return Browser.create(connection, options, chromeProcess, killChrome);
+      return Browser.create(connection, options, chromeProcess, gracefullyCloseChrome);
     } catch (e) {
-      forceKillChrome();
+      killChrome();
       throw e;
     }
 
     /**
      * @return {Promise}
      */
-    function killChrome() {
+    function gracefullyCloseChrome() {
       helper.removeEventListeners(listeners);
       if (temporaryUserDataDir) {
-        forceKillChrome();
+        killChrome();
       } else if (connection) {
         // Attempt to close chrome gracefully
         connection.send('Browser.close').catch(error => {
           debugError(error);
-          forceKillChrome();
+          killChrome();
         });
       }
       return waitForChromeToClose;
     }
 
-    function forceKillChrome() {
+    // This method has to be sync to be used as 'exit' event handler.
+    function killChrome() {
       helper.removeEventListeners(listeners);
       if (chromeProcess.pid && !chromeProcess.killed && !chromeClosed) {
         // Force kill chrome.
@@ -196,10 +197,7 @@ class Launcher {
       }
       // Attempt to remove temporary profile directory to avoid littering.
       try {
-        if (temporaryUserDataDir) {
-          removeFolder.sync(temporaryUserDataDir);
-          temporaryUserDataDir = null;
-        }
+        removeFolder.sync(temporaryUserDataDir);
       } catch (e) { }
     }
   }

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -22,7 +22,7 @@ const {Connection} = require('./Connection');
 const Browser = require('./Browser');
 const readline = require('readline');
 const fs = require('fs');
-const {helper} = require('./helper');
+const {helper, debugError} = require('./helper');
 const ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')).puppeteer.chromium_revision;
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
@@ -173,7 +173,10 @@ class Launcher {
         forceKillChrome();
       } else if (connection) {
         // Attempt to close chrome gracefully
-        connection.send('Browser.close');
+        connection.send('Browser.close').catch(error => {
+          debugError(error);
+          forceKillChrome();
+        });
       }
       return waitForChromeToClose;
     }
@@ -193,7 +196,10 @@ class Launcher {
       }
       // Attempt to remove temporary profile directory to avoid littering.
       try {
-        removeFolder.sync(temporaryUserDataDir);
+        if (temporaryUserDataDir) {
+          removeFolder.sync(temporaryUserDataDir);
+          temporaryUserDataDir = null;
+        }
       } catch (e) { }
     }
   }
@@ -221,7 +227,7 @@ class Launcher {
   static async connect(options = {}) {
     const connectionDelay = options.slowMo || 0;
     const connection = await Connection.createForWebSocket(options.browserWSEndpoint, connectionDelay);
-    return Browser.create(connection, options, null, () => connection.send('Browser.close'));
+    return Browser.create(connection, options, null, () => connection.send('Browser.close').catch(debugError));
   }
 }
 

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const utils = require('./utils.js');
+
 module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, puppeteer}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
@@ -61,12 +63,21 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       remoteBrowser1.on('disconnected', () => ++disconnectedRemote1);
       remoteBrowser2.on('disconnected', () => ++disconnectedRemote2);
 
-      await remoteBrowser2.disconnect();
+      await Promise.all([
+        utils.waitForEvents(remoteBrowser2, 'disconnected'),
+        remoteBrowser2.disconnect(),
+      ]);
+
       expect(disconnectedOriginal).toBe(0);
       expect(disconnectedRemote1).toBe(0);
       expect(disconnectedRemote2).toBe(1);
 
-      await originalBrowser.close();
+      await Promise.all([
+        utils.waitForEvents(remoteBrowser1, 'disconnected'),
+        utils.waitForEvents(originalBrowser, 'disconnected'),
+        originalBrowser.close(),
+      ]);
+
       expect(disconnectedOriginal).toBe(1);
       expect(disconnectedRemote1).toBe(1);
       expect(disconnectedRemote2).toBe(1);


### PR DESCRIPTION
Handle errors property while sending Browser.close()

Fixes #1429.