### PR TITLE
feat(chromium): roll Chromium to r567388

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "564778"
+    "chromium_revision": "567388"
   },
   "scripts": {
     "unit": "node test/test.js",


### PR DESCRIPTION
This roll includes:
- https://crrev.com/567104 - DevTools: introduce Target.exposeDevToolsProtocol() method

The patch includes a drive-by fix to DevToolsAgentHostImpl that
eliminats chromium crashes in certain cases.