### PR TITLE
fix(types): type FrameManager in Page.js

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -78,6 +78,7 @@ class Page extends EventEmitter {
     this._keyboard = new Keyboard(client);
     this._mouse = new Mouse(client, this._keyboard);
     this._touchscreen = new Touchscreen(client, this._keyboard);
+    /** @type {!FrameManager} */
     this._frameManager = new FrameManager(client, frameTree, this);
     this._networkManager = new NetworkManager(client, this._frameManager);
     this._emulationManager = new EmulationManager(client);


### PR DESCRIPTION
TypeScript is unhappy when we pass `this` around in a constructor. Manually typing `this._frameManager` causes many more types to be inferred later on in the code.