### PR TITLE
docs: update page.$$eval and frame.$$eval with 'Array.from'

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -774,7 +774,7 @@ Shortcut for [page.mainFrame().$$(selector)](#frameselector-1).
 - `...args` <...[Serializable]|[JSHandle]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
 
-This method runs `document.querySelectorAll` within the page and passes it as the first argument to `pageFunction`.
+This method runs `Array.from(document.querySelectorAll(selector))` within the page and passes it as the first argument to `pageFunction`.
 
 If `pageFunction` returns a [Promise], then `page.$$eval` would wait for the promise to resolve and return its value.
 
@@ -1896,7 +1896,7 @@ The method runs `document.querySelectorAll` within the frame. If no elements mat
 - `...args` <...[Serializable]|[JSHandle]> Arguments to pass to `pageFunction`
 - returns: <[Promise]<[Serializable]>> Promise which resolves to the return value of `pageFunction`
 
-This method runs `document.querySelectorAll` within the frame and passes it as the first argument to `pageFunction`.
+This method runs `Array.from(document.querySelectorAll(selector))` within the frame and passes it as the first argument to `pageFunction`.
 
 If `pageFunction` returns a [Promise], then `frame.$$eval` would wait for the promise to resolve and return its value.
 


### PR DESCRIPTION
Docs about `page.$$eval` and `frame.$$eval` are not accurate and might be confusing. `document.querySelectorAll` returns `NodeList`, while `frame.$$eval` is actually doing `Array.from(querySelectorAll(selector))`, which actually returns an array. 

This makes things this possible:

`await page.$$eval('div', divs => divs.map...)` 

This patch fixes docs to mention that $$eval is actually performing:

`Array.from(querySelectorAll(selector))`

Which will let the user understand that the element he receives is an array, and not a NodeList.
