### PR TITLE
fix(request): extend error reasons based on missing values from spec

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2628,6 +2628,8 @@ If request gets a 'redirect' response, the request is successfully finished with
   - `accessdenied` - Permission to access a resource, other than the network, was denied
   - `addressunreachable` - The IP address is unreachable. This usually means
     that there is no route to the specified host or network.
+  - `blockedbyclient` - The client chose to block the request.
+  - `blockedbyresponse` - The request failed because the response was delivered along with requirements which are not met ('X-Frame-Options' and 'Content-Security-Policy' ancestor checks, for instance).
   - `connectionaborted` - A connection timed out as a result of not receiving an ACK for data sent.
   - `connectionclosed` - A connection was closed (corresponding to a TCP FIN).
   - `connectionfailed` - A connection attempt failed.

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -506,6 +506,8 @@ const errorReasons = {
   'aborted': 'Aborted',
   'accessdenied': 'AccessDenied',
   'addressunreachable': 'AddressUnreachable',
+  'blockedbyclient': 'BlockedByClient',
+  'blockedbyresponse': 'BlockedByResponse',
   'connectionaborted': 'ConnectionAborted',
   'connectionclosed': 'ConnectionClosed',
   'connectionfailed': 'ConnectionFailed',


### PR DESCRIPTION
As the title indicated, adds two allowed error codes that are specified in the Chrome Developer Tools Protocol specifications but missing from the Puppeteer enum:

https://chromedevtools.github.io/devtools-protocol/tot/Network#type-ErrorReason