### PR TITLE
refactor(network): Create Request class right away from payload

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -196,9 +196,12 @@ class NetworkManager extends EventEmitter {
         redirectChain = request._redirectChain;
       }
     }
-    const isNavigationRequest = event.requestId === event.loaderId && event.type === 'Document';
-    this._handleRequestStart(event.requestId, interceptionId, event.request.url, isNavigationRequest, event.type, event.request, event.frameId, redirectChain);
+    const frame = event.frameId ? this._frameManager.frame(event.frameId) : null;
+    const request = new Request(this._client, frame, interceptionId, this._userRequestInterceptionEnabled, event, redirectChain);
+    this._requestIdToRequest.set(event.requestId, request);
+    this.emit(NetworkManager.Events.Request, request);
   }
+
 
   /**
    * @param {!Protocol.Network.requestServedFromCachePayload} event
@@ -222,25 +225,6 @@ class NetworkManager extends EventEmitter {
     this._attemptedAuthentications.delete(request._interceptionId);
     this.emit(NetworkManager.Events.Response, response);
     this.emit(NetworkManager.Events.RequestFinished, request);
-  }
-
-  /**
-   * @param {string} requestId
-   * @param {?string} interceptionId
-   * @param {string} url
-   * @param {boolean} isNavigationRequest
-   * @param {string} resourceType
-   * @param {!Protocol.Network.Request} requestPayload
-   * @param {?string} frameId
-   * @param {!Array<!Request>} redirectChain
-   */
-  _handleRequestStart(requestId, interceptionId, url, isNavigationRequest, resourceType, requestPayload, frameId, redirectChain) {
-    let frame = null;
-    if (frameId)
-      frame = this._frameManager.frame(frameId);
-    const request = new Request(this._client, requestId, interceptionId, isNavigationRequest, this._userRequestInterceptionEnabled, url, resourceType, requestPayload, frame, redirectChain);
-    this._requestIdToRequest.set(requestId, request);
-    this.emit(NetworkManager.Events.Request, request);
   }
 
   /**
@@ -293,35 +277,31 @@ class NetworkManager extends EventEmitter {
 class Request {
   /**
    * @param {!Puppeteer.CDPSession} client
-   * @param {?string} requestId
-   * @param {string} interceptionId
-   * @param {boolean} isNavigationRequest
-   * @param {boolean} allowInterception
-   * @param {string} url
-   * @param {string} resourceType
-   * @param {!Protocol.Network.Request} payload
    * @param {?Puppeteer.Frame} frame
+   * @param {string} interceptionId
+   * @param {boolean} allowInterception
+   * @param {!Protocol.Network.requestWillBeSentPayload} event
    * @param {!Array<!Request>} redirectChain
    */
-  constructor(client, requestId, interceptionId, isNavigationRequest, allowInterception, url, resourceType, payload, frame, redirectChain) {
+  constructor(client, frame, interceptionId, allowInterception, event, redirectChain) {
     this._client = client;
-    this._requestId = requestId;
-    this._isNavigationRequest = isNavigationRequest;
+    this._requestId = event.requestId;
+    this._isNavigationRequest = event.requestId === event.loaderId && event.type === 'Document';
     this._interceptionId = interceptionId;
     this._allowInterception = allowInterception;
     this._interceptionHandled = false;
     this._response = null;
     this._failureText = null;
 
-    this._url = url;
-    this._resourceType = resourceType.toLowerCase();
-    this._method = payload.method;
-    this._postData = payload.postData;
+    this._url = event.request.url;
+    this._resourceType = event.type.toLowerCase();
+    this._method = event.request.method;
+    this._postData = event.request.postData;
     this._headers = {};
     this._frame = frame;
     this._redirectChain = redirectChain;
-    for (const key of Object.keys(payload.headers))
-      this._headers[key.toLowerCase()] = payload.headers[key];
+    for (const key of Object.keys(event.request.headers))
+      this._headers[key.toLowerCase()] = event.request.headers[key];
 
     this._fromMemoryCache = false;
   }


### PR DESCRIPTION
Similarly to Responses, we now always create Request classes from
requestWillBeSent events.