### PR TITLE
chore(tests): redirect debugError to the output category of tests

### DIFF
--- a/lib/Tracing.js
+++ b/lib/Tracing.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {helper, assert} = require('./helper');
+const {helper, assert, debugError} = require('./helper');
 const fs = require('fs');
 
 const openAsync = helper.promisify(fs.open);
@@ -89,6 +89,8 @@ class Tracing {
     let resultBuffer = null;
     try {
       resultBuffer = Buffer.concat(bufs);
+    } catch (error) {
+      debugError(error);
     } finally {
       return resultBuffer;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ const GOLDEN_DIR = path.join(__dirname, 'golden');
 const OUTPUT_DIR = path.join(__dirname, 'output');
 const {TestRunner, Reporter, Matchers} = require('../utils/testrunner/');
 
-const {helper, assert} = require('../lib/helper');
+const {helper, assert, debugError} = require('../lib/helper');
 if (process.env.COVERAGE)
   helper.recordPublicAPICoverage();
 
@@ -116,9 +116,16 @@ describe('Page', function() {
     const rl = require('readline').createInterface({input: state.browser.process().stderr});
     test.output = '';
     rl.on('line', onLine);
+    const enableDebugError = !debugError.enabled;
+    if (enableDebugError) {
+      require('debug').enable(debugError.namespace);
+      debugError.log = onLine;
+    }
     state.tearDown = () => {
       rl.removeListener('line', onLine);
       rl.close();
+      if (enableDebugError)
+        debugError.log = () => undefined;
     };
     function onLine(line) {
       test.output += line + '\n';


### PR DESCRIPTION
I have seen some flaky test failures where it would be nice to have run the tests with `DEBUG=puppeteer:error`. Instead of always running tests like that, I am redirecting `debugError` to the output category of the test. This is the same thing that we do for Chromium's stderr.

As a drive-by, I added an additional `debugError` where we were usually a try..finally pattern.