### PR TITLE
feat(launcher): add experimental "transport" option to pptr.connect

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,7 @@
   * [browser.newPage()](#browsernewpage)
   * [browser.pages()](#browserpages)
   * [browser.process()](#browserprocess)
+  * [browser.target()](#browsertarget)
   * [browser.targets()](#browsertargets)
   * [browser.userAgent()](#browseruseragent)
   * [browser.version()](#browserversion)
@@ -673,6 +674,11 @@ the method will return an array with all the pages in all browser contexts.
 
 #### browser.process()
 - returns: <?[ChildProcess]> Spawned browser process. Returns `null` if the browser instance was created with [`puppeteer.connect`](#puppeteerconnectoptions) method.
+
+#### browser.target()
+- returns: <[Target]>
+
+A target associated with the browser.
 
 #### browser.targets()
 - returns: <[Array]<[Target]>>

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -186,6 +186,13 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @return {!Target}
+   */
+  target() {
+    return this.targets().find(target => target.type() === 'browser');
+  }
+
+  /**
    * @return {!Promise<!Array<!Puppeteer.Page>>}
    */
   async pages() {

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -270,7 +270,7 @@ class Launcher {
   }
 
   /**
-   * @param {!(BrowserOptions & {browserWSEndpoint: string})} options
+   * @param {!(BrowserOptions & {browserWSEndpoint: string, transport: ?Puppeteer.ConnectionTransport})} options
    * @return {!Promise<!Browser>}
    */
   async connect(options) {
@@ -278,9 +278,9 @@ class Launcher {
       browserWSEndpoint,
       ignoreHTTPSErrors = false,
       defaultViewport = {width: 800, height: 600},
+      transport = await WebSocketTransport.create(browserWSEndpoint),
       slowMo = 0,
     } = options;
-    const transport = await WebSocketTransport.create(browserWSEndpoint);
     const connection = new Connection(browserWSEndpoint, transport, slowMo);
     const {browserContextIds} = await connection.send('Target.getBrowserContexts');
     return Browser.create(connection, browserContextIds, ignoreHTTPSErrors, defaultViewport, null, () => connection.send('Browser.close').catch(debugError));

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -270,7 +270,7 @@ class Launcher {
   }
 
   /**
-   * @param {!(BrowserOptions & {browserWSEndpoint: string, transport: ?Puppeteer.ConnectionTransport})} options
+   * @param {!(BrowserOptions & {browserWSEndpoint: string, transport?: !Puppeteer.ConnectionTransport})} options
    * @return {!Promise<!Browser>}
    */
   async connect(options) {

--- a/lib/Puppeteer.js
+++ b/lib/Puppeteer.js
@@ -37,7 +37,7 @@ module.exports = class {
   }
 
   /**
-   * @param {{browserWSEndpoint: string, ignoreHTTPSErrors: boolean}} options
+   * @param {{browserWSEndpoint: string, ignoreHTTPSErrors: boolean, transport: ?Puppeteer.ConnectionTransport}} options
    * @return {!Promise<!Puppeteer.Browser>}
    */
   connect(options) {

--- a/lib/Puppeteer.js
+++ b/lib/Puppeteer.js
@@ -37,7 +37,7 @@ module.exports = class {
   }
 
   /**
-   * @param {{browserWSEndpoint: string, ignoreHTTPSErrors: boolean, transport: ?Puppeteer.ConnectionTransport}} options
+   * @param {{browserWSEndpoint: string, ignoreHTTPSErrors: boolean, transport?: !Puppeteer.ConnectionTransport}} options
    * @return {!Promise<!Puppeteer.Browser>}
    */
   connect(options) {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -37,6 +37,13 @@ module.exports.addTests = function({testRunner, expect, headless}) {
     });
   });
 
+  describe('Browser.target', function() {
+    it('should return browser target', async({browser}) => {
+      const target = browser.target();
+      expect(target.type()).toBe('browser');
+    });
+  });
+
   describe('Browser.process', function() {
     it('should return child_process instance', async function({browser}) {
       const process = await browser.process();

--- a/utils/ESTreeWalker.js
+++ b/utils/ESTreeWalker.js
@@ -80,6 +80,7 @@ ESTreeWalker._walkOrder = {
   'ArrayExpression': ['elements'],
   'ArrowFunctionExpression': ['params', 'body'],
   'AssignmentExpression': ['left', 'right'],
+  'AssignmentPattern': ['left', 'right'],
   'BinaryExpression': ['left', 'right'],
   'BlockStatement': ['body'],
   'BreakStatement': ['label'],


### PR DESCRIPTION
This patch:
- adds experimental "transport" option to pptr.connect
- uses "transport" option to make sure Puppeteer-Web works with
  Target.exposeDevToolsProtocol

Drive-by: add `browser.target()` to access browser target.