### PR TITLE
fix: worker execution context flakiness

### DIFF
--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -28,7 +28,13 @@ class Worker extends EventEmitter {
     this._client = client;
     this._url = url;
     this._executionContextPromise = new Promise(x => this._executionContextCallback = x);
-    this._client.on('Runtime.executionContextCreated', event => {
+    this._client.once('Runtime.executionContextCreated', async event => {
+      // Get a reference to the main object on the worker as a hack around https://crbug.com/846099.
+      await this._client.send('Runtime.evaluate', {
+        expression: 'this',
+        returnByValue: false,
+        contextId: event.executionContextId
+      }).catch(debugError);
       const jsHandleFactory = remoteObject => new JSHandle(executionContext, client, remoteObject);
       const executionContext = new ExecutionContext(client, event.context, jsHandleFactory, null);
       this._executionContextCallback(executionContext);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1613,8 +1613,9 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
   });
   describe('Workers', function() {
     it('Page.workers', async function({page, server}) {
-      await page.goto(server.PREFIX + '/worker/worker.html');
-      await page.waitForFunction(() => !!worker);
+      await Promise.all([
+        new Promise(x => page.once('workercreated', x)),
+        page.goto(server.PREFIX + '/worker/worker.html')]);
       const worker = page.workers()[0];
       expect(worker.url()).toContain('worker.js');
       const executionContext = await worker.executionContext();


### PR DESCRIPTION
Some of the worker tests were failing on the bots. After investigating, I found one race in the test, and one race upstream in Chromium which I filed upstream as https://crbug.com/846099. But I added a small hack here as a temporary workaround.