### PR TITLE
chore: fix puppeteer@next race condition

### DIFF
--- a/utils/apply_next_version.js
+++ b/utils/apply_next_version.js
@@ -6,7 +6,7 @@ const child_process = require('child_process');
 // If they are not equal - refuse to publish since
 // we're not tip-of-tree.
 const upstream_sha = `git ls-remote https://github.com/GoogleChrome/puppeteer --tags master | cut -f1`;
-const current_sha = `git rev-parse HEAD`
+const current_sha = `git rev-parse HEAD`;
 const command = `if [[ $(${upstream_sha}) == $(${current_sha}) ]]; then echo "yes"; else echo "no"; fi`;
 const output = child_process.execSync(command).toString('utf8');
 if (output.trim() !== 'yes') {

--- a/utils/apply_next_version.js
+++ b/utils/apply_next_version.js
@@ -1,5 +1,20 @@
 const path = require('path');
 const fs = require('fs');
+const child_process = require('child_process');
+
+// Compare current HEAD to upstream master SHA.
+// If they are not equal - refuse to publish since
+// we're not tip-of-tree.
+const upstream_sha = `git ls-remote https://github.com/GoogleChrome/puppeteer --tags master | cut -f1`;
+const current_sha = `git rev-parse HEAD`
+const command = `if [[ $(${upstream_sha}) == $(${current_sha}) ]]; then echo "yes"; else echo "no"; fi`;
+const output = child_process.execSync(command).toString('utf8');
+if (output.trim() !== 'yes') {
+  console.log('REFUSING TO PUBLISH: this is not tip-of-tree!');
+  process.exit(1);
+  return;
+}
+
 
 const package = require('../package.json');
 let version = package.version;


### PR DESCRIPTION
When we merge commits to master, Travis kicks job to build a new commit
and to publish new version of puppeteer@next.

If two commits are landed in almost the same time, then travis starts
two parallel jobs to build each commit. This race condition results
in the incorrect puppeteer@next revision.

This patch teaches apply_next_version.js to verify if current HEAD
is matching upstream HEAD. If it doesn't, the predeploy hook fails
which (hopefully) aborts deployment.

Fixes #2925.