### PR TITLE
chore(ci): temporary disable cirrus win builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,11 @@ env:
 
 task:
   matrix:
+    - name: node6 (windows)
+      allow_failures: true
+      windows_container:
+        dockerfile: .ci/node6/Dockerfile.windows
+        os_version: 2016
     - name: node6 (linux)
       container:
         dockerfile: .ci/node6/Dockerfile.linux
@@ -12,6 +17,11 @@ task:
 
 task:
   matrix:
+    - name: node7 (windows)
+      allow_failures: true
+      windows_container:
+        dockerfile: .ci/node7/Dockerfile.windows
+        os_version: 2016
     - name: node7 (linux)
       container:
         dockerfile: .ci/node7/Dockerfile.linux

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,10 @@ env:
 
 task:
   matrix:
-#    - name: node6 (windows)
-#      windows_container:
-#        dockerfile: .ci/node6/Dockerfile.windows
-#        os_version: 2016
+    #- name: node6 (windows)
+    #  windows_container:
+    #    dockerfile: .ci/node6/Dockerfile.windows
+    #    os_version: 2016
     - name: node6 (linux)
       container:
         dockerfile: .ci/node6/Dockerfile.linux
@@ -16,10 +16,10 @@ task:
 
 task:
   matrix:
-#    - name: node7 (windows)
-#      windows_container:
-#        dockerfile: .ci/node7/Dockerfile.windows
-#        os_version: 2016
+    #- name: node7 (windows)
+    #  windows_container:
+    #    dockerfile: .ci/node7/Dockerfile.windows
+    #    os_version: 2016
     - name: node7 (linux)
       container:
         dockerfile: .ci/node7/Dockerfile.linux

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,10 @@ env:
 
 task:
   matrix:
-    - name: node6 (windows)
-      windows_container:
-        dockerfile: .ci/node6/Dockerfile.windows
-        os_version: 2016
+#    - name: node6 (windows)
+#      windows_container:
+#        dockerfile: .ci/node6/Dockerfile.windows
+#        os_version: 2016
     - name: node6 (linux)
       container:
         dockerfile: .ci/node6/Dockerfile.linux
@@ -16,10 +16,10 @@ task:
 
 task:
   matrix:
-    - name: node7 (windows)
-      windows_container:
-        dockerfile: .ci/node7/Dockerfile.windows
-        os_version: 2016
+#    - name: node7 (windows)
+#      windows_container:
+#        dockerfile: .ci/node7/Dockerfile.windows
+#        os_version: 2016
     - name: node7 (linux)
       container:
         dockerfile: .ci/node7/Dockerfile.linux

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,6 @@ env:
 
 task:
   matrix:
-    #- name: node6 (windows)
-    #  windows_container:
-    #    dockerfile: .ci/node6/Dockerfile.windows
-    #    os_version: 2016
     - name: node6 (linux)
       container:
         dockerfile: .ci/node6/Dockerfile.linux
@@ -16,10 +12,6 @@ task:
 
 task:
   matrix:
-    #- name: node7 (windows)
-    #  windows_container:
-    #    dockerfile: .ci/node7/Dockerfile.windows
-    #    os_version: 2016
     - name: node7 (linux)
       container:
         dockerfile: .ci/node7/Dockerfile.linux


### PR DESCRIPTION
Win bots all fail on Cirrus; disable them until the issue is resolved.

We still have win coverage with AppVeyour.