### PR TITLE
feat: introduce basic Error classes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
   * [puppeteer.connect(options)](#puppeteerconnectoptions)
   * [puppeteer.createBrowserFetcher([options])](#puppeteercreatebrowserfetcheroptions)
   * [puppeteer.defaultArgs()](#puppeteerdefaultargs)
+  * [puppeteer.errors](#puppeteererrors)
   * [puppeteer.executablePath()](#puppeteerexecutablepath)
   * [puppeteer.launch([options])](#puppeteerlaunchoptions)
 - [class: BrowserFetcher](#class-browserfetcher)
@@ -342,6 +343,25 @@ This methods attaches Puppeteer to an existing Chromium instance.
 
 #### puppeteer.defaultArgs()
 - returns: <[Array]<[string]>> The default flags that Chromium will be launched with.
+
+#### puppeteer.errors
+- returns: <[Object]> - a collection of puppeteer error classes
+  - `InvalidNodeError` - thrown whenever Puppeteer didn't like the node it was asked to operate upon
+  - `ProtocolError` - thrown whenever DevTools protocol returns an error
+  - `TimeoutError` - thrown whenever an operation was aborted due to timeout
+
+Error classes could be used to conditionally check for error type.
+For example, to check if the operation failed due to timeout:
+
+```js
+try {
+  await page.waitForSelector('.foo');
+} catch (e) {
+  if (e instanceof puppeteer.errors.TimeoutError) {
+    // Do something if this is a timeout.
+  }
+}
+```
 
 #### puppeteer.executablePath()
 - returns: <[string]> A path where Puppeteer expects to find bundled Chromium. Chromium might not exist there if the download was skipped with [`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`](#environment-variables).
@@ -3001,35 +3021,35 @@ reported.
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [string]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type "String"
 [stream.Readable]: https://nodejs.org/api/stream.html#stream_class_stream_readable "stream.Readable"
-[CDPSession]: #class-cdpsession  "CDPSession"
-[BrowserFetcher]: #class-browserfetcher  "BrowserFetcher"
-[BrowserContext]: #class-browsercontext  "BrowserContext"
-[Error]: https://nodejs.org/api/errors.html#errors_class_error "Error"
-[Frame]: #class-frame "Frame"
-[ConsoleMessage]: #class-consolemessage "ConsoleMessage"
-[ChildProcess]: https://nodejs.org/api/child_process.html "ChildProcess"
-[Coverage]: #class-coverage "Coverage"
-[iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
-[Response]: #class-response  "Response"
-[Request]: #class-request  "Request"
-[Browser]: #class-browser  "Browser"
 [Body]: #class-body  "Body"
-[Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Keyboard]: #class-keyboard "Keyboard"
+[BrowserContext]: #class-browsercontext  "BrowserContext"
+[BrowserFetcher]: #class-browserfetcher  "BrowserFetcher"
+[Browser]: #class-browser  "Browser"
+[CDPSession]: #class-cdpsession  "CDPSession"
+[ChildProcess]: https://nodejs.org/api/child_process.html "ChildProcess"
+[ConsoleMessage]: #class-consolemessage "ConsoleMessage"
+[Coverage]: #class-coverage "Coverage"
 [Dialog]: #class-dialog  "Dialog"
-[JSHandle]: #class-jshandle "JSHandle"
-[ExecutionContext]: #class-executioncontext "ExecutionContext"
-[Mouse]: #class-mouse "Mouse"
-[Map]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map "Map"
-[selector]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors "selector"
-[Tracing]: #class-tracing "Tracing"
 [ElementHandle]: #class-elementhandle "ElementHandle"
-[UIEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail "UIEvent.detail"
-[Serializable]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description "Serializable"
-[Touchscreen]: #class-touchscreen "Touchscreen"
-[Target]: #class-target "Target"
-[USKeyboardLayout]: ../lib/USKeyboardLayout.js "USKeyboardLayout"
-[xpath]: https://developer.mozilla.org/en-US/docs/Web/XPath "xpath"
-[UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
+[Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
+[Error]: https://nodejs.org/api/errors.html#errors_class_error "Error"
+[ExecutionContext]: #class-executioncontext "ExecutionContext"
+[Frame]: #class-frame "Frame"
+[JSHandle]: #class-jshandle "JSHandle"
+[Keyboard]: #class-keyboard "Keyboard"
+[Map]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map "Map"
+[Mouse]: #class-mouse "Mouse"
+[Request]: #class-request  "Request"
+[Response]: #class-response  "Response"
 [SecurityDetails]: #class-securitydetails "SecurityDetails"
+[Serializable]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description "Serializable"
+[Target]: #class-target "Target"
+[Touchscreen]: #class-touchscreen "Touchscreen"
+[Tracing]: #class-tracing "Tracing"
+[UIEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail "UIEvent.detail"
+[USKeyboardLayout]: ../lib/USKeyboardLayout.js "USKeyboardLayout"
+[UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
 [Worker]: #class-worker "Worker"
+[iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
+[selector]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors "selector"
+[xpath]: https://developer.mozilla.org/en-US/docs/Web/XPath "xpath"

--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -156,7 +156,7 @@ class BrowserFetcher {
     else if (this._platform === 'win32' || this._platform === 'win64')
       executablePath = path.join(folderPath, 'chrome-win32', 'chrome.exe');
     else
-      throw 'Unsupported platform: ' + this._platform;
+      throw new Error('Unsupported platform: ' + this._platform);
     let url = downloadURLs[this._platform];
     url = util.format(url, this._downloadHost, revision);
     const local = fs.existsSync(folderPath);

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 const {helper, assert} = require('./helper');
+const {ProtocolError} = require('./errors');
 const debugProtocol = require('debug')('puppeteer:protocol');
 const debugSession = require('debug')('puppeteer:session');
 
 const EventEmitter = require('events');
 const WebSocket = require('ws');
 const Pipe = require('./Pipe');
+
 
 class Connection extends EventEmitter {
   /**
@@ -83,7 +85,7 @@ class Connection extends EventEmitter {
     debugProtocol('SEND ► ' + message);
     this._transport.send(message);
     return new Promise((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, error: new Error(), method});
+      this._callbacks.set(id, {resolve, reject, error: new ProtocolError(), method});
     });
   }
 
@@ -186,7 +188,7 @@ class CDPSession extends EventEmitter {
    */
   send(method, params = {}) {
     if (!this._connection)
-      return Promise.reject(new Error(`Protocol error (${method}): Session closed. Most likely the ${this._targetType} has been closed.`));
+      return Promise.reject(new ProtocolError(`Protocol error (${method}): Session closed. Most likely the ${this._targetType} has been closed.`));
     const id = ++this._lastId;
     const message = JSON.stringify({id, method, params});
     debugSession('SEND ► ' + message);
@@ -199,7 +201,7 @@ class CDPSession extends EventEmitter {
       callback.reject(rewriteError(callback.error, e && e.message));
     });
     return new Promise((resolve, reject) => {
-      this._callbacks.set(id, {resolve, reject, error: new Error(), method});
+      this._callbacks.set(id, {resolve, reject, error: new ProtocolError(), method});
     });
   }
 

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -15,7 +15,8 @@
  */
 const path = require('path');
 const {JSHandle} = require('./ExecutionContext');
-const {helper, assert, debugError} = require('./helper');
+const {helper, debugError} = require('./helper');
+const {InvalidNodeError} = require('./errors');
 
 class ElementHandle extends JSHandle {
   /**
@@ -72,7 +73,7 @@ class ElementHandle extends JSHandle {
       return false;
     }, this);
     if (error)
-      throw new Error(error);
+      throw new InvalidNodeError(error);
   }
 
   /**
@@ -83,11 +84,11 @@ class ElementHandle extends JSHandle {
       objectId: this._remoteObject.objectId
     }).catch(debugError);
     if (!result || !result.quads.length)
-      throw new Error('Node is either not visible or not an HTMLElement');
+      throw new InvalidNodeError('Node is either not visible or not an HTMLElement');
     // Filter out quads that have too small area to click into.
     const quads = result.quads.map(quad => this._fromProtocolQuad(quad)).filter(quad => computeQuadArea(quad) > 1);
     if (!quads.length)
-      throw new Error('Node is either not visible or not an HTMLElement');
+      throw new InvalidNodeError('Node is either not visible or not an HTMLElement');
     // Return the middle point of the first quad.
     const quad = quads[0];
     let x = 0;
@@ -224,7 +225,8 @@ class ElementHandle extends JSHandle {
     let needsViewportReset = false;
 
     let boundingBox = await this.boundingBox();
-    assert(boundingBox, 'Node is either not visible or not an HTMLElement');
+    if (!boundingBox)
+      throw new InvalidNodeError('Node is either not visible or not an HTMLElement');
 
     const viewport = this._page.viewport();
 
@@ -241,7 +243,8 @@ class ElementHandle extends JSHandle {
     await this._scrollIntoViewIfNeeded();
 
     boundingBox = await this.boundingBox();
-    assert(boundingBox, 'Node is either not visible or not an HTMLElement');
+    if (!boundingBox)
+      throw new InvalidNodeError('Node is either not visible or not an HTMLElement');
 
     const { layoutViewport: { pageX, pageY } } = await this._client.send('Page.getLayoutMetrics');
 
@@ -304,7 +307,7 @@ class ElementHandle extends JSHandle {
   async $eval(selector, pageFunction, ...args) {
     const elementHandle = await this.$(selector);
     if (!elementHandle)
-      throw new Error(`Error: failed to find element matching selector "${selector}"`);
+      throw new InvalidNodeError(`Error: failed to find element matching selector "${selector}"`);
     const result = await this.executionContext().evaluate(pageFunction, elementHandle, ...args);
     await elementHandle.dispose();
     return result;

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -15,6 +15,7 @@
  */
 
 const {helper, assert} = require('./helper');
+const {ProtocolError} = require('./errors');
 
 const EVALUATION_SCRIPT_URL = '__puppeteer_evaluation_script__';
 const SOURCE_URL_REGEX = /^[\040\t]*\/\/[@#] sourceURL=\s*(\S*?)\s*$/m;
@@ -132,7 +133,7 @@ class ExecutionContext {
      */
     function rewriteError(error) {
       if (error.message.endsWith('Cannot find context with specified id'))
-        throw new Error('Execution context was destroyed, most likely because of a navigation.');
+        throw new ProtocolError('Execution context was destroyed, most likely because of a navigation.');
       throw error;
     }
   }

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -19,6 +19,7 @@ const EventEmitter = require('events');
 const {helper, assert} = require('./helper');
 const {ExecutionContext, JSHandle} = require('./ExecutionContext');
 const ElementHandle = require('./ElementHandle');
+const {InvalidNodeError, TimeoutError} = require('./errors');
 
 const readFileAsync = helper.promisify(fs.readFile);
 
@@ -634,7 +635,12 @@ class Frame {
       element.dispatchEvent(new Event('input', { 'bubbles': true }));
       element.dispatchEvent(new Event('change', { 'bubbles': true }));
       return options.filter(option => option.selected).map(option => option.value);
-    }, values);
+    }, values).catch(e => {
+      if (e.message === 'Element is not a <select> element.')
+        throw new InvalidNodeError(e.message);
+      else
+        throw e;
+    });
   }
 
   /**
@@ -837,7 +843,7 @@ class WaitTask {
     // Since page navigation requires us to re-install the pageScript, we should track
     // timeout on our end.
     if (timeout) {
-      const timeoutError = new Error(`waiting for ${title} failed: timeout ${timeout}ms exceeded`);
+      const timeoutError = new TimeoutError(`waiting for ${title} failed: timeout ${timeout}ms exceeded`);
       this._timeoutTimer = setTimeout(() => this.terminate(timeoutError), timeout);
     }
     this.rerun();

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -24,6 +24,7 @@ const readline = require('readline');
 const fs = require('fs');
 const {helper, assert, debugError} = require('./helper');
 const ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')).puppeteer.chromium_revision;
+const {TimeoutError} = require('./errors');
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);
@@ -293,7 +294,7 @@ function waitForWSEndpoint(chromeProcess, timeout) {
 
     function onTimeout() {
       cleanup();
-      reject(new Error(`Timed out after ${timeout} ms while trying to connect to Chrome! The only Chrome revision guaranteed to work is r${ChromiumRevision}`));
+      reject(new TimeoutError(`Timed out after ${timeout} ms while trying to connect to Chrome! The only Chrome revision guaranteed to work is r${ChromiumRevision}`));
     }
 
     /**

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -16,6 +16,7 @@
 
 const {helper, assert} = require('./helper');
 const {FrameManager} = require('./FrameManager');
+const {TimeoutError} = require('./errors');
 
 class NavigatorWatcher {
   /**
@@ -70,7 +71,7 @@ class NavigatorWatcher {
       return new Promise(() => {});
     const errorMessage = 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded';
     return new Promise(fulfill => this._maximumTimer = setTimeout(fulfill, this._timeout))
-        .then(() => new Error(errorMessage));
+        .then(() => new TimeoutError(errorMessage));
   }
 
   /**

--- a/lib/Puppeteer.js
+++ b/lib/Puppeteer.js
@@ -16,6 +16,7 @@
 const {helper} = require('./helper');
 const Launcher = require('./Launcher');
 const BrowserFetcher = require('./BrowserFetcher');
+const errors = require('./errors');
 
 module.exports = class {
   /**
@@ -54,6 +55,13 @@ module.exports = class {
    */
   static createBrowserFetcher(options) {
     return new BrowserFetcher(options);
+  }
+
+  /**
+   * @return {!Object}
+   */
+  static get errors() {
+    return errors;
   }
 };
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,13 @@
+class CustomError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = {
+  InvalidNodeError: class extends CustomError {},
+  ProtocolError: class extends CustomError {},
+  TimeoutError: class extends CustomError {},
+};

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -17,6 +17,8 @@ const fs = require('fs');
 const path = require('path');
 
 const debugError = require('debug')(`puppeteer:error`);
+const {TimeoutError} = require('./errors');
+
 /** @type {?Map<string, boolean>} */
 let apiCoverage = null;
 let projectRoot = null;
@@ -262,7 +264,7 @@ class Helper {
     if (timeout) {
       eventTimeout = setTimeout(() => {
         cleanup();
-        rejectCallback(new Error('Timeout exceeded while waiting for event'));
+        rejectCallback(new TimeoutError('Timeout exceeded while waiting for event'));
       }, timeout);
     }
     function cleanup() {

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -16,7 +16,7 @@
 
 const utils = require('./utils');
 
-module.exports.addTests = function({testRunner, expect}) {
+module.exports.addTests = function({testRunner, expect, puppeteer}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
@@ -163,8 +163,8 @@ module.exports.addTests = function({testRunner, expect}) {
     it('should respect timeout', async({page}) => {
       let error = null;
       await page.waitForFunction('false', {timeout: 10}).catch(e => error = e);
-      expect(error).toBeTruthy();
       expect(error.message).toContain('waiting for function failed: timeout');
+      expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
     it('should disable timeout when its set to 0', async({page}) => {
       const watchdog = page.waitForFunction(() => {
@@ -246,7 +246,6 @@ module.exports.addTests = function({testRunner, expect}) {
       const waitPromise = frame.waitForSelector('.box').catch(e => waitError = e);
       await utils.detachFrame(page, 'frame1');
       await waitPromise;
-      expect(waitError).toBeTruthy();
       expect(waitError.message).toContain('waitForFunction failed: frame got detached.');
     });
     it('should survive cross-process navigation', async({page, server}) => {
@@ -315,8 +314,8 @@ module.exports.addTests = function({testRunner, expect}) {
     it('should respect timeout', async({page, server}) => {
       let error = null;
       await page.waitForSelector('div', {timeout: 10}).catch(e => error = e);
-      expect(error).toBeTruthy();
       expect(error.message).toContain('waiting for selector "div" failed: timeout');
+      expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
 
     it('should respond to node attribute mutation', async({page, server}) => {
@@ -350,8 +349,8 @@ module.exports.addTests = function({testRunner, expect}) {
     it('should respect timeout', async({page}) => {
       let error = null;
       await page.waitForXPath('//div', {timeout: 10}).catch(e => error = e);
-      expect(error).toBeTruthy();
       expect(error.message).toContain('waiting for XPath "//div" failed: timeout');
+      expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
     it('should run in specified frame', async({page, server}) => {
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -526,6 +526,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       let error = null;
       await page.goto(server.PREFIX + '/empty.html', {timeout: 1}).catch(e => error = e);
       expect(error.message).toContain('Navigation Timeout Exceeded: 1ms');
+      expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
     it('should fail when exceeding default maximum navigation timeout', async({page, server}) => {
       // Hang for request to the empty.html
@@ -534,6 +535,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       page.setDefaultNavigationTimeout(1);
       await page.goto(server.PREFIX + '/empty.html').catch(e => error = e);
       expect(error.message).toContain('Navigation Timeout Exceeded: 1ms');
+      expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
     it('should disable timeout when its set to 0', async({page, server}) => {
       let error = null;

--- a/test/test.js
+++ b/test/test.js
@@ -137,8 +137,8 @@ describe('Page', function() {
   require('./browsercontext.spec.js').addTests({testRunner, expect, puppeteer});
   require('./cookies.spec.js').addTests({testRunner, expect});
   require('./coverage.spec.js').addTests({testRunner, expect});
-  require('./elementhandle.spec.js').addTests({testRunner, expect});
-  require('./frame.spec.js').addTests({testRunner, expect});
+  require('./elementhandle.spec.js').addTests({testRunner, expect, puppeteer});
+  require('./frame.spec.js').addTests({testRunner, expect, puppeteer});
   require('./input.spec.js').addTests({testRunner, expect, DeviceDescriptors});
   require('./jshandle.spec.js').addTests({testRunner, expect});
   require('./network.spec.js').addTests({testRunner, expect});

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -19,6 +19,10 @@ const mdBuilder = require('./MDBuilder');
 const Documentation = require('./Documentation');
 const Message = require('../Message');
 
+const EXCLUDE_JS_FILES = new Set([
+  'errors.js',
+]);
+
 const EXCLUDE_CLASSES = new Set([
   'CSSCoverage',
   'Connection',
@@ -50,7 +54,7 @@ const EXCLUDE_METHODS = new Set([
  */
 module.exports = async function lint(page, mdSources, jsSources) {
   const mdResult = await mdBuilder(page, mdSources);
-  const jsResult = await jsBuilder(jsSources);
+  const jsResult = await jsBuilder(jsSources.filter(source => !EXCLUDE_JS_FILES.has(source.name())));
   const jsDocumentation = filterJSDocumentation(jsResult.documentation);
   const mdDocumentation = mdResult.documentation;
 

--- a/utils/testrunner/Matchers.js
+++ b/utils/testrunner/Matchers.js
@@ -71,6 +71,11 @@ const DefaultMatchers = {
     return { pass: value > other, message };
   },
 
+  toBeInstanceOf: function(value, other, message) {
+    message = message || `${value.constructor.name} instanceof ${other.name}`;
+    return { pass: value instanceof other, message };
+  },
+
   toBeGreaterThanOrEqual: function(value, other, message) {
     message = message || `${value} >= ${other}`;
     return { pass: value >= other, message };


### PR DESCRIPTION
This patch introduces 3 error classes that are used throughout
the code to report errors:
- `InvalidNodeError` - thrown whenever Puppeteer didn't like the node it
  was asked to operate upon
- `ProtocolError` - thrown whenever DevTools protocol returns an error
- `TimeoutError` - thrown whenever an operation was aborted due to
  timeout.

Fixes #1694