### PR TITLE
fix(workers): swallow errors when auto-detaching from page subtargets

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -97,7 +97,7 @@ class Page extends EventEmitter {
         // If we don't detach from service workers, they will never die.
         client.send('Target.detachFromTarget', {
           sessionId: event.sessionId
-        });
+        }).catch(debugError);
         return;
       }
       const session = client._createSession(event.targetInfo.targetId, event.sessionId);


### PR DESCRIPTION
Page subtargets (e.g. out-of-process iframes and others) sometimes
die before we send the 'detach' command.

This is harmless to us, but we shouldn't have an unhandled promise
rejection in this case.

Example crash: https://cirrus-ci.com/task/4884032470908928