### PR TITLE
feat(Chromium): roll Chromium to r551292

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ws": "^3.0.0"
   },
   "puppeteer": {
-    "chromium_revision": "549031"
+    "chromium_revision": "551292"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",


### PR DESCRIPTION
This roll includes:
- https://crrev.com/551261 - DevTools: page.navigate should fail when server returned HTTP 204
- https://crrev.com/550319 - DevTools: fix resource mimetype for request interception of file:// urls

References #1879
References #1506