### PR TITLE
docs(api.md): Fix missing `await` in extension example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -404,7 +404,7 @@ const puppeteer = require('puppeteer');
 
 (async () => {
   const pathToExtension = require('path').join(__dirname, 'my-extension');
-  const browser = puppeteer.launch({
+  const browser = await puppeteer.launch({
     headless: false,
     args: [
       `--disable-extensions-except=${pathToExtension}`,


### PR DESCRIPTION
The extensions example did not `await puppeteer.launch(...)` throwing errors right after awaiting `browser.targets()`.