### PR TITLE
chore(doclint): remove SourceFactory

### DIFF
--- a/utils/doclint/check_public_api/test/test.js
+++ b/utils/doclint/check_public_api/test/test.js
@@ -17,7 +17,7 @@
 const path = require('path');
 const puppeteer = require('../../../..');
 const checkPublicAPI = require('..');
-const SourceFactory = require('../../SourceFactory');
+const Source = require('../../Source');
 const mdBuilder = require('../MDBuilder');
 const jsBuilder = require('../JSBuilder');
 const GoldenUtils = require('../../../../test/golden-utils');
@@ -64,9 +64,8 @@ async function testLint(state, test) {
     toBeGolden: GoldenUtils.compare.bind(null, dirPath, dirPath)
   });
 
-  const factory = new SourceFactory();
-  const mdSources = await factory.readdir(dirPath, '.md');
-  const jsSources = await factory.readdir(dirPath, '.js');
+  const mdSources = await Source.readdir(dirPath, '.md');
+  const jsSources = await Source.readdir(dirPath, '.js');
   const messages = await checkPublicAPI(page, mdSources, jsSources);
   const errors = messages.map(message => message.text);
   expect(errors.join('\n')).toBeGolden('result.txt');
@@ -77,8 +76,7 @@ async function testMDBuilder(state, test) {
   const {expect} = new Matchers({
     toBeGolden: GoldenUtils.compare.bind(null, dirPath, dirPath)
   });
-  const factory = new SourceFactory();
-  const sources = await factory.readdir(dirPath, '.md');
+  const sources = await Source.readdir(dirPath, '.md');
   const {documentation} = await mdBuilder(page, sources);
   expect(serialize(documentation)).toBeGolden('result.txt');
 }
@@ -88,8 +86,7 @@ async function testJSBuilder(state, test) {
   const {expect} = new Matchers({
     toBeGolden: GoldenUtils.compare.bind(null, dirPath, dirPath)
   });
-  const factory = new SourceFactory();
-  const sources = await factory.readdir(dirPath, '.js');
+  const sources = await Source.readdir(dirPath, '.js');
   const {documentation} = await jsBuilder(sources);
   expect(serialize(documentation)).toBeGolden('result.txt');
 }

--- a/utils/doclint/preprocessor/test.js
+++ b/utils/doclint/preprocessor/test.js
@@ -15,9 +15,7 @@
  */
 
 const preprocessor = require('.');
-const SourceFactory = require('../SourceFactory');
-const factory = new SourceFactory();
-
+const Source = require('../Source');
 const {TestRunner, Reporter, Matchers}  = require('../../testrunner/');
 const runner = new TestRunner();
 new Reporter(runner);
@@ -29,7 +27,7 @@ const {expect} = new Matchers();
 
 describe('preprocessor', function() {
   it('should throw for unknown command', function() {
-    const source = factory.createForTest('doc.md', `
+    const source = new Source('doc.md', `
       <!-- gen:unknown-command -->something<!-- gen:stop -->
     `);
     const messages = preprocessor([source], '1.1.1');
@@ -40,7 +38,7 @@ describe('preprocessor', function() {
   });
   describe('gen:version', function() {
     it('should work', function() {
-      const source = factory.createForTest('doc.md', `
+      const source = new Source('doc.md', `
         Puppeteer <!-- gen:version -->XXX<!-- gen:stop -->
       `);
       const messages = preprocessor([source], '1.2.0');
@@ -52,7 +50,7 @@ describe('preprocessor', function() {
       `);
     });
     it('should work for *-post versions', function() {
-      const source = factory.createForTest('doc.md', `
+      const source = new Source('doc.md', `
         Puppeteer <!-- gen:version -->XXX<!-- gen:stop -->
       `);
       const messages = preprocessor([source], '1.2.0-post');
@@ -64,13 +62,13 @@ describe('preprocessor', function() {
       `);
     });
     it('should tolerate different writing', function() {
-      const source = factory.createForTest('doc.md', `Puppeteer v<!--   gEn:version -->WHAT
+      const source = new Source('doc.md', `Puppeteer v<!--   gEn:version -->WHAT
 <!--     GEN:stop   -->`);
       preprocessor([source], '1.1.1');
       expect(source.text()).toBe(`Puppeteer v<!--   gEn:version -->v1.1.1<!--     GEN:stop   -->`);
     });
     it('should not tolerate missing gen:stop', function() {
-      const source = factory.createForTest('doc.md', `<!--GEN:version-->`);
+      const source = new Source('doc.md', `<!--GEN:version-->`);
       const messages = preprocessor([source], '1.2.0');
       expect(source.hasUpdatedText()).toBe(false);
       expect(messages.length).toBe(1);
@@ -80,7 +78,7 @@ describe('preprocessor', function() {
   });
   describe('gen:empty-if-release', function() {
     it('should clear text when release version', function() {
-      const source = factory.createForTest('doc.md', `
+      const source = new Source('doc.md', `
         <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
       `);
       const messages = preprocessor([source], '1.1.1');
@@ -92,7 +90,7 @@ describe('preprocessor', function() {
       `);
     });
     it('should keep text when non-release version', function() {
-      const source = factory.createForTest('doc.md', `
+      const source = new Source('doc.md', `
         <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
       `);
       const messages = preprocessor([source], '1.1.1-post');
@@ -103,7 +101,7 @@ describe('preprocessor', function() {
     });
   });
   it('should work with multiple commands', function() {
-    const source = factory.createForTest('doc.md', `
+    const source = new Source('doc.md', `
       <!-- gen:version -->XXX<!-- gen:stop -->
       <!-- gen:empty-if-release -->YYY<!-- gen:stop -->
       <!-- gen:version -->ZZZ<!-- gen:stop -->


### PR DESCRIPTION
SourceFactory was meant to cache Sources so that they could be used
in different preprocessor tasks.

This turned out to be over-engineering. This patch kills the layer.