### PR TITLE
feat(chromium): roll Chromium to r588429

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "587164"
+    "chromium_revision": "588429"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -56,10 +56,10 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions}) 
       expect(securityDetails.protocol()).toBe('TLS 1.2');
     });
     it('should work with request interception', async({page, server, httpsServer}) => {
-      let error = null;
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
-      await page.goto(httpsServer.EMPTY_PAGE);
+      const response = await page.goto(httpsServer.EMPTY_PAGE);
+      expect(response.status()).toBe(200);
     });
     it('should work with mixed content', async({page, server, httpsServer}) => {
       httpsServer.setRoute('/mixedcontent.html', (req, res) => {

--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -55,6 +55,12 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions}) 
       const securityDetails = responses[0].securityDetails();
       expect(securityDetails.protocol()).toBe('TLS 1.2');
     });
+    it('should work with request interception', async({page, server, httpsServer}) => {
+      let error = null;
+      await page.setRequestInterception(true);
+      page.on('request', request => request.continue());
+      await page.goto(httpsServer.EMPTY_PAGE);
+    });
     it('should work with mixed content', async({page, server, httpsServer}) => {
       httpsServer.setRoute('/mixedcontent.html', (req, res) => {
         res.end(`<iframe src=${server.EMPTY_PAGE}></iframe>`);


### PR DESCRIPTION
This roll includes:
- https://crrev.com/588420 - DevTools: teach request interception to work with
  Security.setIgnoreCertificateErrors

Fixes #1159.