### PR TITLE
fix(page.exportfunction): remove the name clash, avoid internal chrom…

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -402,15 +402,15 @@ class Page extends EventEmitter {
   async exposeFunction(name, puppeteerFunction) {
     if (this._pageBindings.has(name))
       throw new Error(`Failed to add page binding with name ${name}: window['${name}'] already exists!`);
+    if (!this._pageBindings.size)
+      await this._client.send('Runtime.addBinding', { name: '__pptr_binding' });
     this._pageBindings.set(name, puppeteerFunction);
 
     const expression = helper.evaluationString(addPageBinding, name);
-    await this._client.send('Runtime.addBinding', {name: name});
     await this._client.send('Page.addScriptToEvaluateOnNewDocument', {source: expression});
     await Promise.all(this.frames().map(frame => frame.evaluate(expression).catch(debugError)));
 
     function addPageBinding(bindingName) {
-      const binding = window[bindingName];
       window[bindingName] = async(...args) => {
         const me = window[bindingName];
         let callbacks = me['callbacks'];
@@ -421,7 +421,7 @@ class Page extends EventEmitter {
         const seq = (me['lastSeq'] || 0) + 1;
         me['lastSeq'] = seq;
         const promise = new Promise(fulfill => callbacks.set(seq, fulfill));
-        binding(JSON.stringify({name: bindingName, seq, args}));
+        window['__pptr_binding'](JSON.stringify({name: bindingName, seq, args}));
         return promise;
       };
     }

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1051,6 +1051,18 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       });
       expect(result).toBe(15);
     });
+    it('multiple bindings should work', async({page, server}) => {
+      await page.exposeFunction('multiply', function(a, b) {
+        return a * b;
+      });
+      await page.exposeFunction('divide', function(a, b) {
+        return a / b;
+      });
+      const result = await page.evaluate(async function() {
+        return await divide(await multiply(5, 3), 5);
+      });
+      expect(result).toBe(3);
+    });
     it('should work on frames', async({page, server}) => {
       await page.exposeFunction('compute', function(a, b) {
         return Promise.resolve(a * b);


### PR DESCRIPTION
Avoid the race condition between Page.addScriptToEvaluate and Runtime.addBinding.

This reproduces reliably for me, but I could not implement the test.