### PR TITLE
fix(frame): set execution context null if it's not created

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -68,6 +68,7 @@ class FrameManager extends EventEmitter {
     const frame = this._frames.get(frameId);
     if (!frame)
       return;
+    frame._setContext(null);
     frame._onLoadingStopped();
     this.emit(FrameManager.Events.LifecycleEvent, frame);
   }
@@ -185,7 +186,7 @@ class FrameManager extends EventEmitter {
     const context = new ExecutionContext(this._client, contextPayload, this.createJSHandle.bind(this, contextPayload.id), frame);
     this._contextIdToContext.set(contextPayload.id, context);
     if (frame)
-      frame._setDefaultContext(context);
+      frame._setContext(context);
   }
 
   /**
@@ -193,7 +194,7 @@ class FrameManager extends EventEmitter {
    */
   _removeContext(context) {
     if (context.frame())
-      context.frame()._setDefaultContext(null);
+      context.frame()._setDefaultContext();
   }
 
   /**
@@ -268,7 +269,7 @@ class Frame {
     /** @type {?Promise<!ExecutionContext>} */
     this._contextPromise = null;
     this._contextResolveCallback = null;
-    this._setDefaultContext(null);
+    this._setDefaultContext();
 
     /** @type {!Set<!WaitTask>} */
     this._waitTasks = new Set();
@@ -282,21 +283,23 @@ class Frame {
       this._parentFrame._childFrames.add(this);
   }
 
+  _setDefaultContext() {
+    this._documentPromise = null;
+    this._contextPromise = new Promise(fulfill => {
+      this._contextResolveCallback = fulfill;
+    });
+  }
+
   /**
    * @param {?ExecutionContext} context
    */
-  _setDefaultContext(context) {
-    if (context) {
-      this._contextResolveCallback.call(null, context);
-      this._contextResolveCallback = null;
-      for (const waitTask of this._waitTasks)
-        waitTask.rerun();
-    } else {
-      this._documentPromise = null;
-      this._contextPromise = new Promise(fulfill => {
-        this._contextResolveCallback = fulfill;
-      });
-    }
+  _setContext(context) {
+    if (!this._contextResolveCallback)
+      return;
+    this._contextResolveCallback.call(null, context);
+    this._contextResolveCallback = null;
+    for (const waitTask of this._waitTasks)
+      waitTask.rerun();
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/GoogleChrome/puppeteer/issues/2709

In mixed-content page like [this one](https://www.bennish.net/mixed-content.html), frame stops loading before execution context is created.
This behavior causes `exposeFunction` to be stuck indefinitely because `contextPromise` will never be never resolved.

There is no way setting proper context if it's not created yet, so I think it's better to set `null`.