### PR TITLE
Null check `args`

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -242,7 +242,7 @@ class Launcher {
       if (os.platform() === 'win32')
         chromeArguments.push('--disable-gpu');
     }
-    if (args.every(arg => arg.startsWith('-')))
+    if (args && args.every(arg => arg.startsWith('-')))
       chromeArguments.push('about:blank');
     chromeArguments.push(...args);
     return chromeArguments;


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/puppeteer/issues/3068, i.e. `puppeteer.launch({ args: null })` resulting in error.