### PR TITLE
chore: preserve links to master version of API from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm i puppeteer-core
 
 `puppeteer-core` is intended to be a lightweight version of puppeteer for launching an existing browser installation or for connecting to a remote one.
 
-See [puppeteer vs puppeteer-core](https://github.com/GoogleChrome/puppeteer/blob/v1.7.0/docs/api.md#puppeteer-vs-puppeteer-core).
+See [puppeteer vs puppeteer-core](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteer-vs-puppeteer-core).
 
 ### Usage
 

--- a/utils/doclint/preprocessor/index.js
+++ b/utils/doclint/preprocessor/index.js
@@ -18,7 +18,7 @@ const Message = require('../Message');
 
 module.exports.ensureReleasedAPILinks = function(sources, version) {
   // Release version is everything that doesn't include "-".
-  const apiLinkRegex = /https:\/\/github.com\/GoogleChrome\/puppeteer\/blob\/[^/]*\/docs\/api.md/ig;
+  const apiLinkRegex = /https:\/\/github.com\/GoogleChrome\/puppeteer\/blob\/v[^/]*\/docs\/api.md/ig;
   const lastReleasedAPI = `https://github.com/GoogleChrome/puppeteer/blob/v${version.split('-')[0]}/docs/api.md`;
 
   const messages = [];

--- a/utils/doclint/preprocessor/test.js
+++ b/utils/doclint/preprocessor/test.js
@@ -28,7 +28,7 @@ const {expect} = new Matchers();
 describe('ensureReleasedAPILinks', function() {
   it('should work with non-release version', function() {
     const source = new Source('doc.md', `
-      [API](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page)
+      [API](https://github.com/GoogleChrome/puppeteer/blob/v1.1.0/docs/api.md#class-page)
     `);
     const messages = ensureReleasedAPILinks([source], '1.3.0-post');
     expect(messages.length).toBe(1);
@@ -40,7 +40,7 @@ describe('ensureReleasedAPILinks', function() {
   });
   it('should work with release version', function() {
     const source = new Source('doc.md', `
-      [API](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page)
+      [API](https://github.com/GoogleChrome/puppeteer/blob/v1.1.0/docs/api.md#class-page)
     `);
     const messages = ensureReleasedAPILinks([source], '1.3.0');
     expect(messages.length).toBe(1);
@@ -48,6 +48,16 @@ describe('ensureReleasedAPILinks', function() {
     expect(messages[0].text).toContain('doc.md');
     expect(source.text()).toBe(`
       [API](https://github.com/GoogleChrome/puppeteer/blob/v1.3.0/docs/api.md#class-page)
+    `);
+  });
+  it('should keep master links intact', function() {
+    const source = new Source('doc.md', `
+      [API](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page)
+    `);
+    const messages = ensureReleasedAPILinks([source], '1.3.0');
+    expect(messages.length).toBe(0);
+    expect(source.text()).toBe(`
+      [API](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-page)
     `);
   });
 });


### PR DESCRIPTION
One of our checks makes sure all links from README.md to API.md
point to the last-released version of the API.

This sometimes doesn't work: when we refer to a section
in api.md that is just added, we should be able to reference
the "master" version of the api.md

This patch:
- teaches the doclint check to keep links to tip-of-tree version
  of api.md in README.md intact.
- starts refering to tip-of-tree version of api.md in `puppeter-core` section