### PR TITLE
feat(Response): add response.remoteAddress method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -223,6 +223,7 @@
   * [response.headers()](#responseheaders)
   * [response.json()](#responsejson)
   * [response.ok()](#responseok)
+  * [response.remoteAddress()](#responseremoteaddress)
   * [response.request()](#responserequest)
   * [response.securityDetails()](#responsesecuritydetails)
   * [response.status()](#responsestatus)
@@ -2512,6 +2513,11 @@ This method will throw if the response body is not parsable via `JSON.parse`.
 - returns: <[boolean]>
 
 Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
+
+#### response.remoteAddress()
+- returns: <[Object]>
+  - `ip` <[string]> the IP address of the remote server
+  - `port` <[string]> the port used to connect to the remote server
 
 #### response.request()
 - returns: <[Request]> A matching [Request] object.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -154,7 +154,7 @@ class NetworkManager extends EventEmitter {
     if (event.redirectUrl) {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
       if (request) {
-        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders, false /* fromDiskCache */, false /* fromServiceWorker */, null /* securityDetails */);
+        this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders, false /* fromDiskCache */, false /* fromServiceWorker */, null /* securityDetails */, null /* remoteIPAddress */, null /* remotePort */);
         this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId, request._redirectChain);
       }
       return;
@@ -186,9 +186,11 @@ class NetworkManager extends EventEmitter {
    * @param {boolean} fromDiskCache
    * @param {boolean} fromServiceWorker
    * @param {?Object} securityDetails
+   * @param {?string} remoteIPAddress
+   * @param {?number} remotePort
    */
-  _handleRequestRedirect(request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, securityDetails) {
-    const response = new Response(this._client, request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, securityDetails);
+  _handleRequestRedirect(request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, securityDetails, remoteIPAddress, remotePort) {
+    const response = new Response(this._client, request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, securityDetails, remoteIPAddress, remotePort);
     request._response = response;
     request._redirectChain.push(request);
     response._bodyLoadedPromiseFulfill.call(null, new Error('Response body is unavailable for redirect responses'));
@@ -245,7 +247,7 @@ class NetworkManager extends EventEmitter {
       const request = this._requestIdToRequest.get(event.requestId);
       // If we connect late to the target, we could have missed the requestWillBeSent event.
       if (request) {
-        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers, event.redirectResponse.fromDiskCache, event.redirectResponse.fromServiceWorker, event.redirectResponse.securityDetails);
+        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers, event.redirectResponse.fromDiskCache, event.redirectResponse.fromServiceWorker, event.redirectResponse.securityDetails, event.redirectResponse.remoteIPAddress, event.redirectResponse.remotePort);
         redirectChain = request._redirectChain;
       }
     }
@@ -261,7 +263,8 @@ class NetworkManager extends EventEmitter {
     if (!request)
       return;
     const response = new Response(this._client, request, event.response.status, event.response.headers,
-        event.response.fromDiskCache, event.response.fromServiceWorker, event.response.securityDetails);
+        event.response.fromDiskCache, event.response.fromServiceWorker, event.response.securityDetails,
+        event.response.remoteIPAddress, event.response.remotePort);
     request._response = response;
     this.emit(NetworkManager.Events.Response, response);
   }
@@ -517,8 +520,10 @@ class Response {
    * @param {boolean} fromDiskCache
    * @param {boolean} fromServiceWorker
    * @param {?Object} securityDetails
+   * @param {?string} remoteIPAddress
+   * @param {?number} remotePort
    */
-  constructor(client, request, status, headers, fromDiskCache, fromServiceWorker, securityDetails) {
+  constructor(client, request, status, headers, fromDiskCache, fromServiceWorker, securityDetails, remoteIPAddress, remotePort) {
     this._client = client;
     this._request = request;
     this._contentPromise = null;
@@ -543,6 +548,10 @@ class Response {
           securityDetails['validTo'],
           securityDetails['protocol']);
     }
+    this._remoteAddress = {
+      ip: remoteIPAddress,
+      port: remotePort,
+    };
   }
 
   /**
@@ -632,6 +641,13 @@ class Response {
    */
   fromServiceWorker() {
     return this._fromServiceWorker;
+  }
+
+  /**
+   * @return {{ip: string, port: number}}
+   */
+  remoteAddress() {
+    return this._remoteAddress;
   }
 }
 helper.tracePublicAPI(Response);

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -47,15 +47,17 @@ module.exports.addTests = function({testRunner, expect}) {
     });
     it('Page.Events.Response', async({page, server}) => {
       const responses = [];
+      const url = `http://[::1]:${server.PORT}/empty.html`;
       page.on('response', response => responses.push(response));
-      await page.goto(server.EMPTY_PAGE);
+      await page.goto(url);
       expect(responses.length).toBe(1);
-      expect(responses[0].url()).toBe(server.EMPTY_PAGE);
+      expect(responses[0].url()).toBe(url);
       expect(responses[0].status()).toBe(200);
       expect(responses[0].ok()).toBe(true);
       expect(responses[0].fromCache()).toBe(false);
       expect(responses[0].fromServiceWorker()).toBe(false);
       expect(responses[0].request()).toBeTruthy();
+      expect(responses[0].remoteAddress()).toEqual({ ip: '[::1]', port: server.PORT });
     });
 
     it('Response.fromCache()', async({page, server}) => {

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,7 @@ beforeAll(async state  => {
   const port = 8907 + state.parallelIndex * 2;
   state.server = await SimpleServer.create(assetsPath, port);
   state.server.enableHTTPCache(cachedPath);
+  state.server.PORT = port;
   state.server.PREFIX = `http://localhost:${port}`;
   state.server.CROSS_PROCESS_PREFIX = `http://127.0.0.1:${port}`;
   state.server.EMPTY_PAGE = `http://localhost:${port}/empty.html`;
@@ -83,6 +84,7 @@ beforeAll(async state  => {
   const httpsPort = port + 1;
   state.httpsServer = await SimpleServer.createHTTPS(assetsPath, httpsPort);
   state.httpsServer.enableHTTPCache(cachedPath);
+  state.httpsServer.PORT = httpsPort;
   state.httpsServer.PREFIX = `https://localhost:${httpsPort}`;
   state.httpsServer.CROSS_PROCESS_PREFIX = `https://127.0.0.1:${httpsPort}`;
   state.httpsServer.EMPTY_PAGE = `https://localhost:${httpsPort}/empty.html`;


### PR DESCRIPTION
This patch exposes a remoteAddress property which is a formatted string containing the IP address and port of the remote server

Closes #2171 

I wasn't sure if I should expose the remote address and port separately (rather than a formatted version), so please let me know if that's a better idea.