### PR TITLE
fix(elementhandle): fix return type docs of elementHandle.$x

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2464,9 +2464,9 @@ expect(await tweetHandle.$eval('.retweets', node => node.innerText)).toBe('10');
 
 #### elementHandle.$x(expression)
 - `expression` <[string]> Expression to [evaluate](https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate).
-- returns: <[Promise]<?[ElementHandle]>> Promise which resolves to ElementHandle pointing to the frame element.
+- returns: <[Promise]<[Array]<[ElementHandle]>>>
 
-The method evaluates the XPath expression relative to the elementHandle. If there's no such element, the method will resolve to `null`.
+The method evaluates the XPath expression relative to the elementHandle. If there are no such elements, the method will resolve to an empty array.
 
 #### elementHandle.asElement()
 - returns: <[elementhandle]>


### PR DESCRIPTION
I guess this was a mistake in the docs. The return type of `elementHandle.$x` is actually `Promise<Array<ElementHandle>>`, not `Promise<?ElementHandle>`.

See https://github.com/GoogleChrome/puppeteer/blob/master/lib/ElementHandle.js#L319