### PR TITLE
feat(launcher): use Chromium revision in npm config in launcher

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -23,7 +23,8 @@ const {Browser} = require('./Browser');
 const readline = require('readline');
 const fs = require('fs');
 const {helper, assert, debugError} = require('./helper');
-const ChromiumRevision = require(path.join(helper.projectRoot(), 'package.json')).puppeteer.chromium_revision;
+const ChromiumRevision = process.env.PUPPETEER_CHROMIUM_REVISION || process.env.npm_config_puppeteer_chromium_revision ||
+  require(path.join(helper.projectRoot(), 'package.json')).puppeteer.chromium_revision;
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);


### PR DESCRIPTION
Since Chromium revision specified in npm config was not referred from launcher, it was not possible to launch (or getting the executable path by `executablePath()`) the downloaded Chromium.