### PR TITLE
fix(types): upgrade node types to 8.10.34

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -164,7 +164,6 @@ class Launcher {
         const transport = await WebSocketTransport.create(browserWSEndpoint);
         connection = new Connection(browserWSEndpoint, transport, slowMo);
       } else {
-        // @ts-ignore - TypeScript incorrectly thinks stdio can't go above 2
         const transport = new PipeTransport(/** @type {!NodeJS.WritableStream} */(chromeProcess.stdio[3]), /** @type {!NodeJS.ReadableStream} */ (chromeProcess.stdio[4]));
         connection = new Connection('', transport, slowMo);
       }

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -430,10 +430,8 @@ class Request {
     }
     if (response.contentType)
       responseHeaders['content-type'] = response.contentType;
-    if (responseBody && !('content-length' in responseHeaders)) {
-      // @ts-ignore
+    if (responseBody && !('content-length' in responseHeaders))
       responseHeaders['content-length'] = Buffer.byteLength(responseBody);
-    }
 
     const statusCode = response.status || 200;
     const statusText = statusTexts[statusCode] || '';

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/debug": "0.0.30",
     "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.0",
-    "@types/node": "^8.10.32",
+    "@types/node": "^8.10.34",
     "@types/rimraf": "^2.0.2",
     "@types/ws": "^3.0.2",
     "commonmark": "^0.27.0",


### PR DESCRIPTION
This includes my stdio fix, so we can get rid of a ts-ignore. There was a second ts-ignore that didn't seem to be needed as well.