### PR TITLE
fix(page): Page.goto should properly handle historyAPI in beforeunload

### DIFF
--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -59,10 +59,7 @@ class NavigatorWatcher {
       this._newDocumentNavigationCompleteCallback = fulfill;
     });
 
-    this._timeoutPromise = this._createTimeoutPromise().then(error => {
-      this._cleanup();
-      return error;
-    });
+    this._timeoutPromise = this._createTimeoutPromise();
   }
 
   /**
@@ -136,14 +133,8 @@ class NavigatorWatcher {
     }
   }
 
-  cancel() {
-    this._cleanup();
-  }
-
-  _cleanup() {
+  dispose() {
     helper.removeEventListeners(this._eventListeners);
-    this._sameDocumentNavigationCompleteCallback.call(null, new Error('Navigation failed'));
-    this._newDocumentNavigationCompleteCallback.call(null, new Error('Navigation failed'));
     clearTimeout(this._maximumTimer);
   }
 }

--- a/lib/NavigatorWatcher.js
+++ b/lib/NavigatorWatcher.js
@@ -51,16 +51,39 @@ class NavigatorWatcher {
       helper.addEventListener(this._frameManager, FrameManager.Events.FrameDetached, this._checkLifecycleComplete.bind(this))
     ];
 
-    const lifecycleCompletePromise = new Promise(fulfill => {
-      this._lifecycleCompleteCallback = fulfill;
+    this._sameDocumentNavigationPromise = new Promise(fulfill => {
+      this._sameDocumentNavigationCompleteCallback = fulfill;
     });
-    this._navigationPromise = Promise.race([
-      this._createTimeoutPromise(),
-      lifecycleCompletePromise
-    ]).then(error => {
+
+    this._newDocumentNavigationPromise = new Promise(fulfill => {
+      this._newDocumentNavigationCompleteCallback = fulfill;
+    });
+
+    this._timeoutPromise = this._createTimeoutPromise().then(error => {
       this._cleanup();
       return error;
     });
+  }
+
+  /**
+   * @return {!Promise<?Error>}
+   */
+  sameDocumentNavigationPromise() {
+    return this._sameDocumentNavigationPromise;
+  }
+
+  /**
+   * @return {!Promise<?Error>}
+   */
+  newDocumentNavigationPromise() {
+    return this._newDocumentNavigationPromise;
+  }
+
+  /**
+   * @return {!Promise<?Error>}
+   */
+  timeoutPromise() {
+    return this._timeoutPromise;
   }
 
   /**
@@ -72,13 +95,6 @@ class NavigatorWatcher {
     const errorMessage = 'Navigation Timeout Exceeded: ' + this._timeout + 'ms exceeded';
     return new Promise(fulfill => this._maximumTimer = setTimeout(fulfill, this._timeout))
         .then(() => new TimeoutError(errorMessage));
-  }
-
-  /**
-   * @return {!Promise<?Error>}
-   */
-  async navigationPromise() {
-    return this._navigationPromise;
   }
 
   /**
@@ -97,7 +113,10 @@ class NavigatorWatcher {
       return;
     if (!checkLifecycle(this._frame, this._expectedLifecycle))
       return;
-    this._lifecycleCompleteCallback();
+    if (this._hasSameDocumentNavigation)
+      this._sameDocumentNavigationCompleteCallback();
+    if (this._frame._loaderId !== this._initialLoaderId)
+      this._newDocumentNavigationCompleteCallback();
 
     /**
      * @param {!Puppeteer.Frame} frame
@@ -123,7 +142,8 @@ class NavigatorWatcher {
 
   _cleanup() {
     helper.removeEventListeners(this._eventListeners);
-    this._lifecycleCompleteCallback(new Error('Navigation failed'));
+    this._sameDocumentNavigationCompleteCallback.call(null, new Error('Navigation failed'));
+    this._newDocumentNavigationCompleteCallback.call(null, new Error('Navigation failed'));
     clearTimeout(this._maximumTimer);
   }
 }

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -602,7 +602,7 @@ class Page extends EventEmitter {
         ensureNewDocumentNavigation ? watcher.newDocumentNavigationPromise() : watcher.sameDocumentNavigationPromise(),
       ]);
     }
-    watcher.cancel();
+    watcher.dispose();
     helper.removeEventListeners(eventListeners);
     if (error)
       throw error;
@@ -654,6 +654,7 @@ class Page extends EventEmitter {
       watcher.sameDocumentNavigationPromise(),
       watcher.newDocumentNavigationPromise()
     ]);
+    watcher.dispose();
     helper.removeEventListeners([listener]);
     if (error)
       throw error;

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -591,13 +591,17 @@ class Page extends EventEmitter {
     const mainFrame = this._frameManager.mainFrame();
     const timeout = typeof options.timeout === 'number' ? options.timeout : this._defaultNavigationTimeout;
     const watcher = new NavigatorWatcher(this._frameManager, mainFrame, timeout, options);
-    const navigationPromise = watcher.navigationPromise();
+    let ensureNewDocumentNavigation = false;
     let error = await Promise.race([
       navigate(this._client, url, referrer),
-      navigationPromise,
+      watcher.timeoutPromise(),
     ]);
-    if (!error)
-      error = await navigationPromise;
+    if (!error) {
+      error = await Promise.race([
+        watcher.timeoutPromise(),
+        ensureNewDocumentNavigation ? watcher.newDocumentNavigationPromise() : watcher.sameDocumentNavigationPromise(),
+      ]);
+    }
     watcher.cancel();
     helper.removeEventListeners(eventListeners);
     if (error)
@@ -614,6 +618,7 @@ class Page extends EventEmitter {
     async function navigate(client, url, referrer) {
       try {
         const response = await client.send('Page.navigate', {url, referrer});
+        ensureNewDocumentNavigation = !!response.loaderId;
         return response.errorText ? new Error(`${response.errorText} at ${url}`) : null;
       } catch (error) {
         return error;
@@ -644,7 +649,11 @@ class Page extends EventEmitter {
 
     const responses = new Map();
     const listener = helper.addEventListener(this._networkManager, NetworkManager.Events.Response, response => responses.set(response.url(), response));
-    const error = await watcher.navigationPromise();
+    const error = await Promise.race([
+      watcher.timeoutPromise(),
+      watcher.sameDocumentNavigationPromise(),
+      watcher.newDocumentNavigationPromise()
+    ]);
     helper.removeEventListeners([listener]);
     if (error)
       throw error;

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -552,7 +552,7 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       expect(response.status()).toBe(200);
       expect(response.securityDetails()).toBe(null);
     });
-    xit('should work when page calls history API in beforeunload', async({page, server}) => {
+    it('should work when page calls history API in beforeunload', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.evaluate(() => {
         window.addEventListener('beforeunload', () => history.replaceState(null, 'initial', window.location.href), false);


### PR DESCRIPTION
Protocol's `page.navigate` doesn't report loaderId if the command resulted in a same-document
navigation. In this case we should anticipate same-document navigation and otherwise we should
wait for new document navigation.

Fixes #2764.