### PR TITLE
fix(tests): normalize scrollbars in headful tests

### DIFF
--- a/test/assets/frames/nested-frames.html
+++ b/test/assets/frames/nested-frames.html
@@ -7,6 +7,9 @@ body iframe {
     flex-grow: 1;
     flex-shrink: 1;
 }
+::-webkit-scrollbar{
+    display: none;
+}
 </style>
 <script>
 async function attachFrame(frameId, url) {

--- a/test/assets/grid.html
+++ b/test/assets/grid.html
@@ -45,4 +45,8 @@ body {
     box-sizing: border-box;
     border: 1px solid darkgray;
 }
+
+::-webkit-scrollbar {
+    display: none;
+}
 </style>

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -222,6 +222,9 @@ module.exports.addTests = function({testRunner, expect}) {
           height: 600px;
           margin-left: 50px;
         }
+        ::-webkit-scrollbar{
+          display: none;
+        }
         </style>
         <div class="to-screenshot"></div>
       `);

--- a/utils/testrunner/TestRunner.js
+++ b/utils/testrunner/TestRunner.js
@@ -295,7 +295,11 @@ class TestRunner extends EventEmitter {
   }
 
   _addTest(mode, name, callback) {
-    const test = new Test(this._currentSuite, name, callback, mode, this._timeout);
+    let suite = this._currentSuite;
+    let isSkipped = suite.declaredMode === TestMode.Skip;
+    while ((suite = suite.parentSuite))
+      isSkipped |= suite.declaredMode === TestMode.Skip;
+    const test = new Test(this._currentSuite, name, callback, isSkipped ? TestMode.Skip : mode, this._timeout);
     this._currentSuite.children.push(test);
     this._tests.push(test);
     this._hasFocusedTestsOrSuites = this._hasFocusedTestsOrSuites || mode === TestMode.Focus;


### PR DESCRIPTION
Scrollbars look different on different platforms, so must be made invisible in tests. As a drive-by, xdescribe was broken with the new test runner.