### PR TITLE
test(accessibility): Fix duplicated test

### DIFF
--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -158,7 +158,7 @@ module.exports.addTests = function({testRunner, expect}) {
       });
       it('plain text field with tabindex and without role should not have content', async function({page}) {
         await page.setContent(`
-        <div contenteditable="plaintext-only">Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
+        <div contenteditable="plaintext-only" tabIndex=0>Edit this image:<img src="fakeimage.png" alt="my fake image"></div>`);
         const snapshot = await page.accessibility.snapshot();
         expect(snapshot.children[0]).toEqual({
           role: 'GenericContainer',


### PR DESCRIPTION
[plain text field without role should not have content](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/test/accessibility.spec.js#L150) and [plain text field with tabindex and without role should not have content](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/test/accessibility.spec.js#L150) are duplicated.

By looking at the rest of the tests I bet [plain text field with tabindex and without role should not have content](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/test/accessibility.spec.js#L150) needs a `tabIndex` in the HTML