### PR TITLE
fix(pipe): make sure the pipe is not stuck

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -111,9 +111,8 @@ class Launcher {
       chromeArguments.push(...options.args);
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');
-    const stdio = ['pipe', 'pipe', 'pipe'];
-    if (usePipe)
-      stdio.push('pipe', 'pipe');
+    const stdio = usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe']
+                          : ['pipe', 'pipe', 'pipe'];
     const chromeProcess = childProcess.spawn(
         chromeExecutable,
         chromeArguments,

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -111,8 +111,7 @@ class Launcher {
       chromeArguments.push(...options.args);
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');
-    const stdio = usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe']
-                          : ['pipe', 'pipe', 'pipe'];
+    const stdio = usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'];
     const chromeProcess = childProcess.spawn(
         chromeExecutable,
         chromeArguments,


### PR DESCRIPTION
When process is spawned with the 'pipe' set for stdout and stderr, Node expects these streams to be actually dispatched. If we don't, write into pipe becomes blocking and chrome stalls.

We work around that via setting 'ignore' to the stdin, stdout and stderr when the pipe communication channel is used.