### PR TITLE
feat(test): enable dumpio in tests

### DIFF
--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -206,7 +206,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         const dumpioTextToLog = 'MAGIC_DUMPIO_TEST';
         let dumpioData = '';
         const {spawn} = require('child_process');
-        const options = Object.assign({dumpio: true}, defaultBrowserOptions);
+        const options = Object.assign({}, defaultBrowserOptions, {dumpio: true});
         const res = spawn('node',
             [path.join(__dirname, 'fixtures', 'dumpio.js'), PROJECT_ROOT, JSON.stringify(options), server.EMPTY_PAGE, dumpioTextToLog]);
         res.stderr.on('data', data => dumpioData += data.toString('utf8'));

--- a/utils/testrunner/Reporter.js
+++ b/utils/testrunner/Reporter.js
@@ -83,6 +83,10 @@ class Reporter {
             console.log(stack.join('\n'));
           }
         }
+        if (test.output) {
+          console.log('  Output:');
+          console.log(test.output.split('\n').map(line => '    ' + line).join('\n'));
+        }
         console.log('');
       }
     }


### PR DESCRIPTION
This patch allows logging the output of the Chromium process to be enabled in tests by passing in the environment variable `DUMPIO=true`.

Additionally, the `stderr` of the Chromium process will always be logged in the the "Output" section of failing page tests.