### PR TITLE
test: fix appveyour flakiness

### DIFF
--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -15,9 +15,9 @@
  */
 const fs = require('fs');
 const os = require('os');
-const rm = require('rimraf').sync;
 const path = require('path');
 const {helper} = require('../lib/helper');
+const rmAsync = helper.promisify(require('rimraf'));
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const readFileAsync = helper.promisify(fs.readFile);
 const statAsync = helper.promisify(fs.stat);
@@ -57,7 +57,7 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         expect(await browserFetcher.localRevisions()).toEqual(['123456']);
         await browserFetcher.remove('123456');
         expect(await browserFetcher.localRevisions()).toEqual([]);
-        rm(downloadsFolder);
+        await rmAsync(downloadsFolder);
       });
     });
     describe('AppMode', function() {
@@ -96,7 +96,8 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
         await browser.close();
         expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-        rm(userDataDir);
+        // This might throw. See https://github.com/GoogleChrome/puppeteer/issues/2778
+        await rmAsync(userDataDir).catch(e => {});
       });
       it('userDataDir argument', async({server}) => {
         const userDataDir = await mkdtempAsync(TMP_FOLDER);
@@ -106,7 +107,8 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
         await browser.close();
         expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
-        rm(userDataDir);
+        // This might throw. See https://github.com/GoogleChrome/puppeteer/issues/2778
+        await rmAsync(userDataDir).catch(e => {});
       });
       it('userDataDir option should restore state', async({server}) => {
         const userDataDir = await mkdtempAsync(TMP_FOLDER);
@@ -122,7 +124,8 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         await page2.goto(server.EMPTY_PAGE);
         expect(await page2.evaluate(() => localStorage.hey)).toBe('hello');
         await browser2.close();
-        rm(userDataDir);
+        // This might throw. See https://github.com/GoogleChrome/puppeteer/issues/2778
+        await rmAsync(userDataDir).catch(e => {});
       });
       it('userDataDir option should restore cookies', async({server}) => {
         const userDataDir = await mkdtempAsync(TMP_FOLDER);
@@ -138,7 +141,8 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         await page2.goto(server.EMPTY_PAGE);
         expect(await page2.evaluate(() => document.cookie)).toBe('doSomethingOnlyOnce=true');
         await browser2.close();
-        rm(userDataDir);
+        // This might throw. See https://github.com/GoogleChrome/puppeteer/issues/2778
+        await rmAsync(userDataDir).catch(e => {});
       });
       it('should return the default chrome arguments', async() => {
         const args = puppeteer.defaultArgs();


### PR DESCRIPTION
Crashpad sometimes prevents us from removing a folder in tests.

References #2778.