### PR TITLE
feat(accessibility): snapshot the accessibility tree

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1990,7 +1990,15 @@ Shortcut for [(await worker.executionContext()).evaluateHandle(pageFunction, ...
 
 ### class: Accessibility
 
-The Accessibility class provides methods for inspecting Chromium's accessibility tree. The accessibility tree is used by assistive technology such as a [screen readers](https://en.wikipedia.org/wiki/Screen_reader).
+The Accessibility class provides methods for inspecting Chromium's accessibility tree. The accessibility tree is used by assistive technology such as [screen readers](https://en.wikipedia.org/wiki/Screen_reader).
+
+Accessibility is a very platform-specific thing. On different platforms, there are different screen readers that might have wildly different output.
+
+Blink - Chrome's rendering engine - has a concept of "accessibility tree", which is than translated into different platform-specific APIs. Accessibility namespace gives users
+access to the Blink Accessibility Tree.
+
+Most of the accessibility tree gets filtered out when converting from Blink AX Tree to Platform-specific AX-Tree or by screen readers themselves. By default, Puppeteer tries to approximate this filtering, exposing only the "interesting" nodes of the tree.
+
 
 
 #### accessibility.snapshot([options])
@@ -2012,15 +2020,15 @@ The Accessibility class provides methods for inspecting Chromium's accessibility
   - `multiselectable` <[boolean]> Whether more than one child can be selected.
   - `readonly` <[boolean]> Whether the node is read only.
   - `required` <[boolean]> Whether the node is required.
-  - `selected` <[boolean]> Whether the node is selected in it's parent node.
+  - `selected` <[boolean]> Whether the node is selected in its parent node.
   - `checked` <[boolean]|[string]> Whether the checkbox is checked, or "mixed".
-  - `pressed` <[boolean]|[string]> Whether the checkbox is checked, or "mixed".
+  - `pressed` <[boolean]|[string]> Whether the toggle button is checked, or "mixed".
   - `level` <[number]> The level of a heading.
   - `valuemin` <[number]> The minimum value in a node.
-  - `valuemax` <[number]> the maximum value in a node.
+  - `valuemax` <[number]> The maximum value in a node.
   - `autocomplete` <[string]> What kind of autocomplete is supported by a control.
-  - `hasPopup` <[string]> What kind of popup is currently being shown for a node.
-  - `invalid` <[string]> Whether and in what way is this node's value invalid.
+  - `haspopup` <[string]> What kind of popup is currently being shown for a node.
+  - `invalid` <[string]> Whether and in what way this node's value is invalid.
   - `orientation` <[string]> Whether the node is oriented horizontally or vertically.
   - `children` <[Array]<[AXNode]>> Child nodes of this node, if any.
 
@@ -2028,7 +2036,7 @@ Captures the current state of the accessibility tree. The returned object repres
 
 > **NOTE** The Chromium accessibility tree contains nodes that go unused on most platforms and by
 most screen readers. Puppeteer will discard them as well for an easier to process tree,
-unless `interestingOnly` is set to false.
+unless `interestingOnly` is set to `false`.
 
 An example of dumping the entire accessibility tree:
 ```js
@@ -2039,14 +2047,14 @@ console.log(snapshot);
 An example of logging the focused node's name:
 ```js
 const snapshot = await page.accessibility.snapshot();
-const node = findNode(snapshot, node => node.focused);
-console.log(node.name);
+const node = findFocusedNode(snapshot);
+console.log(node && node.name);
 
-function findNode(node, fn) {
-  if (fn(node))
+function findFocusedNode(node) {
+  if (node.focused)
     return node;
   for (const child of node.children || []) {
-    const foundNode = findNode(child, fn);
+    const foundNode = findFocusedNode(child);
     return foundNode;
   }
   return null;
@@ -3503,4 +3511,4 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [SecurityDetails]: #class-securitydetails "SecurityDetails"
 [Worker]: #class-worker "Worker"
 [Accessibility]: #class-accessibility "Accessibility"
-[AXNode]: #accessibilitysnapshotoptions "Accessibility"
+[AXNode]: #accessibilitysnapshotoptions "AXNode"

--- a/docs/api.md
+++ b/docs/api.md
@@ -90,6 +90,7 @@
   * [page.$$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args)
   * [page.$eval(selector, pageFunction[, ...args])](#pageevalselector-pagefunction-args-1)
   * [page.$x(expression)](#pagexexpression)
+  * [page.accessibility](#pageaccessibility)
   * [page.addScriptTag(options)](#pageaddscripttagoptions)
   * [page.addStyleTag(options)](#pageaddstyletagoptions)
   * [page.authenticate(credentials)](#pageauthenticatecredentials)
@@ -156,6 +157,8 @@
   * [worker.evaluateHandle(pageFunction, ...args)](#workerevaluatehandlepagefunction-args)
   * [worker.executionContext()](#workerexecutioncontext)
   * [worker.url()](#workerurl)
+- [class: Accessibility](#class-accessibility)
+  * [accessibility.snapshot([options])](#accessibilitysnapshotoptions)
 - [class: Keyboard](#class-keyboard)
   * [keyboard.down(key[, options])](#keyboarddownkey-options)
   * [keyboard.press(key[, options])](#keyboardpresskey-options)
@@ -1046,6 +1049,9 @@ Shortcut for [page.mainFrame().$eval(selector, pageFunction)](#frameevalselector
 The method evaluates the XPath expression.
 
 Shortcut for [page.mainFrame().$x(expression)](#framexexpression)
+
+#### page.accessibility
+- returns: <[Accessibility]>
 
 #### page.addScriptTag(options)
 - `options` <[Object]>
@@ -1981,6 +1987,50 @@ Shortcut for [(await worker.executionContext()).evaluateHandle(pageFunction, ...
 
 #### worker.url()
 - returns: <[string]>
+
+### class: Accessibility
+
+The Accessibility class provides methods for inspecting Chromium's accessibility tree. The accessibility tree is used by assistive technology such as a [screen readers](https://en.wikipedia.org/wiki/Screen_reader).
+
+
+#### accessibility.snapshot([options])
+- `options` <[Object]>
+  - `interestingOnly` <[boolean]> Prune uninteresting nodes from the tree. Defaults to `true`.
+- returns: <[Promise]<[Object]>>
+  - `role` <[string]> The [role](https://www.w3.org/TR/wai-aria/#usage_intro).
+  - `name` <[string]> A human readable name for the node.
+  - `value` <[string]|[number]> The current value of the node.
+  - `description` <[string]> An additional human readable description of the node.
+  - `keyshortcuts` <[string]> Keyboard shortcuts associated with this node.
+  - `roledescription` <[string]> A human readable alternative to the role.
+  - `valuetext` <[string]> A description of the current value.
+  - `disabled` <[boolean]> Whether the node is disabled.
+  - `expanded` <[boolean]> Whether the node is expanded or collapsed.
+  - `expanded` <[boolean]> Whether the node is focused.
+  - `modal` <[boolean]> Whether the node is [modal](https://en.wikipedia.org/wiki/Modal_window).
+  - `multiline` <[boolean]> Whether the node text input supports multiline.
+  - `multiselectable` <[boolean]> Whether more than one child can be selected.
+  - `readonly` <[boolean]> Whether the node is read only.
+  - `required` <[boolean]> Whether the node is required.
+  - `selected` <[boolean]> Whether the node is selected in it's parent node.
+  - `checked` <[boolean]|[string]> Whether the checkbox is checked, or "mixed".
+  - `pressed` <[boolean]|[string]> Whether the checkbox is checked, or "mixed".
+  - `level` <[number]> The level of a heading.
+  - `valuemin` <[number]> The minimum value in a node.
+  - `valuemax` <[number]> the maximum value in a node.
+  - `autocomplete` <[string]> What kind of autocomplete is supported by a control.
+  - `hasPopup` <[string]> What kind of popup is currently being shown for a node.
+  - `invalid` <[string]> Whether and in what way is this node's value invalid.
+  - `orientation` <[string]> Whether the node is oriented horizontally or vertically.
+  - `children` <[Array]<[Object]>> Child nodes of this node, if any.
+
+Captures the current state of the accessibility tree. The returned object represents the root
+accessible node of the page.
+
+```js
+const snapshot = await page.accessibility.snapshot();
+console.log(snapshot);
+```
 
 ### class: Keyboard
 
@@ -3431,3 +3481,4 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
 [SecurityDetails]: #class-securitydetails "SecurityDetails"
 [Worker]: #class-worker "Worker"
+[Mouse]: #class-accessibility "Accessibility"

--- a/docs/api.md
+++ b/docs/api.md
@@ -2006,7 +2006,7 @@ The Accessibility class provides methods for inspecting Chromium's accessibility
   - `valuetext` <[string]> A description of the current value.
   - `disabled` <[boolean]> Whether the node is disabled.
   - `expanded` <[boolean]> Whether the node is expanded or collapsed.
-  - `expanded` <[boolean]> Whether the node is focused.
+  - `focused` <[boolean]> Whether the node is focused.
   - `modal` <[boolean]> Whether the node is [modal](https://en.wikipedia.org/wiki/Modal_window).
   - `multiline` <[boolean]> Whether the node text input supports multiline.
   - `multiselectable` <[boolean]> Whether more than one child can be selected.
@@ -3481,4 +3481,4 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
 [SecurityDetails]: #class-securitydetails "SecurityDetails"
 [Worker]: #class-worker "Worker"
-[Mouse]: #class-accessibility "Accessibility"
+[Accessibility]: #class-accessibility "Accessibility"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1996,7 +1996,7 @@ The Accessibility class provides methods for inspecting Chromium's accessibility
 #### accessibility.snapshot([options])
 - `options` <[Object]>
   - `interestingOnly` <[boolean]> Prune uninteresting nodes from the tree. Defaults to `true`.
-- returns: <[Promise]<[Object]>>
+- returns: <[Promise]<[AXNode]>> Returns an AXNode object with the following properties:
   - `role` <[string]> The [role](https://www.w3.org/TR/wai-aria/#usage_intro).
   - `name` <[string]> A human readable name for the node.
   - `value` <[string]|[number]> The current value of the node.
@@ -2022,10 +2022,13 @@ The Accessibility class provides methods for inspecting Chromium's accessibility
   - `hasPopup` <[string]> What kind of popup is currently being shown for a node.
   - `invalid` <[string]> Whether and in what way is this node's value invalid.
   - `orientation` <[string]> Whether the node is oriented horizontally or vertically.
-  - `children` <[Array]<[Object]>> Child nodes of this node, if any.
+  - `children` <[Array]<[AXNode]>> Child nodes of this node, if any.
 
-Captures the current state of the accessibility tree. The returned object represents the root
-accessible node of the page.
+Captures the current state of the accessibility tree. The returned object represents the root accessible node of the page.
+
+The Chromium accessibility tree contains nodes that go unused on most platforms and by
+most screen readers. Puppeteer will discard them as well for an easier to process tree,
+unless `interestingOnly` is set to false.
 
 ```js
 const snapshot = await page.accessibility.snapshot();
@@ -3482,3 +3485,4 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [SecurityDetails]: #class-securitydetails "SecurityDetails"
 [Worker]: #class-worker "Worker"
 [Accessibility]: #class-accessibility "Accessibility"
+[AXNode]: #accessibilitysnapshotoptions "Accessibility"

--- a/docs/api.md
+++ b/docs/api.md
@@ -2026,13 +2026,31 @@ The Accessibility class provides methods for inspecting Chromium's accessibility
 
 Captures the current state of the accessibility tree. The returned object represents the root accessible node of the page.
 
-The Chromium accessibility tree contains nodes that go unused on most platforms and by
+> **NOTE** The Chromium accessibility tree contains nodes that go unused on most platforms and by
 most screen readers. Puppeteer will discard them as well for an easier to process tree,
 unless `interestingOnly` is set to false.
 
+An example of dumping the entire accessibility tree:
 ```js
 const snapshot = await page.accessibility.snapshot();
 console.log(snapshot);
+```
+
+An example of logging the focused node's name:
+```js
+const snapshot = await page.accessibility.snapshot();
+const node = findNode(snapshot, node => node.focused);
+console.log(node.name);
+
+function findNode(node, fn) {
+  if (fn(node))
+    return node;
+  for (const child of node.children || []) {
+    const foundNode = findNode(child, fn);
+    return foundNode;
+  }
+  return null;
+}
 ```
 
 ### class: Keyboard

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -206,9 +206,6 @@ class AXNode {
         break;
     }
 
-    if (this._role === 'combobox' && !this._expanded)
-      return true;
-
     if (this._hasFocusableChild())
       return false;
 

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -45,7 +45,7 @@ const {helper} = require('./helper');
  * @property {number=} valuemax
  *
  * @property {string=} autocomplete
- * @property {string=} hasPopup
+ * @property {string=} haspopup
  * @property {string=} invalid
  * @property {string=} orientation
  *
@@ -130,6 +130,7 @@ class AXNode {
     this._expanded = false;
     this._name = this._payload.name ? this._payload.name.value : '';
     this._role = this._payload.role ? this._payload.role.value : 'Unknown';
+    this._cachedHasFocusableChild;
 
     for (const property of this._payload.properties || []) {
       if (property.name === 'editable') {
@@ -167,11 +168,16 @@ class AXNode {
    * @return {boolean}
    */
   _hasFocusableChild() {
-    for (const child of this._children) {
-      if (child._focusable || child._hasFocusableChild())
-        return true;
+    if (this._cachedHasFocusableChild === undefined) {
+      this._cachedHasFocusableChild = false;
+      for (const child of this._children) {
+        if (child._focusable || child._hasFocusableChild()) {
+          this._cachedHasFocusableChild = true;
+          break;
+        }
+      }
     }
-    return false;
+    return this._cachedHasFocusableChild;
   }
 
   /**
@@ -206,9 +212,9 @@ class AXNode {
         break;
     }
 
+    // Here and below: Android heuristics
     if (this._hasFocusableChild())
       return false;
-
     if (this._focusable && this._name)
       return true;
     if (this._role === 'heading' && this._name)
@@ -277,7 +283,7 @@ class AXNode {
     /** @type {!Map<string, number|string|boolean>} */
     const properties = new Map();
     for (const property of this._payload.properties || [])
-      properties.set(property.name, property.value.value);
+      properties.set(property.name.toLowerCase(), property.value.value);
     if (this._payload.name)
       properties.set('name', this._payload.name.value);
     if (this._payload.value)
@@ -353,7 +359,7 @@ class AXNode {
     /** @type {!Array<keyof SerializedAXNode>} */
     const tokenProperties = [
       'autocomplete',
-      'hasPopup',
+      'haspopup',
       'invalid',
       'orientation',
     ];

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -274,7 +274,7 @@ class AXNode {
     // A non focusable child of a control is not interesting
     let parent = this._parent;
     while (parent) {
-      if (this._isControl())
+      if (parent._isControl())
         return false;
       parent = parent._parent;
     }

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -125,14 +125,17 @@ class AXNode {
     this._children = [];
 
     this._richlyEditable = false;
+    this._editable = false;
     this._focusable = false;
     this._expanded = false;
     this._name = this._payload.name ? this._payload.name.value : '';
     this._role = this._payload.role ? this._payload.role.value : 'Unknown';
 
     for (const property of this._payload.properties || []) {
-      if (property.name === 'editable')
+      if (property.name === 'editable') {
         this._richlyEditable = property.value.value === 'richtext';
+        this._editable = true;
+      }
       if (property.name === 'focusable')
         this._focusable = property.value.value;
       if (property.name === 'expanded')
@@ -146,6 +149,8 @@ class AXNode {
   _isPlainTextField() {
     if (this._richlyEditable)
       return false;
+    if (this._editable)
+      return true;
     return this._role === 'textbox' || this._role === 'ComboBox' || this._role === 'searchbox';
   }
 
@@ -254,7 +259,7 @@ class AXNode {
     if (role === 'Ignored')
       return false;
 
-    if (this._focusable)
+    if (this._focusable || this._richlyEditable)
       return true;
 
     // If it's not focusable but has a control role, then it's interesting.

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -66,27 +66,7 @@ class Accessibility {
   async snapshot({interestingOnly = true} = {}) {
     const {nodes} = await this._client.send('Accessibility.getFullAXTree');
     const root = AXNode.createTree(nodes);
-    if (!interestingOnly)
-      return root.serialize(true);
-
-    /** @type {!Map<!AXNode, !SerializedAXNode>} */
-    const axNodeToSerializedNode = new Map();
-    for (const node of root.interestingSubtree()) {
-      const serializedNode = node.serialize(false);
-      axNodeToSerializedNode.set(node, serializedNode);
-      let parent = node.parent();
-      while (parent) {
-        const serializedParent = axNodeToSerializedNode.get(parent);
-        if (serializedParent) {
-          if (!serializedParent.children)
-            serializedParent.children = [];
-          serializedParent.children.push(serializedNode);
-          break;
-        }
-        parent = parent.parent();
-      }
-    }
-    return axNodeToSerializedNode.get(root);
+    return root.serialize(interestingOnly);
   }
 }
 
@@ -99,47 +79,21 @@ class AXNode {
 
     /** @type {!Array<!AXNode>} */
     this._children = [];
-    /** @type {?AXNode} */
-    this._parent = null;
 
     this._richlyEditable = false;
-    this._editable = false;
     this._focusable = false;
     this._expanded = false;
     this._name = this._payload.name ? this._payload.name.value : '';
     this._role = this._payload.role ? this._payload.role.value : 'Unknown';
 
     for (const property of this._payload.properties || []) {
-      if (property.name === 'editable') {
+      if (property.name === 'editable')
         this._richlyEditable = property.value.value === 'richtext';
-        this._editable = true;
-      }
       if (property.name === 'focusable')
         this._focusable = property.value.value;
       if (property.name === 'expanded')
         this._expanded = property.value.value;
-
-
     }
-  }
-
-  /**
-   * @return {?AXNode}
-   */
-  parent() {
-    return this._parent;
-  }
-
-  /**
-   * @return {Iterable<AXNode>}
-   */
-  * interestingSubtree() {
-    if (this._isInteresting())
-      yield this;
-    if (this._isLeafNode())
-      return;
-    for (const child of this._children)
-      yield* child.interestingSubtree();
   }
 
   /**
@@ -148,13 +102,7 @@ class AXNode {
   _isPlainTextField() {
     if (this._richlyEditable)
       return false;
-    // We need to check both the role and editable state, because some ARIA text
-    // fields may in fact not be editable, whilst some editable fields might not
-    // have the role.
-    if (this._editable && !(this._parent && this._parent._editable))
-      return true;
-    const role = this._role;
-    return role === 'textbox' || role === 'ComboBox' || role === 'searchbox';
+    return this._role === 'textbox' || this._role === 'ComboBox' || this._role === 'searchbox';
   }
 
   /**
@@ -254,12 +202,10 @@ class AXNode {
   }
 
   /**
+   * @param {boolean} insideControl
    * @return {boolean}
    */
-  _isInteresting() {
-    if (!this._parent)
-      return true;
-
+  _isInteresting(insideControl) {
     const role = this._role;
     if (role === 'Ignored')
       return false;
@@ -272,21 +218,17 @@ class AXNode {
       return true;
 
     // A non focusable child of a control is not interesting
-    let parent = this._parent;
-    while (parent) {
-      if (parent._isControl())
-        return false;
-      parent = parent._parent;
-    }
+    if (insideControl)
+      return false;
 
     return this._isLeafNode() && !!this._name;
   }
 
   /**
-   * @param {boolean} withChildren
+   * @param {boolean} interestingOnly
    * @return {!SerializedAXNode}
    */
-  serialize(withChildren) {
+  serialize(interestingOnly) {
     /** @type {!Map<string, number|string|boolean>} */
     const properties = new Map();
     for (const property of this._payload.properties || [])
@@ -376,16 +318,35 @@ class AXNode {
         continue;
       node[tokenProperty] = value;
     }
-    if (withChildren && this._children.length)
-      node.children = this._children.map(child => child.serialize(true));
+    const children = interestingOnly ? this._interestingChildren(false) : this._children;
+    const serializedChildren = children.map(child => child.serialize(interestingOnly));
+    if (serializedChildren.length)
+      node.children = serializedChildren;
     return node;
+  }
+
+  /**
+   * @param {boolean} insideControl
+   * @return {!Array<!AXNode>}
+   */
+  _interestingChildren(insideControl) {
+    if (this._isLeafNode())
+      return [];
+
+    const interestingChildren = [];
+    for (const child of this._children) {
+      if (child._isInteresting(insideControl || this._isControl()))
+        interestingChildren.push(child);
+      else
+        interestingChildren.push(...child._interestingChildren(insideControl || this._isControl()));
+    }
+    return interestingChildren;
   }
 
   /**
    * @param {!AXNode} child
    */
   _addChild(child) {
-    child._parent = this;
     this._children.push(child);
   }
 
@@ -402,10 +363,7 @@ class AXNode {
       for (const childId of node._payload.childIds || [])
         node._addChild(nodeById.get(childId));
     }
-    let root = nodeById.values().next().value;
-    while (root._parent)
-      root = root._parent;
-    return root;
+    return nodeById.values().next().value;
   }
 }
 

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -61,14 +61,58 @@ class Accessibility {
   }
 
   /**
+   * @param {{interestingOnly?: boolean}=} options
    * @return {!Promise<!SerializedAXNode>}
    */
-  async snapshot({interestingOnly = true} = {}) {
+  async snapshot(options = {}) {
+    const {interestingOnly = true} = options;
     const {nodes} = await this._client.send('Accessibility.getFullAXTree');
     const root = AXNode.createTree(nodes);
-    return root.serialize(interestingOnly);
+    if (!interestingOnly)
+      return serializeTree(root)[0];
+
+    /** @type {!Set<!AXNode>} */
+    const interestingNodes = new Set();
+    collectInterestingNodes(interestingNodes, root, false);
+    return serializeTree(root, interestingNodes)[0];
   }
 }
+
+/**
+ * @param {!Set<!AXNode>} collection
+ * @param {!AXNode} node
+ * @param {boolean} insideControl
+ */
+function collectInterestingNodes(collection, node, insideControl) {
+  if (node.isInteresting(insideControl))
+    collection.add(node);
+  if (node.isLeafNode())
+    return;
+  insideControl = insideControl || node.isControl();
+  for (const child of node._children)
+    collectInterestingNodes(collection, child, insideControl);
+}
+
+/**
+ * @param {!AXNode} node
+ * @param {!Set<!AXNode>=} whitelistedNodes
+ * @return {!Array<!SerializedAXNode>}
+ */
+function serializeTree(node, whitelistedNodes) {
+  /** @type {!Array<!SerializedAXNode>} */
+  const children = [];
+  for (const child of node._children)
+    children.push(...serializeTree(child, whitelistedNodes));
+
+  if (whitelistedNodes && !whitelistedNodes.has(node))
+    return children;
+
+  const serializedNode = node.serialize();
+  if (children.length)
+    serializedNode.children = children;
+  return [serializedNode];
+}
+
 
 class AXNode {
   /**
@@ -128,7 +172,7 @@ class AXNode {
   /**
    * @return {boolean}
    */
-  _isLeafNode() {
+  isLeafNode() {
     if (!this._children.length)
       return true;
 
@@ -173,7 +217,7 @@ class AXNode {
   /**
    * @return {boolean}
    */
-  _isControl() {
+  isControl() {
     switch (this._role) {
       case 'button':
       case 'checkbox':
@@ -205,7 +249,7 @@ class AXNode {
    * @param {boolean} insideControl
    * @return {boolean}
    */
-  _isInteresting(insideControl) {
+  isInteresting(insideControl) {
     const role = this._role;
     if (role === 'Ignored')
       return false;
@@ -214,21 +258,20 @@ class AXNode {
       return true;
 
     // If it's not focusable but has a control role, then it's interesting.
-    if (this._isControl())
+    if (this.isControl())
       return true;
 
     // A non focusable child of a control is not interesting
     if (insideControl)
       return false;
 
-    return this._isLeafNode() && !!this._name;
+    return this.isLeafNode() && !!this._name;
   }
 
   /**
-   * @param {boolean} interestingOnly
    * @return {!SerializedAXNode}
    */
-  serialize(interestingOnly) {
+  serialize() {
     /** @type {!Map<string, number|string|boolean>} */
     const properties = new Map();
     for (const property of this._payload.properties || [])
@@ -318,36 +361,7 @@ class AXNode {
         continue;
       node[tokenProperty] = value;
     }
-    const children = interestingOnly ? this._interestingChildren(false) : this._children;
-    const serializedChildren = children.map(child => child.serialize(interestingOnly));
-    if (serializedChildren.length)
-      node.children = serializedChildren;
     return node;
-  }
-
-  /**
-   * @param {boolean} insideControl
-   * @return {!Array<!AXNode>}
-   */
-  _interestingChildren(insideControl) {
-    if (this._isLeafNode())
-      return [];
-
-    const interestingChildren = [];
-    for (const child of this._children) {
-      if (child._isInteresting(insideControl || this._isControl()))
-        interestingChildren.push(child);
-      else
-        interestingChildren.push(...child._interestingChildren(insideControl || this._isControl()));
-    }
-    return interestingChildren;
-  }
-
-  /**
-   * @param {!AXNode} child
-   */
-  _addChild(child) {
-    this._children.push(child);
   }
 
   /**
@@ -361,7 +375,7 @@ class AXNode {
       nodeById.set(payload.nodeId, new AXNode(payload));
     for (const node of nodeById.values()) {
       for (const childId of node._payload.childIds || [])
-        node._addChild(nodeById.get(childId));
+        node._children.push(nodeById.get(childId));
     }
     return nodeById.values().next().value;
   }

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -1,0 +1,413 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const {helper} = require('./helper');
+
+/**
+ * @typedef {Object} SerializedAXNode
+ * @property {string} role
+ *
+ * @property {string=} name
+ * @property {string|number=} value
+ * @property {string=} description
+ *
+ * @property {string=} keyshortcuts
+ * @property {string=} roledescription
+ * @property {string=} valuetext
+ *
+ * @property {boolean=} disabled
+ * @property {boolean=} expanded
+ * @property {boolean=} focused
+ * @property {boolean=} modal
+ * @property {boolean=} multiline
+ * @property {boolean=} multiselectable
+ * @property {boolean=} readonly
+ * @property {boolean=} required
+ * @property {boolean=} selected
+ *
+ * @property {boolean|"mixed"=} checked
+ * @property {boolean|"mixed"=} pressed
+ *
+ * @property {number=} level
+ * @property {number=} valuemin
+ * @property {number=} valuemax
+ *
+ * @property {string=} autocomplete
+ * @property {string=} hasPopup
+ * @property {string=} invalid
+ * @property {string=} orientation
+ *
+ * @property {Array<SerializedAXNode>=} children
+ */
+
+class Accessibility {
+  /**
+   * @param {!Puppeteer.CDPSession} client
+   */
+  constructor(client) {
+    this._client = client;
+  }
+
+  /**
+   * @return {!Promise<!SerializedAXNode>}
+   */
+  async snapshot({interestingOnly = true} = {}) {
+    const {nodes} = await this._client.send('Accessibility.getFullAXTree');
+    const root = AXNode.createTree(nodes);
+    if (!interestingOnly)
+      return root.serialize(true);
+
+    /** @type {!Map<!AXNode, !SerializedAXNode>} */
+    const axNodeToSerializedNode = new Map();
+    for (const node of root.interestingSubtree()) {
+      const serializedNode = node.serialize(false);
+      axNodeToSerializedNode.set(node, serializedNode);
+      let parent = node.parent();
+      while (parent) {
+        const serializedParent = axNodeToSerializedNode.get(parent);
+        if (serializedParent) {
+          if (!serializedParent.children)
+            serializedParent.children = [];
+          serializedParent.children.push(serializedNode);
+          break;
+        }
+        parent = parent.parent();
+      }
+    }
+    return axNodeToSerializedNode.get(root);
+  }
+}
+
+class AXNode {
+  /**
+   * @param {!Protocol.Accessibility.AXNode} payload
+   */
+  constructor(payload) {
+    this._payload = payload;
+
+    /** @type {!Array<!AXNode>} */
+    this._children = [];
+    /** @type {?AXNode} */
+    this._parent = null;
+
+    this._richlyEditable = false;
+    this._editable = false;
+    this._focusable = false;
+    this._expanded = false;
+    this._name = this._payload.name ? this._payload.name.value : '';
+    this._role = this._payload.role ? this._payload.role.value : 'Unknown';
+
+    for (const property of this._payload.properties || []) {
+      if (property.name === 'editable') {
+        this._richlyEditable = property.value.value === 'richtext';
+        this._editable = true;
+      }
+      if (property.name === 'focusable')
+        this._focusable = property.value.value;
+      if (property.name === 'expanded')
+        this._expanded = property.value.value;
+
+
+    }
+  }
+
+  /**
+   * @return {?AXNode}
+   */
+  parent() {
+    return this._parent;
+  }
+
+  /**
+   * @return {Iterable<AXNode>}
+   */
+  * interestingSubtree() {
+    if (this._isInteresting())
+      yield this;
+    if (this._isLeafNode())
+      return;
+    for (const child of this._children)
+      yield* child.interestingSubtree();
+  }
+
+  /**
+   * @return {boolean}
+   */
+  _isPlainTextField() {
+    if (this._richlyEditable)
+      return false;
+    // We need to check both the role and editable state, because some ARIA text
+    // fields may in fact not be editable, whilst some editable fields might not
+    // have the role.
+    if (this._editable && !(this._parent && this._parent._editable))
+      return true;
+    const role = this._role;
+    return role === 'textbox' || role === 'ComboBox' || role === 'searchbox';
+  }
+
+  /**
+   * @return {boolean}
+   */
+  _isTextOnlyObject() {
+    const role = this._role;
+    return (role === 'LineBreak' || role === 'text' ||
+            role === 'InlineTextBox');
+  }
+
+  /**
+   * @return {boolean}
+   */
+  _hasFocusableChild() {
+    for (const child of this._children) {
+      if (child._focusable || child._hasFocusableChild())
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  _isLeafNode() {
+    if (!this._children.length)
+      return true;
+
+    // These types of objects may have children that we use as internal
+    // implementation details, but we want to expose them as leaves to platform
+    // accessibility APIs because screen readers might be confused if they find
+    // any children.
+    if (this._isPlainTextField() || this._isTextOnlyObject())
+      return true;
+
+    // Roles whose children are only presentational according to the ARIA and
+    // HTML5 Specs should be hidden from screen readers.
+    // (Note that whilst ARIA buttons can have only presentational children, HTML5
+    // buttons are allowed to have content.)
+    switch (this._role) {
+      case 'doc-cover':
+      case 'graphics-symbol':
+      case 'img':
+      case 'Meter':
+      case 'scrollbar':
+      case 'slider':
+      case 'separator':
+      case 'progressbar':
+        return true;
+      default:
+        break;
+    }
+
+    if (this._role === 'combobox' && !this._expanded)
+      return true;
+
+    if (this._hasFocusableChild())
+      return false;
+
+    if (this._focusable && this._name)
+      return true;
+    if (this._role === 'heading' && this._name)
+      return true;
+    return false;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  _isControl() {
+    switch (this._role) {
+      case 'button':
+      case 'checkbox':
+      case 'ColorWell':
+      case 'combobox':
+      case 'DisclosureTriangle':
+      case 'listbox':
+      case 'menu':
+      case 'menubar':
+      case 'menuitem':
+      case 'menuitemcheckbox':
+      case 'menuitemradio':
+      case 'radio':
+      case 'scrollbar':
+      case 'searchbox':
+      case 'slider':
+      case 'spinbutton':
+      case 'switch':
+      case 'tab':
+      case 'textbox':
+      case 'tree':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * @return {boolean}
+   */
+  _isInteresting() {
+    if (!this._parent)
+      return true;
+
+    const role = this._role;
+    if (role === 'Ignored')
+      return false;
+
+    if (this._focusable)
+      return true;
+
+    // If it's not focusable but has a control role, then it's interesting.
+    if (this._isControl())
+      return true;
+
+    // A non focusable child of a control is not interesting
+    let parent = this._parent;
+    while (parent) {
+      if (this._isControl())
+        return false;
+      parent = parent._parent;
+    }
+
+    return this._isLeafNode() && !!this._name;
+  }
+
+  /**
+   * @param {boolean} withChildren
+   * @return {!SerializedAXNode}
+   */
+  serialize(withChildren) {
+    /** @type {!Map<string, number|string|boolean>} */
+    const properties = new Map();
+    for (const property of this._payload.properties || [])
+      properties.set(property.name, property.value.value);
+    if (this._payload.name)
+      properties.set('name', this._payload.name.value);
+    if (this._payload.value)
+      properties.set('value', this._payload.value.value);
+    if (this._payload.description)
+      properties.set('description', this._payload.description.value);
+
+    /** @type {SerializedAXNode} */
+    const node = {
+      role: this._role
+    };
+
+    /** @type {!Array<keyof SerializedAXNode>} */
+    const userStringProperties = [
+      'name',
+      'value',
+      'description',
+      'keyshortcuts',
+      'roledescription',
+      'valuetext',
+    ];
+    for (const userStringProperty of userStringProperties) {
+      if (!properties.has(userStringProperty))
+        continue;
+      node[userStringProperty] = properties.get(userStringProperty);
+    }
+
+    /** @type {!Array<keyof SerializedAXNode>} */
+    const booleanProperties = [
+      'disabled',
+      'expanded',
+      'focused',
+      'modal',
+      'multiline',
+      'multiselectable',
+      'readonly',
+      'required',
+      'selected',
+    ];
+    for (const booleanProperty of booleanProperties) {
+      // WebArea's treat focus differently than other nodes. They report whether their frame  has focus,
+      // not whether focus is specifically on the root node.
+      if (booleanProperty === 'focused' && this._role === 'WebArea')
+        continue;
+      const value = properties.get(booleanProperty);
+      if (!value)
+        continue;
+      node[booleanProperty] = value;
+    }
+
+    /** @type {!Array<keyof SerializedAXNode>} */
+    const tristateProperties = [
+      'checked',
+      'pressed',
+    ];
+    for (const tristateProperty of tristateProperties) {
+      if (!properties.has(tristateProperty))
+        continue;
+      const value = properties.get(tristateProperty);
+      node[tristateProperty] = value === 'mixed' ? 'mixed' : value === 'true' ? true : false;
+    }
+    /** @type {!Array<keyof SerializedAXNode>} */
+    const numericalProperties = [
+      'level',
+      'valuemax',
+      'valuemin',
+    ];
+    for (const numericalProperty of numericalProperties) {
+      if (!properties.has(numericalProperty))
+        continue;
+      node[numericalProperty] = properties.get(numericalProperty);
+    }
+    /** @type {!Array<keyof SerializedAXNode>} */
+    const tokenProperties = [
+      'autocomplete',
+      'hasPopup',
+      'invalid',
+      'orientation',
+    ];
+    for (const tokenProperty of tokenProperties) {
+      const value = properties.get(tokenProperty);
+      if (!value || value === 'false')
+        continue;
+      node[tokenProperty] = value;
+    }
+    if (withChildren && this._children.length)
+      node.children = this._children.map(child => child.serialize(true));
+    return node;
+  }
+
+  /**
+   * @param {!AXNode} child
+   */
+  _addChild(child) {
+    child._parent = this;
+    this._children.push(child);
+  }
+
+  /**
+   * @param {!Array<!Protocol.Accessibility.AXNode>} payloads
+   * @return {!AXNode}
+   */
+  static createTree(payloads) {
+    /** @type {!Map<string, !AXNode>} */
+    const nodeById = new Map();
+    for (const payload of payloads)
+      nodeById.set(payload.nodeId, new AXNode(payload));
+    for (const node of nodeById.values()) {
+      for (const childId of node._payload.childIds || [])
+        node._addChild(nodeById.get(childId));
+    }
+    let root = nodeById.values().next().value;
+    while (root._parent)
+      root = root._parent;
+    return root;
+  }
+}
+
+module.exports = {Accessibility};
+helper.tracePublicAPI(Accessibility);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -27,7 +27,7 @@ const {helper, debugError, assert} = require('./helper');
 const {Coverage} = require('./Coverage');
 const {Worker} = require('./Worker');
 const {createJSHandle} = require('./ExecutionContext');
-
+const {Accessibility} = require('./Accessibility');
 const writeFileAsync = helper.promisify(fs.writeFile);
 
 class Page extends EventEmitter {
@@ -78,6 +78,7 @@ class Page extends EventEmitter {
     this._keyboard = new Keyboard(client);
     this._mouse = new Mouse(client, this._keyboard);
     this._touchscreen = new Touchscreen(client, this._keyboard);
+    this._accessibility = new Accessibility(client);
     this._networkManager = new NetworkManager(client);
     /** @type {!FrameManager} */
     this._frameManager = new FrameManager(client, frameTree, this, this._networkManager);
@@ -219,6 +220,13 @@ class Page extends EventEmitter {
    */
   get tracing() {
     return this._tracing;
+  }
+
+  /**
+   * @return {!Accessibility}
+   */
+  get accessibility() {
+    return this._accessibility;
   }
 
   /**

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -19,7 +19,7 @@ module.exports.addTests = function({testRunner, expect}) {
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
-  describe('Accessibility', function() {
+  fdescribe('Accessibility', function() {
     it('should work', async function({page}) {
       await page.setContent(`
       <head>

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports.addTests = function({testRunner, expect}) {
+  const {describe, xdescribe, fdescribe} = testRunner;
+  const {it, fit, xit} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe('Accessibility', function() {
+    it('should work', async function({page}) {
+      await page.setContent(`
+      <head>
+        <title>Accessibility Test</title>
+      </head>
+      <body>
+        <div>Hello World</div>
+        <h1>Inputs</h1>
+        <input placeholder="Empty input" autofocus />
+        <input placeholder="readonly input" readonly />
+        <input placeholder="disabled input" disabled />
+        <input aria-label="Input with whitespace" value="  " />
+        <input value="value only" />
+        <input aria-placeholder="placeholder" value="and a value" />
+        <div aria-hidden="true" id="desc">This is a description!</div>
+        <input aria-placeholder="placeholder" value="and a value" aria-describedby="desc" />
+        <select>
+          <option>First Option</option>
+          <option>Second Option</option>
+        </select>
+      </body>`);
+
+      expect(await page.accessibility.snapshot()).toEqual(
+          { role: 'WebArea',
+            name: 'Accessibility Test',
+            children:
+            [ { role: 'text', name: 'Hello World' },
+              { role: 'heading', name: 'Inputs', level: 1 },
+              { role: 'textbox', name: 'Empty input', focused: true },
+              { role: 'textbox', name: 'readonly input', readonly: true },
+              { role: 'textbox', name: 'disabled input', disabled: true },
+              { role: 'textbox', name: 'Input with whitespace', value: '  ' },
+              { role: 'textbox', name: '', value: 'value only' },
+              { role: 'textbox', name: 'placeholder', value: 'and a value' },
+              { role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!' },
+              { role: 'combobox', name: '', value: 'First Option' } ] }
+      );
+    });
+    it('should only report children of an expanded select', async function({page}) {
+      await page.setContent(`
+      <select autofocus>
+        <option>First Option</option>
+        <option>Second Option</option>
+      </select>`);
+
+      expect(findFocusedNode(await page.accessibility.snapshot())).toEqual({
+        role: 'combobox',
+        name: '',
+        value: 'First Option',
+        focused: true
+      });
+
+      await page.click('select');
+
+      expect(findFocusedNode(await page.accessibility.snapshot())).toEqual({
+        role: 'combobox',
+        name: '',
+        value: 'First Option',
+        expanded: true,
+        focused: true,
+        children: [
+          { role: 'menuitem', name: 'First Option', selected: true },
+          { role: 'menuitem', name: 'Second Option' }
+        ]
+      });
+    });
+    it('should report uninteresting nodes', async function({page}) {
+      await page.setContent(`<textarea autofocus>hi</textarea>`);
+
+      expect(findFocusedNode(await page.accessibility.snapshot({interestingOnly: false}))).toEqual({
+        role: 'textbox',
+        name: '',
+        value: 'hi',
+        focused: true,
+        multiline: true,
+        children: [{
+          role: 'GenericContainer',
+          name: '',
+          children: [{
+            role: 'text', name: 'hi'
+          }]
+        }]
+      });
+    });
+
+    function findFocusedNode(node) {
+      if (node.focused)
+        return node;
+      for (const child of node.children || []) {
+        const focusedChild = findFocusedNode(child);
+        if (focusedChild)
+          return focusedChild;
+      }
+      return null;
+    }
+  });
+};

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -19,7 +19,7 @@ module.exports.addTests = function({testRunner, expect}) {
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
-  fdescribe('Accessibility', function() {
+  describe('Accessibility', function() {
     it('should work', async function({page}) {
       await page.setContent(`
       <head>
@@ -124,6 +124,111 @@ module.exports.addTests = function({testRunner, expect}) {
       });
     });
 
+    it('rich text editable fields', async function({page}) {
+      await page.setContent(`
+      <div contenteditable="true">
+        Edit this image: <img src="fakeimage.png" alt="my fake image">
+      </div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'GenericContainer',
+        name: '',
+        value: 'Edit this image: ',
+        children: [{
+          role: 'text',
+          name: 'Edit this image:'
+        }, {
+          role: 'img',
+          name: 'my fake image'
+        }]
+      });
+    });
+    it('rich text editable fields with role', async function({page}) {
+      await page.setContent(`
+      <div contenteditable="true" role='textbox'>
+        Edit this image: <img src="fakeimage.png" alt="my fake image">
+      </div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'textbox',
+        name: '',
+        value: 'Edit this image: ',
+        children: [{
+          role: 'text',
+          name: 'Edit this image:'
+        }, {
+          role: 'img',
+          name: 'my fake image'
+        }]
+      });
+    });
+    it('plain text field with role', async function({page}) {
+      await page.setContent(`
+      <div contenteditable="plaintext-only" role='textbox'>Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'textbox',
+        name: '',
+        value: 'Edit this image:'
+      });
+    });
+    it('plain text field without role', async function({page}) {
+      await page.setContent(`
+      <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'GenericContainer',
+        name: ''
+      });
+    });
+    it('plain text field without role', async function({page}) {
+      await page.setContent(`
+      <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'GenericContainer',
+        name: ''
+      });
+    });
+    it('non editable textbox with role and tabIndex and label', async function({page}) {
+      await page.setContent(`
+      <div role="textbox" tabIndex=0 aria-checked="true" aria-label="my favorite textbox">
+        this is the inner content
+        <img alt="yo" src="fakeimg.png">
+      </div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'textbox',
+        name: 'my favorite textbox',
+        value: 'this is the inner content '
+      });
+    });
+    it('checkbox with and tabIndex and label', async function({page}) {
+      await page.setContent(`
+      <div role="checkbox" tabIndex=0 aria-checked="true" aria-label="my favorite checkbox">
+        this is the inner content
+        <img alt="yo" src="fakeimg.png">
+      </div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'checkbox',
+        name: 'my favorite checkbox',
+        checked: true
+      });
+    });
+    it('checkbox without label', async function({page}) {
+      await page.setContent(`
+      <div role="checkbox" aria-checked="true">
+        this is the inner content
+        <img alt="yo" src="fakeimg.png">
+      </div>`);
+      const snapshot = await page.accessibility.snapshot();
+      expect(snapshot.children[0]).toEqual({
+        role: 'checkbox',
+        name: 'this is the inner content yo',
+        checked: true
+      });
+    });
     function findFocusedNode(node) {
       if (node.focused)
         return node;

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -72,8 +72,7 @@ module.exports.addTests = function({testRunner, expect}) {
         focused: true
       });
 
-      await page.click('select');
-
+      await page.type('select', ' ');
       expect(findFocusedNode(await page.accessibility.snapshot())).toEqual({
         role: 'combobox',
         name: '',
@@ -85,6 +84,7 @@ module.exports.addTests = function({testRunner, expect}) {
           { role: 'menuitem', name: 'Second Option' }
         ]
       });
+      await page.type('select', '\n');
     });
     it('should report uninteresting nodes', async function({page}) {
       await page.setContent(`<textarea autofocus>hi</textarea>`);
@@ -110,7 +110,6 @@ module.exports.addTests = function({testRunner, expect}) {
         <div role="tab" aria-selected="true"><b>Tab1</b></div>
         <div role="tab">Tab2</div>
       </div>`);
-      console.log(JSON.stringify(await page.accessibility.snapshot(), undefined, 2));
       expect(await page.accessibility.snapshot()).toEqual({
         role: 'WebArea',
         name: '',

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -43,19 +43,21 @@ module.exports.addTests = function({testRunner, expect}) {
       </body>`);
 
       expect(await page.accessibility.snapshot()).toEqual(
-          { role: 'WebArea',
-            name: 'Accessibility Test',
-            children:
-            [ { role: 'text', name: 'Hello World' },
-              { role: 'heading', name: 'Inputs', level: 1 },
-              { role: 'textbox', name: 'Empty input', focused: true },
-              { role: 'textbox', name: 'readonly input', readonly: true },
-              { role: 'textbox', name: 'disabled input', disabled: true },
-              { role: 'textbox', name: 'Input with whitespace', value: '  ' },
-              { role: 'textbox', name: '', value: 'value only' },
-              { role: 'textbox', name: 'placeholder', value: 'and a value' },
-              { role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!' },
-              { role: 'combobox', name: '', value: 'First Option' } ] }
+        {
+          role: 'WebArea',
+          name: 'Accessibility Test',
+          children:
+            [{role: 'text', name: 'Hello World'},
+            {role: 'heading', name: 'Inputs', level: 1},
+            {role: 'textbox', name: 'Empty input', focused: true},
+            {role: 'textbox', name: 'readonly input', readonly: true},
+            {role: 'textbox', name: 'disabled input', disabled: true},
+            {role: 'textbox', name: 'Input with whitespace', value: '  '},
+            {role: 'textbox', name: '', value: 'value only'},
+            {role: 'textbox', name: 'placeholder', value: 'and a value'},
+            {role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!'},
+            {role: 'combobox', name: '', value: 'First Option'}]
+        }
       );
     });
     it('should only report children of an expanded select', async function({page}) {
@@ -80,8 +82,8 @@ module.exports.addTests = function({testRunner, expect}) {
         expanded: true,
         focused: true,
         children: [
-          { role: 'menuitem', name: 'First Option', selected: true },
-          { role: 'menuitem', name: 'Second Option' }
+          {role: 'menuitem', name: 'First Option', selected: true},
+          {role: 'menuitem', name: 'Second Option'}
         ]
       });
       await page.type('select', '\n');
@@ -104,129 +106,131 @@ module.exports.addTests = function({testRunner, expect}) {
         }]
       });
     });
-    it('should not report text nodes inside controls', async function({page}) {
-      await page.setContent(`
-      <div role="tablist">
-        <div role="tab" aria-selected="true"><b>Tab1</b></div>
-        <div role="tab">Tab2</div>
-      </div>`);
-      expect(await page.accessibility.snapshot()).toEqual({
-        role: 'WebArea',
-        name: '',
-        children: [{
-          role: 'tab',
-          name: 'Tab1',
-          selected: true
-        }, {
-          role: 'tab',
-          name: 'Tab2'
-        }]
+    describe('filtering children of leaf nodes', function() {
+      it('should not report text nodes inside controls', async function({page}) {
+        await page.setContent(`
+        <div role="tablist">
+          <div role="tab" aria-selected="true"><b>Tab1</b></div>
+          <div role="tab">Tab2</div>
+        </div>`);
+        expect(await page.accessibility.snapshot()).toEqual({
+          role: 'WebArea',
+          name: '',
+          children: [{
+            role: 'tab',
+            name: 'Tab1',
+            selected: true
+          }, {
+            role: 'tab',
+            name: 'Tab2'
+          }]
+        });
       });
-    });
 
-    it('rich text editable fields', async function({page}) {
-      await page.setContent(`
-      <div contenteditable="true">
-        Edit this image: <img src="fakeimage.png" alt="my fake image">
-      </div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'GenericContainer',
-        name: '',
-        value: 'Edit this image: ',
-        children: [{
-          role: 'text',
-          name: 'Edit this image:'
-        }, {
-          role: 'img',
-          name: 'my fake image'
-        }]
+      it('rich text editable fields should have children', async function({page}) {
+        await page.setContent(`
+        <div contenteditable="true">
+          Edit this image: <img src="fakeimage.png" alt="my fake image">
+        </div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'GenericContainer',
+          name: '',
+          value: 'Edit this image: ',
+          children: [{
+            role: 'text',
+            name: 'Edit this image:'
+          }, {
+            role: 'img',
+            name: 'my fake image'
+          }]
+        });
       });
-    });
-    it('rich text editable fields with role', async function({page}) {
-      await page.setContent(`
-      <div contenteditable="true" role='textbox'>
-        Edit this image: <img src="fakeimage.png" alt="my fake image">
-      </div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'textbox',
-        name: '',
-        value: 'Edit this image: ',
-        children: [{
-          role: 'text',
-          name: 'Edit this image:'
-        }, {
-          role: 'img',
-          name: 'my fake image'
-        }]
+      it('rich text editable fields with role should have children', async function({page}) {
+        await page.setContent(`
+        <div contenteditable="true" role='textbox'>
+          Edit this image: <img src="fakeimage.png" alt="my fake image">
+        </div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'textbox',
+          name: '',
+          value: 'Edit this image: ',
+          children: [{
+            role: 'text',
+            name: 'Edit this image:'
+          }, {
+            role: 'img',
+            name: 'my fake image'
+          }]
+        });
       });
-    });
-    it('plain text field with role', async function({page}) {
-      await page.setContent(`
-      <div contenteditable="plaintext-only" role='textbox'>Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'textbox',
-        name: '',
-        value: 'Edit this image:'
+      it('plain text field with role should not have children', async function({page}) {
+        await page.setContent(`
+        <div contenteditable="plaintext-only" role='textbox'>Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'textbox',
+          name: '',
+          value: 'Edit this image:'
+        });
       });
-    });
-    it('plain text field without role', async function({page}) {
-      await page.setContent(`
-      <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'GenericContainer',
-        name: ''
+      it('plain text field without role should not have content', async function({page}) {
+        await page.setContent(`
+        <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'GenericContainer',
+          name: ''
+        });
       });
-    });
-    it('plain text field without role', async function({page}) {
-      await page.setContent(`
-      <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'GenericContainer',
-        name: ''
+      it('plain text field with tabindex and without role should not have content', async function({page}) {
+        await page.setContent(`
+        <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'GenericContainer',
+          name: ''
+        });
       });
-    });
-    it('non editable textbox with role and tabIndex and label', async function({page}) {
-      await page.setContent(`
-      <div role="textbox" tabIndex=0 aria-checked="true" aria-label="my favorite textbox">
-        this is the inner content
-        <img alt="yo" src="fakeimg.png">
-      </div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'textbox',
-        name: 'my favorite textbox',
-        value: 'this is the inner content '
+      it('non editable textbox with role and tabIndex and label should not have children', async function({page}) {
+        await page.setContent(`
+        <div role="textbox" tabIndex=0 aria-checked="true" aria-label="my favorite textbox">
+          this is the inner content
+          <img alt="yo" src="fakeimg.png">
+        </div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'textbox',
+          name: 'my favorite textbox',
+          value: 'this is the inner content '
+        });
       });
-    });
-    it('checkbox with and tabIndex and label', async function({page}) {
-      await page.setContent(`
-      <div role="checkbox" tabIndex=0 aria-checked="true" aria-label="my favorite checkbox">
-        this is the inner content
-        <img alt="yo" src="fakeimg.png">
-      </div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'checkbox',
-        name: 'my favorite checkbox',
-        checked: true
+      it('checkbox with and tabIndex and label should not have children', async function({page}) {
+        await page.setContent(`
+        <div role="checkbox" tabIndex=0 aria-checked="true" aria-label="my favorite checkbox">
+          this is the inner content
+          <img alt="yo" src="fakeimg.png">
+        </div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'checkbox',
+          name: 'my favorite checkbox',
+          checked: true
+        });
       });
-    });
-    it('checkbox without label', async function({page}) {
-      await page.setContent(`
-      <div role="checkbox" aria-checked="true">
-        this is the inner content
-        <img alt="yo" src="fakeimg.png">
-      </div>`);
-      const snapshot = await page.accessibility.snapshot();
-      expect(snapshot.children[0]).toEqual({
-        role: 'checkbox',
-        name: 'this is the inner content yo',
-        checked: true
+      it('checkbox without label should not have children', async function({page}) {
+        await page.setContent(`
+        <div role="checkbox" aria-checked="true">
+          this is the inner content
+          <img alt="yo" src="fakeimg.png">
+        </div>`);
+        const snapshot = await page.accessibility.snapshot();
+        expect(snapshot.children[0]).toEqual({
+          role: 'checkbox',
+          name: 'this is the inner content yo',
+          checked: true
+        });
       });
     });
     function findFocusedNode(node) {

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -55,36 +55,10 @@ module.exports.addTests = function({testRunner, expect}) {
           {role: 'textbox', name: '', value: 'value only'},
           {role: 'textbox', name: 'placeholder', value: 'and a value'},
           {role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!'},
-          {role: 'combobox', name: '', value: 'First Option'}]
+          {role: 'combobox', name: '', value: 'First Option', children: [
+            {role: 'menuitem', name: 'First Option', selected: true},
+            {role: 'menuitem', name: 'Second Option'}]}]
       });
-    });
-    it('should only report children of an expanded select', async function({page}) {
-      await page.setContent(`
-      <select autofocus>
-        <option>First Option</option>
-        <option>Second Option</option>
-      </select>`);
-
-      expect(findFocusedNode(await page.accessibility.snapshot())).toEqual({
-        role: 'combobox',
-        name: '',
-        value: 'First Option',
-        focused: true
-      });
-
-      await page.type('select', ' ');
-      expect(findFocusedNode(await page.accessibility.snapshot())).toEqual({
-        role: 'combobox',
-        name: '',
-        value: 'First Option',
-        expanded: true,
-        focused: true,
-        children: [
-          {role: 'menuitem', name: 'First Option', selected: true},
-          {role: 'menuitem', name: 'Second Option'}
-        ]
-      });
-      await page.type('select', '\n');
     });
     it('should report uninteresting nodes', async function({page}) {
       await page.setContent(`<textarea autofocus>hi</textarea>`);

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -104,6 +104,26 @@ module.exports.addTests = function({testRunner, expect}) {
         }]
       });
     });
+    it('should not report text nodes inside controls', async function({page}) {
+      await page.setContent(`
+      <div role="tablist">
+        <div role="tab" aria-selected="true"><b>Tab1</b></div>
+        <div role="tab">Tab2</div>
+      </div>`);
+      console.log(JSON.stringify(await page.accessibility.snapshot(), undefined, 2));
+      expect(await page.accessibility.snapshot()).toEqual({
+        role: 'WebArea',
+        name: '',
+        children: [{
+          role: 'tab',
+          name: 'Tab1',
+          selected: true
+        }, {
+          role: 'tab',
+          name: 'Tab2'
+        }]
+      });
+    });
 
     function findFocusedNode(node) {
       if (node.focused)

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -42,23 +42,21 @@ module.exports.addTests = function({testRunner, expect}) {
         </select>
       </body>`);
 
-      expect(await page.accessibility.snapshot()).toEqual(
-        {
-          role: 'WebArea',
-          name: 'Accessibility Test',
-          children:
-            [{role: 'text', name: 'Hello World'},
-            {role: 'heading', name: 'Inputs', level: 1},
-            {role: 'textbox', name: 'Empty input', focused: true},
-            {role: 'textbox', name: 'readonly input', readonly: true},
-            {role: 'textbox', name: 'disabled input', disabled: true},
-            {role: 'textbox', name: 'Input with whitespace', value: '  '},
-            {role: 'textbox', name: '', value: 'value only'},
-            {role: 'textbox', name: 'placeholder', value: 'and a value'},
-            {role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!'},
-            {role: 'combobox', name: '', value: 'First Option'}]
-        }
-      );
+      expect(await page.accessibility.snapshot()).toEqual({
+        role: 'WebArea',
+        name: 'Accessibility Test',
+        children: [
+          {role: 'text', name: 'Hello World'},
+          {role: 'heading', name: 'Inputs', level: 1},
+          {role: 'textbox', name: 'Empty input', focused: true},
+          {role: 'textbox', name: 'readonly input', readonly: true},
+          {role: 'textbox', name: 'disabled input', disabled: true},
+          {role: 'textbox', name: 'Input with whitespace', value: '  '},
+          {role: 'textbox', name: '', value: 'value only'},
+          {role: 'textbox', name: 'placeholder', value: 'and a value'},
+          {role: 'textbox', name: 'placeholder', value: 'and a value', description: 'This is a description!'},
+          {role: 'combobox', name: '', value: 'First Option'}]
+      });
     });
     it('should only report children of an expanded select', async function({page}) {
       await page.setContent(`

--- a/test/test.js
+++ b/test/test.js
@@ -146,6 +146,7 @@ describe('Browser', function() {
     // Page-level tests that are given a browser, a context and a page.
     // Each test is launched in a new browser context.
     require('./CDPSession.spec.js').addTests({testRunner, expect});
+    require('./accessibility.spec.js').addTests({testRunner, expect});
     require('./browser.spec.js').addTests({testRunner, expect, headless});
     require('./cookies.spec.js').addTests({testRunner, expect});
     require('./coverage.spec.js').addTests({testRunner, expect});

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -20,6 +20,7 @@ const Documentation = require('./Documentation');
 const Message = require('../Message');
 
 const EXCLUDE_CLASSES = new Set([
+  'AXNode',
   'CSSCoverage',
   'Connection',
   'CustomError',


### PR DESCRIPTION
This adds `page.accessibility.snapshot()`. It serializes and returns the accessibility tree for the page. By default, uninteresting nodes are filtered out of the snapshot.

fixes #2033