### PR TITLE
feat(launcher): add disable gpu option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -347,6 +347,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
   - `headless` <[boolean]> Whether to run browser in [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome). Defaults to `true` unless the `devtools` option is `true`.
+  - `disableGPU` <[boolean]> Whether to disable GPU. Defaults to `false` unless `headless` option is set to `true`. Set to `false` will force usage of GPU in headless mode.
   - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
   - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -97,7 +97,8 @@ class Launcher {
 
       if (options.disableGPU !== false)
         chromeArguments.push('--disable-gpu');
-    } else if (options.disableGPU === false) {
+
+    } else if (options.disableGPU === true) {
       chromeArguments.push('--disable-gpu');
     }
 

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -320,6 +320,7 @@ function waitForWSEndpoint(chromeProcess, timeout) {
  * @typedef {Object} LaunchOptions
  * @property {boolean=} ignoreHTTPSErrors
  * @property {boolean=} headless
+ * @property {boolean=} disableGPU
  * @property {string=} executablePath
  * @property {number=} slowMo
  * @property {!Array<string>=} args

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -91,11 +91,16 @@ class Launcher {
     if (typeof options.headless !== 'boolean' || options.headless) {
       chromeArguments.push(
           '--headless',
-          '--disable-gpu',
           '--hide-scrollbars',
           '--mute-audio'
       );
+
+      if (options.disableGPU !== false)
+        chromeArguments.push('--disable-gpu');
+    } else if (options.disableGPU === false) {
+      chromeArguments.push('--disable-gpu');
     }
+
     if (!options.ignoreDefaultArgs && Array.isArray(options.args) && options.args.every(arg => arg.startsWith('-')))
       chromeArguments.push('about:blank');
 

--- a/test/disableGPU.spec.js
+++ b/test/disableGPU.spec.js
@@ -21,14 +21,16 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
   const puppeteer = require(PROJECT_ROOT);
 
   const headfulOptions = Object.assign({}, defaultBrowserOptions, {
-    headless: false
+    headless: false,
+    args: ['--no-sandbox']
   });
   const headlessOptions = Object.assign({}, defaultBrowserOptions, {
-    headless: true
+    headless: true,
+    args: ['--no-sandbox']
   });
   const gpuDisabledRegexp = /Command Line(.*)--disable-gpu /;
 
-  fdescribe('disableGPU', function() {
+  describe('disableGPU', function() {
     it('headless should disable GPU by default', async() => {
       const browser = await puppeteer.launch(headlessOptions);
       const page = await browser.newPage();

--- a/test/disableGPU.spec.js
+++ b/test/disableGPU.spec.js
@@ -39,6 +39,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       expect(gpuStatus.match(gpuDisabledRegexp)).not.toBe(null);
       await browser.close();
     });
+
     it('headless should respect disableGPU option', async() => {
       const browser = await puppeteer.launch(Object.assign({disableGPU: false}, headlessOptions));
       const page = await browser.newPage();
@@ -47,6 +48,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       expect(gpuStatus.match(gpuDisabledRegexp)).toBe(null);
       await browser.close();
     });
+
     it('headful should not disable GPU by default', async() => {
       const browser = await puppeteer.launch(headfulOptions);
       const page = await browser.newPage();
@@ -55,6 +57,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       expect(gpuStatus.match(gpuDisabledRegexp)).toBe(null);
       await browser.close();
     });
+
     it('headless should respect disableGPU option', async() => {
       const browser = await puppeteer.launch(Object.assign({disableGPU: true}, headfulOptions));
       const page = await browser.newPage();

--- a/test/disableGPU.spec.js
+++ b/test/disableGPU.spec.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBrowserOptions}) {
+  const {describe, xdescribe, fdescribe} = testRunner;
+  const {it, fit, xit} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+  const puppeteer = require(PROJECT_ROOT);
+
+  const headfulOptions = Object.assign({}, defaultBrowserOptions, {
+    headless: false
+  });
+  const headlessOptions = Object.assign({}, defaultBrowserOptions, {
+    headless: true
+  });
+  const gpuDisabledRegexp = /Command Line(.*)--disable-gpu /;
+
+  fdescribe('disableGPU', function() {
+    it('headless should disable GPU by default', async() => {
+      const browser = await puppeteer.launch(headlessOptions);
+      const page = await browser.newPage();
+      await page.goto('chrome://gpu/');
+      const gpuStatus = await page.$eval('body', body => body.innerText);
+      expect(gpuStatus.match(gpuDisabledRegexp)).not.toBe(null);
+      await browser.close();
+    });
+    it('headless should respect disableGPU option', async() => {
+      const browser = await puppeteer.launch(Object.assign({disableGPU: false}, headlessOptions));
+      const page = await browser.newPage();
+      await page.goto('chrome://gpu/');
+      const gpuStatus = await page.$eval('body', body => body.innerText);
+      expect(gpuStatus.match(gpuDisabledRegexp)).toBe(null);
+      await browser.close();
+    });
+    it('headful should not disable GPU by default', async() => {
+      const browser = await puppeteer.launch(headfulOptions);
+      const page = await browser.newPage();
+      await page.goto('chrome://gpu/');
+      const gpuStatus = await page.$eval('body', body => body.innerText);
+      expect(gpuStatus.match(gpuDisabledRegexp)).toBe(null);
+      await browser.close();
+    });
+    it('headless should respect disableGPU option', async() => {
+      const browser = await puppeteer.launch(Object.assign({disableGPU: true}, headfulOptions));
+      const page = await browser.newPage();
+      await page.goto('chrome://gpu/');
+      const gpuStatus = await page.$eval('body', body => body.innerText);
+      expect(gpuStatus.match(gpuDisabledRegexp)).not.toBe(null);
+      await browser.close();
+    });
+  });
+};

--- a/test/disableGPU.spec.js
+++ b/test/disableGPU.spec.js
@@ -28,42 +28,30 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
     headless: true,
     args: ['--no-sandbox']
   });
-  const gpuDisabledRegexp = /Command Line(.*)--disable-gpu /;
+  const disableGPUArg = '--disable-gpu';
 
-  describe('disableGPU', function() {
+  fdescribe('disableGPU', function() {
     it('headless should disable GPU by default', async() => {
       const browser = await puppeteer.launch(headlessOptions);
-      const page = await browser.newPage();
-      await page.goto('chrome://gpu/');
-      const gpuStatus = await page.$eval('body', body => body.innerText);
-      expect(gpuStatus.match(gpuDisabledRegexp)).not.toBe(null);
+      expect(browser._process.spawnargs).toContain(disableGPUArg);
       await browser.close();
     });
 
     it('headless should respect disableGPU option', async() => {
       const browser = await puppeteer.launch(Object.assign({disableGPU: false}, headlessOptions));
-      const page = await browser.newPage();
-      await page.goto('chrome://gpu/');
-      const gpuStatus = await page.$eval('body', body => body.innerText);
-      expect(gpuStatus.match(gpuDisabledRegexp)).toBe(null);
+      expect(browser._process.spawnargs).not.toContain(disableGPUArg);
       await browser.close();
     });
 
     it('headful should not disable GPU by default', async() => {
       const browser = await puppeteer.launch(headfulOptions);
-      const page = await browser.newPage();
-      await page.goto('chrome://gpu/');
-      const gpuStatus = await page.$eval('body', body => body.innerText);
-      expect(gpuStatus.match(gpuDisabledRegexp)).toBe(null);
+      expect(browser._process.spawnargs).not.toContain(disableGPUArg);
       await browser.close();
     });
 
     it('headless should respect disableGPU option', async() => {
       const browser = await puppeteer.launch(Object.assign({disableGPU: true}, headfulOptions));
-      const page = await browser.newPage();
-      await page.goto('chrome://gpu/');
-      const gpuStatus = await page.$eval('body', body => body.innerText);
-      expect(gpuStatus.match(gpuDisabledRegexp)).not.toBe(null);
+      expect(browser._process.spawnargs).toContain(disableGPUArg);
       await browser.close();
     });
   });

--- a/test/disableGPU.spec.js
+++ b/test/disableGPU.spec.js
@@ -30,7 +30,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
   });
   const disableGPUArg = '--disable-gpu';
 
-  fdescribe('disableGPU', function() {
+  describe('disableGPU', function() {
     it('headless should disable GPU by default', async() => {
       const browser = await puppeteer.launch(headlessOptions);
       expect(browser._process.spawnargs).toContain(disableGPUArg);

--- a/test/test.js
+++ b/test/test.js
@@ -137,6 +137,7 @@ describe('Page', function() {
   require('./browsercontext.spec.js').addTests({testRunner, expect, puppeteer});
   require('./cookies.spec.js').addTests({testRunner, expect});
   require('./coverage.spec.js').addTests({testRunner, expect});
+  require('./disableGPU.spec.js').addTests({testRunner, expect, PROJECT_ROOT, defaultBrowserOptions});
   require('./elementhandle.spec.js').addTests({testRunner, expect});
   require('./frame.spec.js').addTests({testRunner, expect});
   require('./input.spec.js').addTests({testRunner, expect, DeviceDescriptors});


### PR DESCRIPTION
Fixes #1260

The idea is to be able to run test in `headless: true` utilising GPU.  For backwards compatibility default behaviour has not changed. To have a symmetric interface, one will be able to disable GPU in `headless: false` too.

We need this capability to be able to test our integration with `mapbox-gl-js`, which would not run on software render.