### PR TITLE
chore: nicer stack highlight

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -189,5 +189,5 @@ if (process.env.CI && testRunner.hasFocusedTestsOrSuites()) {
   process.exit(1);
 }
 
-new Reporter(testRunner);
+new Reporter(testRunner, utils.projectRoot());
 testRunner.run();


### PR DESCRIPTION
Highlight part of the stack that points to where the actual
test failure happened.

For example, take a look on `page.spec.js` part of the stack trace:

![image](https://user-images.githubusercontent.com/746130/45634130-86417700-ba99-11e8-9544-b4cada0bbe7d.png)
