### PR TITLE
feat(framemanager): click handler random option on multiple elements

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -606,10 +606,17 @@ class Frame {
    * @param {!Object=} options
    */
   async click(selector, options = {}) {
-    const handle = await this.$(selector);
+    let handle = undefined;
+    if (options.random) {
+      handle = await this.$$(selector);
+      handle = handle[handle.length - Math.floor(Math.random() * handle.length)];
+    } else {
+      handle = await this.$(selector);
+    }
     assert(handle, 'No node found for selector: ' + selector);
     await handle.click(options);
     await handle.dispose();
+    return handle;
   }
 
   /**


### PR DESCRIPTION
If multiple elements are returned via the selector, then instead of only allowing the first selector, allow a random one to be chosen.