### PR TITLE
 feature(Page): evaluate should return a special message in case of non serialisable returned value

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -825,7 +825,7 @@ List of all available devices is available in the source code: [DeviceDescriptor
 
 If the function passed to the `page.evaluate` returns a [Promise], then `page.evaluate` would wait for the promise to resolve and return its value.
 
-If the function passed to the `page.evaluate` returns a non-[Serializable] value, then `page.evaluate` resolves to `undefined`.
+If the function passed to the `page.evaluate` returns a non-[Serializable] value, then `page.evaluate` resolves to `Non serializable object returned from evaluate` message.
 
 Passing arguments to `pageFunction`:
 ```js
@@ -1802,7 +1802,7 @@ Gets the full HTML contents of the frame, including the doctype.
 
 If the function passed to the `frame.evaluate` returns a [Promise], then `frame.evaluate` would wait for the promise to resolve and return its value.
 
-If the function passed to the `frame.evaluate` returns a non-[Serializable] value, then `frame.evaluate` resolves to `undefined`.
+If the function passed to the `frame.evaluate` returns a non-[Serializable] value, then `frame.evaluate` resolves to `Non serializable object returned from evaluate` message.
 
 ```js
 const result = await frame.evaluate(() => {

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -46,9 +46,9 @@ class ExecutionContext {
     const handle = await this.evaluateHandle(pageFunction, ...args);
     const result = await handle.jsonValue().catch(error => {
       if (error.message.includes('Object reference chain is too long'))
-        return;
+        return helper.getNonSerializableMessage();
       if (error.message.includes('Object couldn\'t be returned by value'))
-        return;
+        return helper.getNonSerializableMessage();
       throw error;
     });
     await handle.dispose();

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -209,6 +209,10 @@ class Helper {
     apiCoverage = new Map();
   }
 
+  static getNonSerializableMessage() {
+    return 'Non serializable object returned from evaluate';
+  }
+
   /**
    * @param {!Object} obj
    * @return {boolean}

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const utils = require('./utils');
+const {helper} = require('../lib/helper');
 const {waitEvent, getPDFPages, cssPixelsToInches} = require('./utils');
 
 module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescriptors, headless}) {
@@ -124,9 +125,9 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
     it('should properly serialize null fields', async({page}) => {
       expect(await page.evaluate(() => ({a: undefined}))).toEqual({});
     });
-    it('should return undefined for non-serializable objects', async({page, server}) => {
-      expect(await page.evaluate(() => window)).toBe(undefined);
-      expect(await page.evaluate(() => [Symbol('foo4')])).toBe(undefined);
+    fit('should return \'Non serializable object returned from evaluate\' for non-serializable objects', async({page, server}) => {
+      expect(await page.evaluate(() => window)).toBe(helper.getNonSerializableMessage());
+      expect(await page.evaluate(() => [Symbol('foo4')])).toBe(helper.getNonSerializableMessage());
     });
     it('should fail for circular object', async({page, server}) => {
       const result = await page.evaluate(() => {

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -125,7 +125,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
     it('should properly serialize null fields', async({page}) => {
       expect(await page.evaluate(() => ({a: undefined}))).toEqual({});
     });
-    fit('should return \'Non serializable object returned from evaluate\' for non-serializable objects', async({page, server}) => {
+    it('should return \'Non serializable object returned from evaluate\' for non-serializable objects', async({page, server}) => {
       expect(await page.evaluate(() => window)).toBe(helper.getNonSerializableMessage());
       expect(await page.evaluate(() => [Symbol('foo4')])).toBe(helper.getNonSerializableMessage());
     });
@@ -136,7 +136,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
         a.b = b;
         return a;
       });
-      expect(result).toBe(undefined);
+      expect(result).toBe(helper.getNonSerializableMessage());
     });
     it('should accept a string', async({page, server}) => {
       const result = await page.evaluate('1 + 2');


### PR DESCRIPTION
This PR is a followup for the following discussion: https://github.com/GoogleChrome/puppeteer/issues/2418#issuecomment-383156756

I wasn't sure which message do we want for each scenario, and how exactly do we want to implement the entire feature (if we want it at all...). So it is a start - we can discuss it from here.

it will fix #2420 