### PR TITLE
Add `Page.browser()` method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2565,7 +2565,7 @@ Contains the URL of the response.
 
 - returns: <[Browser]>
 
-Get the browser instance for the associated with the target.
+Get the browser instance associated with the target.
 
 #### target.createCDPSession()
 - returns: <[Promise]<[CDPSession]>>

--- a/docs/api.md
+++ b/docs/api.md
@@ -719,7 +719,7 @@ Brings page to front (activates tab).
 
 - returns: <[Browser]>
 
-Get the browser instance for the page.
+Get the browser the page belongs to.
 
 #### page.click(selector[, options])
 - `selector` <[string]> A [selector] to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.
@@ -2565,7 +2565,7 @@ Contains the URL of the response.
 
 - returns: <[Browser]>
 
-Get the browser instance associated with the target.
+Get the browser the target belongs to.
 
 #### target.createCDPSession()
 - returns: <[Promise]<[CDPSession]>>

--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,7 @@
   * [page.addStyleTag(options)](#pageaddstyletagoptions)
   * [page.authenticate(credentials)](#pageauthenticatecredentials)
   * [page.bringToFront()](#pagebringtofront)
+  * [page.browser()](#pagebrowser)
   * [page.click(selector[, options])](#pageclickselector-options)
   * [page.close()](#pageclose)
   * [page.content()](#pagecontent)
@@ -235,6 +236,7 @@
   * [securityDetails.validFrom()](#securitydetailsvalidfrom)
   * [securityDetails.validTo()](#securitydetailsvalidto)
 - [class: Target](#class-target)
+  * [target.browser()](#targetbrowser)
   * [target.createCDPSession()](#targetcreatecdpsession)
   * [target.page()](#targetpage)
   * [target.type()](#targettype)
@@ -712,6 +714,12 @@ To disable authentication, pass `null`.
 - returns: <[Promise]>
 
 Brings page to front (activates tab).
+
+#### page.browser()
+
+- returns: <[Browser]>
+
+Get the browser instance for the page.
 
 #### page.click(selector[, options])
 - `selector` <[string]> A [selector] to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.
@@ -2552,6 +2560,12 @@ Contains the URL of the response.
 - returns: <[number]> [UnixTime] stating the end of validity of the certificate.
 
 ### class: Target
+
+#### target.browser()
+
+- returns: <[Browser]>
+
+Get the browser instance for the associated with the target.
 
 #### target.createCDPSession()
 - returns: <[Promise]<[CDPSession]>>

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -68,7 +68,7 @@ class Browser extends EventEmitter {
    */
   async _targetCreated(event) {
     const targetInfo = event.targetInfo;
-    const target = new Target(targetInfo, () => this._connection.createSession(targetInfo.targetId), this._ignoreHTTPSErrors, !this._appMode, this._screenshotTaskQueue);
+    const target = new Target(targetInfo, this, () => this._connection.createSession(targetInfo.targetId), this._ignoreHTTPSErrors, !this._appMode, this._screenshotTaskQueue);
     console.assert(!this._targets.has(event.targetInfo.targetId), 'Target should not exist before targetCreated');
     this._targets.set(event.targetInfo.targetId, target);
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -114,6 +114,13 @@ class Page extends EventEmitter {
     return this._target;
   }
 
+  /**
+   * @return {!Puppeteer.Browser}
+   */
+  browser() {
+    return this._target.browser();
+  }
+
   _onTargetCrashed() {
     this.emit('error', new Error('Page crashed!'));
   }

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -4,13 +4,15 @@ const {helper} = require('./helper');
 class Target {
   /**
    * @param {!Puppeteer.TargetInfo} targetInfo
+   * @param {!Puppeteer.Browser} browser
    * @param {!function():!Promise<!Puppeteer.CDPSession>} sessionFactory
    * @param {boolean} ignoreHTTPSErrors
    * @param {boolean} setDefaultViewport
    * @param {!Puppeteer.TaskQueue} screenshotTaskQueue
    */
-  constructor(targetInfo, sessionFactory, ignoreHTTPSErrors, setDefaultViewport, screenshotTaskQueue) {
+  constructor(targetInfo, browser, sessionFactory, ignoreHTTPSErrors, setDefaultViewport, screenshotTaskQueue) {
     this._targetInfo = targetInfo;
+    this._browser = browser;
     this._targetId = targetInfo.targetId;
     this._sessionFactory = sessionFactory;
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
@@ -58,6 +60,13 @@ class Target {
     if (type === 'page' || type === 'service_worker' || type === 'browser')
       return type;
     return 'other';
+  }
+
+  /**
+   * @return {!Puppeteer.Browser}
+   */
+  browser() {
+    return this._browser;
   }
 
   /**

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1555,4 +1555,10 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       await closedPromise;
     });
   });
+
+  describe('Page.browser', function() {
+    it('should return the correct browser instance', async function({ page, browser }) {
+      expect(page.browser()).toBe(browser);
+    });
+  });
 };


### PR DESCRIPTION
As suggested in #2275, having access to the browser instance from the page object can be useful. This PR implements that.

This is my first PR and I'm not intimately familiar with the architecture of puppeteer, so I'm not sure if this is the best way of implementing the feature, but feel free to show me the error of my ways if I'm doing something stupid.