### PR TITLE
fix: wait for the chromeProcess to exit, not close

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -133,7 +133,7 @@ class Launcher {
 
     let chromeClosed = false;
     const waitForChromeToClose = new Promise((fulfill, reject) => {
-      chromeProcess.once('close', () => {
+      chromeProcess.once('exit', () => {
         chromeClosed = true;
         // Cleanup as processes exit.
         if (temporaryUserDataDir) {


### PR DESCRIPTION
When closing Chromium with the `Browser.close` protocol command, the 'exit' event can sometimes fire 15 seconds before the close event. This is causing our user-data-dir tests to timeout on the bots.
