### PR TITLE
chore(types): lint using private properties

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -45,7 +45,7 @@ class Browser extends EventEmitter {
       this._contexts.set(contextId, new BrowserContext(this._connection, this, contextId));
 
     /** @type {Map<string, Target>} */
-    this._targets = new Map();
+    this.$_targets = new Map();
     this._connection.on(Connection.Events.Disconnected, () => this.emit(Browser.Events.Disconnected));
     this._connection.on('Target.targetCreated', this._targetCreated.bind(this));
     this._connection.on('Target.targetDestroyed', this._targetDestroyed.bind(this));
@@ -114,10 +114,10 @@ class Browser extends EventEmitter {
     const context = (browserContextId && this._contexts.has(browserContextId)) ? this._contexts.get(browserContextId) : this._defaultContext;
 
     const target = new Target(targetInfo, context, () => this._connection.createSession(targetInfo), this._ignoreHTTPSErrors, this._defaultViewport, this._screenshotTaskQueue);
-    assert(!this._targets.has(event.targetInfo.targetId), 'Target should not exist before targetCreated');
-    this._targets.set(event.targetInfo.targetId, target);
+    assert(!this.$_targets.has(event.targetInfo.targetId), 'Target should not exist before targetCreated');
+    this.$_targets.set(event.targetInfo.targetId, target);
 
-    if (await target._initializedPromise) {
+    if (await target.$_initializedPromise) {
       this.emit(Browser.Events.TargetCreated, target);
       context.emit(BrowserContext.Events.TargetCreated, target);
     }
@@ -127,11 +127,11 @@ class Browser extends EventEmitter {
    * @param {{targetId: string}} event
    */
   async _targetDestroyed(event) {
-    const target = this._targets.get(event.targetId);
-    target._initializedCallback(false);
-    this._targets.delete(event.targetId);
-    target._closedCallback();
-    if (await target._initializedPromise) {
+    const target = this.$_targets.get(event.targetId);
+    target.$_initializedCallback(false);
+    this.$_targets.delete(event.targetId);
+    target.$_closedCallback();
+    if (await target.$_initializedPromise) {
       this.emit(Browser.Events.TargetDestroyed, target);
       target.browserContext().emit(BrowserContext.Events.TargetDestroyed, target);
     }
@@ -141,11 +141,11 @@ class Browser extends EventEmitter {
    * @param {!Protocol.Target.targetInfoChangedPayload} event
    */
   _targetInfoChanged(event) {
-    const target = this._targets.get(event.targetInfo.targetId);
+    const target = this.$_targets.get(event.targetInfo.targetId);
     assert(target, 'target should exist before targetInfoChanged');
     const previousURL = target.url();
-    const wasInitialized = target._isInitialized;
-    target._targetInfoChanged(event.targetInfo);
+    const wasInitialized = target.$_isInitialized;
+    target.$_targetInfoChanged(event.targetInfo);
     if (wasInitialized && previousURL !== target.url()) {
       this.emit(Browser.Events.TargetChanged, target);
       target.browserContext().emit(BrowserContext.Events.TargetChanged, target);
@@ -172,8 +172,8 @@ class Browser extends EventEmitter {
    */
   async _createPageInContext(contextId) {
     const {targetId} = await this._connection.send('Target.createTarget', {url: 'about:blank', browserContextId: contextId || undefined});
-    const target = await this._targets.get(targetId);
-    assert(await target._initializedPromise, 'Failed to create target for page');
+    const target = await this.$_targets.get(targetId);
+    assert(await target.$_initializedPromise, 'Failed to create target for page');
     const page = await target.page();
     return page;
   }
@@ -182,7 +182,7 @@ class Browser extends EventEmitter {
    * @return {!Array<!Target>}
    */
   targets() {
-    return Array.from(this._targets.values()).filter(target => target._isInitialized);
+    return Array.from(this.$_targets.values()).filter(target => target.$_isInitialized);
   }
 
   /**

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -232,13 +232,23 @@ class CDPSession extends EventEmitter {
   }
 
   /**
+   * @param {!CDPSession} parent
    * @param {string} targetType
    * @param {string} sessionId
+   * @return {!CDPSession}
    */
-  _createSession(targetType, sessionId) {
-    const session = new CDPSession(this, targetType, sessionId);
-    this._sessions.set(sessionId, session);
+  static createSession(parent, targetType, sessionId) {
+    const session = new CDPSession(parent, targetType, sessionId);
+    parent._sessions.set(sessionId, session);
     return session;
+  }
+
+  /**
+   * @param {!CDPSession} session
+   * @return {!Connection|CDPSession}
+   */
+  static getParentConnection(session) {
+    return session._connection;
   }
 }
 

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -20,15 +20,6 @@ const path = require('path');
 const EVALUATION_SCRIPT_URL = '__puppeteer_evaluation_script__';
 const SOURCE_URL_REGEX = /^[\040\t]*\/\/[@#] sourceURL=\s*(\S*?)\s*$/m;
 
-function createJSHandle(context, remoteObject) {
-  const frame = context.frame();
-  if (remoteObject.subtype === 'node' && frame) {
-    const frameManager = frame._frameManager;
-    return new ElementHandle(context, context._client, remoteObject, frameManager.page(), frameManager);
-  }
-  return new JSHandle(context, context._client, remoteObject);
-}
-
 class ExecutionContext {
   /**
    * @param {!Puppeteer.CDPSession} client
@@ -88,7 +79,7 @@ class ExecutionContext {
       }).catch(rewriteError);
       if (exceptionDetails)
         throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
-      return createJSHandle(this, remoteObject);
+      return JSHandle.create(this, remoteObject);
     }
 
     if (typeof pageFunction !== 'function')
@@ -122,7 +113,7 @@ class ExecutionContext {
     }).catch(rewriteError);
     if (exceptionDetails)
       throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
-    return createJSHandle(this, remoteObject);
+    return JSHandle.create(this, remoteObject);
 
     /**
      * @param {*} arg
@@ -174,7 +165,15 @@ class ExecutionContext {
     const response = await this._client.send('Runtime.queryObjects', {
       prototypeObjectId: prototypeHandle._remoteObject.objectId
     });
-    return createJSHandle(this, response.objects);
+    return JSHandle.create(this, response.objects);
+  }
+
+  /**
+   * @param {!ExecutionContext} context
+   * @return {boolean}
+   */
+  static isDefault(context) {
+    return context._isDefault;
   }
 }
 
@@ -226,7 +225,7 @@ class JSHandle {
     for (const property of response.result) {
       if (!property.enumerable)
         continue;
-      result.set(property.name, createJSHandle(this._context, property.value));
+      result.set(property.name, JSHandle.create(this._context, property.value));
     }
     return result;
   }
@@ -271,6 +270,27 @@ class JSHandle {
       return 'JSHandle@' + type;
     }
     return 'JSHandle:' + helper.valueFromRemoteObject(this._remoteObject);
+  }
+
+  /**
+   * @param {!JSHandle} handle
+   * @return {!Protocol.Runtime.RemoteObject}
+   */
+  static remoteObject(handle) {
+    return handle._remoteObject;
+  }
+
+  /**
+   * @param {!ExecutionContext} context
+   * @param {!Protocol.Runtime.RemoteObject} remoteObject
+   */
+  static create(context, remoteObject) {
+    const frame = context.frame();
+    if (remoteObject.subtype === 'node' && frame) {
+      const frameManager = frame.$_frameManager;
+      return new ElementHandle(context, context._client, remoteObject, frameManager.page(), frameManager);
+    }
+    return new JSHandle(context, context._client, remoteObject);
   }
 }
 
@@ -333,7 +353,7 @@ class ElementHandle extends JSHandle {
       if (visibleRatio !== 1.0)
         element.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
       return false;
-    }, this, this._page._javascriptEnabled);
+    }, this, this._page.$_javascriptEnabled);
     if (error)
       throw new Error(error);
   }
@@ -660,4 +680,4 @@ helper.tracePublicAPI(ElementHandle);
 helper.tracePublicAPI(JSHandle);
 helper.tracePublicAPI(ExecutionContext);
 
-module.exports = {ExecutionContext, JSHandle, ElementHandle, createJSHandle, EVALUATION_SCRIPT_URL};
+module.exports = {ExecutionContext, JSHandle, ElementHandle, EVALUATION_SCRIPT_URL};

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -343,7 +343,7 @@ class Frame {
    * @param {string} frameId
    */
   constructor(frameManager, client, parentFrame, frameId) {
-    this._frameManager = frameManager;
+    this.$_frameManager = frameManager;
     this._client = client;
     this._parentFrame = parentFrame;
     this._url = '';
@@ -374,7 +374,7 @@ class Frame {
    * @param {!ExecutionContext} context
    */
   _addExecutionContext(context) {
-    if (context._isDefault)
+    if (ExecutionContext.isDefault(context))
       this._setDefaultContext(context);
   }
 
@@ -382,7 +382,7 @@ class Frame {
    * @param {!ExecutionContext} context
    */
   _removeExecutionContext(context) {
-    if (context._isDefault)
+    if (ExecutionContext.isDefault(context))
       this._setDefaultContext(null);
   }
 
@@ -409,7 +409,7 @@ class Frame {
    * @return {!Promise<?Puppeteer.Response>}
    */
   async goto(url, options) {
-    return await this._frameManager.navigateFrame(this, url, options);
+    return await this.$_frameManager.navigateFrame(this, url, options);
   }
 
   /**
@@ -417,7 +417,7 @@ class Frame {
    * @return {!Promise<?Puppeteer.Response>}
    */
   async waitForNavigation(options) {
-    return await this._frameManager.waitForFrameNavigation(this, options);
+    return await this.$_frameManager.waitForFrameNavigation(this, options);
   }
 
   /**
@@ -543,7 +543,7 @@ class Frame {
       document.write(html);
       document.close();
     }, html);
-    const watcher = new LifecycleWatcher(this._frameManager, this, waitUntil, timeout);
+    const watcher = new LifecycleWatcher(this.$_frameManager, this, waitUntil, timeout);
     const error = await Promise.race([
       watcher.timeoutOrTerminationPromise(),
       watcher.lifecyclePromise(),

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -26,8 +26,9 @@ const Tracing = require('./Tracing');
 const {helper, debugError, assert} = require('./helper');
 const {Coverage} = require('./Coverage');
 const {Worker} = require('./Worker');
-const {createJSHandle} = require('./ExecutionContext');
+const {JSHandle} = require('./ExecutionContext');
 const {Accessibility} = require('./Accessibility');
+const {CDPSession} = require('./Connection');
 const writeFileAsync = helper.promisify(fs.writeFile);
 
 class Page extends EventEmitter {
@@ -89,7 +90,7 @@ class Page extends EventEmitter {
     this._pageBindings = new Map();
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
     this._coverage = new Coverage(client);
-    this._javascriptEnabled = true;
+    this.$_javascriptEnabled = true;
     /** @type {?Puppeteer.Viewport} */
     this._viewport = null;
 
@@ -105,7 +106,7 @@ class Page extends EventEmitter {
         }).catch(debugError);
         return;
       }
-      const session = client._createSession(event.targetInfo.type, event.sessionId);
+      const session = CDPSession.createSession(client, event.targetInfo.type, event.sessionId);
       const worker = new Worker(session, event.targetInfo.url, this._addConsoleMessage.bind(this), this._handleException.bind(this));
       this._workers.set(event.sessionId, worker);
       this.emit(Page.Events.WorkerCreated, worker);
@@ -138,7 +139,7 @@ class Page extends EventEmitter {
     client.on('Inspector.targetCrashed', event => this._onTargetCrashed());
     client.on('Performance.metrics', event => this._emitMetrics(event));
     client.on('Log.entryAdded', event => this._onLogEntryAdded(event));
-    this._target._isClosedPromise.then(() => {
+    this._target.$_isClosedPromise.then(() => {
       this.emit(Page.Events.Close);
       this._closed = true;
     });
@@ -502,7 +503,7 @@ class Page extends EventEmitter {
    */
   async _onConsoleAPI(event) {
     const context = this._frameManager.executionContextById(event.executionContextId);
-    const values = event.args.map(arg => createJSHandle(context, arg));
+    const values = event.args.map(arg => JSHandle.create(context, arg));
     this._addConsoleMessage(event.type, values);
   }
 
@@ -568,7 +569,7 @@ class Page extends EventEmitter {
     }
     const textTokens = [];
     for (const arg of args) {
-      const remoteObject = arg._remoteObject;
+      const remoteObject = JSHandle.remoteObject(arg);
       if (remoteObject.objectId)
         textTokens.push(arg.toString());
       else
@@ -730,9 +731,9 @@ class Page extends EventEmitter {
    * @param {boolean} enabled
    */
   async setJavaScriptEnabled(enabled) {
-    if (this._javascriptEnabled === enabled)
+    if (this.$_javascriptEnabled === enabled)
       return;
-    this._javascriptEnabled = enabled;
+    this.$_javascriptEnabled = enabled;
     await this._client.send('Emulation.setScriptExecutionDisabled', { value: !enabled });
   }
 
@@ -838,7 +839,7 @@ class Page extends EventEmitter {
    * @return {!Promise<!Buffer|!String>}
    */
   async _screenshotTask(format, options) {
-    await this._client.send('Target.activateTarget', {targetId: this._target._targetId});
+    await this._client.send('Target.activateTarget', {targetId: this._target.$_targetId});
     let clip = options.clip ? Object.assign({}, options['clip'], {scale: 1}) : undefined;
 
     if (options.fullPage) {
@@ -941,13 +942,14 @@ class Page extends EventEmitter {
    * @param {!{runBeforeUnload: (boolean|undefined)}=} options
    */
   async close(options = {runBeforeUnload: undefined}) {
-    assert(!!this._client._connection, 'Protocol error: Connection closed. Most likely the page has been closed.');
+    const parentConnection = CDPSession.getParentConnection(this._client);
+    assert(!!parentConnection, 'Protocol error: Connection closed. Most likely the page has been closed.');
     const runBeforeUnload = !!options.runBeforeUnload;
     if (runBeforeUnload) {
       await this._client.send('Page.close');
     } else {
-      await this._client._connection.send('Target.closeTarget', { targetId: this._target._targetId });
-      await this._target._isClosedPromise;
+      await parentConnection.send('Target.closeTarget', { targetId: this._target.$_targetId });
+      await this._target.$_isClosedPromise;
     }
   }
 

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -13,18 +13,18 @@ class Target {
   constructor(targetInfo, browserContext, sessionFactory, ignoreHTTPSErrors, defaultViewport, screenshotTaskQueue) {
     this._targetInfo = targetInfo;
     this._browserContext = browserContext;
-    this._targetId = targetInfo.targetId;
+    this.$_targetId = targetInfo.targetId;
     this._sessionFactory = sessionFactory;
     this._ignoreHTTPSErrors = ignoreHTTPSErrors;
     this._defaultViewport = defaultViewport;
     this._screenshotTaskQueue = screenshotTaskQueue;
     /** @type {?Promise<!Puppeteer.Page>} */
     this._pagePromise = null;
-    this._initializedPromise = new Promise(fulfill => this._initializedCallback = fulfill);
-    this._isClosedPromise = new Promise(fulfill => this._closedCallback = fulfill);
-    this._isInitialized = this._targetInfo.type !== 'page' || this._targetInfo.url !== '';
-    if (this._isInitialized)
-      this._initializedCallback(true);
+    this.$_initializedPromise = new Promise(fulfill => this.$_initializedCallback = fulfill);
+    this.$_isClosedPromise = new Promise(fulfill => this.$_closedCallback = fulfill);
+    this.$_isInitialized = this._targetInfo.type !== 'page' || this._targetInfo.url !== '';
+    if (this.$_isInitialized)
+      this.$_initializedCallback(true);
   }
 
   /**
@@ -83,18 +83,18 @@ class Target {
     const { openerId } = this._targetInfo;
     if (!openerId)
       return null;
-    return this.browser()._targets.get(openerId);
+    return this.browser().$_targets.get(openerId);
   }
 
   /**
    * @param {!Protocol.Target.TargetInfo} targetInfo
    */
-  _targetInfoChanged(targetInfo) {
+  $_targetInfoChanged(targetInfo) {
     this._targetInfo = targetInfo;
 
-    if (!this._isInitialized && (this._targetInfo.type !== 'page' || this._targetInfo.url !== '')) {
-      this._isInitialized = true;
-      this._initializedCallback(true);
+    if (!this.$_isInitialized && (this._targetInfo.type !== 'page' || this._targetInfo.url !== '')) {
+      this.$_isInitialized = true;
+      this.$_initializedCallback(true);
       return;
     }
   }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -31,7 +31,7 @@ function traceAPICoverage(classType, publicName) {
   className = className.substring(0, 1).toLowerCase() + className.substring(1);
   for (const methodName of Reflect.ownKeys(classType.prototype)) {
     const method = Reflect.get(classType.prototype, methodName);
-    if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function')
+    if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || methodName.startsWith('$_') || typeof method !== 'function')
       continue;
     apiCoverage.set(`${className}.${methodName}`, false);
     Reflect.set(classType.prototype, methodName, function(...args) {
@@ -138,7 +138,7 @@ class Helper {
   static tracePublicAPI(classType, publicName) {
     for (const methodName of Reflect.ownKeys(classType.prototype)) {
       const method = Reflect.get(classType.prototype, methodName);
-      if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function' || method.constructor.name !== 'AsyncFunction')
+      if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || methodName.startsWith('$_') || typeof method !== 'function' || method.constructor.name !== 'AsyncFunction')
         continue;
       Reflect.set(classType.prototype, methodName, function(...args) {
         const syncStack = new Error();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-node6-transformer": "node utils/node6-transform/test/test.js",
     "build": "node utils/node6-transform/index.js",
     "unit-node6": "node node6/test/test.js",
-    "tsc": "tsc -p .",
+    "tsc": "tsc -p . && node utils/check_private_properties.js",
     "prepublishOnly": "npm run build",
     "apply-next-version": "node utils/apply_next_version.js",
     "bundle": "npx browserify -r ./index.js:puppeteer -o utils/browser/puppeteer-web.js",

--- a/utils/check_private_properties.js
+++ b/utils/check_private_properties.js
@@ -1,0 +1,105 @@
+const ts = require('typescript');
+const path = require('path');
+const srcRoot = path.join(__dirname, '..', 'lib');
+const configPath = path.join(__dirname, '..', 'tsconfig.json');
+const configParseResult = ts.getParsedCommandLineOfConfigFile(configPath, {}, {
+  useCaseSensitiveFileNames: false,
+  readDirectory: ts.sys.readDirectory,
+  fileExists: ts.sys.fileExists,
+  readFile: ts.sys.readFile,
+  getCurrentDirectory: ts.sys.getCurrentDirectory,
+  onUnRecoverableConfigFileDiagnostic: e => {
+    console.error('failed to parse config', configPath);
+    console.error(e);
+    process.exit(1);
+  }
+});
+
+const host = ts.createCompilerHost(configParseResult.options, true);
+const program = ts.createProgram(configParseResult.fileNames, configParseResult.options, host);
+
+const checker = program.getTypeChecker();
+const diagnostics = [];
+/** @type {!Map<ts.Declaration, {name: string, wasUsedExternally: boolean}>} */
+const internalProperties = new Map();
+for (const sourceFile of program.getSourceFiles()) {
+  if (!path.normalize(sourceFile.fileName).startsWith(srcRoot))
+    continue;
+  visit(sourceFile);
+}
+
+for (const [declaration, {name, wasUsedExternally}] of internalProperties) {
+  if (!wasUsedExternally) {
+    diagnostics.push({
+      category: ts.DiagnosticCategory.Error,
+      code: '',
+      file: declaration.getSourceFile(),
+      messageText: `Internal property could be made private '${name}'`,
+      start: declaration.getStart(),
+      length: name.length
+    });
+  }
+}
+
+process.stderr.write(ts.formatDiagnostics(diagnostics, {
+  getCanonicalFileName(path) {
+    return path;
+  },
+  getCurrentDirectory() {
+    return process.cwd();
+  },
+  getNewLine() {
+    return ts.sys.newLine;
+  }
+}));
+process.exit(diagnostics.length);
+
+/**
+ * @param {ts.Node} node
+ */
+function visit(node) {
+  checkForPrivateIdentifier(node);
+  node.forEachChild(visit);
+}
+
+/**
+ * @param {ts.Node} node
+ */
+function checkForPrivateIdentifier(node) {
+  if (node.kind !== ts.SyntaxKind.Identifier)
+    return;
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol)
+    return;
+  const name = symbol.getName();
+  if (name.startsWith('$_')) {
+    const declaration = symbol.getDeclarations()[0];
+    if (!internalProperties.has(declaration))
+      internalProperties.set(declaration, {name, wasUsedExternally: false});
+    if (!nodeWasDeclaredLocally(node))
+      internalProperties.get(declaration).wasUsedExternally = true;
+  }
+  if (name.startsWith('_') && !nodeWasDeclaredLocally(node)) {
+    diagnostics.push({
+      category: ts.DiagnosticCategory.Error,
+      code: '',
+      file: node.getSourceFile(),
+      messageText: `Invalid usage of private property '${name}'`,
+      start: node.getStart(),
+      length: name.length
+    });
+  }
+}
+
+/**
+ * @param {ts.Node} node
+ */
+function nodeWasDeclaredLocally(node) {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol)
+    return true;
+  const declaration = symbol.getDeclarations()[0];
+  if (!declaration)
+    return true;
+  return declaration.getSourceFile() === node.getSourceFile();
+}

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -136,7 +136,7 @@ function filterJSDocumentation(jsDocumentation) {
     if (EXCLUDE_CLASSES.has(cls.name))
       continue;
     const members = cls.membersArray.filter(member => {
-      if (member.name.startsWith('_'))
+      if (member.name.startsWith('_') || methodName.startsWith('$_'))
         return false;
       // Exclude all constructors by default.
       if (member.name === 'constructor' && member.type === 'method')


### PR DESCRIPTION
This adds a new linting step that forbids using variables prefixed by `_` outside the file they were declared in.

Sometimes we used `_` not to mean file-private, but to mean not part of our public api. Some of these  usages became static methods on the class, and some became prefixed with `$_` to mean internal. Most current usages of `$_` are a bit ugly, and I can refactor them away in follow up patches.