### PR TITLE
fix(launcher): do not add --disable-gpu on OSX and Linux

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -91,10 +91,11 @@ class Launcher {
     if (typeof options.headless !== 'boolean' || options.headless) {
       chromeArguments.push(
           '--headless',
-          '--disable-gpu',
           '--hide-scrollbars',
           '--mute-audio'
       );
+      if (os.platform() === 'win32')
+        chromeArguments.push('--disable-gpu');
     }
     if (!options.ignoreDefaultArgs && Array.isArray(options.args) && options.args.every(arg => arg.startsWith('-')))
       chromeArguments.push('about:blank');


### PR DESCRIPTION
This patch conditionally adds the `--disable-gpu` flag if only we
run headless on windows.

Fixes #1260.