### PR TITLE
fix: check skip download environment variable values

### DIFF
--- a/install.js
+++ b/install.js
@@ -20,15 +20,15 @@ if (require('./package.json').name === 'puppeteer-core')
 
 buildNode6IfNecessary();
 
-if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === "true") {
+if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === 'true') {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;
 }
-if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === "true" || process.env.npm_config_puppeteer_skip_chromium_download === "true") {
+if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === 'true' || process.env.npm_config_puppeteer_skip_chromium_download === 'true') {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in npm config.');
   return;
 }
-if (process.env.NPM_PACKAGE_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === "true" || process.env.npm_package_config_puppeteer_skip_chromium_download === "true") {
+if (process.env.NPM_PACKAGE_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === 'true' || process.env.npm_package_config_puppeteer_skip_chromium_download === 'true') {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in project config.');
   return;
 }

--- a/install.js
+++ b/install.js
@@ -20,15 +20,15 @@ if (require('./package.json').name === 'puppeteer-core')
 
 buildNode6IfNecessary();
 
-if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
+if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === "true") {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;
 }
-if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_config_puppeteer_skip_chromium_download) {
+if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === "true" || process.env.npm_config_puppeteer_skip_chromium_download === "true") {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in npm config.');
   return;
 }
-if (process.env.NPM_PACKAGE_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_package_config_puppeteer_skip_chromium_download) {
+if (process.env.NPM_PACKAGE_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD === "true" || process.env.npm_package_config_puppeteer_skip_chromium_download === "true") {
   console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in project config.');
   return;
 }


### PR DESCRIPTION
Currently the code only checks for the existence and not the value of the flag since environment variables are strings. This PR casts the value to a boolean.

Some context: At [Sourcegraph](https://github.com/sourcegraph/sourcegraph), we're trying to speed up our CI by not installing Chromium except the build steps where we need it (which is only 2 currently). We'd like to set `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` globally and then `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false` for only the steps we need.

As a workaround we're setting the env var to the empty string so it evaluates to false but it would be nice to be able to be explicit.