### PR TITLE
feat(npm): support depending on un-published code

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "unit-node6": "node node6/test/test.js",
     "tsc": "node utils/protocol-types-generator && tsc -p .",
     "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "apply-next-version": "node utils/apply_next_version.js"
   },
   "author": "The Chromium Authors",


### PR DESCRIPTION
Just noticed that a commit just landed to support waitForNavigation on same-document navigations and it's really important for our project.

To use it, it looks like we'll have to wait for a publish. The npm prepare script was added in 5.0.0 and allows you to depend on a git project directly as it'll install it's devDependencies and run the prepare script as though it was published