### PR TITLE
chore(ci): switch Windows containers

### DIFF
--- a/.ci/node6/Dockerfile.windows
+++ b/.ci/node6/Dockerfile.windows
@@ -1,15 +1,12 @@
-FROM microsoft/windowsservercore:1709
-
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+FROM microsoft/windowsservercore:latest
 
 ENV NODE_VERSION 6.12.3
 
-RUN netsh interface ipv4 set subinterface 'vEthernet (Ethernet)' mtu=1460 store=persistent
+RUN setx /m PATH "%PATH%;C:\nodejs"
 
-RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+RUN powershell -Command \
+    netsh interface ipv4 show interfaces ; \
+    netsh interface ipv4 set subinterface 18 mtu=1460 store=persistent ; \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
-
-SHELL ["cmd", "/S", "/C"]
-
-RUN setx /m PATH "%PATH%;C:\nodejs"

--- a/.ci/node7/Dockerfile.windows
+++ b/.ci/node7/Dockerfile.windows
@@ -1,15 +1,11 @@
-FROM microsoft/windowsservercore:1709
-
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+FROM microsoft/windowsservercore:latest
 
 ENV NODE_VERSION 7.10.1
 
-RUN netsh interface ipv4 set subinterface 'vEthernet (Ethernet)' mtu=1460 store=persistent
+RUN setx /m PATH "%PATH%;C:\nodejs"
 
-RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+RUN powershell -Command \
+    netsh interface ipv4 set subinterface 18 mtu=1460 store=persistent ; \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
     Expand-Archive node.zip -DestinationPath C:\ ; \
     Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
-
-SHELL ["cmd", "/S", "/C"]
-
-RUN setx /m PATH "%PATH%;C:\nodejs"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ task:
     - name: node6 (windows)
       windows_container:
         dockerfile: .ci/node6/Dockerfile.windows
+        os_version: 2016
     - name: node6 (linux)
       container:
         dockerfile: .ci/node6/Dockerfile.linux
@@ -18,6 +19,7 @@ task:
     - name: node7 (windows)
       windows_container:
         dockerfile: .ci/node7/Dockerfile.windows
+        os_version: 2016
     - name: node7 (linux)
       container:
         dockerfile: .ci/node7/Dockerfile.linux


### PR DESCRIPTION
Cirrus CI got some optimizations for containers based of `microsoft/windowsservercore:latest`.

Now startup time for windows builds is around 1:30 seconds instead of around 4 minutes.

to: @aslushnikov 