### PR TITLE
test: fix random tests flakiness

### DIFF
--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -53,8 +53,10 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       const context = await browser.createIncognitoBrowserContext();
       const page = await context.newPage();
       await page.goto(server.EMPTY_PAGE);
-      page.evaluate(url => window.open(url), server.EMPTY_PAGE);
-      const popupTarget = await utils.waitEvent(browser, 'targetcreated');
+      const [popupTarget] = await Promise.all([
+        utils.waitEvent(browser, 'targetcreated'),
+        page.evaluate(url => window.open(url), server.EMPTY_PAGE)
+      ]);
       expect(popupTarget.browserContext()).toBe(context);
       await context.close();
     });

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -387,10 +387,10 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
     });
     it('should trigger correct Log', async({page, server}) => {
       await page.goto('about:blank');
-      let message;
-      page.on('console', event => message = event);
-      page.evaluate(async url => fetch(url).catch(e => {}), server.EMPTY_PAGE);
-      await waitEvent(page, 'console');
+      const [message] = await Promise.all([
+        waitEvent(page, 'console'),
+        page.evaluate(async url => fetch(url).catch(e => {}), server.EMPTY_PAGE)
+      ]);
       expect(message.text()).toContain('No \'Access-Control-Allow-Origin\'');
       expect(message.type()).toEqual('error');
     });


### PR DESCRIPTION
These tests were not awaiting `page.evaluate` command, so
page could have been closed before the command returned.