### PR TITLE
style: convert to arrow function expression

### DIFF
--- a/test/assets/input/mouse-helper.js
+++ b/test/assets/input/mouse-helper.js
@@ -1,6 +1,6 @@
 // This injects a box into the page that moves with the mouse;
 // Useful for debugging
-(function(){
+(() => {
   const box = document.createElement('div');
   box.classList.add('mouse-helper');
   const styleElement = document.createElement('style');

--- a/test/assets/worker/worker.js
+++ b/test/assets/worker/worker.js
@@ -8,7 +8,7 @@ self.addEventListener('message', event => {
   console.log('got this data: ' + event.data);
 });
 
-(async function() {
+(async() => {
   while (true) {
     self.postMessage(workerFunction.toString());
     await new Promise(x => setTimeout(x, 100));

--- a/test/utils.js
+++ b/test/utils.js
@@ -20,7 +20,7 @@ const utils = module.exports = {
    * @param {string} frameId
    * @param {string} url
    */
-  attachFrame: async function(page, frameId, url) {
+  attachFrame: async(page, frameId, url) => {
     await page.evaluate(attachFrame, frameId, url);
 
     function attachFrame(frameId, url) {
@@ -36,7 +36,7 @@ const utils = module.exports = {
    * @param {!Page} page
    * @param {string} frameId
    */
-  detachFrame: async function(page, frameId) {
+  detachFrame: async(page, frameId) => {
     await page.evaluate(detachFrame, frameId);
 
     function detachFrame(frameId) {
@@ -50,7 +50,7 @@ const utils = module.exports = {
    * @param {string} frameId
    * @param {string} url
    */
-  navigateFrame: async function(page, frameId, url) {
+  navigateFrame: async(page, frameId, url) => {
     await page.evaluate(navigateFrame, frameId, url);
 
     function navigateFrame(frameId, url) {
@@ -65,7 +65,7 @@ const utils = module.exports = {
    * @param {string=} indentation
    * @return {string}
    */
-  dumpFrames: function(frame, indentation) {
+  dumpFrames: (frame, indentation) => {
     indentation = indentation || '';
     let result = indentation + frame.url().replace(/:\d{4}\//, ':<PORT>/');
     for (const child of frame.childFrames())
@@ -78,7 +78,5 @@ const utils = module.exports = {
    * @param {string} eventName
    * @return {!Promise<!Object>}
    */
-  waitEvent: function(emitter, eventName) {
-    return new Promise(fulfill => emitter.once(eventName, fulfill));
-  },
+  waitEvent: (emitter, eventName) => new Promise(fulfill => emitter.once(eventName, fulfill)),
 };

--- a/utils/doclint/check_public_api/test/check-returns/foo.js
+++ b/utils/doclint/check_public_api/test/check-returns/foo.js
@@ -4,9 +4,7 @@ class Foo {
   }
 
   returnNothing() {
-    let e = () => {
-      return 10;
-    }
+    let e = () => 10
     e();
   }
 

--- a/utils/doclint/check_public_api/test/test.js
+++ b/utils/doclint/check_public_api/test/test.js
@@ -33,16 +33,16 @@ const {beforeAll, beforeEach, afterAll, afterEach} = runner;
 let browser;
 let page;
 
-beforeAll(async function() {
+beforeAll(async () => {
   browser = await puppeteer.launch({args: ['--no-sandbox']});
   page = await browser.newPage();
 });
 
-afterAll(async function() {
+afterAll(async () => {
   await browser.close();
 });
 
-describe('checkPublicAPI', function() {
+describe('checkPublicAPI', () => {
   it('diff-classes', testLint);
   it('diff-methods', testLint);
   it('diff-properties', testLint);

--- a/utils/doclint/preprocessor/index.js
+++ b/utils/doclint/preprocessor/index.js
@@ -16,7 +16,7 @@
 
 const Message = require('../Message');
 
-module.exports = function(sources, version) {
+module.exports = (sources, version) => {
   // Release version is everything that doesn't include "-".
   const isReleaseVersion = !version.includes('-');
   const lastReleasedAPILink = `[API](https://github.com/GoogleChrome/puppeteer/blob/v${version.split('-')[0]}/docs/api.md)`;

--- a/utils/doclint/preprocessor/test.js
+++ b/utils/doclint/preprocessor/test.js
@@ -25,8 +25,8 @@ const {it, fit, xit} = runner;
 const {beforeAll, beforeEach, afterAll, afterEach} = runner;
 const {expect} = new Matchers();
 
-describe('preprocessor', function() {
-  it('should throw for unknown command', function() {
+describe('preprocessor', () => {
+  it('should throw for unknown command', () => {
     const source = new Source('doc.md', `
       <!-- gen:unknown-command -->something<!-- gen:stop -->
     `);
@@ -36,8 +36,8 @@ describe('preprocessor', function() {
     expect(messages[0].type).toBe('error');
     expect(messages[0].text).toContain('Unknown command');
   });
-  describe('gen:version', function() {
-    it('should work', function() {
+  describe('gen:version', () => {
+    it('should work', () => {
       const source = new Source('doc.md', `
         Puppeteer <!-- gen:version -->XXX<!-- gen:stop -->
       `);
@@ -49,7 +49,7 @@ describe('preprocessor', function() {
         Puppeteer <!-- gen:version -->v1.2.0<!-- gen:stop -->
       `);
     });
-    it('should work for *-post versions', function() {
+    it('should work for *-post versions', () => {
       const source = new Source('doc.md', `
         Puppeteer <!-- gen:version -->XXX<!-- gen:stop -->
       `);
@@ -61,13 +61,13 @@ describe('preprocessor', function() {
         Puppeteer <!-- gen:version -->Tip-Of-Tree<!-- gen:stop -->
       `);
     });
-    it('should tolerate different writing', function() {
+    it('should tolerate different writing', () => {
       const source = new Source('doc.md', `Puppeteer v<!--   gEn:version -->WHAT
 <!--     GEN:stop   -->`);
       preprocessor([source], '1.1.1');
       expect(source.text()).toBe(`Puppeteer v<!--   gEn:version -->v1.1.1<!--     GEN:stop   -->`);
     });
-    it('should not tolerate missing gen:stop', function() {
+    it('should not tolerate missing gen:stop', () => {
       const source = new Source('doc.md', `<!--GEN:version-->`);
       const messages = preprocessor([source], '1.2.0');
       expect(source.hasUpdatedText()).toBe(false);
@@ -76,8 +76,8 @@ describe('preprocessor', function() {
       expect(messages[0].text).toContain(`Failed to find 'gen:stop'`);
     });
   });
-  describe('gen:empty-if-release', function() {
-    it('should clear text when release version', function() {
+  describe('gen:empty-if-release', () => {
+    it('should clear text when release version', () => {
       const source = new Source('doc.md', `
         <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
       `);
@@ -89,7 +89,7 @@ describe('preprocessor', function() {
         <!-- gen:empty-if-release --><!-- gen:stop -->
       `);
     });
-    it('should keep text when non-release version', function() {
+    it('should keep text when non-release version', () => {
       const source = new Source('doc.md', `
         <!-- gen:empty-if-release -->XXX<!-- gen:stop -->
       `);
@@ -100,8 +100,8 @@ describe('preprocessor', function() {
       `);
     });
   });
-  describe('gen:empty-if-release', function() {
-    it('should work with non-release version', function() {
+  describe('gen:empty-if-release', () => {
+    it('should work with non-release version', () => {
       const source = new Source('doc.md', `
         <!-- gen:last-released-api -->XXX<!-- gen:stop -->
       `);
@@ -113,7 +113,7 @@ describe('preprocessor', function() {
         <!-- gen:last-released-api -->[API](https://github.com/GoogleChrome/puppeteer/blob/v1.3.0/docs/api.md)<!-- gen:stop -->
       `);
     });
-    it('should work with release version', function() {
+    it('should work with release version', () => {
       const source = new Source('doc.md', `
         <!-- gen:last-released-api -->XXX<!-- gen:stop -->
       `);
@@ -126,7 +126,7 @@ describe('preprocessor', function() {
       `);
     });
   });
-  describe('gen:toc', function() {
+  describe('gen:toc', () => {
     it('should work', () => {
       const source = new Source('doc.md', `<!-- gen:toc -->XXX<!-- gen:stop -->
         ### class: page
@@ -146,7 +146,7 @@ describe('preprocessor', function() {
         #### page.$$`);
     });
   });
-  it('should work with multiple commands', function() {
+  it('should work with multiple commands', () => {
     const source = new Source('doc.md', `
       <!-- gen:version -->XXX<!-- gen:stop -->
       <!-- gen:empty-if-release -->YYY<!-- gen:stop -->

--- a/utils/node6-transform/test/test.js
+++ b/utils/node6-transform/test/test.js
@@ -25,68 +25,68 @@ const {beforeAll, beforeEach, afterAll, afterEach} = runner;
 
 const {expect} = new Matchers();
 
-describe('TransformAsyncFunctions', function() {
-  it('should convert a function expression', function(done) {
+describe('TransformAsyncFunctions', () => {
+  it('should convert a function expression', done => {
     const input = `(async function(){ return 123 })()`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should convert an arrow function', function(done) {
+  it('should convert an arrow function', done => {
     const input = `(async () => 123)()`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should convert an arrow function with curly braces', function(done) {
+  it('should convert an arrow function with curly braces', done => {
     const input = `(async () => { return 123 })()`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should convert a function declaration', function(done) {
+  it('should convert a function declaration', done => {
     const input = `async function f(){ return 123; } f();`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should convert await', function(done) {
+  it('should convert await', done => {
     const input = `async function f(){ return 23 + await Promise.resolve(100); } f();`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should convert method', function(done) {
+  it('should convert method', done => {
     const input = `class X{async f() { return 123 }} (new X()).f();`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should pass arguments', function(done) {
+  it('should pass arguments', done => {
     const input = `(async function(a, b){ return await a + await b })(Promise.resolve(100), 23)`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should still work across eval', function(done) {
+  it('should still work across eval', done => {
     const input = `var str = (async function(){ return 123; }).toString(); eval('(' + str + ')')();`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should work with double await', function(done) {
+  it('should work with double await', done => {
     const input = `async function f(){ return 23 + await Promise.resolve(50 + await Promise.resolve(50)); } f();`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should work paren around arrow function', function(done) {
+  it('should work paren around arrow function', done => {
     const input = `(async x => ( 123))()`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);
     output.then(result => expect(result).toBe(123)).then(done);
   });
-  it('should work async arrow with await', function(done) {
+  it('should work async arrow with await', done => {
     const input = `(async() => await 123)()`;
     const output = eval(transformAsyncFunctions(input));
     expect(output instanceof Promise).toBe(true);


### PR DESCRIPTION
Converting a few instances of traditional functions to ES6-style arrow functions. Performed the necessary safety checks to ensure behavior is preserved, e.g., that this is not used inside the function.
