### PR TITLE
fix(coverage): report anonymous scripts with debugger:// urls

### DIFF
--- a/lib/Coverage.js
+++ b/lib/Coverage.js
@@ -144,7 +144,9 @@ class JSCoverage {
 
     const coverage = [];
     for (const entry of profileResponse.result) {
-      const url = this._scriptURLs.get(entry.scriptId);
+      let url = this._scriptURLs.get(entry.scriptId);
+      if (!url && this._reportAnonymousScripts)
+        url = 'debugger://VM' + entry.scriptId;
       const text = this._scriptSources.get(entry.scriptId);
       if (text === undefined || url === undefined)
         continue;

--- a/test/coverage.spec.js
+++ b/test/coverage.spec.js
@@ -44,7 +44,7 @@ module.exports.addTests = function({testRunner, expect}) {
       const coverage = await page.coverage.stopJSCoverage();
       expect(coverage.length).toBe(1);
     });
-    fit('shouldn\'t ignore eval() scripts if reportAnonymousScripts is true', async function({page, server}) {
+    it('shouldn\'t ignore eval() scripts if reportAnonymousScripts is true', async function({page, server}) {
       await page.coverage.startJSCoverage({reportAnonymousScripts: true});
       await page.goto(server.PREFIX + '/jscoverage/eval.html');
       const coverage = await page.coverage.stopJSCoverage();

--- a/test/coverage.spec.js
+++ b/test/coverage.spec.js
@@ -38,27 +38,26 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(coverage.length).toBe(1);
       expect(coverage[0].url).toBe('nicename.js');
     });
-    describe('anonymous scripts coverage', function() {
-      it('should ignore eval() scripts by default', async function({page, server}) {
-        await page.coverage.startJSCoverage();
-        await page.goto(server.PREFIX + '/jscoverage/eval.html');
-        const coverage = await page.coverage.stopJSCoverage();
-        expect(coverage.length).toBe(1);
-      });
-      it('shouldn\'t ignore eval() scripts if reportAnonymousScripts is true', async function({page, server}) {
-        await page.coverage.startJSCoverage({reportAnonymousScripts: true});
-        await page.goto(server.PREFIX + '/jscoverage/eval.html');
-        const coverage = await page.coverage.stopJSCoverage();
-        expect(coverage.length).toBe(2);
-      });
-      it('should ignore injected scripts regardless of reportAnonymousScripts', async function({page, server}) {
-        await page.coverage.startJSCoverage({reportAnonymousScripts: true});
-        await page.goto(server.EMPTY_PAGE);
-        await page.evaluate('console.log("foo")');
-        await page.evaluate(() => console.log('bar'));
-        const coverage = await page.coverage.stopJSCoverage();
-        expect(coverage.length).toBe(0);
-      });
+    it('should ignore eval() scripts by default', async function({page, server}) {
+      await page.coverage.startJSCoverage();
+      await page.goto(server.PREFIX + '/jscoverage/eval.html');
+      const coverage = await page.coverage.stopJSCoverage();
+      expect(coverage.length).toBe(1);
+    });
+    fit('shouldn\'t ignore eval() scripts if reportAnonymousScripts is true', async function({page, server}) {
+      await page.coverage.startJSCoverage({reportAnonymousScripts: true});
+      await page.goto(server.PREFIX + '/jscoverage/eval.html');
+      const coverage = await page.coverage.stopJSCoverage();
+      expect(coverage.find(entry => entry.url.startsWith('debugger://'))).not.toBe(null);
+      expect(coverage.length).toBe(2);
+    });
+    it('should ignore pptr internal scripts if reportAnonymousScripts is true', async function({page, server}) {
+      await page.coverage.startJSCoverage({reportAnonymousScripts: true});
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate('console.log("foo")');
+      await page.evaluate(() => console.log('bar'));
+      const coverage = await page.coverage.stopJSCoverage();
+      expect(coverage.length).toBe(0);
     });
     it('should report multiple scripts', async function({page, server}) {
       await page.coverage.startJSCoverage();


### PR DESCRIPTION
Chrome DevTools shows anonymous scripts with yellow background and names
them with `debugger://VM<scriptId>` prefix.

This patch starts reporting the same debugger:// urls for anonymous
scripts in puppeteer's JS coverage. This might simplify debugging, e.g.
using `debugger;` statement to reveal the script in DevTools and later
matching it against the one in the coverage.