### PR TITLE
fix: Inclusion of target platform configuration on installation script

### DIFF
--- a/install.js
+++ b/install.js
@@ -32,7 +32,10 @@ if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_c
 const downloadHost = process.env.PUPPETEER_DOWNLOAD_HOST || process.env.npm_config_puppeteer_download_host;
 
 const puppeteer = require('./index');
-const browserFetcher = puppeteer.createBrowserFetcher({ host: downloadHost });
+
+const platform = process.env.PUPPETEER_PLATFORM || require('../../package.json').puppeteer.platform || '';
+
+const browserFetcher = puppeteer.createBrowserFetcher({ host: downloadHost, platform });
 
 const revision = process.env.PUPPETEER_CHROMIUM_REVISION || process.env.npm_config_puppeteer_chromium_revision
   || require('./package.json').puppeteer.chromium_revision;

--- a/install.js
+++ b/install.js
@@ -33,7 +33,7 @@ const downloadHost = process.env.PUPPETEER_DOWNLOAD_HOST || process.env.npm_conf
 
 const puppeteer = require('./index');
 
-const platform = process.env.PUPPETEER_PLATFORM || require('../../package.json').puppeteer.platform || '';
+const platform = process.env.PUPPETEER_PLATFORM || '';
 
 const browserFetcher = puppeteer.createBrowserFetcher({ host: downloadHost, platform });
 


### PR DESCRIPTION
Included was the ability to inform with the destination platform where the process will be deployed.

For cases where the build process of package to be deployed runs on a different platform from which it will be run.