### PR TITLE
test: do not handle sigint for all the browsers launched in tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,7 @@ assert(fs.existsSync(puppeteer.executablePath()), `Chromium is not Downloaded. R
 
 const slowMo = parseInt((process.env.SLOW_MO || '0').trim(), 10);
 const defaultBrowserOptions = {
+  handleSIGINT: false,
   executablePath,
   slowMo,
   headless,


### PR DESCRIPTION
Puppeteer's default handler issues "process.exit(130)", causing
test runner to shut too early.

As a result, test runner doesn't show run summary.