### PR TITLE
docs(api.md) add note on page.pdf() color rendering behavior

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1256,6 +1256,8 @@ await page.emulateMedia('screen');
 await page.pdf({path: 'page.pdf'});
 ```
 
+> **NOTE** By default, `page.pdf()` generates a pdf with modified colors for printing. Use the [`-webkit-print-color-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust) property to force rendering of exact colors.
+
 The `width`, `height`, and `margin` options accept values labeled with units. Unlabeled values are treated as pixels.
 
 A few examples:


### PR DESCRIPTION
Adds guidance for producing accurate colors in PDF output. `page.pdf()` can produce unexpected document colors unless forced to render exact colors.

References #2685