### PR TITLE
test: split out dialog tests

### DIFF
--- a/test/dialog.spec.js
+++ b/test/dialog.spec.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports.addTests = function({testRunner, expect}) {
+  const {describe, xdescribe, fdescribe} = testRunner;
+  const {it, fit, xit} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe('Page.Events.Dialog', function() {
+    it('should fire', async({page, server}) => {
+      page.on('dialog', dialog => {
+        expect(dialog.type()).toBe('alert');
+        expect(dialog.defaultValue()).toBe('');
+        expect(dialog.message()).toBe('yo');
+        dialog.accept();
+      });
+      await page.evaluate(() => alert('yo'));
+    });
+    it('should allow accepting prompts', async({page, server}) => {
+      page.on('dialog', dialog => {
+        expect(dialog.type()).toBe('prompt');
+        expect(dialog.defaultValue()).toBe('yes.');
+        expect(dialog.message()).toBe('question?');
+        dialog.accept('answer!');
+      });
+      const result = await page.evaluate(() => prompt('question?', 'yes.'));
+      expect(result).toBe('answer!');
+    });
+    it('should dismiss the prompt', async({page, server}) => {
+      page.on('dialog', dialog => {
+        dialog.dismiss();
+      });
+      const result = await page.evaluate(() => prompt('question?'));
+      expect(result).toBe(null);
+    });
+  });
+};

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -171,16 +171,6 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(error).toBeTruthy();
       expect(error.message).toContain('JSHandles can be evaluated only in the context they were created');
     });
-    it('should accept object handle as an argument', async({page, server}) => {
-      const navigatorHandle = await page.evaluateHandle(() => navigator);
-      const text = await page.evaluate(e => e.userAgent, navigatorHandle);
-      expect(text).toContain('Mozilla');
-    });
-    it('should accept object handle to primitive types', async({page, server}) => {
-      const aHandle = await page.evaluateHandle(() => 5);
-      const isFive = await page.evaluate(e => Object.is(e, 5), aHandle);
-      expect(isFive).toBeTruthy();
-    });
     it('should simulate a user gesture', async({page, server}) => {
       await page.evaluate(playAudio);
       // also test evaluating strings

--- a/test/jshandle.spec.js
+++ b/test/jshandle.spec.js
@@ -19,6 +19,23 @@ module.exports.addTests = function({testRunner, expect}) {
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
+  describe('Page.evaluateHandle', function() {
+    it('should work', async({page, server}) => {
+      const windowHandle = await page.evaluateHandle(() => window);
+      expect(windowHandle).toBeTruthy();
+    });
+    it('should accept object handle as an argument', async({page, server}) => {
+      const navigatorHandle = await page.evaluateHandle(() => navigator);
+      const text = await page.evaluate(e => e.userAgent, navigatorHandle);
+      expect(text).toContain('Mozilla');
+    });
+    it('should accept object handle to primitive types', async({page, server}) => {
+      const aHandle = await page.evaluateHandle(() => 5);
+      const isFive = await page.evaluate(e => Object.is(e, 5), aHandle);
+      expect(isFive).toBeTruthy();
+    });
+  });
+
   describe('JSHandle.getProperty', function() {
     it('should work', async({page, server}) => {
       const aHandle = await page.evaluateHandle(() => ({

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -189,13 +189,6 @@ module.exports.addTests = function({testRunner, expect, headless}) {
     });
   });
 
-  describe('Page.evaluateHandle', function() {
-    it('should work', async({page, server}) => {
-      const windowHandle = await page.evaluateHandle(() => window);
-      expect(windowHandle).toBeTruthy();
-    });
-  });
-
   describe('ExecutionContext.queryObjects', function() {
     it('should work', async({page, server}) => {
       // Instantiate an object
@@ -495,35 +488,6 @@ module.exports.addTests = function({testRunner, expect, headless}) {
         return await compute(3, 5);
       });
       expect(result).toBe(15);
-    });
-  });
-
-  describe('Page.Events.Dialog', function() {
-    it('should fire', async({page, server}) => {
-      page.on('dialog', dialog => {
-        expect(dialog.type()).toBe('alert');
-        expect(dialog.defaultValue()).toBe('');
-        expect(dialog.message()).toBe('yo');
-        dialog.accept();
-      });
-      await page.evaluate(() => alert('yo'));
-    });
-    it('should allow accepting prompts', async({page, server}) => {
-      page.on('dialog', dialog => {
-        expect(dialog.type()).toBe('prompt');
-        expect(dialog.defaultValue()).toBe('yes.');
-        expect(dialog.message()).toBe('question?');
-        dialog.accept('answer!');
-      });
-      const result = await page.evaluate(() => prompt('question?', 'yes.'));
-      expect(result).toBe('answer!');
-    });
-    it('should dismiss the prompt', async({page, server}) => {
-      page.on('dialog', dialog => {
-        dialog.dismiss();
-      });
-      const result = await page.evaluate(() => prompt('question?'));
-      expect(result).toBe(null);
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -161,6 +161,7 @@ describe('Browser', function() {
     require('./jshandle.spec.js').addTests({testRunner, expect});
     require('./network.spec.js').addTests({testRunner, expect});
     require('./page.spec.js').addTests({testRunner, expect, headless});
+    require('./dialog.spec.js').addTests({testRunner, expect, headless});
     require('./navigation.spec.js').addTests({testRunner, expect, headless});
     require('./evaluation.spec.js').addTests({testRunner, expect, headless});
     require('./emulation.spec.js').addTests({testRunner, expect, headless});


### PR DESCRIPTION
This patch splits out dialog tests into  `dialog.spec.js` and moves
a few jshandle-related tests to `jshandle.spec.js`.