### PR TITLE
fix(tests): make tests work on non-English locales

### DIFF
--- a/test/server/SimpleServer.js
+++ b/test/server/SimpleServer.js
@@ -221,7 +221,7 @@ class SimpleServer {
         return;
       }
       response.setHeader('Cache-Control', 'public, max-age=31536000');
-      response.setHeader('Last-Modified', this._startTime.toString());
+      response.setHeader('Last-Modified', this._startTime.toISOString());
     } else {
       response.setHeader('Cache-Control', 'no-cache, no-store');
     }


### PR DESCRIPTION
`Date.prototype.toString` may return non-ASCII characters, which aren't accepted by `setHeader`.

E.g., on Russian locale, it might look like this:
```
> new Date().toString()
'Thu Jun 14 2018 13:11:50 GMT+0300 (Финляндия (лето))'
```