### PR TITLE
fix(Launcher): PUPPETEER_CHROMIUM_REVISION not used when launching chromium #2490

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -23,7 +23,7 @@ const Browser = require('./Browser');
 const readline = require('readline');
 const fs = require('fs');
 const {helper, debugError} = require('./helper');
-const ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')).puppeteer.chromium_revision;
+const process.env.PUPPETEER_CHROMIUM_REVISION || ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')).puppeteer.chromium_revision;
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);


### PR DESCRIPTION
fix(Launcher): PUPPETEER_CHROMIUM_REVISION not used when launching chromium #2490

Check for PUPPETEER_CHROMIUM_REVISION when launching the browser, can be used during installation