### PR TITLE
docs(troubleshooting): added link to alixaxel/chrome-aws-lambda

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -344,7 +344,6 @@ There's also another [simple guide](https://timleland.com/headless-chrome-on-her
 AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) deployment package sizes to ~50MB. This presents challenges for running headless Chrome (and therefore Puppeteer) on Lambda. The community has put together a few resources that work around the issues:
 
 - https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (tracks the latest Chromium snapshots)
-- https://github.com/universalbasket/aws-lambda-chrome
 - https://github.com/alixaxel/chrome-aws-lambda (kept updated with the latest stable release of puppeteer)
 - https://github.com/Kikobeats/aws-lambda-chrome
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -345,13 +345,14 @@ AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) de
 
 - https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (tracks the latest Chromium snapshots)
 - https://github.com/universalbasket/aws-lambda-chrome
+- https://github.com/alixaxel/chrome-aws-lambda (kept updated with the latest stable release of puppeteer)
 - https://github.com/Kikobeats/aws-lambda-chrome
 
 ## Code Transpilation Issues
 
-If you are using a JavaScript transpiler like babel or TypeScript, calling `evaluate()` with an async function might not work. This is because while `puppeteer` uses `Function.prototype.toString()` to serialize functions while transpilers could be changing the output code in such a way it's incompatible with `puppeteer`. 
+If you are using a JavaScript transpiler like babel or TypeScript, calling `evaluate()` with an async function might not work. This is because while `puppeteer` uses `Function.prototype.toString()` to serialize functions while transpilers could be changing the output code in such a way it's incompatible with `puppeteer`.
 
-Some workarounds to this problem would be to instruct the transpiler not to mess up with the code, for example, configure TypeScript to use latest ecma version (`"target": "es2018"`). Another workaround could be using string templates instead of functions: 
+Some workarounds to this problem would be to instruct the transpiler not to mess up with the code, for example, configure TypeScript to use latest ecma version (`"target": "es2018"`). Another workaround could be using string templates instead of functions:
 
 ```js
 await page.evaluate(`(async() => {


### PR DESCRIPTION
I've been maintaining and compiling the latest version of Chromium for AWS Lambda.

Would be great to have it included in the docs.

---

I'd also think it would be worthwhile removing https://github.com/universalbasket/aws-lambda-chrome since it hasn't been updated in nearly a year, please let me know if this is something we'd want to remove in this PR.