### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,25 +31,25 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "extract-zip": "^1.6.6",
     "https-proxy-agent": "^2.2.1",
     "mime": "^2.0.3",
-    "progress": "^2.0.0",
+    "progress": "^2.0.1",
     "proxy-from-env": "^1.0.0",
     "rimraf": "^2.6.1",
-    "ws": "^5.1.1"
+    "ws": "^6.1.0"
   },
   "devDependencies": {
-    "@types/debug": "0.0.30",
+    "@types/debug": "0.0.31",
     "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.0",
     "@types/node": "^8.10.34",
     "@types/rimraf": "^2.0.2",
-    "@types/ws": "^3.0.2",
-    "commonmark": "^0.27.0",
+    "@types/ws": "^6.0.1",
+    "commonmark": "^0.28.1",
     "cross-env": "^5.0.5",
-    "eslint": "^4.19.1",
+    "eslint": "^5.9.0",
     "esprima": "^4.0.0",
     "jpeg-js": "^0.3.4",
     "minimist": "^1.2.0",
@@ -57,7 +57,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "^3.1.1"
+    "typescript": "^3.1.6"
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,


### PR DESCRIPTION
Major updates are:
- `ws` moved to major 6 - no breaking changes for us.
- `eslint` updated to major 5 - adds support for object spread.