### PR TITLE
docs: Added cutoff values for scale option in page.pdf function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1411,7 +1411,7 @@ Page is guaranteed to have a main frame which persists during navigations.
 #### page.pdf(options)
 - `options` <[Object]> Options object which might have the following properties:
   - `path` <[string]> The file path to save the PDF to. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the PDF won't be saved to the disk.
-  - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`.
+  - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`. Scale amount must be between 0.1 and 2.
   - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
   - `headerTemplate` <[string]> HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
     - `date` formatted print date


### PR DESCRIPTION
I thought it would be useful to add the lowest and highest values for the scale option to the page.pdf function call in the api documentation. The library throws an error and doesn't generate a pdf if you go beyond those values. I didn't manually test it, the values are based on the warning Chrome gives you if you try to set the scale value outside of that range (divided by 100), so let me know if they're wrong.

It may be useful to change the behavior in the future so that if the value is set beyond that range puppeteer sets the value to the closest value within the range and throws a warning.

Let me know what you think!