### PR TITLE
test: cleanup page.waitForRequest/page.waitForResponse tests

### DIFF
--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -790,39 +790,38 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
     it('should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [request] = await Promise.all([
-        page.waitForRequest(server.PREFIX + '/404'),
-        page.evaluate(() => fetch('/404', {method: 'GET'}))
+        page.waitForRequest(server.PREFIX + '/digits/2.png'),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        })
       ]);
-      expect(request.method()).toBe('GET');
-      expect(request.url()).toBe(server.PREFIX + '/404');
-    });
-    it('should work with regex pattern', async({page, server}) => {
-      await page.goto(server.EMPTY_PAGE);
-      const [request] = await Promise.all([
-        page.waitForRequest(request => new RegExp(`${server.PREFIX}/(200|404)`).test(request.url())),
-        page.evaluate(() => fetch('/404', {method: 'GET'}))
-      ]);
-      expect(request.method()).toBe('GET');
-      expect(request.url()).toBe(server.PREFIX + '/404');
+      expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
     });
     it('should work with predicate', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [request] = await Promise.all([
-        page.waitForRequest(request => request.url() === server.PREFIX + '/404' && request.method() === 'PATCH'),
-        page.evaluate(() => fetch('/404', {method: 'PATCH'}))
+        page.waitForRequest(request => request.url() === server.PREFIX + '/digits/2.png'),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        })
       ]);
-      expect(request.method()).toBe('PATCH');
-      expect(request.url()).toBe(server.PREFIX + '/404');
+      expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
     });
     it('should work with no timeout', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [request] = await Promise.all([
-        page.waitForRequest(server.PREFIX + '/404', { timeout: 0}),
-        page.waitFor(50),
-        page.evaluate(() => fetch('/404', {method: 'GET'}))
+        page.waitForRequest(server.PREFIX + '/digits/2.png', {timeout: 0}),
+        page.evaluate(() => setTimeout(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }, 50))
       ]);
-      expect(request.method()).toBe('GET');
-      expect(request.url()).toBe(server.PREFIX + '/404');
+      expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
     });
   });
 
@@ -830,42 +829,38 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
     it('should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [response] = await Promise.all([
-        page.waitForResponse(server.PREFIX + '/grid.html'),
-        page.waitFor(100),
-        page.evaluate(() => fetch('/grid.html', {method: 'GET'}))
+        page.waitForResponse(server.PREFIX + '/digits/2.png'),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        })
       ]);
-      expect(response.ok()).toBe(true);
-      expect(response.url()).toBe(server.PREFIX + '/grid.html');
-    });
-    it('should work with regex', async({page, server}) => {
-      await page.goto(server.EMPTY_PAGE);
-      const [response] = await Promise.all([
-        page.waitForResponse(response => new RegExp(`${server.PREFIX}/(get|grid.html)`).test(response.url())),
-        page.waitFor(100),
-        page.evaluate(() => fetch('/grid.html', {method: 'GET'}))
-      ]);
-      expect(response.ok()).toBe(true);
-      expect(response.url()).toBe(server.PREFIX + '/grid.html');
+      expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
     });
     it('should work with predicate', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [response] = await Promise.all([
-        page.waitForResponse(response => response.url() === server.PREFIX + '/grid.html' && response.status() === 200),
-        page.waitFor(100),
-        page.evaluate(() => fetch('/grid.html', {method: 'PATCH'}))
+        page.waitForResponse(response => response.url() === server.PREFIX + '/digits/2.png'),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        })
       ]);
-      expect(response.ok()).toBe(true);
-      expect(response.url()).toBe(server.PREFIX + '/grid.html');
+      expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
     });
     it('should work with no timeout', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [response] = await Promise.all([
-        page.waitForResponse(server.PREFIX + '/grid.html', { timeout: 0}),
-        page.waitFor(50),
-        page.evaluate(() => fetch('/grid.html', {method: 'GET'}))
+        page.waitForResponse(server.PREFIX + '/digits/2.png', {timeout: 0}),
+        page.evaluate(() => setTimeout(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }, 50))
       ]);
-      expect(response.ok()).toBe(true);
-      expect(response.url()).toBe(server.PREFIX + '/grid.html');
+      expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
     });
   });
 


### PR DESCRIPTION
This patch removes unnecessary regexp tests and unifies all tests
between each other.