### PR TITLE
feat(chromium): roll Chromium to r594312

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "591618"
+    "chromium_revision": "594312"
   },
   "scripts": {
     "unit": "node test/test.js",


### PR DESCRIPTION
This roll includes:
- https://crrev.com/593256 - Support fetching missing intermediate certificates in headless
- https://crrev.com/594161 - DevTools: allow addScriptToEvaluateOnNewDocument accept optional worldName parameter.

References #2671.
Fixes #2377.