### PR TITLE
feat(launcher): exclude mute-audio in headless with ignoreDefaultArgs

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -91,9 +91,12 @@ class Launcher {
     if (typeof options.headless !== 'boolean' || options.headless) {
       chromeArguments.push(
           '--headless',
-          '--hide-scrollbars',
-          '--mute-audio'
+          '--hide-scrollbars'
       );
+
+      if (!options.ignoreDefaultArgs)
+        chromeArguments.push('--mute-audio');
+
       if (os.platform() === 'win32')
         chromeArguments.push('--disable-gpu');
     }

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -211,6 +211,15 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
         await page.close();
         await browser.close();
       });
+      it('should not include --mute-audio in headless mode if ignoreDefaultArgs is true', async() => {
+        const options = Object.assign({}, defaultBrowserOptions);
+        options.headless = true;
+        options.ignoreDefaultArgs = true;
+        const browser = await puppeteer.launch(options);
+        const { spawnargs } = browser.process();
+        expect(spawnargs.includes('--mute-audio')).toBe(false);
+        await browser.close();
+      });
       it('should have default url when launching browser', async function() {
         const browser = await puppeteer.launch(defaultBrowserOptions);
         const pages = (await browser.pages()).map(page => page.url());


### PR DESCRIPTION
## Motivation
Despite `ignoreDefaultArgs` is implemented in https://github.com/GoogleChrome/puppeteer/pull/1623/files, but `--mute-audio` still isn't able to be overridden. 

cc @aslushnikov @JoelEinbinder
