### PR TITLE
feat(network): introduce Request.isNavigationRequest() method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -231,6 +231,7 @@
   * [request.failure()](#requestfailure)
   * [request.frame()](#requestframe)
   * [request.headers()](#requestheaders)
+  * [request.isNavigationRequest()](#requestisnavigationrequest)
   * [request.method()](#requestmethod)
   * [request.postData()](#requestpostdata)
   * [request.redirectChain()](#requestredirectchain)
@@ -2647,6 +2648,11 @@ page.on('requestfailed', request => {
 
 #### request.headers()
 - returns: <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.
+
+#### request.isNavigationRequest()
+- returns: <[boolean]>
+
+Whether this request is driving frame's navigation.
 
 #### request.method()
 - returns: <[string]> Request's method (GET, POST, etc.)

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -155,7 +155,7 @@ class NetworkManager extends EventEmitter {
       const request = this._interceptionIdToRequest.get(event.interceptionId);
       if (request) {
         this._handleRequestRedirect(request, event.responseStatusCode, event.responseHeaders, false /* fromDiskCache */, false /* fromServiceWorker */, null /* securityDetails */);
-        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.resourceType, event.request, event.frameId, request._redirectChain);
+        this._handleRequestStart(request._requestId, event.interceptionId, event.redirectUrl, event.isNavigationRequest, event.resourceType, event.request, event.frameId, request._redirectChain);
       }
       return;
     }
@@ -163,10 +163,10 @@ class NetworkManager extends EventEmitter {
     const requestId = this._requestHashToRequestIds.firstValue(requestHash);
     if (requestId) {
       this._requestHashToRequestIds.delete(requestHash, requestId);
-      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId, []);
+      this._handleRequestStart(requestId, event.interceptionId, event.request.url, event.isNavigationRequest, event.resourceType, event.request, event.frameId, []);
     } else {
       this._requestHashToInterceptionIds.set(requestHash, event.interceptionId);
-      this._handleRequestStart(null, event.interceptionId, event.request.url, event.resourceType, event.request, event.frameId, []);
+      this._handleRequestStart(null, event.interceptionId, event.request.url, event.isNavigationRequest, event.resourceType, event.request, event.frameId, []);
     }
   }
 
@@ -203,16 +203,17 @@ class NetworkManager extends EventEmitter {
    * @param {?string} requestId
    * @param {?string} interceptionId
    * @param {string} url
+   * @param {boolean} isNavigationRequest
    * @param {string} resourceType
    * @param {!Protocol.Network.Request} requestPayload
    * @param {?string} frameId
    * @param {!Array<!Request>} redirectChain
    */
-  _handleRequestStart(requestId, interceptionId, url, resourceType, requestPayload, frameId, redirectChain) {
+  _handleRequestStart(requestId, interceptionId, url, isNavigationRequest, resourceType, requestPayload, frameId, redirectChain) {
     let frame = null;
     if (frameId)
       frame = this._frameManager.frame(frameId);
-    const request = new Request(this._client, requestId, interceptionId, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame, redirectChain);
+    const request = new Request(this._client, requestId, interceptionId, isNavigationRequest, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame, redirectChain);
     if (requestId)
       this._requestIdToRequest.set(requestId, request);
     if (interceptionId)
@@ -249,7 +250,8 @@ class NetworkManager extends EventEmitter {
         redirectChain = request._redirectChain;
       }
     }
-    this._handleRequestStart(event.requestId, null, event.request.url, event.type, event.request, event.frameId, redirectChain);
+    const isNavigationRequest = event.requestId === event.loaderId && event.type === 'Document';
+    this._handleRequestStart(event.requestId, null, event.request.url, isNavigationRequest, event.type, event.request, event.frameId, redirectChain);
   }
 
   /**
@@ -307,6 +309,7 @@ class Request {
    * @param {!Puppeteer.CDPSession} client
    * @param {?string} requestId
    * @param {string} interceptionId
+   * @param {boolean} isNavigationRequest
    * @param {boolean} allowInterception
    * @param {string} url
    * @param {string} resourceType
@@ -314,9 +317,10 @@ class Request {
    * @param {?Puppeteer.Frame} frame
    * @param {!Array<!Request>} redirectChain
    */
-  constructor(client, requestId, interceptionId, allowInterception, url, resourceType, payload, frame, redirectChain) {
+  constructor(client, requestId, interceptionId, isNavigationRequest, allowInterception, url, resourceType, payload, frame, redirectChain) {
     this._client = client;
     this._requestId = requestId;
+    this._isNavigationRequest = isNavigationRequest;
     this._interceptionId = interceptionId;
     this._allowInterception = allowInterception;
     this._interceptionHandled = false;
@@ -383,6 +387,13 @@ class Request {
    */
   frame() {
     return this._frame;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isNavigationRequest() {
+    return this._isNavigationRequest;
   }
 
   /**

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -201,30 +201,30 @@ module.exports.addTests = function({testRunner, expect}) {
 
   describe('Request.isNavigationRequest', () => {
     it('should work', async({page, server}) => {
-      const requests = [];
-      page.on('request', request => requests.push(request));
+      const requests = new Map();
+      page.on('request', request => requests.set(request.url().split('/').pop(), request));
       server.setRedirect('/rrredirect', '/frames/one-frame.html');
       await page.goto(server.PREFIX + '/rrredirect');
-      expect(requests[0].isNavigationRequest()).toBe(true);
-      expect(requests[1].isNavigationRequest()).toBe(true);
-      expect(requests[2].isNavigationRequest()).toBe(true);
-      expect(requests[3].isNavigationRequest()).toBe(false);
-      expect(requests[4].isNavigationRequest()).toBe(false);
+      expect(requests.get('rrredirect').isNavigationRequest()).toBe(true);
+      expect(requests.get('one-frame.html').isNavigationRequest()).toBe(true);
+      expect(requests.get('frame.html').isNavigationRequest()).toBe(true);
+      expect(requests.get('script.js').isNavigationRequest()).toBe(false);
+      expect(requests.get('style.css').isNavigationRequest()).toBe(false);
     });
     it('should work with request interception', async({page, server}) => {
-      const requests = [];
+      const requests = new Map();
       page.on('request', request => {
-        requests.push(request);
+        requests.set(request.url().split('/').pop(), request);
         request.continue();
       });
       await page.setRequestInterception(true);
       server.setRedirect('/rrredirect', '/frames/one-frame.html');
       await page.goto(server.PREFIX + '/rrredirect');
-      expect(requests[0].isNavigationRequest()).toBe(true);
-      expect(requests[1].isNavigationRequest()).toBe(true);
-      expect(requests[2].isNavigationRequest()).toBe(true);
-      expect(requests[3].isNavigationRequest()).toBe(false);
-      expect(requests[4].isNavigationRequest()).toBe(false);
+      expect(requests.get('rrredirect').isNavigationRequest()).toBe(true);
+      expect(requests.get('one-frame.html').isNavigationRequest()).toBe(true);
+      expect(requests.get('frame.html').isNavigationRequest()).toBe(true);
+      expect(requests.get('script.js').isNavigationRequest()).toBe(false);
+      expect(requests.get('style.css').isNavigationRequest()).toBe(false);
     });
     it('should work when navigating to image', async({page, server}) => {
       const requests = [];


### PR DESCRIPTION
This patch introduces `Request.isNavigationRequest()` method.

Fixes #2627, #1132.