### PR TITLE
feat(launcher): set executablePath via PUPPETEER_EXECUTABLE_PATH

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -310,8 +310,9 @@ If puppeteer doesn't find them in the environment, a lowercased variant of these
 
 - `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` - defines HTTP proxy settings that are used to download and run Chromium.
 - `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` - do not download bundled Chromium during installation step.
-- `PUPPETEER_DOWNLOAD_HOST` - overwrite host part of URL that is used to download Chromium
+- `PUPPETEER_DOWNLOAD_HOST` - overwrite host part of URL that is used to download Chromium.
 - `PUPPETEER_CHROMIUM_REVISION` - specify a certain version of chrome you'd like puppeteer to use during the installation step.
+- `PUPPETEER_EXECUTABLE_PATH` - set the default [`executablePath`](#puppeteerlaunchoptions) for launch.
 
 > **NOTE** PUPPETEER_* env variables are not accounted for in the [`puppeteer-core`](https://www.npmjs.com/package/puppeteer-core) package.
 
@@ -426,7 +427,7 @@ The default flags that Chromium will be launched with.
 - `options` <[Object]>  Set of configurable options to set on the browser. Can have the following fields:
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
   - `headless` <[boolean]> Whether to run browser in [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome). Defaults to `true` unless the `devtools` option is `true`.
-  - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).
+  - `executablePath` <[string]> Path to a Chromium or Chrome executable to run instead of the bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If specified, `PUPPETEER_EXECUTABLE_PATH` will set the default value of this.
   - `slowMo` <[number]> Slows down Puppeteer operations by the specified amount of milliseconds. Useful so that you can see what is going on.
   - `defaultViewport` <?[Object]> Sets a consistent viewport for each page. Defaults to an 800x600 viewport. `null` disables the default viewport.
     - `width` <[number]> page width in pixels.

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -95,10 +95,14 @@ class Launcher {
 
     let chromeExecutable = executablePath;
     if (!executablePath) {
-      const browserFetcher = new BrowserFetcher();
-      const revisionInfo = browserFetcher.revisionInfo(ChromiumRevision);
-      assert(revisionInfo.local, `Chromium revision is not downloaded. Run "npm install" or "yarn install"`);
-      chromeExecutable = revisionInfo.executablePath;
+      if (process.env.PUPPETEER_EXECUTABLE_PATH || process.env.npm_config_puppeteer_executable_path) {
+        chromeExecutable = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.npm_config_puppeteer_executable_path;
+      } else {
+        const browserFetcher = new BrowserFetcher();
+        const revisionInfo = browserFetcher.revisionInfo(ChromiumRevision);
+        assert(revisionInfo.local, `Chromium revision is not downloaded. Run "npm install" or "yarn install"`);
+        chromeExecutable = revisionInfo.executablePath;
+      }
     }
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -70,7 +70,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions}) 
         await neverResolves;
         expect(error.message).toContain('Protocol error');
       });
-      it('should reject if executable path is invalid', async({server}) => {
+      it('should reject if executable path is invalid', async() => {
         let waitError = null;
         const options = Object.assign({}, defaultBrowserOptions, {executablePath: 'random-invalid-path'});
         await puppeteer.launch(options).catch(e => waitError = e);
@@ -253,6 +253,23 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions}) 
         const page = await browser.newPage();
         expect(page.viewport()).toBe(null);
         await browser.close();
+      });
+
+      describe('environment variables', function() {
+        const env = process.env;
+        beforeEach(() => {
+          process.env = Object.assign({}, env);
+        });
+        afterEach(() => {
+          process.env = env;
+        });
+        it('should allow PUPPETEER_EXECUTABLE_PATH to set executablePath', async() => {
+          process.env.PUPPETEER_EXECUTABLE_PATH = 'another-random-invalid-path';
+          let waitError = null;
+          await puppeteer.launch(defaultBrowserOptions).catch(e => waitError = e);
+          console.log(waitError.message)
+          expect(waitError.message.startsWith('Failed to launch chrome! spawn another-random-invalid-path ENOENT')).toBe(true);
+        });
       });
     });
     describe('Puppeteer.connect', function() {


### PR DESCRIPTION
This patch allows users to set PUPPETEER_EXECUTABLE_PATH or
less usefully npm_config_puppeteer_executable_path to set the
executablePath. This is useful when puppeteer is wrapped by some
other library.