### PR TITLE
docs(readme.md): fix a typo megabytes not megabits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm i puppeteer
 # or "yarn add puppeteer"
 ```
 
-Note: When you install Puppeteer, it downloads a recent version of Chromium (~170Mb Mac, ~282Mb Linux, ~280Mb Win) that is guaranteed to work with the API. To skip the download, see [Environment variables](https://github.com/GoogleChrome/puppeteer/blob/v1.7.0/docs/api.md#environment-variables).
+Note: When you install Puppeteer, it downloads a recent version of Chromium (~170MB Mac, ~282MB Linux, ~280MB Win) that is guaranteed to work with the API. To skip the download, see [Environment variables](https://github.com/GoogleChrome/puppeteer/blob/v1.7.0/docs/api.md#environment-variables).
 
 
 ### puppeteer-core


### PR DESCRIPTION
I haven't checked but I assume these sizes are in megabytes, not megabits...