### PR TITLE
chore(ci): disable brew auto-update

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,6 +25,8 @@ task:
   osx_instance:
     image: high-sierra-base
   name: node8 (macOS)
+  env:
+    HOMEBREW_NO_AUTO_UPDATE: 1
   node_install_script:
     - brew install node@8
     - brew link --force node@8


### PR DESCRIPTION
Seems something in brew was updated which caused CI to fail to install node 8

to: @aslushnikov 