### PR TITLE
fix(csscoverage): don't prematurely disable the CSS domain

### DIFF
--- a/lib/Coverage.js
+++ b/lib/Coverage.js
@@ -224,8 +224,8 @@ class CSSCoverage {
   async stop() {
     assert(this._enabled, 'CSSCoverage is not enabled');
     this._enabled = false;
-    const [ruleTrackingResponse] = await Promise.all([
-      this._client.send('CSS.stopRuleUsageTracking'),
+    const ruleTrackingResponse = await this._client.send('CSS.stopRuleUsageTracking');
+    await Promise.all([
       this._client.send('CSS.disable'),
       this._client.send('DOM.disable'),
     ]);

--- a/test/coverage.spec.js
+++ b/test/coverage.spec.js
@@ -189,7 +189,7 @@ module.exports.addTests = function({testRunner, expect}) {
         expect(coverage.length).toBe(0);
       });
     });
-    xit('should work with a recently loaded stylesheet', async function({page, server}) {
+    it('should work with a recently loaded stylesheet', async function({page, server}) {
       await page.coverage.startCSSCoverage();
       await page.evaluate(async url => {
         document.body.textContent = 'hello, world';


### PR DESCRIPTION
CSS stylesheets can still be parsed and added events emitted during the `CSS.stopRuleUsageTracking` call. It needs to be awaited before calling CSS.disable, otherwise the text content of those style sheets will be unavailable.