### PR TITLE
feat(page): don't report clientside error with a node stack attached

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -424,7 +424,9 @@ class Page extends EventEmitter {
    */
   _handleException(exceptionDetails) {
     const message = helper.getExceptionMessage(exceptionDetails);
-    this.emit(Page.Events.PageError, new Error(message));
+    const err = new Error(message);
+    err.stack = ''; // Don't report clientside error with a node stack attached
+    this.emit(Page.Events.PageError, err);
   }
 
   async _onConsoleAPI(event) {


### PR DESCRIPTION
If you're listening to errors reported via the `'pageerror'` event, it's very odd for it to have a callstack from node appended to the clientside callstack.

Repro:

<details>

```js
(async function() {
  const browser = await puppeteer.launch();
  const page = await browser.newPage();

  page.on('pageerror', error => console.error('pageerror recieved', error));

  await page.goto('https://output.jsbin.com/yuxaxeh/quiet');
  await browser.close();
})();
```

</details>

### Before
![image](https://user-images.githubusercontent.com/39191/40251558-754e376e-5a8e-11e8-8fa9-3268259a8f09.png)

### After
![image](https://user-images.githubusercontent.com/39191/40251563-7b709240-5a8e-11e8-9224-f1a299c7622a.png)
