### PR TITLE
fix(BrowserFetcher): ensure executable has proper permissions

### DIFF
--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -38,6 +38,7 @@ const downloadURLs = {
 const readdirAsync = helper.promisify(fs.readdir.bind(fs));
 const mkdirAsync = helper.promisify(fs.mkdir.bind(fs));
 const unlinkAsync = helper.promisify(fs.unlink.bind(fs));
+const chmodAsync = helper.promisify(fs.chmod.bind(fs));
 
 function existsAsync(filePath) {
   let fulfill = null;
@@ -115,7 +116,10 @@ class BrowserFetcher {
       if (await existsAsync(zipPath))
         await unlinkAsync(zipPath);
     }
-    return this.revisionInfo(revision);
+    const revisionInfo = this.revisionInfo(revision);
+    if (revisionInfo)
+      await chmodAsync(revisionInfo.executablePath, 0o755);
+    return revisionInfo;
   }
 
   /**

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -52,7 +52,8 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         revisionInfo = await browserFetcher.download('123456');
         expect(revisionInfo.local).toBe(true);
         expect(await readFileAsync(revisionInfo.executablePath, 'utf8')).toBe('LINUX BINARY\n');
-        expect((await statAsync(revisionInfo.executablePath)).mode & 0777).toBe(0755);
+        const expectedPermissions = os.platform() === 'win32' ? 0666 : 0755;
+        expect((await statAsync(revisionInfo.executablePath)).mode & 0777).toBe(expectedPermissions);
         expect(await browserFetcher.localRevisions()).toEqual(['123456']);
         await browserFetcher.remove('123456');
         expect(await browserFetcher.localRevisions()).toEqual([]);

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -20,6 +20,7 @@ const path = require('path');
 const {helper} = require('../lib/helper');
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const readFileAsync = helper.promisify(fs.readFile);
+const statAsync = helper.promisify(fs.stat);
 const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
 const utils = require('./utils');
 
@@ -51,6 +52,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         revisionInfo = await browserFetcher.download('123456');
         expect(revisionInfo.local).toBe(true);
         expect(await readFileAsync(revisionInfo.executablePath, 'utf8')).toBe('LINUX BINARY\n');
+        expect((await statAsync(revisionInfo.executablePath)).mode&0777).toBe(0755);
         expect(await browserFetcher.localRevisions()).toEqual(['123456']);
         await browserFetcher.remove('123456');
         expect(await browserFetcher.localRevisions()).toEqual([]);

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -52,7 +52,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         revisionInfo = await browserFetcher.download('123456');
         expect(revisionInfo.local).toBe(true);
         expect(await readFileAsync(revisionInfo.executablePath, 'utf8')).toBe('LINUX BINARY\n');
-        expect((await statAsync(revisionInfo.executablePath)).mode&0777).toBe(0755);
+        expect((await statAsync(revisionInfo.executablePath)).mode & 0777).toBe(0755);
         expect(await browserFetcher.localRevisions()).toEqual(['123456']);
         await browserFetcher.remove('123456');
         expect(await browserFetcher.localRevisions()).toEqual([]);


### PR DESCRIPTION
This patch ensures Chromium executable has permissions to be executed
by non-owner users.

Fixes #2283.