### PR TITLE
fix(Page): support anchor navigation

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -39,6 +39,7 @@ class FrameManager extends EventEmitter {
 
     this._client.on('Page.frameAttached', event => this._onFrameAttached(event.frameId, event.parentFrameId));
     this._client.on('Page.frameNavigated', event => this._onFrameNavigated(event.frame));
+    this._client.on('Page.navigatedWithinDocument', event => this._onFrameNavigatedWithinDocument(event.frameId, event.url));
     this._client.on('Page.frameDetached', event => this._onFrameDetached(event.frameId));
     this._client.on('Runtime.executionContextCreated', event => this._onExecutionContextCreated(event.context));
     this._client.on('Runtime.executionContextDestroyed', event => this._onExecutionContextDestroyed(event.executionContextId));
@@ -146,6 +147,19 @@ class FrameManager extends EventEmitter {
 
   /**
    * @param {string} frameId
+   * @param {string} url
+   */
+  _onFrameNavigatedWithinDocument(frameId, url) {
+    const frame = this._frames.get(frameId);
+    if (!frame)
+      return;
+    frame._navigatedWithinDocument(url);
+    this.emit(FrameManager.Events.FrameNavigatedWithinDocument, frame);
+    this.emit(FrameManager.Events.FrameNavigated, frame);
+  }
+
+  /**
+   * @param {string} frameId
    */
   _onFrameDetached(frameId) {
     const frame = this._frames.get(frameId);
@@ -217,7 +231,8 @@ FrameManager.Events = {
   FrameAttached: 'frameattached',
   FrameNavigated: 'framenavigated',
   FrameDetached: 'framedetached',
-  LifecycleEvent: 'lifecycleevent'
+  LifecycleEvent: 'lifecycleevent',
+  FrameNavigatedWithinDocument: 'framenavigatedwithindocument'
 };
 
 /**
@@ -748,6 +763,13 @@ class Frame {
   _navigated(framePayload) {
     this._name = framePayload.name;
     this._url = framePayload.url;
+  }
+
+  /**
+   * @param {string} url
+   */
+  _navigatedWithinDocument(url) {
+    this._url = url;
   }
 
   /**

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -43,8 +43,10 @@ class NavigatorWatcher {
     this._frame = frame;
     this._initialLoaderId = frame._loaderId;
     this._timeout = timeout;
+    this._hasSameDocumentNavigation = false;
     this._eventListeners = [
       helper.addEventListener(this._frameManager, FrameManager.Events.LifecycleEvent, this._checkLifecycleComplete.bind(this)),
+      helper.addEventListener(this._frameManager, FrameManager.Events.FrameNavigatedWithinDocument, this._navigatedWithingDocument.bind(this)),
       helper.addEventListener(this._frameManager, FrameManager.Events.FrameDetached, this._checkLifecycleComplete.bind(this))
     ];
 
@@ -78,9 +80,19 @@ class NavigatorWatcher {
     return this._navigationPromise;
   }
 
+  /**
+   * @param {!Puppeteer.Frame} frame
+   */
+  _navigatedWithingDocument(frame) {
+    if (frame !== this._frame)
+      return;
+    this._hasSameDocumentNavigation = true;
+    this._checkLifecycleComplete();
+  }
+
   _checkLifecycleComplete() {
     // We expect navigation to commit.
-    if (this._frame._loaderId === this._initialLoaderId)
+    if (this._frame._loaderId === this._initialLoaderId && !this._hasSameDocumentNavigation)
       return;
     if (!checkLifecycle(this._frame, this._expectedLifecycle))
       return;

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -46,7 +46,7 @@ class NavigatorWatcher {
     this._hasSameDocumentNavigation = false;
     this._eventListeners = [
       helper.addEventListener(this._frameManager, FrameManager.Events.LifecycleEvent, this._checkLifecycleComplete.bind(this)),
-      helper.addEventListener(this._frameManager, FrameManager.Events.FrameNavigatedWithinDocument, this._navigatedWithingDocument.bind(this)),
+      helper.addEventListener(this._frameManager, FrameManager.Events.FrameNavigatedWithinDocument, this._navigatedWithinDocument.bind(this)),
       helper.addEventListener(this._frameManager, FrameManager.Events.FrameDetached, this._checkLifecycleComplete.bind(this))
     ];
 
@@ -83,7 +83,7 @@ class NavigatorWatcher {
   /**
    * @param {!Puppeteer.Frame} frame
    */
-  _navigatedWithingDocument(frame) {
+  _navigatedWithinDocument(frame) {
     if (frame !== this._frame)
       return;
     this._hasSameDocumentNavigation = true;

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -422,6 +422,14 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(detachedFrames.length).toBe(1);
       expect(detachedFrames[0].isDetached()).toBe(true);
     });
+    it('should send "framenavigated" when navigating on anchor URLs', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await Promise.all([
+        page.goto(server.EMPTY_PAGE + '#foo'),
+        utils.waitEvent(page, 'framenavigated')
+      ]);
+      expect(page.url()).toBe(server.EMPTY_PAGE + '#foo');
+    });
     it('should persist mainFrame on cross-process navigation', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const mainFrame = page.mainFrame();

--- a/test/test.js
+++ b/test/test.js
@@ -99,9 +99,6 @@ beforeEach(async({server, httpsServer}) => {
   httpsServer.reset();
 });
 
-// Top-level tests that launch Browser themselves.
-require('./puppeteer.spec.js').addTests({testRunner, expect, PROJECT_ROOT, defaultBrowserOptions});
-
 describe('Page', function() {
   beforeAll(async state => {
     state.browser = await puppeteer.launch(defaultBrowserOptions);
@@ -135,6 +132,9 @@ describe('Page', function() {
   require('./target.spec.js').addTests({testRunner, expect});
   require('./tracing.spec.js').addTests({testRunner, expect});
 });
+
+// Top-level tests that launch Browser themselves.
+require('./puppeteer.spec.js').addTests({testRunner, expect, PROJECT_ROOT, defaultBrowserOptions});
 
 if (process.env.COVERAGE) {
   describe('COVERAGE', function(){


### PR DESCRIPTION
This patch fixes puppeteer navigation primitives to work with
same-document navigation.

In browser world, same-document navigation happens when document's URL is changed,
but document instance is not re-created. Some common scenarios
for same-document navigation are:
- History API
- anchor navigation

With this patch:
- pptr starts dispatching `framenavigated` event when frame's URL gets
changed due to same-document navigation
- `page.waitForNavigation` now works with same-document navigation
- `page.goBack()` and `page.goForward()` are handled correctly.

Fixes #257.