### PR TITLE
refactor(waittask): prepare WaitTask for IsolatedWorlds

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -309,7 +309,7 @@ class Frame {
       this._contextResolveCallback.call(null, context);
       this._contextResolveCallback = null;
       for (const waitTask of this._waitTasks)
-        waitTask.rerun();
+        waitTask.rerun(context);
     } else {
       this._documentPromise = null;
       this._contextPromise = new Promise(fulfill => {
@@ -727,7 +727,11 @@ class Frame {
   waitForFunction(pageFunction, options = {}, ...args) {
     const timeout = helper.isNumber(options.timeout) ? options.timeout : 30000;
     const polling = options.polling || 'raf';
-    return new WaitTask(this, pageFunction, 'function', polling, timeout, ...args).promise;
+    const task = new WaitTask(pageFunction, 'function', polling, timeout, ...args);
+    task.setCleanupCallback(() => this._waitTasks.delete(task));
+    this._waitTasks.add(task);
+    this.executionContext().then(context => task.rerun(context));
+    return task.promise;
   }
 
   /**
@@ -749,7 +753,11 @@ class Frame {
     const polling = waitForVisible || waitForHidden ? 'raf' : 'mutation';
     const timeout = helper.isNumber(options.timeout) ? options.timeout : 30000;
     const title = `${isXPath ? 'XPath' : 'selector'} "${selectorOrXPath}"${waitForHidden ? ' to be hidden' : ''}`;
-    return new WaitTask(this, predicate, title, polling, timeout, selectorOrXPath, isXPath, waitForVisible, waitForHidden).promise;
+    const task = new WaitTask(predicate, title, polling, timeout, selectorOrXPath, isXPath, waitForVisible, waitForHidden);
+    task.setCleanupCallback(() => this._waitTasks.delete(task));
+    this._waitTasks.add(task);
+    this.executionContext().then(context => task.rerun(context));
+    return task.promise;
 
     /**
      * @param {string} selectorOrXPath
@@ -830,13 +838,12 @@ helper.tracePublicAPI(Frame);
 
 class WaitTask {
   /**
-   * @param {!Frame} frame
    * @param {Function|string} predicateBody
    * @param {string|number} polling
    * @param {number} timeout
    * @param {!Array<*>} args
    */
-  constructor(frame, predicateBody, title, polling, timeout, ...args) {
+  constructor(predicateBody, title, polling, timeout, ...args) {
     if (helper.isString(polling))
       assert(polling === 'raf' || polling === 'mutation', 'Unknown polling option: ' + polling);
     else if (helper.isNumber(polling))
@@ -844,13 +851,12 @@ class WaitTask {
     else
       throw new Error('Unknown polling options: ' + polling);
 
-    this._frame = frame;
     this._polling = polling;
     this._timeout = timeout;
     this._predicateBody = helper.isString(predicateBody) ? 'return ' + predicateBody : 'return (' + predicateBody + ')(...args)';
     this._args = args;
     this._runCount = 0;
-    frame._waitTasks.add(this);
+    this._cleanupCallback = null;
     this.promise = new Promise((resolve, reject) => {
       this._resolve = resolve;
       this._reject = reject;
@@ -861,30 +867,35 @@ class WaitTask {
       const timeoutError = new TimeoutError(`waiting for ${title} failed: timeout ${timeout}ms exceeded`);
       this._timeoutTimer = setTimeout(() => this.terminate(timeoutError), timeout);
     }
-    this.rerun();
+  }
+
+  /**
+   * @param {function()} callback
+   */
+  setCleanupCallback(callback) {
+    this._cleanupCallback = callback;
   }
 
   /**
    * @param {!Error} error
    */
   terminate(error) {
-    this._terminated = true;
     this._reject(error);
     this._cleanup();
   }
 
-  async rerun() {
+  async rerun(executionContext) {
     const runCount = ++this._runCount;
     /** @type {?Puppeteer.JSHandle} */
     let success = null;
     let error = null;
     try {
-      success = await (await this._frame.executionContext()).evaluateHandle(waitForPredicatePageFunction, this._predicateBody, this._polling, this._timeout, ...this._args);
+      success = await executionContext.evaluateHandle(waitForPredicatePageFunction, this._predicateBody, this._polling, this._timeout, ...this._args);
     } catch (e) {
       error = e;
     }
 
-    if (this._terminated || runCount !== this._runCount) {
+    if (this._completed || runCount !== this._runCount) {
       if (success)
         await success.dispose();
       return;
@@ -893,7 +904,7 @@ class WaitTask {
     // Ignore timeouts in pageScript - we track timeouts ourselves.
     // If the frame's execution context has already changed, `frame.evaluate` will
     // throw an error - ignore this predicate run altogether.
-    if (!error && await this._frame.evaluate(s => !s, success).catch(e => true)) {
+    if (!error && await executionContext.evaluate(s => !s, success).catch(e => true)) {
       await success.dispose();
       return;
     }
@@ -917,9 +928,10 @@ class WaitTask {
   }
 
   _cleanup() {
+    this._completed = true;
     clearTimeout(this._timeoutTimer);
-    this._frame._waitTasks.delete(this);
-    this._runningTask = null;
+    if (this._cleanupCallback)
+      this._cleanupCallback.call(null);
   }
 }
 


### PR DESCRIPTION
`WaitTask` will belong to `IsolatedWorld` rather then `Frame`.
This patch decouples `WaitTask` from `Frame`.

References #1215