### PR TITLE
chore: make sure Puppeteer bundling works

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 test/assets/modernizr.js
 third_party/*
+utils/browser/puppeteer-web.js
 utils/doclint/check_public_api/test/
 utils/testrunner/examples/
 node6/*

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ package-lock.json
 yarn.lock
 /node6
 /lib/protocol.d.ts
+/utils/browser/puppeteer-web.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
   - 'if [ "$NODE8" = "true" ]; then npm run lint; fi'
   - 'if [ "$NODE8" = "true" ]; then npm run coverage; fi'
   - 'if [ "$NODE8" = "true" ]; then npm run test-doclint; fi'
+  - 'if [ "$NODE8" = "true" ]; then npm run bundle; fi'
+  - 'if [ "$NODE8" = "true" ]; then npm run unit-bundle; fi'
   - 'if [ "$NODE6" = "true" ]; then npm run unit-node6; fi'
 jobs:
   include:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "unit-node6": "node node6/test/test.js",
     "tsc": "tsc -p .",
     "prepublishOnly": "npm run build",
-    "apply-next-version": "node utils/apply_next_version.js"
+    "apply-next-version": "node utils/apply_next_version.js",
+    "bundle": "npx browserify -r ./index.js:puppeteer -o utils/browser/puppeteer-web.js",
+    "unit-bundle": "node utils/browser/test.js"
   },
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
@@ -55,5 +57,14 @@
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
     "typescript": "^3.0.1"
+  },
+  "browser": {
+    "./lib/BrowserFetcher.js": false,
+    "./node6/lib/Puppeteer": false,
+    "ws": "./utils/browser/WebSocket",
+    "fs": false,
+    "child_process": false,
+    "rimraf": false,
+    "readline": false
   }
 }

--- a/utils/browser/WebSocket.js
+++ b/utils/browser/WebSocket.js
@@ -1,0 +1,1 @@
+module.exports = window.WebSocket;

--- a/utils/browser/test.js
+++ b/utils/browser/test.js
@@ -1,0 +1,76 @@
+const path = require('path');
+const fs = require('fs');
+const puppeteer = require('../..');
+const SimpleServer = require('../../test/server/SimpleServer');
+const {TestRunner, Reporter, Matchers} = require('../testrunner/');
+
+const puppeteerWebPath = path.join(__dirname, 'puppeteer-web.js');
+if (!fs.existsSync(puppeteerWebPath))
+  throw new Error(`puppeteer-web is not built; run "npm run bundle"`);
+const puppeteerWeb = fs.readFileSync(puppeteerWebPath, 'utf8');
+
+const testRunner = new TestRunner();
+const {describe, fdescribe, xdescribe} = testRunner;
+const {it, xit, fit} = testRunner;
+const {afterAll, beforeAll, afterEach, beforeEach} = testRunner;
+const {expect} = new Matchers();
+
+beforeAll(async state => {
+  const assetsPath = path.join(__dirname, '..', '..', 'test', 'assets');
+  const port = 8998;
+  state.server = await SimpleServer.create(assetsPath, port);
+  state.serverConfig = {
+    PREFIX: `http://localhost:${port}`,
+    EMPTY_PAGE: `http://localhost:${port}/empty.html`,
+  };
+  state.browser = await puppeteer.launch();
+});
+
+afterAll(async state => {
+  await Promise.all([
+    state.server.stop(),
+    state.browser.close()
+  ]);
+  state.browser = null;
+  state.server = null;
+});
+
+beforeEach(async state => {
+  state.page = await state.browser.newPage();
+  await state.page.evaluateOnNewDocument(puppeteerWeb);
+  await state.page.addScriptTag({
+    content: puppeteerWeb + '\n//# sourceURL=puppeteer-web.js'
+  });
+});
+
+afterEach(async state => {
+  await state.page.close();
+  state.page = null;
+});
+
+describe('Puppeteer-Web', () => {
+  it('should work over web socket', async({page, serverConfig}) => {
+    const browser2 = await puppeteer.launch();
+    // Use in-page puppeteer to create a new page and navigate it to the EMPTY_PAGE
+    await page.evaluate(async(browserWSEndpoint, serverConfig) => {
+      const puppeteer = require('puppeteer');
+      const browser = await puppeteer.connect({browserWSEndpoint});
+      const page = await browser.newPage();
+      await page.goto(serverConfig.EMPTY_PAGE);
+    }, browser2.wsEndpoint(), serverConfig);
+    const pageURLs = (await browser2.pages()).map(page => page.url()).sort();
+    expect(pageURLs).toEqual([
+      'about:blank',
+      serverConfig.EMPTY_PAGE
+    ]);
+    await browser2.close();
+  });
+});
+
+if (process.env.CI && testRunner.hasFocusedTestsOrSuites()) {
+  console.error('ERROR: "focused" tests/suites are prohibitted on bots. Remove any "fit"/"fdescribe" declarations.');
+  process.exit(1);
+}
+
+new Reporter(testRunner);
+testRunner.run();

--- a/utils/browser/test.js
+++ b/utils/browser/test.js
@@ -15,6 +15,10 @@ const {it, xit, fit} = testRunner;
 const {afterAll, beforeAll, afterEach, beforeEach} = testRunner;
 const {expect} = new Matchers();
 
+const defaultBrowserOptions = {
+  args: ['--no-sandbox']
+};
+
 beforeAll(async state => {
   const assetsPath = path.join(__dirname, '..', '..', 'test', 'assets');
   const port = 8998;
@@ -23,7 +27,7 @@ beforeAll(async state => {
     PREFIX: `http://localhost:${port}`,
     EMPTY_PAGE: `http://localhost:${port}/empty.html`,
   };
-  state.browser = await puppeteer.launch();
+  state.browser = await puppeteer.launch(defaultBrowserOptions);
 });
 
 afterAll(async state => {
@@ -50,7 +54,7 @@ afterEach(async state => {
 
 describe('Puppeteer-Web', () => {
   it('should work over web socket', async({page, serverConfig}) => {
-    const browser2 = await puppeteer.launch();
+    const browser2 = await puppeteer.launch(defaultBrowserOptions);
     // Use in-page puppeteer to create a new page and navigate it to the EMPTY_PAGE
     await page.evaluate(async(browserWSEndpoint, serverConfig) => {
       const puppeteer = require('puppeteer');


### PR DESCRIPTION
This patch:
- adds "browser" field to the package.json with default
  bundling options.
- introduces "bundle" and "unit-bundle" commands to
  create bundle and test bundle
- starts running bundle tests on Travis Node 8 bots

Fixes #2374.