### PR TITLE
fix(Launcher): exit the process after killing chrome on SIGINT

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -143,7 +143,7 @@ class Launcher {
 
     const listeners = [ helper.addEventListener(process, 'exit', killChrome) ];
     if (options.handleSIGINT !== false)
-      listeners.push(helper.addEventListener(process, 'SIGINT', killChrome));
+      listeners.push(helper.addEventListener(process, 'SIGINT', () => { killChrome(); process.exit(130); }));
     if (options.handleSIGTERM !== false)
       listeners.push(helper.addEventListener(process, 'SIGTERM', gracefullyCloseChrome));
     if (options.handleSIGHUP !== false)


### PR DESCRIPTION
👋 Hey

This is a fix for this issue https://github.com/facebook/jest/issues/5748

In the issue, `puppeteer.launch` method is called from jest `globalSetup` script which [is running on the same process as jest](https://github.com/facebook/jest/blob/6a77ee37ec2d46ece7e9cfd0f891d11c113cc4c4/packages/jest-cli/src/run_jest.js#L242).

Puppeteer catches `SIGINT` in order to kill chrome, but it also replaces the default behaviour of `SIGINT`, [which is to exit with status code 130](https://nodejs.org/dist/latest-v9.x/docs/api/all.html#process_signal_events). In jest's case, the process does not exit, which keeps the process hanging in a weird way.

This PR makes sure that the process exits after killing chrome.