### PR TITLE
feat(page): allow screenshot to return a base64 string

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1315,7 +1315,8 @@ Shortcut for [page.mainFrame().executionContext().queryObjects(prototypeHandle)]
     - `width` <[number]> width of clipping area
     - `height` <[number]> height of clipping area
   - `omitBackground` <[boolean]> Hides default white background and allows capturing screenshots with transparency. Defaults to `false`.
-- returns: <[Promise]<[Buffer]>> Promise which resolves to buffer with captured screenshot
+  - `encoding` <[string]> The encoding of the image, can be either `base64` or `binary`. Defaults to `binary`.
+- returns: <[Promise]<[Buffer|String]>> Promise which resolves to buffer or a base64 string (depending on the value of `encoding`) with captured screenshot.
 
 > **NOTE** Screenshots take at least 1/6 second on OS X. See https://crbug.com/741689 for discussion.
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -723,7 +723,7 @@ class Page extends EventEmitter {
 
   /**
    * @param {!Object=} options
-   * @return {!Promise<!Buffer>}
+   * @return {!Promise<!Buffer|!String>}
    */
   async screenshot(options = {}) {
     let screenshotType = null;
@@ -763,7 +763,7 @@ class Page extends EventEmitter {
   /**
    * @param {"png"|"jpeg"} format
    * @param {!Object=} options
-   * @return {!Promise<!Buffer>}
+   * @return {!Promise<!Buffer|!String>}
    */
   async _screenshotTask(format, options) {
     await this._client.send('Target.activateTarget', {targetId: this._target._targetId});
@@ -795,7 +795,7 @@ class Page extends EventEmitter {
     if (options.fullPage)
       await this.setViewport(this._viewport);
 
-    const buffer = Buffer.from(result.data, 'base64');
+    const buffer = options.encoding === 'base64' ? result.data : Buffer.from(result.data, 'base64');
     if (options.path)
       await writeFileAsync(options.path, buffer);
     return buffer;

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1504,6 +1504,14 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       });
       expect(screenshot).toBeGolden('screenshot-clip-odd-size.png');
     });
+    it('should return base64', async({page, server}) => {
+      await page.setViewport({width: 500, height: 500});
+      await page.goto(server.PREFIX + '/grid.html');
+      const screenshot = await page.screenshot({
+        encoding: 'base64'
+      });
+      expect(Buffer.from(screenshot, 'base64')).toBeGolden('screenshot-sanity.png');
+    });
   });
 
   describe('Page.select', function() {


### PR DESCRIPTION
Fixes #2566 

Add `encoding` to the options passed to screenshot. When set to `base64` will return a base64 string instead of a buffer. 