### PR TITLE
feat(element-handle): remove throw in case of empty elementHandle

### DIFF
--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -306,8 +306,6 @@ class ElementHandle extends JSHandle {
         (element, selector) => Array.from(element.querySelectorAll(selector)),
         this, selector
     );
-    if (!(await arrayHandle.jsonValue()).length)
-      throw new Error(`Error: failed to find elements matching selector "${selector}"`);
 
     const result = await this.executionContext().evaluate(pageFunction, arrayHandle, ...args);
     await arrayHandle.dispose();

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -336,6 +336,15 @@ module.exports.addTests = function({testRunner, expect}) {
       const content = await elementHandle.$$eval('.a', nodes => nodes.map(n => n.innerText));
       expect(content).toEqual(['a1-child-div', 'a2-child-div']);
     });
+
+    it('should not throw in case of missing selector', async({page, server}) => {
+      const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"></div>';
+      await page.setContent(htmlContent);
+      const elementHandle = await page.$('#myId');
+      const nodesLength = await elementHandle.$$eval('.a', nodes => nodes.length);
+      expect(nodesLength).toBe(0);
+    });
+
   });
 
   describe('ElementHandle.$$', function() {

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -336,14 +336,6 @@ module.exports.addTests = function({testRunner, expect}) {
       const content = await elementHandle.$$eval('.a', nodes => nodes.map(n => n.innerText));
       expect(content).toEqual(['a1-child-div', 'a2-child-div']);
     });
-
-    it('should throw in case of missing selector', async({page, server}) => {
-      const htmlContent = '<div class="a">not-a-child-div</div><div id="myId"></div>';
-      await page.setContent(htmlContent);
-      const elementHandle = await page.$('#myId');
-      const errorMessage = await elementHandle.$$eval('.a', nodes => nodes.map(n => n.innerText)).catch(error => error.message);
-      expect(errorMessage).toBe(`Error: failed to find elements matching selector ".a"`);
-    });
   });
 
   describe('ElementHandle.$$', function() {


### PR DESCRIPTION
Fixes #2708 

`elementHandle.$$eval` introduced a breaking change in `page.$$eval`: In case of an empty selector, it throws an error. I'm not sure what is the best solution for that, so I added this PR, mainly for discussion.

Possible solutions:

1. Remove the check for $$eval empty result from elementHandle.$$eval (which will also be a breaking change for this feature?). We can fix this later on V2.0.0.
2. Remove the usage of elementHandle.$$eval in [frameManager.$$eval](https://github.com/GoogleChrome/puppeteer/commit/1e07925e26783d586ab63a6eb88063ca51fb5647#diff-16f3b9739b97830927de83812ac92d78). This will undo the breaking change, leaving elementHandle.$$eval with the test for empty result.
3. Do nothing...

