### PR TITLE
chore(types): generate protocol.d.ts on install

### DIFF
--- a/install.js
+++ b/install.js
@@ -109,21 +109,26 @@ function buildNode6IfNecessary() {
   // folder.
   if (!fs.existsSync(path.join('utils', 'node6-transform')))
     return;
-  let asyncawait = true;
-  try {
-    new Function('async function test(){await 1}');
-  } catch (error) {
-    asyncawait = false;
-  }
   // if async/await is supported, then node6 is not needed.
-  if (asyncawait)
+  if (supportsAsyncAwait())
     return;
   // Re-build node6/ folder.
   console.log('Building Puppeteer for Node 6');
   require(path.join(__dirname, 'utils', 'node6-transform'));
 }
 
+function supportsAsyncAwait() {
+  try {
+    new Function('async function test(){await 1}');
+  } catch (error) {
+    return false;
+  }
+  return true;
+}
+
 function generateProtocolTypesIfNecessary(updated) {
+  if (!supportsAsyncAwait())
+    return;
   const fs = require('fs');
   const path = require('path');
   if (!fs.existsSync(path.join(__dirname, 'utils', 'protocol-types-generator')))

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test-node6-transformer": "node utils/node6-transform/test/test.js",
     "build": "node utils/node6-transform/index.js",
     "unit-node6": "node node6/test/test.js",
-    "tsc": "node utils/protocol-types-generator && tsc -p .",
+    "tsc": "tsc -p .",
     "prepublishOnly": "npm run build",
     "apply-next-version": "node utils/apply_next_version.js"
   },

--- a/utils/protocol-types-generator/index.js
+++ b/utils/protocol-types-generator/index.js
@@ -1,6 +1,7 @@
 // @ts-check
+const path = require('path');
 const puppeteer = require('../..');
-puppeteer.launch({
+module.exports = puppeteer.launch({
   pipe: false,
   executablePath: process.env.CHROME,
   args: ['--no-sandbox', '--disable-dev-shm-usage']
@@ -9,6 +10,7 @@ puppeteer.launch({
   const page = await browser.newPage();
   await page.goto(`http://${origin}/json/protocol`);
   const json = JSON.parse(await page.evaluate(() => document.documentElement.innerText));
+  const version = await browser.version();
   await browser.close();
   const output = `// This is generated from /utils/protocol-types-generator/index.js
 declare global {
@@ -70,7 +72,9 @@ declare global {
 // empty export to keep file a module
 export {}
 `;
-  require('fs').writeFileSync(require('path').join(__dirname, '..', '..', 'lib', 'protocol.d.ts'), output);
+  const outputPath = path.join(__dirname, '..', '..', 'lib', 'protocol.d.ts');
+  require('fs').writeFileSync(outputPath, output);
+  console.log(`Wrote protocol.d.ts for ${version} to ${path.relative(process.cwd(), outputPath)}`);
 });
 
 


### PR DESCRIPTION
Previously protocol.d.ts was generated on `npm run tsc`. This was inconvenient because it meant that vscode checking was wrong until type checking was run manually, and was inefficient because it necessarily regenerated the types even if no new Chromium was downloaded. This patch generates the types when npm install is run from the github checkout, assuming a new Chromium revision was downloaded.