### PR TITLE
chore: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^3.1.0",
-    "extract-zip": "^1.6.5",
-    "https-proxy-agent": "^2.1.0",
+    "extract-zip": "^1.6.6",
+    "https-proxy-agent": "^2.2.1",
     "mime": "^2.0.3",
     "progress": "^2.0.0",
     "proxy-from-env": "^1.0.0",
     "rimraf": "^2.6.1",
-    "ws": "^3.0.0"
+    "ws": "^5.1.1"
   },
   "puppeteer": {
     "chromium_revision": "557152"
@@ -47,7 +47,7 @@
     "@types/ws": "^3.0.2",
     "commonmark": "^0.27.0",
     "cross-env": "^5.0.5",
-    "eslint": "^4.0.0",
+    "eslint": "^4.19.1",
     "esprima": "^4.0.0",
     "markdown-toc": "^1.2.0",
     "minimist": "^1.2.0",

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -63,14 +63,14 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       const events = [];
       context.on('targetcreated', target => events.push('CREATED: ' + target.url()));
       context.on('targetchanged', target => events.push('CHANGED: ' + target.url()));
-      context.on('targetdestroyed', target => events.push('DESTRYOED: ' + target.url()));
+      context.on('targetdestroyed', target => events.push('DESTROYED: ' + target.url()));
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.close();
       expect(events).toEqual([
         'CREATED: about:blank',
-        'CHANGED: http://localhost:8907/empty.html',
-        'DESTRYOED: http://localhost:8907/empty.html'
+        `CHANGED: ${server.EMPTY_PAGE}`,
+        `DESTROYED: ${server.EMPTY_PAGE}`
       ]);
       await context.close();
     });


### PR DESCRIPTION
This patch bumps dependencies so that `npm audit` doesn't yell
at us.

Drive-by: fix browsercontext test to run nicely in parallel mode.