### PR TITLE
feat: expose frame's execution contexts

### DIFF
--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -30,7 +30,23 @@ class ExecutionContext {
     this._client = client;
     this._frame = frame;
     this._contextId = contextPayload.id;
+    this._isDefault = contextPayload.auxData ? !!contextPayload.auxData['isDefault'] : false;
+    this._name = contextPayload.name;
     this._objectHandleFactory = objectHandleFactory;
+  }
+
+  /**
+   * @return {string}
+   */
+  name() {
+    return this._name;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isDefault() {
+    return this._isDefault;
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -180,21 +180,14 @@ class FrameManager extends EventEmitter {
   }
 
   _onExecutionContextCreated(contextPayload) {
-    const frameId = contextPayload.auxData && contextPayload.auxData.isDefault ? contextPayload.auxData.frameId : null;
-    const frame = frameId ? this._frames.get(frameId) : null;
+    const frameId = contextPayload.auxData ? contextPayload.auxData.frameId : null;
+    const frame = this._frames.get(frameId) || null;
     /** @type {!ExecutionContext} */
     const context = new ExecutionContext(this._client, contextPayload, obj => this.createJSHandle(context, obj), frame);
     this._contextIdToContext.set(contextPayload.id, context);
     if (frame)
-      frame._setDefaultContext(context);
-  }
-
-  /**
-   * @param {!ExecutionContext} context
-   */
-  _removeContext(context) {
-    if (context.frame())
-      context.frame()._setDefaultContext(null);
+      frame._addExecutionContext(context);
+    this.emit(FrameManager.Events.ExecutionContextCreated, context);
   }
 
   /**
@@ -205,13 +198,20 @@ class FrameManager extends EventEmitter {
     if (!context)
       return;
     this._contextIdToContext.delete(executionContextId);
-    this._removeContext(context);
+    if (context.frame())
+      context.frame()._removeExecutionContext(context);
+    this.emit(FrameManager.Events.ExecutionContextDestroyed, context);
   }
 
   _onExecutionContextsCleared() {
-    for (const context of this._contextIdToContext.values())
-      this._removeContext(context);
+    const contexts = Array.from(this._contextIdToContext.values());
     this._contextIdToContext.clear();
+    for (const context of contexts) {
+      if (context.frame())
+        context.frame()._removeExecutionContext(context);
+    }
+    for (const context of contexts)
+      this.emit(FrameManager.Events.ExecutionContextDestroyed, context);
   }
 
   /**
@@ -253,7 +253,9 @@ FrameManager.Events = {
   FrameNavigated: 'framenavigated',
   FrameDetached: 'framedetached',
   LifecycleEvent: 'lifecycleevent',
-  FrameNavigatedWithinDocument: 'framenavigatedwithindocument'
+  FrameNavigatedWithinDocument: 'framenavigatedwithindocument',
+  ExecutionContextCreated: 'executioncontextcreated',
+  ExecutionContextDestroyed: 'executioncontextdestroyed',
 };
 
 /**
@@ -278,6 +280,8 @@ class Frame {
     this._contextResolveCallback = null;
     this._setDefaultContext(null);
 
+    this._executionContexts = new Set();
+
     /** @type {!Set<!WaitTask>} */
     this._waitTasks = new Set();
     this._loaderId = '';
@@ -288,6 +292,24 @@ class Frame {
     this._childFrames = new Set();
     if (this._parentFrame)
       this._parentFrame._childFrames.add(this);
+  }
+
+  /**
+   * @param {!ExecutionContext} context
+   */
+  _addExecutionContext(context) {
+    this._executionContexts.add(context);
+    if (context.isDefault())
+      this._setDefaultContext(context);
+  }
+
+  /**
+   * @param {!ExecutionContext} context
+   */
+  _removeExecutionContext(context) {
+    this._executionContexts.delete(context);
+    if (context.isDefault())
+      this._setDefaultContext(null);
   }
 
   /**
@@ -312,6 +334,13 @@ class Frame {
    */
   executionContext() {
     return this._contextPromise;
+  }
+
+  /**
+   * @return {!Array<!ExecutionContext>}
+   */
+  executionContexts() {
+    return Array.from(this._executionContexts);
   }
 
   /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -121,6 +121,8 @@ class Page extends EventEmitter {
     this._frameManager.on(FrameManager.Events.FrameAttached, event => this.emit(Page.Events.FrameAttached, event));
     this._frameManager.on(FrameManager.Events.FrameDetached, event => this.emit(Page.Events.FrameDetached, event));
     this._frameManager.on(FrameManager.Events.FrameNavigated, event => this.emit(Page.Events.FrameNavigated, event));
+    this._frameManager.on(FrameManager.Events.ExecutionContextCreated, event => this.emit(Page.Events.ExecutionContextCreated, event));
+    this._frameManager.on(FrameManager.Events.ExecutionContextDestroyed, event => this.emit(Page.Events.ExecutionContextDestroyed, event));
 
     this._networkManager.on(NetworkManager.Events.Request, event => this.emit(Page.Events.Request, event));
     this._networkManager.on(NetworkManager.Events.Response, event => this.emit(Page.Events.Response, event));
@@ -1128,6 +1130,8 @@ Page.Events = {
   Metrics: 'metrics',
   WorkerCreated: 'workercreated',
   WorkerDestroyed: 'workerdestroyed',
+  ExecutionContextCreated: 'executioncontextcreated',
+  ExecutionContextDestroyed: 'executioncontextdestroyed',
 };
 
 

--- a/test/assets/simple-extension/content-script.js
+++ b/test/assets/simple-extension/content-script.js
@@ -1,0 +1,3 @@
+console.log('hey from the content-script');
+self.thisIsTheContentScript = true;
+

--- a/test/assets/simple-extension/manifest.json
+++ b/test/assets/simple-extension/manifest.json
@@ -1,12 +1,14 @@
 {
   "name": "Simple extension",
   "version": "0.1",
-  "app": {
-    "background": {
-      "scripts": ["index.js"]
-    }
+  "background": {
+    "scripts": ["index.js"]
   },
-  "permissions": ["background"],
-  
+  "content_scripts": [{
+    "matches": ["<all_urls>"],
+    "css": [],
+    "js": ["content-script.js"]
+  }],
+  "permissions": ["background", "activeTab"],
   "manifest_version": 2
 }

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -77,6 +77,11 @@ module.exports.addTests = function({testRunner, expect, puppeteer, DeviceDescrip
       const result = await page.evaluate(() => 7 * 3);
       expect(result).toBe(21);
     });
+    it('should have nice default execution context', async({page, server}) => {
+      const executionContext = await page.mainFrame().executionContext();
+      expect(executionContext.name()).toBe('');
+      expect(executionContext.isDefault()).toBe(true);
+    });
     it('should throw when evaluation triggers reload', async({page, server}) => {
       let error = null;
       await page.evaluate(() => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -78,7 +78,14 @@ const utils = module.exports = {
    * @param {string} eventName
    * @return {!Promise<!Object>}
    */
-  waitEvent: function(emitter, eventName) {
-    return new Promise(fulfill => emitter.once(eventName, fulfill));
+  waitEvent: function(emitter, eventName, predicate = () => true) {
+    return new Promise(fulfill => {
+      emitter.on(eventName, function listener(event) {
+        if (!predicate(event))
+          return;
+        emitter.removeListener(eventName, listener);
+        fulfill(event);
+      });
+    });
   },
 };


### PR DESCRIPTION
This patch exposes frame's execution contexts, making it possible
to debug extension's content scripts.

This is a resurrected #2812.