### PR TITLE
chore: add a bunch of non-needed files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,16 @@ package-lock.json
 /utils
 /docs
 yarn.lock
+
+# other
+/.ci
+/examples
+.appveyour.yml
+.cirrus.yml
+.editorconfig
+.eslintignore
+.eslintrc.js
+.travis.yml
+README.md
+tsconfig.json
+


### PR DESCRIPTION
There's no need to publish these files. This saves ~22kb
in published size.