### PR TITLE
docs(api.md): add note on page.pdf() color rendering behavior

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1250,6 +1250,8 @@ Page is guaranteed to have a main frame which persists during navigations.
 
 `page.pdf()` generates a pdf of the page with `print` css media. To generate a pdf with `screen` media, call [page.emulateMedia('screen')](#pageemulatemediamediatype) before calling `page.pdf()`:
 
+> **NOTE** By default, `page.pdf()` generates a pdf with modified colors for printing. Use the [`-webkit-print-color-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust) property to force rendering of exact colors.
+
 ```js
 // Generates a PDF with 'screen' media type.
 await page.emulateMedia('screen');


### PR DESCRIPTION
Adds guidance for producing accurate colors in PDF output. page.pdf() can produce unexpected document colors unless forced to render exact colors.

References #2685