### PR TITLE
fix: Change networkidle2 to networkidle0

### DIFF
--- a/examples/custom-event.js
+++ b/examples/custom-event.js
@@ -42,7 +42,7 @@ const puppeteer = require('puppeteer');
 
   await listenFor('app-ready'); // Listen for "app-ready" custom event on page load.
 
-  await page.goto('https://www.chromestatus.com/features', {waitUntil: 'networkidle2'});
+  await page.goto('https://www.chromestatus.com/features', {waitUntil: 'networkidle0'});
 
   await browser.close();
 })();


### PR DESCRIPTION
Switch example to networkidle0 to solve inconsistency of console messages 
Fixes #2587 