### PR TITLE
fix: don't pass a reference to the page into frames

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -118,7 +118,7 @@ class FrameManager extends EventEmitter {
       return;
     assert(parentFrameId);
     const parentFrame = this._frames.get(parentFrameId);
-    const frame = new Frame(this._client, this._page, parentFrame, frameId);
+    const frame = new Frame(this._client, parentFrame, frameId);
     this._frames.set(frame._id, frame);
     this.emit(FrameManager.Events.FrameAttached, frame);
   }
@@ -145,7 +145,7 @@ class FrameManager extends EventEmitter {
         frame._id = framePayload.id;
       } else {
         // Initial main frame navigation.
-        frame = new Frame(this._client, this._page, null, framePayload.id);
+        frame = new Frame(this._client, null, framePayload.id);
       }
       this._frames.set(framePayload.id, frame);
       this._mainFrame = frame;
@@ -256,9 +256,8 @@ class Frame {
    * @param {?Frame} parentFrame
    * @param {string} frameId
    */
-  constructor(client, page, parentFrame, frameId) {
+  constructor(client, parentFrame, frameId) {
     this._client = client;
-    this._page = page;
     this._parentFrame = parentFrame;
     this._url = '';
     this._id = frameId;


### PR DESCRIPTION
There was a `._page` property on frames which was unused (and not typed).