### PR TITLE
fix: disable OOPIF by default

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -38,6 +38,8 @@ const DEFAULT_ARGS = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
+  //TODO Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
+  '--disable-features=site-per-process',
   '--disable-hang-monitor',
   '--disable-popup-blocking',
   '--disable-prompt-on-repost',
@@ -106,7 +108,6 @@ class Launcher {
     }
     if (Array.isArray(options.args))
       chromeArguments.push(...options.args);
-
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');
     const stdio = ['pipe', 'pipe', 'pipe'];

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -38,7 +38,7 @@ const DEFAULT_ARGS = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
-  //TODO Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
+  // TODO: Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
   '--disable-features=site-per-process',
   '--disable-hang-monitor',
   '--disable-popup-blocking',

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -85,8 +85,9 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         const frame = document.createElement('iframe');
         frame.setAttribute('src', 'https://google.com/');
         document.body.appendChild(frame);
+        return new Promise(x => frame.onload = x);
       });
-      await page.waitForSelector('iframe[src]');
+      await page.waitForSelector('iframe[src="https://google.com/"]');
       const urls = page.frames().map(frame => frame.url()).sort();
       expect(urls).toEqual([
         server.EMPTY_PAGE,

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -82,9 +82,9 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       await page.setRequestInterception(true);
       page.on('request', r => r.respond({body: 'YO, GOOGLE.COM'}));
       await page.evaluate(() => {
-        const frame = document.createElement('iframe')
-        frame.setAttribute('src', 'https://google.com/')
-        document.body.appendChild(frame)
+        const frame = document.createElement('iframe');
+        frame.setAttribute('src', 'https://google.com/');
+        document.body.appendChild(frame);
       });
       await page.waitForSelector('iframe[src]');
       const urls = page.frames().map(frame => frame.url()).sort();

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -83,7 +83,6 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       page.on('request', r => r.respond({body: 'YO, GOOGLE.COM'}));
       await page.evaluate(() => {
         const frame = document.createElement('iframe')
-        frame.setAttribute('name', 'bob')
         frame.setAttribute('src', 'https://google.com/')
         document.body.appendChild(frame)
       });


### PR DESCRIPTION
This patch disables OOPIF by default.

**NOTE**: this is a temporary bandaid for the time we're crafting
the full-fledged support for site isolation over DevTools protocol.

References #2548.