### PR TITLE
fix(page): Use _pageBindings as a Map

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -384,9 +384,9 @@ class Page extends EventEmitter {
    * @param {function(?)} puppeteerFunction
    */
   async exposeFunction(name, puppeteerFunction) {
-    if (this._pageBindings[name])
+    if (this._pageBindings.has(name))
       throw new Error(`Failed to add page binding with name ${name}: window['${name}'] already exists!`);
-    this._pageBindings[name] = puppeteerFunction;
+    this._pageBindings.set(name, puppeteerFunction);
 
     const expression = helper.evaluationString(addPageBinding, name);
     await this._client.send('Runtime.addBinding', {name: name});
@@ -486,7 +486,7 @@ class Page extends EventEmitter {
    */
   async _onBindingCalled(event) {
     const {name, seq, args} = JSON.parse(event.payload);
-    const result = await this._pageBindings[name](...args);
+    const result = await this._pageBindings.get(name)(...args);
     const expression = helper.evaluationString(deliverResult, name, seq, result);
     this._client.send('Runtime.evaluate', { expression, contextId: event.executionContextId }).catch(debugError);
 


### PR DESCRIPTION
In accordance with its declared type, `Map<string, Function>`.
Currently, it is used as a plain old JS object. The compiler marks this
usage as an error when `noImplicitAny: true`. This change switches to
use the appropriate Map methods `has/get/set`.

Fixes #3000