### PR TITLE
docs(api.md): Fix ElementHandle example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2847,7 +2847,7 @@ Examples:
 ```
 ```js
 const feedHandle = await page.$('.feed');
-expect(await feedHandle.$$eval('.tweet', nodes => nodes.map(n => n.innerText)).toEqual(['Hello!', 'Hi!']);
+expect(await feedHandle.$$eval('.tweet', nodes => nodes.map(n => n.innerText))).toEqual(['Hello!', 'Hi!']);
 ```
 
 #### elementHandle.$eval(selector, pageFunction, ...args)


### PR DESCRIPTION
This patch fixes an ElementHandle example by
adding a missing parenthesis.