### PR TITLE
refactor: move to flatten protocol

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -94,13 +94,11 @@ class Connection extends EventEmitter {
       const sessionId = object.params.sessionId;
       const session = new CDPSession(this, object.params.targetInfo.type, sessionId);
       this._sessions.set(sessionId, session);
-      this.emit(Connection.Events.SessionAttached, session);
     } else if (object.method === 'Target.detachedFromTarget') {
       const session = this._sessions.get(object.params.sessionId);
       if (session) {
         session._onClosed();
         this._sessions.delete(object.params.sessionId);
-        this.emit(Connection.Events.SessionDetached, session);
       }
     }
     if (object.sessionId) {
@@ -156,8 +154,6 @@ class Connection extends EventEmitter {
 
 Connection.Events = {
   Disconnected: Symbol('Connection.Events.Disconnected'),
-  SessionAttached: Symbol('Connection.Events.SessionAttached'),
-  SessionDetached: Symbol('Connection.Events.SessionDetached'),
 };
 
 class CDPSession extends EventEmitter {

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -15,7 +15,6 @@
  */
 const {helper, assert} = require('./helper');
 const debugProtocol = require('debug')('puppeteer:protocol');
-const debugSession = require('debug')('puppeteer:session');
 const EventEmitter = require('events');
 
 class Connection extends EventEmitter {
@@ -45,11 +44,15 @@ class Connection extends EventEmitter {
    * @return {!Connection}
    */
   static fromSession(session) {
-    let connection = session._connection;
-    // TODO(lushnikov): move to flatten protocol to avoid this.
-    while (connection instanceof CDPSession)
-      connection = connection._connection;
-    return connection;
+    return session._connection;
+  }
+
+  /**
+   * @param {string} sessionId
+   * @return {?CDPSession}
+   */
+  session(sessionId) {
+    return this._sessions.get(sessionId) || null;
   }
 
   /**
@@ -65,13 +68,18 @@ class Connection extends EventEmitter {
    * @return {!Promise<?Object>}
    */
   send(method, params = {}) {
-    const id = ++this._lastId;
-    const message = JSON.stringify({id, method, params});
-    debugProtocol('SEND ► ' + message);
-    this._transport.send(message);
+    const id = this._rawSend({method, params});
     return new Promise((resolve, reject) => {
       this._callbacks.set(id, {resolve, reject, error: new Error(), method});
     });
+  }
+
+  _rawSend(message) {
+    const id = ++this._lastId;
+    message = JSON.stringify(Object.assign({}, message, {id}));
+    debugProtocol('SEND ► ' + message);
+    this._transport.send(message);
+    return id;
   }
 
   /**
@@ -82,6 +90,25 @@ class Connection extends EventEmitter {
       await new Promise(f => setTimeout(f, this._delay));
     debugProtocol('◀ RECV ' + message);
     const object = JSON.parse(message);
+    if (object.method === 'Target.attachedToTarget') {
+      const sessionId = object.params.sessionId;
+      const session = new CDPSession(this, object.params.targetInfo.type, sessionId);
+      this._sessions.set(sessionId, session);
+      this.emit(Connection.Events.SessionAttached, session);
+    } else if (object.method === 'Target.detachedFromTarget') {
+      const session = this._sessions.get(object.params.sessionId);
+      if (session) {
+        session._onClosed();
+        this._sessions.delete(object.params.sessionId);
+        this.emit(Connection.Events.SessionDetached, session);
+      }
+    }
+    if (object.sessionId) {
+      const session = this._sessions.get(object.sessionId);
+      if (session)
+        session._onMessage(object);
+      return;
+    }
     if (object.id) {
       const callback = this._callbacks.get(object.id);
       // Callbacks could be all rejected if someone has called `.dispose()`.
@@ -92,20 +119,9 @@ class Connection extends EventEmitter {
         else
           callback.resolve(object.result);
       }
-    } else {
-      if (object.method === 'Target.receivedMessageFromTarget') {
-        const session = this._sessions.get(object.params.sessionId);
-        if (session)
-          session._onMessage(object.params.message);
-      } else if (object.method === 'Target.detachedFromTarget') {
-        const session = this._sessions.get(object.params.sessionId);
-        if (session)
-          session._onClosed();
-        this._sessions.delete(object.params.sessionId);
-      } else {
-        this.emit(object.method, object.params);
-      }
+      return;
     }
+    this.emit(object.method, object.params);
   }
 
   _onClose() {
@@ -133,34 +149,30 @@ class Connection extends EventEmitter {
    * @return {!Promise<!CDPSession>}
    */
   async createSession(targetInfo) {
-    const {sessionId} = await this.send('Target.attachToTarget', {targetId: targetInfo.targetId});
-    const session = new CDPSession(this, targetInfo.type, sessionId);
-    this._sessions.set(sessionId, session);
-    return session;
+    const {sessionId} = await this.send('Target.attachToTarget', {targetId: targetInfo.targetId, flatten: true});
+    return this._sessions.get(sessionId);
   }
 }
 
 Connection.Events = {
   Disconnected: Symbol('Connection.Events.Disconnected'),
+  SessionAttached: Symbol('Connection.Events.SessionAttached'),
+  SessionDetached: Symbol('Connection.Events.SessionDetached'),
 };
 
 class CDPSession extends EventEmitter {
   /**
-   * @param {!Connection|!CDPSession} connection
+   * @param {!Connection} connection
    * @param {string} targetType
    * @param {string} sessionId
    */
   constructor(connection, targetType, sessionId) {
     super();
-    this._lastId = 0;
     /** @type {!Map<number, {resolve: function, reject: function, error: !Error, method: string}>}*/
     this._callbacks = new Map();
-    /** @type {null|Connection|CDPSession} */
     this._connection = connection;
     this._targetType = targetType;
     this._sessionId = sessionId;
-    /** @type {!Map<string, !CDPSession>}*/
-    this._sessions = new Map();
   }
 
   /**
@@ -171,28 +183,16 @@ class CDPSession extends EventEmitter {
   send(method, params = {}) {
     if (!this._connection)
       return Promise.reject(new Error(`Protocol error (${method}): Session closed. Most likely the ${this._targetType} has been closed.`));
-    const id = ++this._lastId;
-    const message = JSON.stringify({id, method, params});
-    debugSession('SEND ► ' + message);
-    this._connection.send('Target.sendMessageToTarget', {sessionId: this._sessionId, message}).catch(e => {
-      // The response from target might have been already dispatched.
-      if (!this._callbacks.has(id))
-        return;
-      const callback = this._callbacks.get(id);
-      this._callbacks.delete(id);
-      callback.reject(rewriteError(callback.error, e && e.message));
-    });
+    const id = this._connection._rawSend({sessionId: this._sessionId, method, params});
     return new Promise((resolve, reject) => {
       this._callbacks.set(id, {resolve, reject, error: new Error(), method});
     });
   }
 
   /**
-   * @param {string} message
+   * @param {*} object
    */
-  _onMessage(message) {
-    debugSession('◀ RECV ' + message);
-    const object = JSON.parse(message);
+  _onMessage(object) {
     if (object.id && this._callbacks.has(object.id)) {
       const callback = this._callbacks.get(object.id);
       this._callbacks.delete(object.id);
@@ -201,17 +201,6 @@ class CDPSession extends EventEmitter {
       else
         callback.resolve(object.result);
     } else {
-      if (object.method === 'Target.receivedMessageFromTarget') {
-        const session = this._sessions.get(object.params.sessionId);
-        if (session)
-          session._onMessage(object.params.message);
-      } else if (object.method === 'Target.detachedFromTarget') {
-        const session = this._sessions.get(object.params.sessionId);
-        if (session) {
-          session._onClosed();
-          this._sessions.delete(object.params.sessionId);
-        }
-      }
       assert(!object.id);
       this.emit(object.method, object.params);
     }
@@ -228,16 +217,6 @@ class CDPSession extends EventEmitter {
       callback.reject(rewriteError(callback.error, `Protocol error (${callback.method}): Target closed.`));
     this._callbacks.clear();
     this._connection = null;
-  }
-
-  /**
-   * @param {string} targetType
-   * @param {string} sessionId
-   */
-  _createSession(targetType, sessionId) {
-    const session = new CDPSession(this, targetType, sessionId);
-    this._sessions.set(sessionId, session);
-    return session;
   }
 }
 helper.tracePublicAPI(CDPSession);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -17,6 +17,7 @@
 const fs = require('fs');
 const EventEmitter = require('events');
 const mime = require('mime');
+const {Connection} = require('./Connection');
 const {NetworkManager} = require('./NetworkManager');
 const {Dialog} = require('./Dialog');
 const {EmulationManager} = require('./EmulationManager');
@@ -46,7 +47,7 @@ class Page extends EventEmitter {
     const page = new Page(client, target, frameTree, ignoreHTTPSErrors, screenshotTaskQueue);
 
     await Promise.all([
-      client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false}),
+      client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false, flatten: true}),
       client.send('Page.setLifecycleEventsEnabled', { enabled: true }),
       client.send('Network.enable', {}),
       client.send('Runtime.enable', {}),
@@ -105,11 +106,10 @@ class Page extends EventEmitter {
         }).catch(debugError);
         return;
       }
-      const session = client._createSession(event.targetInfo.type, event.sessionId);
+      const session = Connection.fromSession(client).session(event.sessionId);
       const worker = new Worker(session, event.targetInfo.url, this._addConsoleMessage.bind(this), this._handleException.bind(this));
       this._workers.set(event.sessionId, worker);
       this.emit(Page.Events.WorkerCreated, worker);
-
     });
     client.on('Target.detachedFromTarget', event => {
       const worker = this._workers.get(event.sessionId);


### PR DESCRIPTION
DevTools protocol is dropping nested targets and switching to
flatten protocol. This patch adopts the new scheme.

Once this change lands, tip-of-tree Puppeteer will be incompatible
with Chromium below 72.0.3606.0. We'll need to adopt multiple pptr versions approach for [carlo](https://github.com/GoogleChromeLabs/carlo) to make it work nicely.