### PR TITLE
feat(page): exposed additional info for ConsoleMessage object

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -178,6 +178,7 @@
   * [dialog.type()](#dialogtype)
 - [class: ConsoleMessage](#class-consolemessage)
   * [consoleMessage.args()](#consolemessageargs)
+  * [consoleMessage.location()](#consolemessagelocation)
   * [consoleMessage.text()](#consolemessagetext)
   * [consoleMessage.type()](#consolemessagetype)
 - [class: Frame](#class-frame)
@@ -2170,6 +2171,12 @@ puppeteer.launch().then(async browser => {
 
 #### consoleMessage.args()
 - returns: <[Array]<[JSHandle]>>
+
+#### consoleMessage.location()
+- returns: <[Object]>
+  - `url` <[string]> URL of the resource if known
+  - `lineNumber` <[number]> line number in the resource 
+  - `columnNumber` <[number]> line number in the resource 
 
 #### consoleMessage.text()
 - returns: <[string]>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -495,10 +495,12 @@ class Page extends EventEmitter {
   async _onConsoleAPI(event) {
     const context = this._frameManager.executionContextById(event.executionContextId);
     const values = event.args.map(arg => createJSHandle(context, arg));
-    let location;
+    const location = {};
     if (event.stackTrace && event.stackTrace.callFrames) {
       const {url, lineNumber, columnNumber} = event.stackTrace.callFrames[0];
-      location = {url, lineNumber, columnNumber};
+      if (url) location.url = url;
+      if (lineNumber) location.lineNumber = lineNumber;
+      if (columnNumber) location.columnNumber = columnNumber;
     }
     this._addConsoleMessage(event.type, values, location);
   }
@@ -521,6 +523,7 @@ class Page extends EventEmitter {
   /**
    * @param {string} type
    * @param {!Array<!Puppeteer.JSHandle>} args
+   * @param {ConsoleMessage.Location} location
    */
   _addConsoleMessage(type, args, location) {
     if (!this.listenerCount(Page.Events.Console)) {
@@ -1129,12 +1132,19 @@ Page.Events = {
  * @property {("Strict"|"Lax")=} sameSite
  */
 
+/**
+ * @typedef {Object} ConsoleMessage.Location
+ * @property {string=} url
+ * @property {number=} lineNumber
+ * @property {number=} columnNumber
+ */
+
 class ConsoleMessage {
   /**
    * @param {string} type
    * @param {string} text
    * @param {!Array<!Puppeteer.JSHandle>} args
-   * @param {Object} location
+   * @param {ConsoleMessage.Location} location
    */
   constructor(type, text, args = [], location = {}) {
     this._type = type;

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -179,11 +179,11 @@ class Page extends EventEmitter {
    * @param {!Protocol.Log.entryAddedPayload} event
    */
   _onLogEntryAdded(event) {
-    const {level, text, args, source} = event.entry;
+    const {level, text, args, source, url, lineNumber} = event.entry;
     if (args)
       args.map(arg => helper.releaseObject(this._client, arg));
     if (source !== 'worker')
-      this.emit(Page.Events.Console, new ConsoleMessage(level, text));
+      this.emit(Page.Events.Console, new ConsoleMessage(level, text, undefined, { url, lineNumber }));
   }
 
   /**
@@ -495,7 +495,12 @@ class Page extends EventEmitter {
   async _onConsoleAPI(event) {
     const context = this._frameManager.executionContextById(event.executionContextId);
     const values = event.args.map(arg => createJSHandle(context, arg));
-    this._addConsoleMessage(event.type, values);
+    let location;
+    if (event.stackTrace && event.stackTrace.callFrames) {
+      const {url, lineNumber, columnNumber} = event.stackTrace.callFrames[0];
+      location = {url, lineNumber, columnNumber};
+    }
+    this._addConsoleMessage(event.type, values, location);
   }
 
   /**
@@ -517,7 +522,7 @@ class Page extends EventEmitter {
    * @param {string} type
    * @param {!Array<!Puppeteer.JSHandle>} args
    */
-  _addConsoleMessage(type, args) {
+  _addConsoleMessage(type, args, location) {
     if (!this.listenerCount(Page.Events.Console)) {
       args.forEach(arg => arg.dispose());
       return;
@@ -530,7 +535,7 @@ class Page extends EventEmitter {
       else
         textTokens.push(helper.valueFromRemoteObject(remoteObject));
     }
-    const message = new ConsoleMessage(type, textTokens.join(' '), args);
+    const message = new ConsoleMessage(type, textTokens.join(' '), args, location);
     this.emit(Page.Events.Console, message);
   }
 
@@ -1129,11 +1134,13 @@ class ConsoleMessage {
    * @param {string} type
    * @param {string} text
    * @param {!Array<!Puppeteer.JSHandle>} args
+   * @param {Object} location
    */
-  constructor(type, text, args = []) {
+  constructor(type, text, args = [], location = {}) {
     this._type = type;
     this._text = text;
     this._args = args;
+    this._location = location;
   }
 
   /**
@@ -1155,6 +1162,13 @@ class ConsoleMessage {
    */
   args() {
     return this._args;
+  }
+
+  /**
+   * @return {Object}
+   */
+  location() {
+    return this._location;
   }
 }
 

--- a/test/assets/console-message-1.html
+++ b/test/assets/console-message-1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Log Entry Test</title>
+  </head>
+  <body>
+      <script>
+        fetch('http://wat')
+      </script>
+  </body>
+</html>

--- a/test/assets/console-message-2.html
+++ b/test/assets/console-message-2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Log Entry Test</title>
+  </head>
+  <body>
+      <script>
+        console.warn('wat')
+      </script>
+  </body>
+</html>

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -498,7 +498,6 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       page.on('console', msg => {
         message = msg;
       });
-      // console.log(server.PREFIX + '/warn.html?wham')
       await Promise.all([
         page.goto(server.PREFIX + '/console-message-1.html'),
         waitEvent(page, 'console'),

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -493,6 +493,42 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       expect(message.text()).toContain('No \'Access-Control-Allow-Origin\'');
       expect(message.type()).toEqual('error');
     });
+    it('should show correct additional info when console event emitted for logEntry', async({page, server}) => {
+      let message = null;
+      page.on('console', msg => {
+        message = msg;
+      });
+      // console.log(server.PREFIX + '/warn.html?wham')
+      await Promise.all([
+        page.goto(server.PREFIX + '/console-message-1.html'),
+        waitEvent(page, 'console'),
+      ]);
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      expect(message.text()).toContain(`ERR_NAME_NOT_RESOLVED`);
+      expect(message.type()).toEqual('error');
+      expect(message.location()).toEqual({
+        url: 'http://wat/',
+        lineNumber: undefined
+      });
+    });
+    it('should show correct additional info when console event emitted for consoleAPI', async({page, server}) => {
+      let message = null;
+      page.on('console', msg => {
+        message = msg;
+      });
+      await Promise.all([
+        page.goto(server.PREFIX + '/console-message-2.html'),
+        waitEvent(page, 'console'),
+      ]);
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      expect(message.text()).toContain(`wat`);
+      expect(message.type()).toEqual('warning');
+      expect(message.location()).toEqual({
+        url: `http://localhost:${server.PORT}/console-message-2.html`,
+        lineNumber: 7,
+        columnNumber: 16
+      });
+    });
   });
 
   describe('Page.Events.DOMContentLoaded', function() {


### PR DESCRIPTION
This patch add additional method to ConsoleMessage object sent on console event. Currently, added URL and line number to additionalInfo.

Fixes #3029