### PR TITLE
feat(chromium): roll Chromium to r587164

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "586620"
+    "chromium_revision": "587164"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "583214"
+    "chromium_revision": "586620"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -914,6 +914,15 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       });
       expect(result).toBe(36);
     });
+    it('should be callable from-inside evaluateOnNewDocument', async({page, server}) => {
+      let called = false;
+      await page.exposeFunction('woof', function() {
+        called = true;
+      });
+      await page.evaluateOnNewDocument(() => woof());
+      await page.reload();
+      expect(called).toBe(true);
+    });
     it('should survive navigation', async({page, server}) => {
       await page.exposeFunction('compute', function(a, b) {
         return a * b;


### PR DESCRIPTION
This roll includes:
- https://crrev.com/584293 - DevTools: execute scripts in addScriptToEvaluateOnLoad in order
- https://crrev.com/585630 - DevTools: introduce Browser.grantPermissions
- https://crrev.com/587156 - Revert "[Base] Use background mode for ThreadPriority::BACKGROUND threads (behind feature) (reland)."

The "revert" patch fixes headless functionality on windows.

References #846.
Fixes #3106.