### PR TITLE
feat: support for setting executablePath via an env variable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -348,7 +348,7 @@ This methods attaches Puppeteer to an existing Chromium instance.
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
   - `headless` <[boolean]> Whether to run browser in [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome). Defaults to `true` unless the `devtools` option is `true`.
-  - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
+  - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If `executablePath` was not set, puppeteer will try to get it from `process.env.PUPPETEER_EXECUTABLE_PATH`.
   - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `ignoreDefaultArgs` <[boolean]> Do not use [`puppeteer.defaultArgs()`](#puppeteerdefaultargs). Dangerous option; use with care. Defaults to `false`.

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -99,7 +99,7 @@ class Launcher {
     if (!options.ignoreDefaultArgs && Array.isArray(options.args) && options.args.every(arg => arg.startsWith('-')))
       chromeArguments.push('about:blank');
 
-    let chromeExecutable = options.executablePath;
+    let chromeExecutable = options.executablePath || process.env.PUPPETEER_EXECUTABLE_PATH;
     if (typeof chromeExecutable !== 'string') {
       const browserFetcher = new BrowserFetcher();
       const revisionInfo = browserFetcher.revisionInfo(ChromiumRevision);


### PR DESCRIPTION
In some cases you have no access to `options.executablePath` (e.g. [storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots/storyshots-puppeteer)), but you want to strictly define the chromium version.

With this pr you can do that.

Related to https://github.com/GoogleChrome/puppeteer/pull/2290