### PR TITLE
chore(types): upgrade to TypeScript 3.1.1

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -789,7 +789,7 @@ class Frame {
       return this.waitForSelector(string, options);
     }
     if (helper.isNumber(selectorOrFunctionOrTimeout))
-      return new Promise(fulfill => setTimeout(fulfill, selectorOrFunctionOrTimeout));
+      return new Promise(fulfill => setTimeout(fulfill, /** @type {number} */ (selectorOrFunctionOrTimeout)));
     if (typeof selectorOrFunctionOrTimeout === 'function')
       return this.waitForFunction(selectorOrFunctionOrTimeout, options, ...args);
     return Promise.reject(new Error('Unsupported target type: ' + (typeof selectorOrFunctionOrTimeout)));

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -163,6 +163,7 @@ class Launcher {
         const transport = await WebSocketTransport.create(browserWSEndpoint);
         connection = new Connection(browserWSEndpoint, transport, slowMo);
       } else {
+        // @ts-ignore - TypeScript incorrectly thinks stdio can't go above 2
         const transport = new PipeTransport(/** @type {!NodeJS.WritableStream} */(chromeProcess.stdio[3]), /** @type {!NodeJS.ReadableStream} */ (chromeProcess.stdio[4]));
         connection = new Connection('', transport, slowMo);
       }

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -114,6 +114,7 @@ class Launcher {
     }
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');
+    /** @type {!Array<"ignore"|"pipe">} */
     const stdio = usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'];
     const chromeProcess = childProcess.spawn(
         chromeExecutable,

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1019,7 +1019,7 @@ const supportedMetrics = new Set([
   'JSHeapTotalSize',
 ]);
 
-/** @enum {string} */
+/** @enum {!{width: number, height: number}} */
 Page.PaperFormats = {
   letter: {width: 8.5, height: 11},
   legal: {width: 8.5, height: 14},

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/debug": "0.0.30",
     "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.0",
-    "@types/node": "^8.0.26",
+    "@types/node": "^8.10.32",
     "@types/rimraf": "^2.0.2",
     "@types/ws": "^3.0.2",
     "commonmark": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "^3.0.1"
+    "typescript": "^3.1.1"
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,


### PR DESCRIPTION
This upgrades  us to TypeScript 3.1.1, which fixes some build failures. Annoyingly TypeScript does a better job of checking `process.stdio`, which exposes that the DefinitelyTyped definition for it is wrong. See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11587. I'll look into submitting a patch for that later.