### PR TITLE
docs(api.md): add frame example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2180,6 +2180,14 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
+An example of getting text from an iframe element:
+
+```js
+  const frame = page.frames().find(frame => frame.name() === 'myframe');
+  const text = await frame.$eval('.selector', element => element.textContent);
+  console.log(text);
+```
+
 #### frame.$(selector)
 - `selector` <[string]> A [selector] to query frame for
 - returns: <[Promise]<?[ElementHandle]>> Promise which resolves to ElementHandle pointing to the frame element.


### PR DESCRIPTION
Add an example on how to work with frame's API.

Fixes #3232.