### PR TITLE
chore: upgrade to TypeScript 3.0.1

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -15,9 +15,9 @@
  */
 
 const { helper, assert } = require('./helper');
-const Target = require('./Target');
+const {Target} = require('./Target');
 const EventEmitter = require('events');
-const TaskQueue = require('./TaskQueue');
+const {TaskQueue} = require('./TaskQueue');
 
 class Browser extends EventEmitter {
   /**

--- a/lib/Dialog.js
+++ b/lib/Dialog.js
@@ -80,5 +80,5 @@ Dialog.Type = {
   Prompt: 'prompt'
 };
 
-module.exports = Dialog;
+module.exports = {Dialog};
 helper.tracePublicAPI(Dialog);

--- a/lib/ElementHandle.js
+++ b/lib/ElementHandle.js
@@ -389,5 +389,5 @@ function computeQuadArea(quad) {
   return area;
 }
 
-module.exports = ElementHandle;
+module.exports = {ElementHandle};
 helper.tracePublicAPI(ElementHandle);

--- a/lib/EmulationManager.js
+++ b/lib/EmulationManager.js
@@ -51,4 +51,4 @@ class EmulationManager {
   }
 }
 
-module.exports = EmulationManager;
+module.exports = {EmulationManager};

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -100,7 +100,7 @@ class ExecutionContext {
     /**
      * @param {*} arg
      * @return {*}
-     * @this {Frame}
+     * @this {ExecutionContext}
      */
     function convertArgument(arg) {
       if (Object.is(arg, -0))

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 const EventEmitter = require('events');
 const {helper, assert} = require('./helper');
 const {ExecutionContext, JSHandle} = require('./ExecutionContext');
-const ElementHandle = require('./ElementHandle');
+const {ElementHandle} = require('./ElementHandle');
 
 const readFileAsync = helper.promisify(fs.readFile);
 

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -191,6 +191,7 @@ class Mouse {
     this._keyboard = keyboard;
     this._x = 0;
     this._y = 0;
+    /** @type {'none'|'left'|'right'|'middle'} */
     this._button = 'none';
   }
 

--- a/lib/Multimap.js
+++ b/lib/Multimap.js
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * @template T
+ * @template V
+ */
 class Multimap {
   constructor() {
     this._map = new Map();
   }
 
+  /**
+   * @param {T} key
+   * @param {V} value
+   */
   set(key, value) {
     let set = this._map.get(key);
     if (!set) {
@@ -28,6 +35,10 @@ class Multimap {
     set.add(value);
   }
 
+  /**
+   * @param {T} key
+   * @return {!Set<V>}
+   */
   get(key) {
     let result = this._map.get(key);
     if (!result)
@@ -35,10 +46,19 @@ class Multimap {
     return result;
   }
 
+  /**
+   * @param {T} key
+   * @return {boolean}
+   */
   has(key) {
     return this._map.has(key);
   }
 
+  /**
+   * @param {T} key
+   * @param {V} value
+   * @return {boolean}
+   */
   hasValue(key, value) {
     const set = this._map.get(key);
     if (!set)
@@ -53,6 +73,11 @@ class Multimap {
     return this._map.size;
   }
 
+  /**
+   * @param {T} key
+   * @param {V} value
+   * @return {boolean}
+   */
   delete(key, value) {
     const values = this.get(key);
     const result = values.delete(value);
@@ -61,10 +86,17 @@ class Multimap {
     return result;
   }
 
+  /**
+   * @param {T} key
+   */
   deleteAll(key) {
     this._map.delete(key);
   }
 
+  /**
+   * @param {T} key
+   * @return {V}
+   */
   firstValue(key) {
     const set = this._map.get(key);
     if (!set)
@@ -72,10 +104,16 @@ class Multimap {
     return set.values().next().value;
   }
 
+  /**
+   * @return {T}
+   */
   firstKey() {
     return this._map.keys().next().value;
   }
 
+  /**
+   * @return {!Array<V>}
+   */
   valuesArray() {
     const result = [];
     for (const key of this._map.keys())
@@ -83,6 +121,9 @@ class Multimap {
     return result;
   }
 
+  /**
+   * @return {!Array<T>}
+   */
   keysArray() {
     return Array.from(this._map.keys());
   }

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -134,4 +134,4 @@ const puppeteerToProtocolLifecycle = {
   'networkidle2': 'networkAlmostIdle',
 };
 
-module.exports = NavigatorWatcher;
+module.exports = {NavigatorWatcher};

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -41,9 +41,9 @@ class NetworkManager extends EventEmitter {
     this._attemptedAuthentications = new Set();
     this._userRequestInterceptionEnabled = false;
     this._protocolRequestInterceptionEnabled = false;
-    /** @type {!Multimap} */
+    /** @type {!Multimap<string, string>} */
     this._requestHashToRequestIds = new Multimap();
-    /** @type {!Multimap} */
+    /** @type {!Multimap<string, string>} */
     this._requestHashToInterceptionIds = new Multimap();
 
     this._client.on('Network.requestWillBeSent', this._onRequestWillBeSent.bind(this));

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -18,15 +18,15 @@ const fs = require('fs');
 const EventEmitter = require('events');
 const mime = require('mime');
 const {NetworkManager} = require('./NetworkManager');
-const NavigatorWatcher = require('./NavigatorWatcher');
-const Dialog = require('./Dialog');
-const EmulationManager = require('./EmulationManager');
+const {NavigatorWatcher} = require('./NavigatorWatcher');
+const {Dialog} = require('./Dialog');
+const {EmulationManager} = require('./EmulationManager');
 const {FrameManager} = require('./FrameManager');
 const {Keyboard, Mouse, Touchscreen} = require('./Input');
 const Tracing = require('./Tracing');
 const {helper, debugError, assert} = require('./helper');
 const {Coverage} = require('./Coverage');
-const Worker = require('./Worker');
+const {Worker} = require('./Worker');
 
 const writeFileAsync = helper.promisify(fs.writeFile);
 
@@ -1194,5 +1194,5 @@ class ConsoleMessage {
 }
 
 
-module.exports = Page;
+module.exports = {Page};
 helper.tracePublicAPI(Page);

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -1,4 +1,4 @@
-const Page = require('./Page');
+const {Page} = require('./Page');
 const {helper} = require('./helper');
 
 class Target {
@@ -102,4 +102,4 @@ class Target {
 
 helper.tracePublicAPI(Target);
 
-module.exports = Target;
+module.exports = {Target};

--- a/lib/TaskQueue.js
+++ b/lib/TaskQueue.js
@@ -14,4 +14,4 @@ class TaskQueue {
   }
 }
 
-module.exports = TaskQueue;
+module.exports = {TaskQueue};

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -76,5 +76,5 @@ class Worker extends EventEmitter {
   }
 }
 
-module.exports = Worker;
+module.exports = {Worker};
 helper.tracePublicAPI(Worker);

--- a/lib/externs.d.ts
+++ b/lib/externs.d.ts
@@ -1,12 +1,12 @@
 import { Connection as RealConnection, CDPSession as RealCDPSession } from './Connection.js';
 import { Browser as RealBrowser, BrowserContext as RealBrowserContext} from './Browser.js';
-import * as RealTarget from './Target.js';
-import * as RealPage from './Page.js';
-import * as RealTaskQueue from './TaskQueue.js';
+import {Target as RealTarget} from './Target.js';
+import {Page as RealPage} from './Page.js';
+import {TaskQueue as RealTaskQueue} from './TaskQueue.js';
 import {Mouse as RealMouse, Keyboard as RealKeyboard, Touchscreen as RealTouchscreen}  from './Input.js';
 import {Frame as RealFrame, FrameManager as RealFrameManager}  from './FrameManager.js';
 import {JSHandle as RealJSHandle, ExecutionContext as RealExecutionContext}  from './ExecutionContext.js';
-import * as RealElementHandle  from './ElementHandle.js';
+import {ElementHandle as RealElementHandle}  from './ElementHandle.js';
 import { NetworkManager as RealNetworkManager, Request as RealRequest, Response as RealResponse } from './NetworkManager.js';
 import * as child_process from 'child_process';
 declare global {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "~2.8.1"
+    "typescript": "^3.0.1"
   }
 }


### PR DESCRIPTION
`@this` annotations are now enforced.
`@template` works on classes, so I added the types back onto the multimap.
The `externs.d.ts` file can no longer import files that export a single class.