### PR TITLE
refactor(network): Create Response class right away from payload

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -192,7 +192,7 @@ class NetworkManager extends EventEmitter {
       const request = this._requestIdToRequest.get(event.requestId);
       // If we connect late to the target, we could have missed the requestWillBeSent event.
       if (request) {
-        this._handleRequestRedirect(request, event.redirectResponse.status, event.redirectResponse.headers, event.redirectResponse.fromDiskCache, event.redirectResponse.fromServiceWorker, event.redirectResponse.securityDetails);
+        this._handleRequestRedirect(request, event.redirectResponse);
         redirectChain = request._redirectChain;
       }
     }
@@ -211,14 +211,10 @@ class NetworkManager extends EventEmitter {
 
   /**
    * @param {!Request} request
-   * @param {number} redirectStatus
-   * @param {!Object} redirectHeaders
-   * @param {boolean} fromDiskCache
-   * @param {boolean} fromServiceWorker
-   * @param {?Object} securityDetails
+   * @param {!Protocol.Network.Response} responsePayload
    */
-  _handleRequestRedirect(request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, securityDetails) {
-    const response = new Response(this._client, request, redirectStatus, redirectHeaders, fromDiskCache, fromServiceWorker, securityDetails);
+  _handleRequestRedirect(request, responsePayload) {
+    const response = new Response(this._client, request, responsePayload);
     request._response = response;
     request._redirectChain.push(request);
     response._bodyLoadedPromiseFulfill.call(null, new Error('Response body is unavailable for redirect responses'));
@@ -255,8 +251,7 @@ class NetworkManager extends EventEmitter {
     // FileUpload sends a response without a matching request.
     if (!request)
       return;
-    const response = new Response(this._client, request, event.response.status, event.response.headers,
-        !!event.response.fromDiskCache, !!event.response.fromServiceWorker, event.response.securityDetails);
+    const response = new Response(this._client, request, event.response);
     request._response = response;
     this.emit(NetworkManager.Events.Response, response);
   }
@@ -516,13 +511,9 @@ class Response {
   /**
    * @param {!Puppeteer.CDPSession} client
    * @param {!Request} request
-   * @param {number} status
-   * @param {!Object} headers
-   * @param {boolean} fromDiskCache
-   * @param {boolean} fromServiceWorker
-   * @param {?Object} securityDetails
+   * @param {!Protocol.Network.Response} responsePayload
    */
-  constructor(client, request, status, headers, fromDiskCache, fromServiceWorker, securityDetails) {
+  constructor(client, request, responsePayload) {
     this._client = client;
     this._request = request;
     this._contentPromise = null;
@@ -531,22 +522,14 @@ class Response {
       this._bodyLoadedPromiseFulfill = fulfill;
     });
 
-    this._status = status;
+    this._status = responsePayload.status;
     this._url = request.url();
-    this._fromDiskCache = fromDiskCache;
-    this._fromServiceWorker = fromServiceWorker;
+    this._fromDiskCache = !!responsePayload.fromDiskCache;
+    this._fromServiceWorker = !!responsePayload.fromServiceWorker;
     this._headers = {};
-    for (const key of Object.keys(headers))
-      this._headers[key.toLowerCase()] = headers[key];
-    this._securityDetails = null;
-    if (securityDetails) {
-      this._securityDetails = new SecurityDetails(
-          securityDetails['subjectName'],
-          securityDetails['issuer'],
-          securityDetails['validFrom'],
-          securityDetails['validTo'],
-          securityDetails['protocol']);
-    }
+    for (const key of Object.keys(responsePayload.headers))
+      this._headers[key.toLowerCase()] = responsePayload.headers[key];
+    this._securityDetails = responsePayload.securityDetails ? new SecurityDetails(responsePayload.securityDetails) : null;
   }
 
   /**
@@ -676,19 +659,14 @@ function generateRequestHash(request) {
 
 class SecurityDetails {
   /**
-   * @param {string} subjectName
-   * @param {string} issuer
-   * @param {number} validFrom
-   * @param {number} validTo
-   * @param {string} protocol
+   * @param {!Protocol.Network.SecurityDetails} securityPayload
    */
-
-  constructor(subjectName, issuer, validFrom, validTo, protocol) {
-    this._subjectName = subjectName;
-    this._issuer = issuer;
-    this._validFrom = validFrom;
-    this._validTo = validTo;
-    this._protocol = protocol;
+  constructor(securityPayload) {
+    this._subjectName = securityPayload['subjectName'];
+    this._issuer = securityPayload['issuer'];
+    this._validFrom = securityPayload['validFrom'];
+    this._validTo = securityPayload['validTo'];
+    this._protocol = securityPayload['protocol'];
   }
 
   /**


### PR DESCRIPTION
Before v1.7.0 we were creating Response objects either from protocol's
Network.Response struct, or from the data available in the
requestIntercepted.

With the recent chagens to the request interception logic, we can
always create response from Newtork.Response struct; this allows
us to simply create Response objects from protocol payload.