### PR TITLE
feat(chromium): roll Chromium to r571040

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "568432"
+    "chromium_revision": "571040"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/assets/frames/frame.html
+++ b/test/assets/frames/frame.html
@@ -1,3 +1,8 @@
 <link rel='stylesheet' href='./style.css'>
 <script src='./script.js' type='text/javascript'></script>
+<style>
+div {
+  line-height: 18px;
+}
+</style>
 <div>Hi, I'm frame</div>

--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -50,7 +50,7 @@ module.exports.addTests = function({testRunner, expect}) {
       const box = await elementHandle.boundingBox();
       expect(box).toEqual({ x: 8, y: 8, width: 100, height: 200 });
     });
-    xit('should work with SVG nodes', async({page, server}) => {
+    it('should work with SVG nodes', async({page, server}) => {
       await page.setContent(`
         <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
           <rect id="theRect" x="30" y="50" width="200" height="300"></rect>


### PR DESCRIPTION
This roll includes:
- https://crrev.com/570566 - DevTools: teach DOM.getBoxModel to work with SVG nodes

Fixes #1247.