### PR TITLE
feat(ElementHandle): accessible name

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -185,6 +185,7 @@
   * [elementHandle.$(selector)](#elementhandleselector)
   * [elementHandle.$$(selector)](#elementhandleselector)
   * [elementHandle.$x(expression)](#elementhandlexexpression)
+  * [elementHandle.accessibleName()](#elementhandleaccessiblename)
   * [elementHandle.asElement()](#elementhandleaselement)
   * [elementHandle.boundingBox()](#elementhandleboundingbox)
   * [elementHandle.boxModel()](#elementhandleboxmodel)
@@ -2204,8 +2205,14 @@ The method runs `element.querySelectorAll` within the page. If no elements match
 
 The method evaluates the XPath expression relative to the elementHandle. If there's no such element, the method will resolve to `null`.
 
+#### elementHandle.accessibleName()
+- returns: <[Promise]<?[string]>>
+
+This method computed the acessible name of the element that would exposed to a screen reader.
+Might return `null` if the element is ignored for accessibility, e.g. a hidden element or a simple container element.
+
 #### elementHandle.asElement()
-- returns: <[elementhandle]>
+- returns: <[ElementHandle]>
 
 #### elementHandle.boundingBox()
 - returns: <[Promise]<?[Object]>>

--- a/docs/api.md
+++ b/docs/api.md
@@ -185,7 +185,7 @@
   * [elementHandle.$(selector)](#elementhandleselector)
   * [elementHandle.$$(selector)](#elementhandleselector)
   * [elementHandle.$x(expression)](#elementhandlexexpression)
-  * [elementHandle.accessibleName()](#elementhandleaccessiblename)
+  * [elementHandle.a11yInfo()](#elementhandlea11yinfo)
   * [elementHandle.asElement()](#elementhandleaselement)
   * [elementHandle.boundingBox()](#elementhandleboundingbox)
   * [elementHandle.boxModel()](#elementhandleboxmodel)
@@ -2205,11 +2205,8 @@ The method runs `element.querySelectorAll` within the page. If no elements match
 
 The method evaluates the XPath expression relative to the elementHandle. If there's no such element, the method will resolve to `null`.
 
-#### elementHandle.accessibleName()
-- returns: <[Promise]<?[string]>>
-
-This method computed the acessible name of the element that would exposed to a screen reader.
-Might return `null` if the element is ignored for accessibility, e.g. a hidden element or a simple container element.
+#### elementHandle.a11yInfo()
+- returns: <[Promise]<[Object]>>
 
 #### elementHandle.asElement()
 - returns: <[ElementHandle]>

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -309,16 +309,41 @@ class ElementHandle extends JSHandle {
   }
 
   /**
-   * @return {!Promise<?string>}
+   * @return {!Promise<!Object>}
    */
-  async accessibleName() {
+  async a11yInfo() {
     const {nodes} = await this._client.send('Accessibility.getPartialAXTree', {
       objectId: this._remoteObject.objectId,
       fetchRelatives: false
     });
-    if (!nodes[0] || !nodes[0].name)
-      return null;
-    return nodes[0].name.value;
+    const node = nodes[0];
+    if (!node)
+      return {};
+    const info = {};
+    if (node.name)
+      info.name = node.name.value;
+    if (node.role)
+      info.role = node.role.value;
+    if (node.value)
+      info.value = node.value.value;
+    const acceptableTypes = new Set([
+      'boolean',
+      'tristate',
+      'booleanOrUndefined',
+      'integer',
+      'number',
+      'string',
+      'computedString',
+      'token',
+      'tokenList',
+      'role',
+      'internalRole',
+      'valueUndefined']);
+    for (const property of node.properties || []) {
+      if (acceptableTypes.has(property.value.type))
+        info[property.name] = property.value.value;
+    }
+    return info;
   }
 }
 

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -307,6 +307,19 @@ class ElementHandle extends JSHandle {
     }
     return result;
   }
+
+  /**
+   * @return {!Promise<?string>}
+   */
+  async accessibleName() {
+    const {nodes} = await this._client.send('Accessibility.getPartialAXTree', {
+      objectId: this._remoteObject.objectId,
+      fetchRelatives: false
+    });
+    if (!nodes[0] || !nodes[0].name)
+      return null;
+    return nodes[0].name.value;
+  }
 }
 
 module.exports = ElementHandle;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "549031"
+    "chromium_revision": "549239"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -332,4 +332,39 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(second).toEqual([]);
     });
   });
+
+  describe('Accessibility', function() {
+    it('ElemetnHandle.accessibleName', async({page, server}) => {
+      await page.setContent(`
+        <div class="test" tabIndex=0>hello</div>
+
+        <div class="test" aria-label="hello">aria label</div>
+
+        <div class="test" title="hello">title</div>
+
+        <style> div.psuedo::before{content:'hello'} </style>
+        <div class="test psuedo" tabIndex=0"></div>
+
+        <span id="mylabel">hello</span>
+        <div class="test" aria-labeledby="mylabel">labeledby</diV>
+
+        <div class="test" tabIndex=0><span>h</span>el<span>l</span>o</div>
+
+        <input class="test" placeholder="hello">
+
+        <img class="test" alt="hello"></img>
+
+        <div class="antitest"><div>hello</div></div>
+
+        <div class="antitest" tabIndex=0 style="display:none">hello</div>
+
+        <div class="antitest" tabIndex=0 style="visibility:hidden">hello</div>
+        `);
+      for (const div of await page.$$('.test'))
+        expect(await div.accessibleName()).toBe('hello');
+      for (const div of await page.$$('.antitest'))
+        expect(await div.accessibleName()).toBe(null);
+
+    });
+  });
 };

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -334,7 +334,7 @@ module.exports.addTests = function({testRunner, expect}) {
   });
 
   describe('Accessibility', function() {
-    it('ElemetnHandle.accessibleName', async({page, server}) => {
+    it('ElemetnHandle.a11yInfo', async({page, server}) => {
       await page.setContent(`
         <div class="test" tabIndex=0>hello</div>
 
@@ -361,9 +361,9 @@ module.exports.addTests = function({testRunner, expect}) {
         <div class="antitest" tabIndex=0 style="visibility:hidden">hello</div>
         `);
       for (const div of await page.$$('.test'))
-        expect(await div.accessibleName()).toBe('hello');
+        expect((await div.a11yInfo()).name).toBe('hello');
       for (const div of await page.$$('.antitest'))
-        expect(await div.accessibleName()).toBe(null);
+        expect((await div.a11yInfo()).name).toBe(undefined);
 
     });
   });


### PR DESCRIPTION
This relies on an upstream [patch](https://chromium-review.googlesource.com/c/chromium/src/+/1000713), but I expect bikeshedding on the API so I will do the roll separately.

`elementHandle.accessibleName()` returns the computed accessible name for the node. This is not the entirety of what would be read by a screen reader for this element, that depends on the role and value of this node. But the accessible name is one of the hardest properties to compute because it can't be read directly from the aria attributes.