### PR TITLE
fix(page): dispatch errors into page

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -428,7 +428,7 @@ class Page extends EventEmitter {
         }
         const seq = (me['lastSeq'] || 0) + 1;
         me['lastSeq'] = seq;
-        const promise = new Promise(fulfill => callbacks.set(seq, fulfill));
+        const promise = new Promise((resolve, reject) => callbacks.set(seq, {resolve, reject}));
         binding(JSON.stringify({name: bindingName, seq, args}));
         return promise;
       };
@@ -511,12 +511,29 @@ class Page extends EventEmitter {
    */
   async _onBindingCalled(event) {
     const {name, seq, args} = JSON.parse(event.payload);
-    const result = await this._pageBindings.get(name)(...args);
-    const expression = helper.evaluationString(deliverResult, name, seq, result);
+    let result = null;
+    let error = null;
+    try {
+      result = await this._pageBindings.get(name)(...args);
+    } catch (e) {
+      error = e;
+    }
+    let expression = null;
+    if (error)
+      expression = helper.evaluationString(deliverError, name, seq, error.message, error.stack)
+    else
+      expression = helper.evaluationString(deliverResult, name, seq, result);
     this._client.send('Runtime.evaluate', { expression, contextId: event.executionContextId }).catch(debugError);
 
     function deliverResult(name, seq, result) {
-      window[name]['callbacks'].get(seq)(result);
+      window[name]['callbacks'].get(seq).resolve(result);
+      window[name]['callbacks'].delete(seq);
+    }
+
+    function deliverError(name, seq, message, stack) {
+      let error = new Error(message);
+      error.stack = stack;
+      window[name]['callbacks'].get(seq).reject(error);
       window[name]['callbacks'].delete(seq);
     }
   }

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -511,18 +511,16 @@ class Page extends EventEmitter {
    */
   async _onBindingCalled(event) {
     const {name, seq, args} = JSON.parse(event.payload);
-    let result = null;
-    let error = null;
-    try {
-      result = await this._pageBindings.get(name)(...args);
-    } catch (e) {
-      error = e;
-    }
     let expression = null;
-    if (error)
-      expression = helper.evaluationString(deliverError, name, seq, error.message, error.stack)
-    else
+    try {
+      const result = await this._pageBindings.get(name)(...args);
       expression = helper.evaluationString(deliverResult, name, seq, result);
+    } catch (error) {
+      if (error instanceof Error)
+        expression = helper.evaluationString(deliverError, name, seq, error.message, error.stack);
+      else
+        expression = helper.evaluationString(deliverErrorValue, name, seq, error);
+    }
     this._client.send('Runtime.evaluate', { expression, contextId: event.executionContextId }).catch(debugError);
 
     function deliverResult(name, seq, result) {
@@ -534,6 +532,11 @@ class Page extends EventEmitter {
       let error = new Error(message);
       error.stack = stack;
       window[name]['callbacks'].get(seq).reject(error);
+      window[name]['callbacks'].delete(seq);
+    }
+
+    function deliverErrorValue(name, seq, value) {
+      window[name]['callbacks'].get(seq).reject(value);
       window[name]['callbacks'].delete(seq);
     }
   }

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -523,11 +523,22 @@ class Page extends EventEmitter {
     }
     this._client.send('Runtime.evaluate', { expression, contextId: event.executionContextId }).catch(debugError);
 
+    /**
+     * @param {string} name
+     * @param {number} seq
+     * @param {*} result
+     */
     function deliverResult(name, seq, result) {
       window[name]['callbacks'].get(seq).resolve(result);
       window[name]['callbacks'].delete(seq);
     }
 
+    /**
+     * @param {string} name
+     * @param {number} seq
+     * @param {string} message
+     * @param {string} stack
+     */
     function deliverError(name, seq, message, stack) {
       const error = new Error(message);
       error.stack = stack;
@@ -535,6 +546,11 @@ class Page extends EventEmitter {
       window[name]['callbacks'].delete(seq);
     }
 
+    /**
+     * @param {string} name
+     * @param {number} seq
+     * @param {*} value
+     */
     function deliverErrorValue(name, seq, value) {
       window[name]['callbacks'].get(seq).reject(value);
       window[name]['callbacks'].delete(seq);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -529,7 +529,7 @@ class Page extends EventEmitter {
     }
 
     function deliverError(name, seq, message, stack) {
-      let error = new Error(message);
+      const error = new Error(message);
       error.stack = stack;
       window[name]['callbacks'].get(seq).reject(error);
       window[name]['callbacks'].delete(seq);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1033,6 +1033,20 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       });
       expect(result).toBe(36);
     });
+    it('should throw exception in page context', async({page, server}) => {
+      await page.exposeFunction('woof', function() {
+        throw new Error('WOOF WOOF');
+      });
+      const {message, stack} = await page.evaluate(async () => {
+        try {
+          await woof();
+        } catch (e) {
+          return {message: e.message, stack: e.stack};
+        }
+      });
+      expect(message).toBe('WOOF WOOF');
+      expect(stack).toContain(__filename);
+    });
     it('should be callable from-inside evaluateOnNewDocument', async({page, server}) => {
       let called = false;
       await page.exposeFunction('woof', function() {

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1047,6 +1047,19 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       expect(message).toBe('WOOF WOOF');
       expect(stack).toContain(__filename);
     });
+    it('should support throwing "null"', async({page, server}) => {
+      await page.exposeFunction('woof', function() {
+        throw null;
+      });
+      const thrown = await page.evaluate(async () => {
+        try {
+          await woof();
+        } catch (e) {
+          return e;
+        }
+      });
+      expect(thrown).toBe(null);
+    });
     it('should be callable from-inside evaluateOnNewDocument', async({page, server}) => {
       let called = false;
       await page.exposeFunction('woof', function() {

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -1037,7 +1037,7 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       await page.exposeFunction('woof', function() {
         throw new Error('WOOF WOOF');
       });
-      const {message, stack} = await page.evaluate(async () => {
+      const {message, stack} = await page.evaluate(async() => {
         try {
           await woof();
         } catch (e) {
@@ -1051,7 +1051,7 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       await page.exposeFunction('woof', function() {
         throw null;
       });
-      const thrown = await page.evaluate(async () => {
+      const thrown = await page.evaluate(async() => {
         try {
           await woof();
         } catch (e) {


### PR DESCRIPTION
Errors thrown on the node side of the `page.exposeFunction` callback
should be dispatched into the page.

Fixes #3549