### PR TITLE
docs(readme): Add installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm i puppeteer
 # or "yarn add puppeteer"
 ```
 
-Note: When you install Puppeteer, it downloads a recent version of Chromium (~170MB Mac, ~282MB Linux, ~280MB Win) that is guaranteed to work with the API. To skip the download, see [Environment variables](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#environment-variables).
+Note: When you install Puppeteer, it downloads a recent version of Chromium (~170MB Mac, ~282MB Linux, ~280MB Win) that is guaranteed to work with the API. To skip the download, see [Environment variables](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#environment-variables). If you are in the mainland of China, because of the GFW, you may need to set `PUPPETEER_DOWNLOAD_HOST` properly. You can execute `npm config set puppeteer_download_host=https://storage.googleapis.com.cnpmjs.org` before install Puppeteer or add a `.npmrc` file in your project root for modify the [npm config](https://docs.npmjs.com/cli/config) which will be used to download Chromium.
 
 
 ### puppeteer-core

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm i puppeteer
 # or "yarn add puppeteer"
 ```
 
-Note: When you install Puppeteer, it downloads a recent version of Chromium (~170MB Mac, ~282MB Linux, ~280MB Win) that is guaranteed to work with the API. To skip the download, see [Environment variables](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#environment-variables). If you are in the mainland of China, because of the GFW, you may need to set `PUPPETEER_DOWNLOAD_HOST` properly. You can execute `npm config set puppeteer_download_host=https://storage.googleapis.com.cnpmjs.org` before install Puppeteer or add a `.npmrc` file in your project root for modify the [npm config](https://docs.npmjs.com/cli/config) which will be used to download Chromium.
+Note: When you install Puppeteer, it downloads a recent version of Chromium (~170MB Mac, ~282MB Linux, ~280MB Win) that is guaranteed to work with the API. To skip the download, see [Environment variables](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#environment-variables). If you are in the mainland of China, because of the GFW, you may need to set `PUPPETEER_DOWNLOAD_HOST` properly. You can execute `npm config set puppeteer_download_host=https://storage.googleapis.com.cnpmjs.org` before installing Puppeteer or add a `.npmrc` file in your project root to modify the [npm config](https://docs.npmjs.com/cli/config) which will be used to download Chromium.
 
 
 ### puppeteer-core


### PR DESCRIPTION
Many person in the main land of China can't install Puppeteer when download Chromium, because of the GFW. Solutions provided in [#1597](https://github.com/GoogleChrome/puppeteer/issues/1597) are not work now. Because of the  mirror `https://npm.taobao.org/mirrors/chromium-browser-snapshots/` is not keep sync. It will cause 404 error. A better solution is provided [here](https://github.com/cnpm/cnpmjs.org/issues/1246). There are many similar issues can be found in this repo. So, i think it's better to add additional note to the installation section.
Fixes #1597