### PR TITLE
feat(page): add 'preferCSSPageSize' to page.pdf options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1277,6 +1277,7 @@ Page is guaranteed to have a main frame which persists during navigations.
     - `right` <[string]> Right margin, accepts values labeled with units.
     - `bottom` <[string]> Bottom margin, accepts values labeled with units.
     - `left` <[string]> Left margin, accepts values labeled with units.
+  - `preferCSSPageSize` <[boolean]> Prefer page size as defined by css. Defaults to `false`.
 - returns: <[Promise]<[Buffer]>> Promise which resolves with PDF buffer.
 
 > **NOTE** Generating a pdf is currently only supported in Chrome headless.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1277,7 +1277,7 @@ Page is guaranteed to have a main frame which persists during navigations.
     - `right` <[string]> Right margin, accepts values labeled with units.
     - `bottom` <[string]> Bottom margin, accepts values labeled with units.
     - `left` <[string]> Left margin, accepts values labeled with units.
-  - `preferCSSPageSize` <[boolean]> Prefer page size as defined by css. Defaults to `false`.
+  - `preferCSSPageSize` <[boolean]> Give any CSS `@page` size declared in the page priority over what is declared in `width` and `height` or `format` options. Defaults to `false`, which will scale the content to fit the paper size.
 - returns: <[Promise]<[Buffer]>> Promise which resolves with PDF buffer.
 
 > **NOTE** Generating a pdf is currently only supported in Chrome headless.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -889,6 +889,7 @@ class Page extends EventEmitter {
     const marginLeft = convertPrintParameterToInches(marginOptions.left) || 0;
     const marginBottom = convertPrintParameterToInches(marginOptions.bottom) || 0;
     const marginRight = convertPrintParameterToInches(marginOptions.right) || 0;
+    const preferCSSPageSize = options.preferCSSPageSize || false;
 
     const result = await this._client.send('Page.printToPDF', {
       landscape: landscape,
@@ -903,7 +904,8 @@ class Page extends EventEmitter {
       marginBottom: marginBottom,
       marginLeft: marginLeft,
       marginRight: marginRight,
-      pageRanges: pageRanges
+      pageRanges: pageRanges,
+      preferCSSPageSize: preferCSSPageSize
     });
     const buffer = Buffer.from(result.data, 'base64');
     if (options.path)


### PR DESCRIPTION
Adds an option to set the `preferCSSPageSize` boolean when sending `Page.printToPDF`

Per #1963