### PR TITLE
feat(page): Added 'referer' as a parameter in options of Page.goto()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1268,6 +1268,7 @@ Navigate to the next page in history.
     - `domcontentloaded` - consider navigation to be finished when the `DOMContentLoaded` event is fired.
     - `networkidle0` - consider navigation to be finished when there are no more than 0 network connections for at least `500` ms.
     - `networkidle2` - consider navigation to be finished when there are no more than 2 network connections for at least `500` ms.
+  - `referer` <[string]> Referer header value. If provided it will take prefrence over the referer header value set by [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
 - returns: <[Promise]<?[Response]>> Promise which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
 The `page.goto` will throw an error if:

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -563,7 +563,7 @@ class Page extends EventEmitter {
    * @return {!Promise<?Puppeteer.Response>}
    */
   async goto(url, options = {}) {
-    const referrer = this._networkManager.extraHTTPHeaders()['referer'];
+    const referrer = typeof options.referer === 'string' ? options.referer : this._networkManager.extraHTTPHeaders()['referer'];
 
     /** @type {Map<string, !Puppeteer.Request>} */
     const requests = new Map();

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -677,6 +677,17 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       }
       expect(error.message).toContain(url);
     });
+    it('should send referer', async({page, server}) => {
+      await page.setRequestInterception(true);
+      page.on('request', request => request.continue());
+      const [request] = await Promise.all([
+        server.waitForRequest('/grid.html'),
+        page.goto(server.PREFIX + '/grid.html', {
+          referer: 'http://google.com/',
+        }),
+      ]);
+      expect(request.headers['referer']).toBe('http://google.com/');
+    });
   });
 
   describe('Page.waitForNavigation', function() {


### PR DESCRIPTION
If referer is passed to the options object its value will be used as the referer instead of the value set by Page.setExtraHTTPHeaders().

Fixes #3090