### PR TITLE
feat: async stacks for all "async" public methods

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -138,11 +138,9 @@ class Helper {
   static tracePublicAPI(classType, publicName) {
     for (const methodName of Reflect.ownKeys(classType.prototype)) {
       const method = Reflect.get(classType.prototype, methodName);
-      if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function')
+      if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function' || method.constructor.name !== 'AsyncFunction')
         continue;
-      if (method.constructor.name !== 'AsyncFunction' && method.constructor.name !== 'GeneratorFunction')
-        continue;
-      Reflect.set(classType.prototype, methodName, async function(...args) {
+      Reflect.set(classType.prototype, methodName, function(...args) {
         const syncStack = new Error();
         return method.call(this, ...args).catch(e => {
           const stack = syncStack.stack.substring(syncStack.stack.indexOf('\n') + 1);

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -19,6 +19,39 @@ const debugError = require('debug')(`puppeteer:error`);
 /** @type {?Map<string, boolean>} */
 let apiCoverage = null;
 
+/**
+ * @param {!Object} classType
+ * @param {string=} publicName
+ */
+function traceAPICoverage(classType, publicName) {
+  if (!apiCoverage)
+    return;
+
+  let className = publicName || classType.prototype.constructor.name;
+  className = className.substring(0, 1).toLowerCase() + className.substring(1);
+  for (const methodName of Reflect.ownKeys(classType.prototype)) {
+    const method = Reflect.get(classType.prototype, methodName);
+    if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function')
+      continue;
+    apiCoverage.set(`${className}.${methodName}`, false);
+    Reflect.set(classType.prototype, methodName, function(...args) {
+      apiCoverage.set(`${className}.${methodName}`, true);
+      return method.call(this, ...args);
+    });
+  }
+
+  if (classType.Events) {
+    for (const event of Object.values(classType.Events))
+      apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, false);
+    const method = Reflect.get(classType.prototype, 'emit');
+    Reflect.set(classType.prototype, 'emit', function(event, ...args) {
+      if (this.listenerCount(event))
+        apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, true);
+      return method.call(this, event, ...args);
+    });
+  }
+}
+
 class Helper {
   /**
    * @param {Function|string} fun
@@ -103,32 +136,25 @@ class Helper {
    * @param {string=} publicName
    */
   static tracePublicAPI(classType, publicName) {
-    if (!apiCoverage)
-      return;
-
-    let className = publicName || classType.prototype.constructor.name;
-    className = className.substring(0, 1).toLowerCase() + className.substring(1);
     for (const methodName of Reflect.ownKeys(classType.prototype)) {
       const method = Reflect.get(classType.prototype, methodName);
       if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function')
         continue;
-      apiCoverage.set(`${className}.${methodName}`, false);
-      Reflect.set(classType.prototype, methodName, function(...args) {
-        apiCoverage.set(`${className}.${methodName}`, true);
-        return method.call(this, ...args);
+      if (method.constructor.name !== 'AsyncFunction' && method.constructor.name !== 'GeneratorFunction')
+        continue;
+      Reflect.set(classType.prototype, methodName, async function(...args) {
+        const syncStack = new Error();
+        return method.call(this, ...args).catch(e => {
+          const stack = syncStack.stack.substring(syncStack.stack.indexOf('\n') + 1);
+          const clientStack = stack.substring(stack.indexOf('\n'));
+          if (!e.stack.includes(clientStack))
+            e.stack += '\n  -- ASYNC --\n' + stack;
+          throw e;
+        });
       });
     }
 
-    if (classType.Events) {
-      for (const event of Object.values(classType.Events))
-        apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, false);
-      const method = Reflect.get(classType.prototype, 'emit');
-      Reflect.set(classType.prototype, 'emit', function(event, ...args) {
-        if (this.listenerCount(event))
-          apiCoverage.set(`${className}.emit(${JSON.stringify(event)})`, true);
-        return method.call(this, event, ...args);
-      });
-    }
+    traceAPICoverage(classType, publicName);
   }
 
   /**

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -65,6 +65,25 @@ module.exports.addTests = function({testRunner, expect, headless}) {
     });
   });
 
+  let asyncawait = true;
+  try {
+    new Function('async function foo() {await 1}');
+  } catch (e) {
+    asyncawait = false;
+  }
+  (asyncawait ? describe : xdescribe)('Async stacks', () => {
+    it('should work', async({page, server}) => {
+      server.setRoute('/empty.html', (req, res) => {
+        res.statusCode = 204;
+        res.end();
+      });
+      let error = null;
+      await page.goto(server.EMPTY_PAGE).catch(e => error = e);
+      expect(error).not.toBe(null);
+      expect(error.message).toContain('net::ERR_ABORTED');
+    });
+  });
+
   describe('Page.Events.error', function() {
     it('should throw when page crashes', async({page}) => {
       let error = null;
@@ -546,7 +565,6 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       await page.goto(server.EMPTY_PAGE).catch(e => error = e);
       expect(error).not.toBe(null);
       expect(error.message).toContain('net::ERR_ABORTED');
-      expect(error.stack).toContain(__filename);
     });
     it('should navigate to empty page with domcontentloaded', async({page, server}) => {
       const response = await page.goto(server.EMPTY_PAGE, {waitUntil: 'domcontentloaded'});

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -546,6 +546,7 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       await page.goto(server.EMPTY_PAGE).catch(e => error = e);
       expect(error).not.toBe(null);
       expect(error.message).toContain('net::ERR_ABORTED');
+      expect(error.stack).toContain(__filename);
     });
     it('should navigate to empty page with domcontentloaded', async({page, server}) => {
       const response = await page.goto(server.EMPTY_PAGE, {waitUntil: 'domcontentloaded'});


### PR DESCRIPTION
This patch traces all public async methods and wraps them
in a helper method that tags the sync stack trace.

Later on, if the method call throws an exception, we add
a captured stack trace to the original stack trace with the "--ASYNC--"
heading.

An example of a stack trace:

```
Error: net::ERR_ABORTED at http://localhost:8907/empty.html
    at navigate (/Users/lushnikov/prog/puppeteer/lib/Page.js:622:37)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  -- ASYNC --
    at Page.<anonymous> (/Users/lushnikov/prog/puppeteer/lib/helper.js:147:27)
    at fit (/Users/lushnikov/prog/puppeteer/test/page.spec.js:546:18)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```