### PR TITLE
chore(ci): Configure OSX builds on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,3 +20,15 @@ task:
   lint_script: npm run lint
   coverage_script: npm run coverage
   test_doclint_script: npm run test-doclint
+
+task:
+  osx_instance:
+    image: high-sierra-base
+  name: node8 (macOS)
+  node_install_script:
+    - brew install node@8
+    - brew link --force node@8
+  install_script: npm install --unsafe-perm
+  lint_script: npm run lint
+  coverage_script: npm run coverage
+  test_doclint_script: npm run test-doclint


### PR DESCRIPTION
Cirrus CI recently started supporting Mac OS builds. This PR adds a CI task to test Puppeteer on MacOS.

It uses Node 8 since only [Node 6 and Node 8 are LTS](https://github.com/nodejs/Release#release-schedule) so `brew` only has receipts for those two TLS versions besides the latest one.