### PR TITLE
chore: drop DEBUG for public API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,19 +230,18 @@ Puppeteer creates its own Chromium user profile which it **cleans up on every ru
 
      The test will now stop executing in the above evaluate statement, and chromium will stop in debug mode.
 
-5. Enable verbose logging - All public API calls and internal protocol traffic
+5. Enable verbose logging - internal DevTools protocol traffic
    will be logged via the [`debug`](https://github.com/visionmedia/debug) module under the `puppeteer` namespace.
 
         # Basic verbose logging
         env DEBUG="puppeteer:*" node script.js
 
         # Debug output can be enabled/disabled by namespace
-        env DEBUG="puppeteer:*,-puppeteer:protocol" node script.js # everything BUT protocol messages
+        env DEBUG="puppeteer:protocol" node script.js # protocol connection messages
         env DEBUG="puppeteer:session" node script.js # protocol session messages (protocol messages to targets)
-        env DEBUG="puppeteer:mouse,puppeteer:keyboard" node script.js # only Mouse and Keyboard API calls
 
         # Protocol traffic can be rather noisy. This example filters out all Network domain messages
-        env DEBUG="puppeteer:*" env DEBUG_COLORS=true node script.js 2>&1 | grep -v '"Network'
+        env DEBUG="puppeteer:session" env DEBUG_COLORS=true node script.js 2>&1 | grep -v '"Network'
 
 6. Debug your Puppeteer (node) code easily, using [ndb](https://github.com/GoogleChromeLabs/ndb)
   

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -103,66 +103,31 @@ class Helper {
    * @param {string=} publicName
    */
   static tracePublicAPI(classType, publicName) {
+    if (!apiCoverage)
+      return;
+
     let className = publicName || classType.prototype.constructor.name;
     className = className.substring(0, 1).toLowerCase() + className.substring(1);
-    const debug = require('debug')(`puppeteer:${className}`);
-    if (!debug.enabled && !apiCoverage)
-      return;
     for (const methodName of Reflect.ownKeys(classType.prototype)) {
       const method = Reflect.get(classType.prototype, methodName);
       if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function')
         continue;
-      if (apiCoverage)
-        apiCoverage.set(`${className}.${methodName}`, false);
+      apiCoverage.set(`${className}.${methodName}`, false);
       Reflect.set(classType.prototype, methodName, function(...args) {
-        const argsText = args.map(stringifyArgument).join(', ');
-        const callsite = `${className}.${methodName}(${argsText})`;
-        if (debug.enabled)
-          debug(callsite);
-        if (apiCoverage)
-          apiCoverage.set(`${className}.${methodName}`, true);
+        apiCoverage.set(`${className}.${methodName}`, true);
         return method.call(this, ...args);
       });
     }
 
     if (classType.Events) {
-      if (apiCoverage) {
-        for (const event of Object.values(classType.Events))
-          apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, false);
-      }
+      for (const event of Object.values(classType.Events))
+        apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, false);
       const method = Reflect.get(classType.prototype, 'emit');
       Reflect.set(classType.prototype, 'emit', function(event, ...args) {
-        const argsText = [JSON.stringify(event)].concat(args.map(stringifyArgument)).join(', ');
-        if (debug.enabled && this.listenerCount(event))
-          debug(`${className}.emit(${argsText})`);
-        if (apiCoverage && this.listenerCount(event))
+        if (this.listenerCount(event))
           apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, true);
         return method.call(this, event, ...args);
       });
-    }
-
-    /**
-     * @param {!Object} arg
-     * @return {string}
-     */
-    function stringifyArgument(arg) {
-      if (Helper.isString(arg) || Helper.isNumber(arg) || !arg)
-        return JSON.stringify(arg);
-      if (typeof arg === 'function') {
-        let text = arg.toString().split('\n').map(line => line.trim()).join('');
-        if (text.length > 20)
-          text = text.substring(0, 20) + '…';
-        return `"${text}"`;
-      }
-      const state = {};
-      const keys = Object.keys(arg);
-      for (const key of keys) {
-        const value = arg[key];
-        if (Helper.isString(value) || Helper.isNumber(value))
-          state[key] = JSON.stringify(value);
-      }
-      const name = arg.constructor.name === 'Object' ? '' : arg.constructor.name;
-      return name + JSON.stringify(state);
     }
   }
 


### PR DESCRIPTION
This proved to be useless: we've never used it since we
released the initial version of puppeteer more than a year ago.

I plan to add async stack tagging for public API calls to make all our errors nice for users;
this is a pre-cleanup to drop the complexity before adding new stuff.