### PR TITLE
feat: add page.clear method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -84,6 +84,7 @@ Next Release: **Sep 6, 2018**
   * [page.authenticate(credentials)](#pageauthenticatecredentials)
   * [page.bringToFront()](#pagebringtofront)
   * [page.browser()](#pagebrowser)
+  * [page.clear(selector)](#pageclearselector)
   * [page.click(selector[, options])](#pageclickselector-options)
   * [page.close(options)](#pagecloseoptions)
   * [page.content()](#pagecontent)
@@ -1017,6 +1018,10 @@ Brings page to front (activates tab).
 - returns: <[Browser]>
 
 Get the browser the page belongs to.
+
+#### page.clear(selector)
+- `selector` <[string]> A [selector] of an element to clear. If there are multiple elements satisfying the selector, the first will be used.
+- returns: <[Promise]>
 
 #### page.click(selector[, options])
 - `selector` <[string]> A [selector] to search for element to click. If there are multiple elements satisfying the selector, the first will be clicked.

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -159,8 +159,6 @@ class Keyboard {
     let delay = 0;
     if (options && options.delay)
       delay = options.delay;
-    if (!text)
-      await this.press(text, {delay});
     for (const char of text) {
       if (keyDefinitions[char])
         await this.press(char, {delay});

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -159,6 +159,8 @@ class Keyboard {
     let delay = 0;
     if (options && options.delay)
       delay = options.delay;
+    if (!text)
+      await this.press(text, {delay});
     for (const char of text) {
       if (keyDefinitions[char])
         await this.press(char, {delay});

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1015,6 +1015,13 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {string} selector
+   */
+  async clear(selector) {
+    return this.$eval(selector, el => el.value = '');
+  }
+
+  /**
    * @param {(string|number|Function)} selectorOrFunctionOrTimeout
    * @param {!Object=} options
    * @param {!Array<*>} args

--- a/test/input.spec.js
+++ b/test/input.spec.js
@@ -478,6 +478,12 @@ module.exports.addTests = function({testRunner, expect}) {
       await page.type('textarea', '👹 Tokyo street Japan 🇯🇵');
       expect(await page.$eval('textarea', textarea => textarea.value)).toBe('👹 Tokyo street Japan 🇯🇵');
     });
+    it('should clear input', async({page, server}) => {
+      await page.goto(server.PREFIX + '/input/textarea.html');
+      await page.type('textarea', 'some txt');
+      await page.clear('textarea');
+      expect(await page.$eval('textarea', textarea => textarea.value)).toBe('');
+    });
     it('should type emoji into an iframe', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'emoji-test', server.PREFIX + '/input/textarea.html');


### PR DESCRIPTION
1. I wasn't sure about implementation (if to use `setSelection` + backspace or just to clear the value). Setting `element.value = ''` was the easiest... (:
2. Didn't handle case of non input type selector (what do we want to do?)

Fixed #3094