### PR TITLE
fix(launcher): add flags to improve reliability

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -35,6 +35,7 @@ const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile-');
 const DEFAULT_ARGS = [
   '--disable-background-networking',
   '--disable-background-timer-throttling',
+  '--disable-backgrounding-occluded-windows',
   '--disable-breakpad',
   '--disable-client-side-phishing-detection',
   '--disable-default-apps',
@@ -43,8 +44,10 @@ const DEFAULT_ARGS = [
   // TODO: Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
   '--disable-features=site-per-process',
   '--disable-hang-monitor',
+  '--disable-ipc-flooding-protection',
   '--disable-popup-blocking',
   '--disable-prompt-on-repost',
+  '--disable-renderer-backgrounding',
   '--disable-sync',
   '--disable-translate',
   '--metrics-recording-only',


### PR DESCRIPTION
- The "IPC flooding protection" was added in https://crrev.com/604305
and should be disabled for our automation usescases.
- The other two flags are coming from https://github.com/smooth-code/jest-puppeteer/issues/137