### PR TITLE
fix(launcher): ensureInitialPage awaits forever

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -183,32 +183,32 @@ class Launcher {
       if (browser.targets().find(target => target.type() === 'page'))
         return;
 
-        let initialPageCallback;
-        let initialCallbackDone = false;
+      let initialPageCallback;
+      let initialCallbackDone = false;
 
-        const initialPagePromise = new Promise(resolve => initialPageCallback = resolve);
-        const listeners = [helper.addEventListener(browser, 'targetcreated', target => {
-          if (target.type() === 'page' && !initialCallbackDone) {
-            initialPageCallback();
-            initialCallbackDone = true;
-          }
-        })];
+      const initialPagePromise = new Promise(resolve => initialPageCallback = resolve);
+      const listeners = [helper.addEventListener(browser, 'targetcreated', target => {
+        if (target.type() === 'page' && !initialCallbackDone) {
+          initialPageCallback();
+          initialCallbackDone = true;
+        }
+      })];
 
-        let timeout = setTimeout(() => {
-          if (!initialCallbackDone) {
-            initialCallbackDone = true;
-              if (browser.targets().find(target => target.type() === 'page'))
-                return;
+      const timeout = setTimeout(() => {
+        if (!initialCallbackDone) {
+          initialCallbackDone = true;
+          if (browser.targets().find(target => target.type() === 'page'))
+            return;
 
-              initialPageCallback();
-          }
-        }, 500);
+          initialPageCallback();
+        }
+      }, 500);
 
-        await initialPagePromise;
+      await initialPagePromise;
 
-        clearTimeout(timeout);
+      clearTimeout(timeout);
 
-        helper.removeEventListeners(listeners);
+      helper.removeEventListeners(listeners);
     }
 
     /**

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -179,19 +179,36 @@ class Launcher {
      * @param {!Browser} browser
      */
     async function ensureInitialPage(browser) {
-      // Wait for initial page target to be created.
-      if (browser.targets().find(target => target.type() === 'page'))
-        return;
+        // Wait for initial page target to be created.
+        if (browser.targets().find(target => target.type() === 'page'))
+            return;
 
-      let initialPageCallback;
-      const initialPagePromise = new Promise(resolve => initialPageCallback = resolve);
-      const listeners = [helper.addEventListener(browser, 'targetcreated', target => {
-        if (target.type() === 'page')
-          initialPageCallback();
-      })];
+        let initialPageCallback;
+        let initialCallbackDone = false;
 
-      await initialPagePromise;
-      helper.removeEventListeners(listeners);
+        const initialPagePromise = new Promise(resolve => initialPageCallback = resolve);
+        const listeners = [helper.addEventListener(browser, 'targetcreated', target => {
+            if (target.type() === 'page' && !initialCallbackDone) {
+                initialPageCallback();
+                initialCallbackDone = true;
+            }
+        })];
+
+        let timeout = setTimeout(() => {
+            if (!initialCallbackDone) {
+                initialCallbackDone = true;
+                if (browser.targets().find(target => target.type() === 'page'))
+                    return;
+
+                initialPageCallback();
+            }
+        }, 500);
+
+        await initialPagePromise;
+
+        clearTimeout(timeout);
+
+        helper.removeEventListeners(listeners);
     }
 
     /**

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -179,29 +179,29 @@ class Launcher {
      * @param {!Browser} browser
      */
     async function ensureInitialPage(browser) {
-        // Wait for initial page target to be created.
-        if (browser.targets().find(target => target.type() === 'page'))
-            return;
+      // Wait for initial page target to be created.
+      if (browser.targets().find(target => target.type() === 'page'))
+        return;
 
         let initialPageCallback;
         let initialCallbackDone = false;
 
         const initialPagePromise = new Promise(resolve => initialPageCallback = resolve);
         const listeners = [helper.addEventListener(browser, 'targetcreated', target => {
-            if (target.type() === 'page' && !initialCallbackDone) {
-                initialPageCallback();
-                initialCallbackDone = true;
-            }
+          if (target.type() === 'page' && !initialCallbackDone) {
+            initialPageCallback();
+            initialCallbackDone = true;
+          }
         })];
 
         let timeout = setTimeout(() => {
-            if (!initialCallbackDone) {
-                initialCallbackDone = true;
-                if (browser.targets().find(target => target.type() === 'page'))
-                    return;
+          if (!initialCallbackDone) {
+            initialCallbackDone = true;
+              if (browser.targets().find(target => target.type() === 'page'))
+                return;
 
-                initialPageCallback();
-            }
+              initialPageCallback();
+          }
         }, 500);
 
         await initialPagePromise;


### PR DESCRIPTION
There might be a situation when event was sent before listener attached and initialPageCallback is never called.