### PR TITLE
feat(FrameManager): improve waiting for selector to be hidden error message

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -728,7 +728,8 @@ class Frame {
     const waitForHidden = !!options.hidden;
     const polling = waitForVisible || waitForHidden ? 'raf' : 'mutation';
     const timeout = helper.isNumber(options.timeout) ? options.timeout : 30000;
-    return new WaitTask(this, predicate, `${isXPath ? 'XPath' : 'selector'} "${selectorOrXPath}"`, polling, timeout, selectorOrXPath, isXPath, waitForVisible, waitForHidden).promise;
+    const title = `${isXPath ? 'XPath' : 'selector'} "${selectorOrXPath}"${waitForHidden ? ' to be hidden' : ''}`;
+    return new WaitTask(this, predicate, title, polling, timeout, selectorOrXPath, isXPath, waitForVisible, waitForHidden).promise;
 
     /**
      * @param {string} selectorOrXPath

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -318,6 +318,13 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(error).toBeTruthy();
       expect(error.message).toContain('waiting for selector "div" failed: timeout');
     });
+    it('should have an error message specifically for awaiting an element to be hidden', async({page, server}) => {
+      await page.setContent(`<div></div>`);
+      let error = null;
+      await page.waitForSelector('div', {hidden: true, timeout: 10}).catch(e => error = e);
+      expect(error).toBeTruthy();
+      expect(error.message).toContain('waiting for selector "div" to be hidden failed: timeout');
+    });
 
     it('should respond to node attribute mutation', async({page, server}) => {
       let divFound = false;


### PR DESCRIPTION
Improves error message for when a `waitForSelector` call uses the hidden: true option.

Rather than just saying

```
waiting for selector "div" failed: timeout
```

it will say

```
waiting for selector "div" to be hidden failed: timeout
```

(when appropriate).

Addresses #2854
