### PR TITLE
feat: browser.waitForTarget

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -704,14 +704,14 @@ the method will return an array with all the targets in all browser contexts.
 #### browser.waitForTarget(predicate[, options])
 - `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
 - `options` <[Object]>
-  - `timeout` <[number]> <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
+  - `timeout` <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
 - returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
 
 This searches for a target in all browser contexts.
 
 An example of finding a target for a page opened via `window.open`:
 ```js
-await page.evaluate(() => window.open('https://www.example.com/'))
+await page.evaluate(() => window.open('https://www.example.com/'));
 const newWindowTarget = await browser.waitForTarget(target => target.url() === 'https://www.example.com/');
 ```
 
@@ -842,14 +842,14 @@ An array of all active targets inside the browser context.
 #### browserContext.waitForTarget(predicate[, options])
 - `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
 - `options` <[Object]>
-  - `timeout` <[number]> <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
+  - `timeout` <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
 - returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
 
 This searches for a target in this specific browser context.
 
 An example of finding a target for a page opened via `window.open`:
 ```js
-await page.evaluate(() => window.open('https://www.example.com/'))
+await page.evaluate(() => window.open('https://www.example.com/'));
 const newWindowTarget = await browserContext.waitForTarget(target => target.url() === 'https://www.example.com/');
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -707,6 +707,14 @@ the method will return an array with all the targets in all browser contexts.
   - `timeout` <[number]> <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
 - returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
 
+This searches for a target in all browser contexts.
+
+An example of finding a target for a page opened via `window.open`:
+```js
+await page.evaluate(() => window.open('https://www.example.com/'))
+const newWindowTarget = await browser.waitForTarget(target => target.url() === 'https://www.example.com/');
+```
+
 #### browser.wsEndpoint()
 - returns: <[string]> Browser websocket url.
 
@@ -836,6 +844,14 @@ An array of all active targets inside the browser context.
 - `options` <[Object]>
   - `timeout` <[number]> <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
 - returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
+
+This searches for a target in this specific browser context.
+
+An example of finding a target for a page opened via `window.open`:
+```js
+await page.evaluate(() => window.open('https://www.example.com/'))
+const newWindowTarget = await browserContext.waitForTarget(target => target.url() === 'https://www.example.com/');
+```
 
 ### class: Page
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,7 @@
   * [browser.targets()](#browsertargets)
   * [browser.userAgent()](#browseruseragent)
   * [browser.version()](#browserversion)
+  * [browser.waitForTarget(predicate[, options])](#browserwaitfortargetpredicate-options)
   * [browser.wsEndpoint()](#browserwsendpoint)
 - [class: BrowserContext](#class-browsercontext)
   * [event: 'targetchanged'](#event-targetchanged-1)
@@ -65,6 +66,7 @@
   * [browserContext.overridePermissions(origin, permissions)](#browsercontextoverridepermissionsorigin-permissions)
   * [browserContext.pages()](#browsercontextpages)
   * [browserContext.targets()](#browsercontexttargets)
+  * [browserContext.waitForTarget(predicate[, options])](#browsercontextwaitfortargetpredicate-options)
 - [class: Page](#class-page)
   * [event: 'close'](#event-close)
   * [event: 'console'](#event-console)
@@ -699,6 +701,12 @@ the method will return an array with all the targets in all browser contexts.
 
 > **NOTE** the format of browser.version() might change with future releases of Chromium.
 
+#### browser.waitForTarget(predicate[, options])
+- `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
+- `options` <[Object]>
+  - `timeout` <[number]> <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
+- returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
+
 #### browser.wsEndpoint()
 - returns: <[string]> Browser websocket url.
 
@@ -822,6 +830,12 @@ An array of all pages inside the browser context.
 - returns: <[Array]<[Target]>>
 
 An array of all active targets inside the browser context.
+
+#### browserContext.waitForTarget(predicate[, options])
+- `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
+- `options` <[Object]>
+  - `timeout` <[number]> <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
+- returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
 
 ### class: Page
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -193,6 +193,36 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @param {function(!Target):boolean} predicate
+   * @param {{timeout?: number}=} options
+   */
+  async waitForTarget(predicate, options = {}) {
+    const {
+      timeout = 30000
+    } = options;
+    const existingTarget = this.targets().find(predicate);
+    if (existingTarget)
+      return existingTarget;
+    let resolve;
+    const targetPromise = new Promise(x => resolve = x);
+    this.on(Browser.Events.TargetCreated, check);
+    this.on(Browser.Events.TargetChanged, check);
+    let target;
+    try {
+      target = await (timeout ? helper.waitWithTimeout(targetPromise, 'target', timeout) : targetPromise);
+    } finally {
+      this.removeListener(Browser.Events.TargetCreated, check);
+      this.removeListener(Browser.Events.TargetChanged, check);
+    }
+    return target;
+
+    function check(target) {
+      if (predicate(target))
+        resolve(target);
+    }
+  }
+
+  /**
    * @return {!Promise<!Array<!Puppeteer.Page>>}
    */
   async pages() {
@@ -260,6 +290,14 @@ class BrowserContext extends EventEmitter {
    */
   targets() {
     return this._browser.targets().filter(target => target.browserContext() === this);
+  }
+
+  /**
+   * @param {function(!Target):boolean} predicate
+   * @param {{timeout?: number}=} options
+   */
+  waitForTarget(predicate, options) {
+    return this._browser.waitForTarget(target => target.browserContext() === this && predicate(target), options);
   }
 
   /**

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -207,15 +207,18 @@ class Browser extends EventEmitter {
     const targetPromise = new Promise(x => resolve = x);
     this.on(Browser.Events.TargetCreated, check);
     this.on(Browser.Events.TargetChanged, check);
-    let target;
     try {
-      target = await (timeout ? helper.waitWithTimeout(targetPromise, 'target', timeout) : targetPromise);
+      if (!timeout)
+        return await targetPromise;
+      return await helper.waitWithTimeout(targetPromise, 'target', timeout);
     } finally {
       this.removeListener(Browser.Events.TargetCreated, check);
       this.removeListener(Browser.Events.TargetChanged, check);
     }
-    return target;
 
+    /**
+     * @param {!Target} target
+     */
     function check(target) {
       if (predicate(target))
         resolve(target);

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -248,6 +248,28 @@ class Helper {
     }
     return promise;
   }
+
+  /**
+   * @template T
+   * @param {!Promise<T>} promise
+   * @param {string} taskName
+   * @param {number} timeout
+   * @return {!Promise<T>}
+   */
+  static async waitWithTimeout(promise, taskName, timeout) {
+    let reject;
+    const timeoutError = new TimeoutError(`waiting for ${taskName} failed: timeout ${timeout}ms exceeded`);
+    const timeoutPromise = new Promise((resolve, x) => reject = x);
+    const timeoutInterval = setTimeout(() => reject(timeoutError), timeout);
+    /** @type {T} */
+    let value;
+    try {
+      value = await Promise.race([promise, timeoutPromise]);
+    } finally {
+      clearInterval(timeoutInterval);
+    }
+    return value;
+  }
 }
 
 /**

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -260,15 +260,12 @@ class Helper {
     let reject;
     const timeoutError = new TimeoutError(`waiting for ${taskName} failed: timeout ${timeout}ms exceeded`);
     const timeoutPromise = new Promise((resolve, x) => reject = x);
-    const timeoutInterval = setTimeout(() => reject(timeoutError), timeout);
-    /** @type {T} */
-    let value;
+    const timeoutTimer = setTimeout(() => reject(timeoutError), timeout);
     try {
-      value = await Promise.race([promise, timeoutPromise]);
+      return await Promise.race([promise, timeoutPromise]);
     } finally {
-      clearInterval(timeoutInterval);
+      clearTimeout(timeoutTimer);
     }
-    return value;
   }
 }
 

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -90,7 +90,6 @@ module.exports.addTests = function({testRunner, expect}) {
       await page.goto(server.EMPTY_PAGE);
       const target = await targetPromise;
       expect(await target.page()).toBe(page);
-      await page.close();
       await context.close();
     });
     it('should timeout waiting for a non-existent target', async function({browser, server}) {

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -16,6 +16,7 @@
 
 const utils = require('./utils');
 const puppeteer = utils.requireRoot('index');
+const {TimeoutError} = utils.requireRoot('Errors');
 
 module.exports.addTests = function({testRunner, expect}) {
   const {describe, xdescribe, fdescribe} = testRunner;
@@ -77,6 +78,25 @@ module.exports.addTests = function({testRunner, expect}) {
         `CHANGED: ${server.EMPTY_PAGE}`,
         `DESTROYED: ${server.EMPTY_PAGE}`
       ]);
+      await context.close();
+    });
+    it('should wait for a target', async function({browser, server}) {
+      const context = await browser.createIncognitoBrowserContext();
+      let resolved = false;
+      const targetPromise = context.waitForTarget(target => target.url() === server.EMPTY_PAGE);
+      targetPromise.then(() => resolved = true);
+      const page = await context.newPage();
+      expect(resolved).toBe(false);
+      await page.goto(server.EMPTY_PAGE);
+      const target = await targetPromise;
+      expect(await target.page()).toBe(page);
+      await page.close();
+      await context.close();
+    });
+    it('should timeout waiting for a non-existent target', async function({browser, server}) {
+      const context = await browser.createIncognitoBrowserContext();
+      const error = await context.waitForTarget(target => target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
+      expect(error).toBeInstanceOf(TimeoutError);
       await context.close();
     });
     it('should isolate localStorage and cookies', async function({browser, server}) {

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -121,7 +121,7 @@ module.exports.addTests = function({testRunner, expect}) {
         server.waitForRequest('/one-style.css')
       ]);
       // Connect to the opened page.
-      const target = context.targets().find(target => target.url().includes('one-style.html'));
+      const target = await context.waitForTarget(target => target.url().includes('one-style.html'));
       const newPage = await target.page();
       // Issue a redirect.
       serverResponse.writeHead(302, { location: '/injectedstyle.css' });


### PR DESCRIPTION
This adds `browser.waitForTarget` and `browserContext.waitForTarget`. It also fixes a flaky test that was incorrectly expecting targets to appear instantly.