### PR TITLE
fix(browser): ensure first page is created when browser is launched

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -166,21 +166,30 @@ class Launcher {
       const ignoreHTTPSErrors = !!options.ignoreHTTPSErrors;
       const setDefaultViewport = !options.appMode;
       const browser = await Browser.create(connection, [], ignoreHTTPSErrors, setDefaultViewport, chromeProcess, gracefullyCloseChrome);
-      // Wait for initial page target to be created.
-      await new Promise(resolve => {
-        waitForInitialPage();
-
-        function waitForInitialPage() {
-          if (browser.targets().find(target => target.type() === 'page'))
-            resolve();
-          else
-            browser.once('targetcreated', waitForInitialPage);
-        }
-      });
+      await ensureInitialPage(browser);
       return browser;
     } catch (e) {
       killChrome();
       throw e;
+    }
+
+    /**
+     * @param {!Browser} browser
+     */
+    async function ensureInitialPage(browser) {
+      // Wait for initial page target to be created.
+      if (browser.targets().find(target => target.type() === 'page'))
+        return;
+
+      let initialPageCallback;
+      const initialPagePromise = new Promise(resolve => initialPageCallback = resolve);
+      const listeners = [helper.addEventListener(browser, 'targetcreated', target => {
+        if (target.type() === 'page')
+          initialPageCallback();
+      })];
+
+      await initialPagePromise;
+      helper.removeEventListeners(listeners);
     }
 
     /**

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -165,7 +165,19 @@ class Launcher {
       }
       const ignoreHTTPSErrors = !!options.ignoreHTTPSErrors;
       const setDefaultViewport = !options.appMode;
-      return Browser.create(connection, [], ignoreHTTPSErrors, setDefaultViewport, chromeProcess, gracefullyCloseChrome);
+      const browser = await Browser.create(connection, [], ignoreHTTPSErrors, setDefaultViewport, chromeProcess, gracefullyCloseChrome);
+      // Wait for initial page target to be created.
+      await new Promise(resolve => {
+        waitForInitialPage();
+
+        function waitForInitialPage() {
+          if (browser.targets().find(target => target.type() === 'page'))
+            resolve();
+          else
+            browser.once('targetcreated', waitForInitialPage);
+        }
+      });
+      return browser;
     } catch (e) {
       killChrome();
       throw e;

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -238,6 +238,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       it('should support the pipe option', async() => {
         const options = Object.assign({pipe: true}, defaultBrowserOptions);
         const browser = await puppeteer.launch(options);
+        expect((await browser.pages()).length).toBe(1);
         expect(browser.wsEndpoint()).toBe('');
         const page = await browser.newPage();
         expect(await page.evaluate('11 * 11')).toBe(121);


### PR DESCRIPTION
It's impossible to launch chromium without initial page.
This patch makes sure that `puppeteer.launch()` always returns a browser
with at least one page user can connect to.