### PR TITLE
fix(networkmanager): Remove header 'cookie' from request hash

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -675,7 +675,7 @@ function generateRequestHash(request) {
     for (let header of headers) {
       const headerValue = request.headers[header];
       header = header.toLowerCase();
-      if (header === 'accept' || header === 'referer' || header === 'x-devtools-emulate-network-conditions-client-id')
+      if (header === 'accept' || header === 'referer' || header === 'x-devtools-emulate-network-conditions-client-id' || header === 'cookie')
         continue;
       hash.headers[header] = headerValue;
     }


### PR DESCRIPTION
This fixes an issue in which a response may not be recorded or trigger an event because of differing cookie headers from the request.

I didn't see anywhere to add testing for this functionality, however if you would like tests added, just point me in the right direction.