### PR TITLE
fix(page): respect timeout 0 in page.waitForFunction

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -911,7 +911,8 @@ class WaitTask {
 async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...args) {
   const predicate = new Function('...args', predicateBody);
   let timedOut = false;
-  setTimeout(() => timedOut = true, timeout);
+  if (timeout)
+    setTimeout(() => timedOut = true, timeout);
   if (polling === 'raf')
     return await pollRaf();
   if (polling === 'mutation')

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -163,8 +163,7 @@ module.exports.addTests = function({testRunner, expect}) {
         window.__counter = (window.__counter || 0) + 1;
         return window.__injected;
       }, {timeout: 0, polling: 10});
-      await page.waitFor(100);
-      expect(await page.evaluate(() => window.__counter)).not.toBe(0);
+      await page.waitForFunction(() => window.__counter > 10);
       await page.evaluate(() => window.__injected = true);
       await watchdog;
     });

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -159,10 +159,14 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(error.message).toContain('waiting for function failed: timeout');
     });
     it('should disable timeout when its set to 0', async({page}) => {
-      let error = null;
-      const res = await page.waitForFunction(() => new Promise(res => setTimeout(() => res(42), 100)), {timeout: 0}).catch(e => error = e);
-      expect(error).toBe(null);
-      expect(await res.jsonValue()).toBe(42);
+      const watchdog = page.waitForFunction(() => {
+        window.__counter = (window.__counter || 0) + 1;
+        return window.__injected;
+      }, {timeout: 0, polling: 10});
+      await page.waitFor(100);
+      expect(await page.evaluate(() => window.__counter)).not.toBe(0);
+      await page.evaluate(() => window.__injected = true);
+      await watchdog;
     });
   });
 


### PR DESCRIPTION
The in-page task should not set timeout when timeout is 0.

Fixes #2540.