### PR TITLE
feat(targets): add target.opener()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -261,6 +261,7 @@
   * [target.browser()](#targetbrowser)
   * [target.browserContext()](#targetbrowsercontext)
   * [target.createCDPSession()](#targetcreatecdpsession)
+  * [target.opener()](#targetopener)
   * [target.page()](#targetpage)
   * [target.type()](#targettype)
   * [target.url()](#targeturl)
@@ -2809,6 +2810,11 @@ The browser context the target belongs to.
 - returns: <[Promise]<[CDPSession]>>
 
 Creates a Chrome Devtools Protocol session attached to the target.
+
+#### target.opener()
+- returns: <[?Target]>
+
+Get the target that opened this target.
 
 #### target.page()
 - returns: <[Promise]<?[Page]>>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2814,7 +2814,7 @@ Creates a Chrome Devtools Protocol session attached to the target.
 #### target.opener()
 - returns: <?[Target]>
 
-Get the target that opened this target.
+Get the target that opened this target. Top-level targets return `null`.
 
 #### target.page()
 - returns: <[Promise]<?[Page]>>

--- a/docs/api.md
+++ b/docs/api.md
@@ -2812,7 +2812,7 @@ The browser context the target belongs to.
 Creates a Chrome Devtools Protocol session attached to the target.
 
 #### target.opener()
-- returns: <[?Target]>
+- returns: <?[Target]>
 
 Get the target that opened this target.
 

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -77,6 +77,16 @@ class Target {
   }
 
   /**
+   * @return {Puppeteer.Target}
+   */
+  opener() {
+    const { openerId } = this._targetInfo;
+    if (!openerId)
+      return null;
+    return this.browser()._targets.get(openerId);
+  }
+
+  /**
    * @param {!Protocol.Target.TargetInfo} targetInfo
    */
   _targetInfoChanged(targetInfo) {

--- a/test/assets/popup/popup.html
+++ b/test/assets/popup/popup.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Popup</title>
+  </head>
+  <body>
+    I am a popup
+  </body>
+</html>

--- a/test/assets/popup/window-open.html
+++ b/test/assets/popup/window-open.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Popup test</title>
+  </head>
+  <body>
+    <script>
+      window.open('./popup.html');
+    </script>
+  </body>
+</html>

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -139,5 +139,17 @@ module.exports.addTests = function({testRunner, expect, puppeteer, browserWithEx
       // Cleanup.
       await newPage.close();
     });
+    it('should have an opener', async({page, server, browser}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const [
+        createdTarget
+      ] = await Promise.all([
+        new Promise(fulfill => browser.once('targetcreated', target => fulfill(target))),
+        page.goto(server.PREFIX + '/popup/window-open.html')
+      ]);
+      expect((await createdTarget.page()).url()).toBe(server.PREFIX + '/popup/popup.html');
+      expect(createdTarget.opener()).toBe(page.target());
+      expect(page.target().opener()).toBe(null);
+    });
   });
 };

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -141,9 +141,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, browserWithEx
     });
     it('should have an opener', async({page, server, browser}) => {
       await page.goto(server.EMPTY_PAGE);
-      const [
-        createdTarget
-      ] = await Promise.all([
+      const [createdTarget] = await Promise.all([
         new Promise(fulfill => browser.once('targetcreated', target => fulfill(target))),
         page.goto(server.PREFIX + '/popup/window-open.html')
       ]);


### PR DESCRIPTION
feat(targets): add target.opener()

This adds a `.opener` property to a target so that its origin can be tracked.
For now returns `null` when there's no `openerId`.

Fixes https://github.com/GoogleChrome/puppeteer/issues/1830