### PR TITLE
readme(examples) : full md link for d.g.c./web docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ NODE_PATH=../ node examples/search.js
 
 ## Larger examples
 
-More complex and use case driven examples can be found at https://github.com/GoogleChromeLabs/puppeteer-examples.
+More complex and use case driven examples can be found at [github.com/GoogleChromeLabs/puppeteer-examples](https://github.com/GoogleChromeLabs/puppeteer-examples).
 
 # Tips & Tricks
 


### PR DESCRIPTION
The implicit links doesnt render for the site:
https://developers.google.com/web/tools/puppeteer/examples


<img width="784" alt="screen shot 2018-04-14 at 11 51 56 am" src="https://user-images.githubusercontent.com/238208/38771572-41f3d168-3fda-11e8-8bf8-90402b7cf4e2.png">
