### PR TITLE
fix(launcher): always add `about:blank` to default arguments

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -97,7 +97,7 @@ class Launcher {
       if (os.platform() === 'win32')
         chromeArguments.push('--disable-gpu');
     }
-    if (!options.ignoreDefaultArgs && Array.isArray(options.args) && options.args.every(arg => arg.startsWith('-')))
+    if (Array.isArray(options.args) && options.args.every(arg => arg.startsWith('-')))
       chromeArguments.push('about:blank');
 
     let chromeExecutable = options.executablePath;


### PR DESCRIPTION
Chrome Headless used to open about:blank by default; however, this
was recently changed.

We should open starting page no matter what to keep the environment
predictable.