### PR TITLE
test(csscoverage): failing test when a stylesheet was recently added

### DIFF
--- a/test/coverage.spec.js
+++ b/test/coverage.spec.js
@@ -189,5 +189,19 @@ module.exports.addTests = function({testRunner, expect}) {
         expect(coverage.length).toBe(0);
       });
     });
+    xit('should work with a recently loaded stylesheet', async function({page, server}) {
+      await page.coverage.startCSSCoverage();
+      await page.evaluate(async url => {
+        document.body.textContent = 'hello, world';
+
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = url;
+        document.head.appendChild(link);
+        await new Promise(x => link.onload = x);
+      }, server.PREFIX + '/csscoverage/stylesheet1.css');
+      const coverage = await page.coverage.stopCSSCoverage();
+      expect(coverage.length).toBe(1);
+    });
   });
 };


### PR DESCRIPTION
If nobody forces a layout, CSS coverage is inconsistent. This causes some flakes on the bots. The test in this PR fails 90% of the time on my local machine.