### PR TITLE
feat(launcher): disable crash reporting by default

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -33,6 +33,7 @@ const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile-');
 const DEFAULT_ARGS = [
   '--disable-background-networking',
   '--disable-background-timer-throttling',
+  '--disable-breakpad',
   '--disable-client-side-phishing-detection',
   '--disable-default-apps',
   '--disable-dev-shm-usage',


### PR DESCRIPTION
This patch disables crash reporting since it's not needed for
automation purposes.

It also deals some troubles for us since crashpad is a separate
process on Windows which has a larger lifetime than chromium.
This, in turn, prevents us from cleaning up profile directory.