### PR TITLE
fix(NetworkManager): fix NetworkManager._onRequestWillBeSent method

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -236,10 +236,10 @@ class NetworkManager extends EventEmitter {
         request._requestId = event.requestId;
         this._requestIdToRequest.set(event.requestId, request);
         this._requestHashToInterceptionIds.delete(requestHash, interceptionId);
+        return;
       } else {
         this._requestHashToRequestIds.set(requestHash, event.requestId);
       }
-      return;
     }
     let redirectChain = [];
     if (event.redirectResponse) {


### PR DESCRIPTION
fix(NetworkManager): fix NetworkManager._onRequestWillBeSent method

description
the headers of request sometimes changed after interception and the request cannot be found by request hash, in this case we should recode the new request to _requestIdToRequest.

Fixes #2971