### PR TITLE
test: add missing `rm` function to `test.js`

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 const fs = require('fs');
+const rm = require('rimraf').sync;
 const path = require('path');
 const SimpleServer = require('./server/SimpleServer');
 const GoldenUtils = require('./golden-utils');


### PR DESCRIPTION
This was missing while we were splitting the tests.

Fixes #2236.