### PR TITLE
feat(tracing): enable high resolution JavaScript sampling

### DIFF
--- a/lib/Tracing.js
+++ b/lib/Tracing.js
@@ -40,7 +40,7 @@ class Tracing {
       '-*', 'devtools.timeline', 'v8.execute', 'disabled-by-default-devtools.timeline',
       'disabled-by-default-devtools.timeline.frame', 'toplevel',
       'blink.console', 'blink.user_timing', 'latencyInfo', 'disabled-by-default-devtools.timeline.stack',
-      'disabled-by-default-v8.cpu_profiler'
+      'disabled-by-default-v8.cpu_profiler', 'disabled-by-default-v8.cpu_profiler.hires'
     ];
     const categoriesArray = options.categories || defaultCategories;
 


### PR DESCRIPTION
I've been told that this will make our JavaScript tracing 💯x more accurate, at minimal performance loss. Let's turn it on for everyone always.

alternative to #2637