### PR TITLE
fix: wait for execution context after navigation

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -291,7 +291,6 @@ class Frame {
     /** @type {?Promise<!ExecutionContext>} */
     this._contextPromise = null;
     this._contextResolveCallback = null;
-    this._rawContextPromise = null;
     this._setDefaultContext(null);
 
     this._navigationPromise = null;
@@ -312,11 +311,8 @@ class Frame {
   /**
    * @param {?ExecutionContext} context
    */
-  async _setDefaultContext(context) {
+  _setDefaultContext(context) {
     if (context) {
-      // If we navigated, this context is stale
-      if (await this._navigationPromise)
-        return;
       this._contextResolveCallback.call(null, context);
       this._contextResolveCallback = null;
       for (const waitTask of this._waitTasks)
@@ -332,8 +328,13 @@ class Frame {
   /**
    * @return {!Promise<!ExecutionContext>}
    */
-  executionContext() {
-    return this._contextPromise;
+  async executionContext() {
+    let context = await this._contextPromise;
+    while (this._navigationPromise) {
+      await this._navigationPromise;
+      context = await this._contextPromise;
+    }
+    return context;
   }
 
   /**
@@ -342,7 +343,7 @@ class Frame {
    * @return {!Promise<!Puppeteer.JSHandle>}
    */
   async evaluateHandle(pageFunction, ...args) {
-    const context = await this._contextPromise;
+    const context = await this.executionContext();
     return context.evaluateHandle(pageFunction, ...args);
   }
 
@@ -352,7 +353,7 @@ class Frame {
    * @return {!Promise<*>}
    */
   async evaluate(pageFunction, ...args) {
-    const context = await this._contextPromise;
+    const context = await this.executionContext();
     return context.evaluate(pageFunction, ...args);
   }
 
@@ -372,7 +373,7 @@ class Frame {
   async _document() {
     if (this._documentPromise)
       return this._documentPromise;
-    this._documentPromise = this._contextPromise.then(async context => {
+    this._documentPromise = this.executionContext().then(async context => {
       const document = await context.evaluateHandle('document');
       return document.asElement();
     });
@@ -408,7 +409,7 @@ class Frame {
    * @return {!Promise<(!Object|undefined)>}
    */
   async $$eval(selector, pageFunction, ...args) {
-    const context = await this._contextPromise;
+    const context = await this.executionContext();
     const arrayHandle = await context.evaluateHandle(selector => Array.from(document.querySelectorAll(selector)), selector);
     const result = await this.evaluate(pageFunction, arrayHandle, ...args);
     await arrayHandle.dispose();
@@ -493,7 +494,7 @@ class Frame {
     if (typeof options.url === 'string') {
       const url = options.url;
       try {
-        const context = await this._contextPromise;
+        const context = await this.executionContext();
         return (await context.evaluateHandle(addScriptUrl, url, options.type)).asElement();
       } catch (error) {
         throw new Error(`Loading script from ${url} failed`);
@@ -503,12 +504,12 @@ class Frame {
     if (typeof options.path === 'string') {
       let contents = await readFileAsync(options.path, 'utf8');
       contents += '//# sourceURL=' + options.path.replace(/\n/g, '');
-      const context = await this._contextPromise;
+      const context = await this.executionContext();
       return (await context.evaluateHandle(addScriptContent, contents, options.type)).asElement();
     }
 
     if (typeof options.content === 'string') {
-      const context = await this._contextPromise;
+      const context = await this.executionContext();
       return (await context.evaluateHandle(addScriptContent, options.content, options.type)).asElement();
     }
 
@@ -559,7 +560,7 @@ class Frame {
     if (typeof options.url === 'string') {
       const url = options.url;
       try {
-        const context = await this._contextPromise;
+        const context = await this.executionContext();
         return (await context.evaluateHandle(addStyleUrl, url)).asElement();
       } catch (error) {
         throw new Error(`Loading style from ${url} failed`);
@@ -569,12 +570,12 @@ class Frame {
     if (typeof options.path === 'string') {
       let contents = await readFileAsync(options.path, 'utf8');
       contents += '/*# sourceURL=' + options.path.replace(/\n/g, '') + '*/';
-      const context = await this._contextPromise;
+      const context = await this.executionContext();
       return (await context.evaluateHandle(addStyleContent, contents)).asElement();
     }
 
     if (typeof options.content === 'string') {
-      const context = await this._contextPromise;
+      const context = await this.executionContext();
       return (await context.evaluateHandle(addStyleContent, options.content)).asElement();
     }
 
@@ -805,21 +806,11 @@ class Frame {
       this._navigationPromise = null;
       this._navigationCallback = null;
     });
-    const originalContextPromise = this._contextPromise;
-    const promise = this._navigationPromise.then(navigated => {
-      if (promise === this._contextPromise) {
-        console.assert(!navigated, 'The default execution context should not survive navigation.');
-        return originalContextPromise;
-      }
-      // A context was added or removed during the navigation, so we return the new contextPromise.
-      return this._contextPromise;
-    });
-    this._contextPromise = promise;
   }
 
   _navigationCanceled() {
     if (this._navigationCallback)
-      this._navigationCallback(false);
+      this._navigationCallback();
   }
 
   /**
@@ -831,7 +822,7 @@ class Frame {
     this._navigationURL = framePayload.url;
     this._url = framePayload.url;
     if (this._navigationCallback)
-      this._navigationCallback(true);
+      this._navigationCallback();
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -46,8 +46,30 @@ class FrameManager extends EventEmitter {
     this._client.on('Runtime.executionContextDestroyed', event => this._onExecutionContextDestroyed(event.executionContextId));
     this._client.on('Runtime.executionContextsCleared', event => this._onExecutionContextsCleared());
     this._client.on('Page.lifecycleEvent', event => this._onLifecycleEvent(event));
+    this._client.on('Page.frameScheduledNavigation', event => this._onFrameScheduledNavigation(event));
+    this._client.on('Page.frameCanceledNavigation', event => this._onFrameCanceledNavigation(event));
 
     this._handleFrameTree(frameTree);
+  }
+
+  /**
+   * @param {!Protocol.Page.frameScheduledNavigationPayload} event
+   */
+  _onFrameScheduledNavigation(event) {
+    if (event.delay > 0)
+      return;
+    const frame = this._frames.get(event.frameId);
+    if (frame)
+      frame._navigationScheduled();
+  }
+
+  /**
+   * @param {!Protocol.Page.frameCanceledNavigationPayload} event
+   */
+  _onFrameCanceledNavigation(event) {
+    const frame = this._frames.get(event.frameId);
+    if (frame)
+      frame._navigationCanceled();
   }
 
   /**
@@ -128,6 +150,7 @@ class FrameManager extends EventEmitter {
    */
   _onFrameNavigated(framePayload) {
     const isMainFrame = !framePayload.parentId;
+    /** @type {!Frame} */
     let frame = isMainFrame ? this._mainFrame : this._frames.get(framePayload.id);
     console.assert(isMainFrame || frame, 'We either navigate top level or have old version of the navigated frame');
 
@@ -268,7 +291,11 @@ class Frame {
     /** @type {?Promise<!ExecutionContext>} */
     this._contextPromise = null;
     this._contextResolveCallback = null;
+    this._rawContextPromise = null;
     this._setDefaultContext(null);
+
+    this._navigationPromise = null;
+    this._navigationCallback = null;
 
     /** @type {!Set<!WaitTask>} */
     this._waitTasks = new Set();
@@ -285,8 +312,11 @@ class Frame {
   /**
    * @param {?ExecutionContext} context
    */
-  _setDefaultContext(context) {
+  async _setDefaultContext(context) {
     if (context) {
+      // If we navigated, this context is stale
+      if (await this._navigationPromise)
+        return;
       this._contextResolveCallback.call(null, context);
       this._contextResolveCallback = null;
       for (const waitTask of this._waitTasks)
@@ -766,6 +796,32 @@ class Frame {
     }
   }
 
+  _navigationScheduled() {
+    if (this._navigationPromise)
+      return;
+    this._navigationPromise = new Promise(callback => {
+      this._navigationCallback = callback;
+    }).then(() => {
+      this._navigationPromise = null;
+      this._navigationCallback = null;
+    });
+    const originalContextPromise = this._contextPromise;
+    const promise = this._navigationPromise.then(navigated => {
+      if (promise === this._contextPromise) {
+        console.assert(!navigated, 'The default execution context should not survive navigation.');
+        return originalContextPromise;
+      }
+      // A context was added or removed during the navigation, so we return the new contextPromise.
+      return this._contextPromise;
+    });
+    this._contextPromise = promise;
+  }
+
+  _navigationCanceled() {
+    if (this._navigationCallback)
+      this._navigationCallback(false);
+  }
+
   /**
    * @param {!Protocol.Page.Frame} framePayload
    */
@@ -774,6 +830,8 @@ class Frame {
     // TODO(lushnikov): remove this once requestInterception has loaderId exposed.
     this._navigationURL = framePayload.url;
     this._url = framePayload.url;
+    if (this._navigationCallback)
+      this._navigationCallback(true);
   }
 
   /**

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1618,8 +1618,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
     });
   });
 
-  // for (var i = 0; i < 1000; i++)
-  fdescribe('Execution Context / Navigation race', function() {
+  describe('Execution Context / Navigation race', function() {
     it('should wait for a-click navigation', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.setContent('<a href="grid.html">click here</a>');

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1617,4 +1617,146 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       expect(page.browser()).toBe(browser);
     });
   });
+
+  // for (var i = 0; i < 1000; i++)
+  fdescribe('Execution Context / Navigation race', function() {
+    it('should wait for a-click navigation', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent('<a href="grid.html">click here</a>');
+      await page.click('a');
+      expect(await page.evaluate(() => document.location.href)).toBe(server.PREFIX + '/grid.html');
+    });
+    it('should wait for cross-process a-click navigation', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent(`<a href="${server.CROSS_PROCESS_PREFIX}/grid.html">click here</a>`);
+      await page.click('a');
+      expect(await page.evaluate(() => document.location.href)).toBe(server.CROSS_PROCESS_PREFIX + '/grid.html');
+    });
+    it('should wait for a-keyboard navigation', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent('<a href="grid.html">click here</a>');
+      const a = await page.$('a');
+      await a.press('Enter');
+      expect(await page.evaluate(() => document.location.href)).toBe(server.PREFIX + '/grid.html');
+    });
+    it('should not wait for a-click to a 204', async({page, server}) => {
+      server.setRoute('/nextpage', async(req, res) => {
+        res.statusCode = 204;
+        res.end();
+      });
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent('<a href="/nextpage">click here</a>');
+      await page.click('a');
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+    it('should not wait for a-click with preventDefault', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent('<a href="grid.html">click here</a>');
+      await page.evaluate(() => document.querySelector('a').addEventListener('click', e => e.preventDefault()));
+      await page.click('a');
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+    it('should not wait for a-click that was canceled by the renderer', async({page, server}) => {
+      server.setRoute('/nextpage', async(req, res) => {
+        // stall
+      });
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent('<a href="/nextpage">click here</a>');
+      await page.evaluate(() => document.querySelector('a').addEventListener('click', e => setTimeout(() => document.open())));
+      await page.click('a');
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+    it('should wait for a navigation side effect', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        document.location.href = 'grid.html';
+      });
+      expect(await page.evaluate(() => document.location.href)).toBe(server.PREFIX + '/grid.html');
+    });
+    it('reload', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        window.__dontFindThis = true;
+        document.location.reload();
+      });
+      expect(await page.evaluate(() => window.__dontFindThis)).not.toBe(true);
+    });
+    it('navigation after a renderer-canceled navigation to a different page', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        document.location.href = 'grid.html';
+        document.location.href = 'tamperable.html';
+      });
+      expect(await page.evaluate(() => document.location.href)).toBe(server.PREFIX + '/tamperable.html');
+    });
+    it('navigation after a renderer-canceled navigation to the same page', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        document.location.href = 'grid.html';
+        document.location.href = 'empty.html';
+      });
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+    it('fail to naviagte', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      server.setRoute('/nextpage', async(req, res) => {
+        res.statusCode = 204;
+        res.end();
+      });
+      await page.evaluate(() => {
+        document.location.href = '/nextpage';
+      });
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+    it('cancel a navigation after it commits and has an execution context', async({page, server}) => {
+      let cleanup;
+      const promise = new Promise(x => cleanup = x);
+      await page.goto(server.EMPTY_PAGE);
+      server.setRoute('/nextpage', async(req, res) => {
+        await evalPromise;
+        res.write('<body><div id="token">token</div>');
+        await page.waitForSelector('#token');
+        await page._client.send('Page.stopLoading');
+        cleanup();
+      });
+      const evalPromise = page.evaluate(() => {
+        document.location.href = '/nextpage';
+      });
+      await evalPromise;
+      expect(await page.evaluate(() => document.location.href)).toBe(server.PREFIX + '/nextpage');
+      await promise;
+      expect(await page.evaluate(() => document.location.href)).toBe(server.PREFIX + '/nextpage');
+    });
+    it('cancel a navigation before it commits', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      server.setRoute('/nextpage', async(req, res) => {
+        await page._client.send('Page.stopLoading');
+      });
+      await page.evaluate(() => {
+        document.location.href = '/nextpage';
+      });
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+    it('cancel a navigation by the renderer after it hits the browser', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      server.setRoute('/nextpage', async(req, res) => {
+        await evalPromise;
+        await page.keyboard.down('1');
+      });
+      const evalPromise = page.evaluate(() => {
+        document.location.href = '/nextpage';
+        document.onkeydown = () => {
+          window.__shouldFindThis = true;
+          document.open();
+        };
+      });
+      await evalPromise;
+      expect(await page.evaluate(() => window.__shouldFindThis)).toBe(true);
+    });
+    it('should ignore the meta tag refresh', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setContent(`<meta http-equiv="refresh" content="30">`);
+      expect(await page.evaluate(() => document.location.href)).toBe(server.EMPTY_PAGE);
+    });
+  });
 };


### PR DESCRIPTION
This is blocked on https://chromium-review.googlesource.com/c/chromium/src/+/1066978

Waits for navigations to resolve before returning the frame's execution context.