### PR TITLE
refactor: use browser-compliant interface of 'ws'

### DIFF
--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -25,9 +25,9 @@ class WebSocketTransport {
    */
   static create(url) {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url, { perMessageDeflate: false });
-      ws.on('open', () => resolve(new WebSocketTransport(ws)));
-      ws.on('error', reject);
+      const ws = new WebSocket(url, [], { perMessageDeflate: false });
+      ws.addEventListener('open', () => resolve(new WebSocketTransport(ws)));
+      ws.addEventListener('error', reject);
     });
   }
 
@@ -36,16 +36,16 @@ class WebSocketTransport {
    */
   constructor(ws) {
     this._ws = ws;
-    this._ws.on('message', event => {
+    this._ws.addEventListener('message', event => {
       if (this.onmessage)
-        this.onmessage.call(null, event);
+        this.onmessage.call(null, event.data);
     });
-    this._ws.on('close', event => {
+    this._ws.addEventListener('close', event => {
       if (this.onclose)
         this.onclose.call(null);
     });
     // Silently ignore all errors - we don't know what to do with them.
-    this._ws.on('error', () => {});
+    this._ws.addEventListener('error', () => {});
     this.onmessage = null;
     this.onclose = null;
   }


### PR DESCRIPTION
Bundled version of Puppeteer should rely on native WebSocket.

Luckily, 'ws' module supports the same interface as the native
browser websockets. This patch switches WebSocketTransport to
use the browser-compliant interface of 'ws'.

After this patch, I was able to bundle Puppeteer for browser
using the following config in `package.json`:

```json
"browser": {
  "./lib/BrowserFetcher.js": false,
  "./node6/lib/Puppeteer": false,
  "ws": "./lib/BrowserWebSocket",
  "fs": false,
  "child_process": false,
  "rimraf": false,
  "readline": false
}
```

where `./lib/BrowserWebSocket` is:

```js
module.exports = window.WebSocket;
```

and the bundling command is:

```sh
$ browserify -r ./index.js:puppeteer > ppweb.js
```

References #2119 