### PR TITLE
Problem with non-HTTP requests.

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -136,6 +136,7 @@ class NetworkManager extends EventEmitter {
         this._onRequest(event, interceptionId);
         this._requestHashToInterceptionIds.delete(requestHash, interceptionId);
       } else {
+        this._onRequest(event, null);
         this._requestHashToRequestIds.set(requestHash, event.requestId);
         this._requestIdToRequestWillBeSentEvent.set(event.requestId, event);
       }


### PR DESCRIPTION
If I enabled request interception, event Page.Events.Request not returns requests with url started with "xyz://" (using in mobile applications for the webview).