### PR TITLE
chore: testrunner's ".not" should print appropriate message

### DIFF
--- a/utils/testrunner/Matchers.js
+++ b/utils/testrunner/Matchers.js
@@ -37,13 +37,13 @@ class Expect {
     this.not.not = this;
     for (const matcherName of Object.keys(matchers)) {
       const matcher = matchers[matcherName];
-      this[matcherName] = applyMatcher.bind(null, matcherName, matcher, false, value);
-      this.not[matcherName] = applyMatcher.bind(null, matcherName, matcher, true, value);
+      this[matcherName] = applyMatcher.bind(null, matcherName, matcher, false /* inverse */, value);
+      this.not[matcherName] = applyMatcher.bind(null, matcherName, matcher, true /* inverse */, value);
     }
 
     function applyMatcher(matcherName, matcher, inverse, value, ...args) {
       const result = matcher.call(null, value, ...args);
-      const message = `expect.${matcherName} failed` + (result.message ? `: ${result.message}` : '');
+      const message = `expect.${inverse ? 'not.' : ''}${matcherName} failed` + (result.message ? `: ${result.message}` : '');
       console.assert(result.pass !== inverse, message);
     }
   }

--- a/utils/testrunner/examples/fail.js
+++ b/utils/testrunner/examples/fail.js
@@ -43,6 +43,9 @@ describe('testsuite', () => {
   it('toContain', async (state) => {
     expect('asdf').toContain('e');
   });
+  it('not.toContain', async (state) => {
+    expect('asdf').not.toContain('a');
+  });
   it('toEqual', async (state) => {
     expect([1,2,3]).toEqual([1,2,3,4]);
   });


### PR DESCRIPTION
When failing, the ".not" matchers should print their name
with ".not" prefix.