### PR TITLE
feat(Page): allow disabling viewport emulation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1275,7 +1275,7 @@ puppeteer.launch().then(async browser => {
 - returns: <[Promise]> Promise which resolves when the user agent is set.
 
 #### page.setViewport(viewport)
-- `viewport` <[Object]>
+- `viewport` <?[Object]> Disables viewport emulation if `null` is passed.
   - `width` <[number]> page width in pixels.
   - `height` <[number]> page height in pixels.
   - `deviceScaleFactor` <[number]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
@@ -1335,7 +1335,7 @@ Shortcut for [page.mainFrame().type(selector, text[, options])](#frametypeselect
 This is a shortcut for [page.mainFrame().url()](#frameurl)
 
 #### page.viewport()
-- returns: <[Object]>
+- returns: <?[Object]> `null` if viewport emulation is disabled.
   - `width` <[number]> page width in pixels.
   - `height` <[number]> page height in pixels.
   - `deviceScaleFactor` <[number]> Specify device scale factor (can be though of as dpr). Defaults to `1`.

--- a/lib/EmulationManager.js
+++ b/lib/EmulationManager.js
@@ -31,13 +31,20 @@ class EmulationManager {
    */
   async emulateViewport(viewport) {
     if (!viewport) {
-      await this._client.send('Emulation.clearDeviceMetricsOverride');
-      const reloadNeeded = !!this._injectedTouchScriptId;
+      await Promise.all([
+        this._client.send('Emulation.clearDeviceMetricsOverride'),
+        this._client.send('Emulation.setTouchEmulationEnabled', { enabled: false })
+      ]);
+      let reloadNeeded = false;
       if (this._injectedTouchScriptId) {
         await this._client.send('Page.removeScriptToEvaluateOnNewDocument', {identifier: this._injectedTouchScriptId});
         this._injectedTouchScriptId = null;
+        reloadNeeded = true;
       }
-      this._emulatingMobile = false;
+      if (this._emulatingMobile) {
+        this._emulatingMobile = false;
+        reloadNeeded = true;
+      }
       return reloadNeeded;
     }
 

--- a/lib/EmulationManager.js
+++ b/lib/EmulationManager.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const {helper} = require('./helper');
 
 class EmulationManager {
   /**
@@ -25,14 +26,25 @@ class EmulationManager {
   }
 
   /**
-   * @param {!EmulationManager.Viewport} viewport
+   * @param {?EmulationManager.Viewport} viewport
    * @return {Promise<boolean>}
    */
   async emulateViewport(viewport) {
+    if (!viewport) {
+      await this._client.send('Emulation.clearDeviceMetricsOverride');
+      const reloadNeeded = !!this._injectedTouchScriptId;
+      if (this._injectedTouchScriptId) {
+        await this._client.send('Page.removeScriptToEvaluateOnNewDocument', {identifier: this._injectedTouchScriptId});
+        this._injectedTouchScriptId = null;
+      }
+      this._emulatingMobile = false;
+      return reloadNeeded;
+    }
+
     const mobile = viewport.isMobile || false;
     const width = viewport.width;
     const height = viewport.height;
-    const deviceScaleFactor = viewport.deviceScaleFactor || 1;
+    const deviceScaleFactor = helper.isNumber(viewport.deviceScaleFactor) ? viewport.deviceScaleFactor : 1;
     /** @type {Protocol.Emulation.ScreenOrientation} */
     const screenOrientation = viewport.isLandscape ? { angle: 90, type: 'landscapePrimary' } : { angle: 0, type: 'portraitPrimary' };
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -83,6 +83,7 @@ class Page extends EventEmitter {
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
     this._coverage = new Coverage(client);
     this._defaultNavigationTimeout = 30000;
+    this._viewport = null;
 
     this._screenshotTaskQueue = screenshotTaskQueue;
 
@@ -626,7 +627,7 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @param {!Page.Viewport} viewport
+   * @param {?Page.Viewport} viewport
    */
   async setViewport(viewport) {
     const needsReload = await this._emulationManager.emulateViewport(viewport);
@@ -636,7 +637,7 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @return {!Page.Viewport}
+   * @return {?Page.Viewport}
    */
   viewport() {
     return this._viewport;

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1151,7 +1151,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       expect(await page.evaluate(() => window.innerWidth)).toBe(400);
     });
     it('should be disabled when passed "null"', async({page, server}) => {
-      await page.goto(server.PREFIX + '/empty.html');
+      await page.goto(server.PREFIX + '/mobile.html');
       await page.setViewport({width: 123, height: 321});
       expect(await page.evaluate(() => window.innerWidth)).toBe(123);
       await page.setViewport(null);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1150,6 +1150,13 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       await page.setViewport({width: 400, height: 300});
       expect(await page.evaluate(() => window.innerWidth)).toBe(400);
     });
+    it('should be disabled when passed "null"', async({page, server}) => {
+      await page.goto(server.PREFIX + '/empty.html');
+      await page.setViewport({width: 123, height: 321});
+      expect(await page.evaluate(() => window.innerWidth)).toBe(123);
+      await page.setViewport(null);
+      expect(await page.evaluate(() => window.innerWidth)).not.toBe(123);
+    });
     it('should support touch emulation', async({page, server}) => {
       await page.goto(server.PREFIX + '/mobile.html');
       expect(await page.evaluate(() => 'ontouchstart' in window)).toBe(false);


### PR DESCRIPTION
This patch:
- teaches page.setViewpot() to accept `null` to disable
viewport emulation.
- allows passing `0` as viewport's deviceScaleFactor to use machine-defined
deviceScaleFactor.

References #1183.
Fixes #2358.