### PR TITLE
test: use new browser context for every page test

### DIFF
--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -40,15 +40,15 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       expect(browser.browserContexts().length).toBe(1);
     });
     it('should close all belonging targets once closing context', async function({browser, server}) {
-      expect((await browser.pages()).length).toBe(2);
+      expect((await browser.pages()).length).toBe(1);
 
       const context = await browser.createIncognitoBrowserContext();
       await context.newPage();
-      expect((await browser.pages()).length).toBe(3);
+      expect((await browser.pages()).length).toBe(2);
       expect((await context.pages()).length).toBe(1);
 
       await context.close();
-      expect((await browser.pages()).length).toBe(2);
+      expect((await browser.pages()).length).toBe(1);
     });
     it('window.open should use parent tab context', async function({browser, server}) {
       const context = await browser.createIncognitoBrowserContext();

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -26,8 +26,8 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
   const iPhoneLandscape = DeviceDescriptors['iPhone 6 landscape'];
 
   describe('Page.close', function() {
-    it('should reject all promises when page is closed', async({browser}) => {
-      const newPage = await browser.newPage();
+    it('should reject all promises when page is closed', async({context}) => {
+      const newPage = await context.newPage();
       const neverResolves = newPage.evaluate(() => new Promise(r => {}));
       newPage.close();
       let error = null;
@@ -40,8 +40,8 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       await newPage.close();
       expect(await browser.pages()).not.toContain(newPage);
     });
-    it('should run beforeunload if asked for', async({browser, server}) => {
-      const newPage = await browser.newPage();
+    it('should run beforeunload if asked for', async({context, server}) => {
+      const newPage = await context.newPage();
       await newPage.goto(server.PREFIX + '/beforeunload.html');
       // We have to interact with a page so that 'beforeunload' handlers
       // fire.
@@ -54,8 +54,8 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       dialog.accept();
       await waitEvent(newPage, 'close');
     });
-    it('should set the page close state', async({ browser }) => {
-      const newPage = await browser.newPage();
+    it('should set the page close state', async({context}) => {
+      const newPage = await context.newPage();
       expect(newPage.isClosed()).toBe(false);
       await newPage.close();
       expect(newPage.isClosed()).toBe(true);
@@ -1532,10 +1532,10 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       });
       expect(screenshot).toBeGolden('screenshot-grid-fullpage.png');
     });
-    it('should run in parallel in multiple pages', async({page, server, browser}) => {
+    it('should run in parallel in multiple pages', async({page, server, context}) => {
       const N = 2;
       const pages = await Promise.all(Array(N).fill(0).map(async() => {
-        const page = await browser.newPage();
+        const page = await context.newPage();
         await page.goto(server.PREFIX + '/grid.html');
         return page;
       }));
@@ -1664,16 +1664,16 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
   });
 
   describe('Page.Events.Close', function() {
-    it('should work with window.close', async function({ page, browser, server }) {
-      const newPagePromise = new Promise(fulfill => browser.once('targetcreated', target => fulfill(target.page())));
+    it('should work with window.close', async function({ page, context, server }) {
+      const newPagePromise = new Promise(fulfill => context.once('targetcreated', target => fulfill(target.page())));
       await page.evaluate(() => window['newPage'] = window.open('about:blank'));
       const newPage = await newPagePromise;
       const closedPromise = new Promise(x => newPage.on('close', x));
       await page.evaluate(() => window['newPage'].close());
       await closedPromise;
     });
-    it('should work with page.close', async function({ page, browser, server }) {
-      const newPage = await browser.newPage();
+    it('should work with page.close', async function({ page, context, server }) {
+      const newPage = await context.newPage();
       const closedPromise = new Promise(x => newPage.on('close', x));
       await newPage.close();
       await closedPromise;

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -292,8 +292,8 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
       const page = await browser.newPage();
       await page.goto(server.EMPTY_PAGE);
       await page.close();
-      await browser.close();
       expect(events).toEqual(['CREATED', 'CHANGED', 'DESTROYED']);
+      await browser.close();
     });
   });
 

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -282,6 +282,21 @@ module.exports.addTests = function({testRunner, expect, PROJECT_ROOT, defaultBro
     });
   });
 
+  describe('Browser target events', function() {
+    it('should work', async({server}) => {
+      const browser = await puppeteer.launch(defaultBrowserOptions);
+      const events = [];
+      browser.on('targetcreated', () => events.push('CREATED'));
+      browser.on('targetchanged', () => events.push('CHANGED'));
+      browser.on('targetdestroyed', () => events.push('DESTROYED'));
+      const page = await browser.newPage();
+      await page.goto(server.EMPTY_PAGE);
+      await page.close();
+      await browser.close();
+      expect(events).toEqual(['CREATED', 'CHANGED', 'DESTROYED']);
+    });
+  });
+
   describe('Browser.Events.disconnected', function() {
     it('should be emitted when: browser gets closed, disconnected or underlying websocket gets closed', async() => {
       const originalBrowser = await puppeteer.launch(defaultBrowserOptions);

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -29,10 +29,10 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
         target.url() === 'about:blank')).toBeTruthy('Missing blank page');
       expect(targets.some(target => target.type() === 'browser')).toBeTruthy('Missing browser target');
     });
-    it('Browser.pages should return all of the pages', async({page, server, browser}) => {
-      // The pages will be the testing page and the original newtab page
-      const allPages = await browser.pages();
-      expect(allPages.length).toBe(2);
+    it('Browser.pages should return all of the pages', async({page, server, context}) => {
+      // The pages will be the testing page
+      const allPages = await context.pages();
+      expect(allPages.length).toBe(1);
       expect(allPages).toContain(page);
       expect(allPages[0]).not.toBe(allPages[1]);
     });
@@ -48,8 +48,8 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       expect(await originalPage.evaluate(() => ['Hello', 'world'].join(' '))).toBe('Hello world');
       expect(await originalPage.$('body')).toBeTruthy();
     });
-    it('should report when a new page is created and closed', async({page, server, browser}) => {
-      const otherPagePromise = new Promise(fulfill => browser.once('targetcreated', target => fulfill(target.page())));
+    it('should report when a new page is created and closed', async({page, server, context}) => {
+      const otherPagePromise = new Promise(fulfill => context.once('targetcreated', target => fulfill(target.page())));
       await page.evaluate(url => window.open(url), server.CROSS_PROCESS_PREFIX);
       const otherPage = await otherPagePromise;
       expect(otherPage.url()).toContain(server.CROSS_PROCESS_PREFIX);
@@ -57,61 +57,61 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       expect(await otherPage.evaluate(() => ['Hello', 'world'].join(' '))).toBe('Hello world');
       expect(await otherPage.$('body')).toBeTruthy();
 
-      let allPages = await browser.pages();
+      let allPages = await context.pages();
       expect(allPages).toContain(page);
       expect(allPages).toContain(otherPage);
 
-      const closePagePromise = new Promise(fulfill => browser.once('targetdestroyed', target => fulfill(target.page())));
+      const closePagePromise = new Promise(fulfill => context.once('targetdestroyed', target => fulfill(target.page())));
       await otherPage.close();
       expect(await closePagePromise).toBe(otherPage);
 
-      allPages = await Promise.all(browser.targets().map(target => target.page()));
+      allPages = await Promise.all(context.targets().map(target => target.page()));
       expect(allPages).toContain(page);
       expect(allPages).not.toContain(otherPage);
     });
-    it('should report when a service worker is created and destroyed', async({page, server, browser}) => {
+    it('should report when a service worker is created and destroyed', async({page, server, context}) => {
       await page.goto(server.EMPTY_PAGE);
-      const createdTarget = new Promise(fulfill => browser.once('targetcreated', target => fulfill(target)));
+      const createdTarget = new Promise(fulfill => context.once('targetcreated', target => fulfill(target)));
 
       await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
 
       expect((await createdTarget).type()).toBe('service_worker');
       expect((await createdTarget).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
 
-      const destroyedTarget = new Promise(fulfill => browser.once('targetdestroyed', target => fulfill(target)));
+      const destroyedTarget = new Promise(fulfill => context.once('targetdestroyed', target => fulfill(target)));
       await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
       expect(await destroyedTarget).toBe(await createdTarget);
     });
-    it('should report when a target url changes', async({page, server, browser}) => {
+    it('should report when a target url changes', async({page, server, context}) => {
       await page.goto(server.EMPTY_PAGE);
-      let changedTarget = new Promise(fulfill => browser.once('targetchanged', target => fulfill(target)));
+      let changedTarget = new Promise(fulfill => context.once('targetchanged', target => fulfill(target)));
       await page.goto(server.CROSS_PROCESS_PREFIX + '/');
       expect((await changedTarget).url()).toBe(server.CROSS_PROCESS_PREFIX + '/');
 
-      changedTarget = new Promise(fulfill => browser.once('targetchanged', target => fulfill(target)));
+      changedTarget = new Promise(fulfill => context.once('targetchanged', target => fulfill(target)));
       await page.goto(server.EMPTY_PAGE);
       expect((await changedTarget).url()).toBe(server.EMPTY_PAGE);
     });
-    it('should not report uninitialized pages', async({page, server, browser}) => {
+    it('should not report uninitialized pages', async({page, server, context}) => {
       let targetChanged = false;
       const listener = () => targetChanged = true;
-      browser.on('targetchanged', listener);
-      const targetPromise = new Promise(fulfill => browser.once('targetcreated', target => fulfill(target)));
-      const newPagePromise = browser.newPage();
+      context.on('targetchanged', listener);
+      const targetPromise = new Promise(fulfill => context.once('targetcreated', target => fulfill(target)));
+      const newPagePromise = context.newPage();
       const target = await targetPromise;
       expect(target.url()).toBe('about:blank');
 
       const newPage = await newPagePromise;
-      const targetPromise2 = new Promise(fulfill => browser.once('targetcreated', target => fulfill(target)));
+      const targetPromise2 = new Promise(fulfill => context.once('targetcreated', target => fulfill(target)));
       const evaluatePromise = newPage.evaluate(() => window.open('about:blank'));
       const target2 = await targetPromise2;
       expect(target2.url()).toBe('about:blank');
       await evaluatePromise;
       await newPage.close();
       expect(targetChanged).toBe(false, 'target should not be reported as changed');
-      browser.removeListener('targetchanged', listener);
+      context.removeListener('targetchanged', listener);
     });
-    it('should not crash while redirecting if original request was missed', async({page, server, browser}) => {
+    it('should not crash while redirecting if original request was missed', async({page, server, context}) => {
       let serverResponse = null;
       server.setRoute('/one-style.css', (req, res) => serverResponse = res);
       // Open a new page. Use window.open to connect to the page later.
@@ -120,7 +120,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
         server.waitForRequest('/one-style.css')
       ]);
       // Connect to the opened page.
-      const target = browser.targets().find(target => target.url().includes('one-style.html'));
+      const target = context.targets().find(target => target.url().includes('one-style.html'));
       const newPage = await target.page();
       // Issue a redirect.
       serverResponse.writeHead(302, { location: '/injectedstyle.css' });
@@ -130,10 +130,10 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       // Cleanup.
       await newPage.close();
     });
-    it('should have an opener', async({page, server, browser}) => {
+    it('should have an opener', async({page, server, context}) => {
       await page.goto(server.EMPTY_PAGE);
       const [createdTarget] = await Promise.all([
-        new Promise(fulfill => browser.once('targetcreated', target => fulfill(target))),
+        new Promise(fulfill => context.once('targetcreated', target => fulfill(target))),
         page.goto(server.PREFIX + '/popup/window-open.html')
       ]);
       expect((await createdTarget.page()).url()).toBe(server.PREFIX + '/popup/popup.html');

--- a/test/test.js
+++ b/test/test.js
@@ -102,7 +102,7 @@ beforeEach(async({server, httpsServer}) => {
   httpsServer.reset();
 });
 
-describe('Page', function() {
+describe('Browser', function() {
   beforeAll(async state => {
     state.browser = await puppeteer.launch(defaultBrowserOptions);
   });
@@ -113,7 +113,6 @@ describe('Page', function() {
   });
 
   beforeEach(async(state, test) => {
-    state.page = await state.browser.newPage();
     const rl = require('readline').createInterface({input: state.browser.process().stderr});
     test.output = '';
     rl.on('line', onLine);
@@ -128,25 +127,40 @@ describe('Page', function() {
 
   afterEach(async state => {
     state.tearDown();
-    await state.page.close();
-    state.page = null;
   });
 
-  // Page-level tests that are given a browser and a page.
-  require('./CDPSession.spec.js').addTests({testRunner, expect});
-  require('./browser.spec.js').addTests({testRunner, expect, puppeteer, headless});
+  describe('Page', function() {
+    beforeEach(async state => {
+      state.context = await state.browser.createIncognitoBrowserContext();
+      state.page = await state.context.newPage();
+    });
+
+    afterEach(async state => {
+      // This closes all pages.
+      await state.context.close();
+      state.context = null;
+      state.page = null;
+    });
+
+    // Page-level tests that are given a browser, a context and a page.
+    // Each test is launched in a new browser context.
+    require('./CDPSession.spec.js').addTests({testRunner, expect});
+    require('./browser.spec.js').addTests({testRunner, expect, puppeteer, headless});
+    require('./cookies.spec.js').addTests({testRunner, expect});
+    require('./coverage.spec.js').addTests({testRunner, expect});
+    require('./elementhandle.spec.js').addTests({testRunner, expect});
+    require('./frame.spec.js').addTests({testRunner, expect});
+    require('./input.spec.js').addTests({testRunner, expect, DeviceDescriptors});
+    require('./jshandle.spec.js').addTests({testRunner, expect});
+    require('./network.spec.js').addTests({testRunner, expect});
+    require('./page.spec.js').addTests({testRunner, expect, puppeteer, DeviceDescriptors, headless});
+    require('./target.spec.js').addTests({testRunner, expect, puppeteer});
+    require('./tracing.spec.js').addTests({testRunner, expect});
+    require('./worker.spec.js').addTests({testRunner, expect});
+  });
+
+  // Browser-level tests that are given a browser.
   require('./browsercontext.spec.js').addTests({testRunner, expect, puppeteer});
-  require('./cookies.spec.js').addTests({testRunner, expect});
-  require('./coverage.spec.js').addTests({testRunner, expect});
-  require('./elementhandle.spec.js').addTests({testRunner, expect});
-  require('./frame.spec.js').addTests({testRunner, expect});
-  require('./input.spec.js').addTests({testRunner, expect, DeviceDescriptors});
-  require('./jshandle.spec.js').addTests({testRunner, expect});
-  require('./network.spec.js').addTests({testRunner, expect});
-  require('./page.spec.js').addTests({testRunner, expect, puppeteer, DeviceDescriptors, headless});
-  require('./target.spec.js').addTests({testRunner, expect, puppeteer});
-  require('./tracing.spec.js').addTests({testRunner, expect});
-  require('./worker.spec.js').addTests({testRunner, expect});
 });
 
 // Top-level tests that launch Browser themselves.


### PR DESCRIPTION
This allows us:
- dogfood browser contexts the way we want them to be used
- simplifies the dance around service workers / cookies setting up and tier down.