### PR TITLE
feat(executioncontext): warn on nested js handle

### DIFF
--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -122,7 +122,8 @@ class ExecutionContext {
         userGesture: true
       });
     } catch (err) {
-      err.message += ' Are you passing a nested JSHandle?';
+      if (err instanceof TypeError && err.message === 'Converting circular structure to JSON')
+        err.message += ' Are you passing a nested JSHandle?';
       throw err;
     }
     const { exceptionDetails, result: remoteObject } = await funcCallResultP.catch(rewriteError);

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -121,10 +121,9 @@ class ExecutionContext {
         awaitPromise: true,
         userGesture: true
       });
-    } catch (e) {
-      if (e instanceof TypeError && e.message === 'Converting circular structure to JSON')
-        warnOnNestedJSHandle(args);
-      throw e;
+    } catch (err) {
+      err.message += ' Are you passing a nested JSHandle?';
+      throw err;
     }
     const { exceptionDetails, result: remoteObject } = await funcCallResultP.catch(rewriteError);
     if (exceptionDetails)
@@ -168,28 +167,6 @@ class ExecutionContext {
       if (error.message.endsWith('Cannot find context with specified id'))
         throw new Error('Execution context was destroyed, most likely because of a navigation.');
       throw error;
-    }
-    /**
-     * @param {!Array<*>} args
-     */
-    function warnOnNestedJSHandle(args) {
-      const alreadyTraversed = [];
-      function walk(obj, level) {
-        if (alreadyTraversed.includes(obj)) return;
-
-        if (obj instanceof JSHandle) {
-          if (level >= 1)
-            console.warn('Found JSHandle nested within an argument. JSHandles may only be passed as top-level arguments');
-        } else if (Array.isArray(obj)) {
-          alreadyTraversed.push(obj);
-          obj.forEach(elem => walk(elem, level + 1));
-        } else if (typeof obj === typeof {}) {
-          alreadyTraversed.push(obj);
-          Object.keys(obj).forEach(k => walk(obj[k], level + 1));
-        }
-      }
-
-      args.forEach(arg => walk(arg, 0));
     }
 
   }

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -111,9 +111,9 @@ class ExecutionContext {
         throw new Error('Passed function is not well-serializable!');
       }
     }
-    let funcCallResultP;
+    let callFunctionOnPromise;
     try {
-      funcCallResultP = this._client.send('Runtime.callFunctionOn', {
+      callFunctionOnPromise = this._client.send('Runtime.callFunctionOn', {
         functionDeclaration: functionText + '\n' + suffix + '\n',
         executionContextId: this._contextId,
         arguments: args.map(convertArgument.bind(this)),
@@ -126,7 +126,7 @@ class ExecutionContext {
         err.message += ' Are you passing a nested JSHandle?';
       throw err;
     }
-    const { exceptionDetails, result: remoteObject } = await funcCallResultP.catch(rewriteError);
+    const { exceptionDetails, result: remoteObject } = await callFunctionOnPromise.catch(rewriteError);
     if (exceptionDetails)
       throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
     return createJSHandle(this, remoteObject);

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -111,15 +111,22 @@ class ExecutionContext {
         throw new Error('Passed function is not well-serializable!');
       }
     }
-
-    const { exceptionDetails, result: remoteObject } = await this._client.send('Runtime.callFunctionOn', {
-      functionDeclaration: functionText + '\n' + suffix + '\n',
-      executionContextId: this._contextId,
-      arguments: args.map(convertArgument.bind(this)),
-      returnByValue: false,
-      awaitPromise: true,
-      userGesture: true
-    }).catch(rewriteError);
+    let funcCallResultP;
+    try {
+      funcCallResultP = this._client.send('Runtime.callFunctionOn', {
+        functionDeclaration: functionText + '\n' + suffix + '\n',
+        executionContextId: this._contextId,
+        arguments: args.map(convertArgument.bind(this)),
+        returnByValue: false,
+        awaitPromise: true,
+        userGesture: true
+      });
+    } catch (e) {
+      if (e instanceof TypeError && e.message === 'Converting circular structure to JSON')
+        warnOnNestedJSHandle(args);
+      throw e;
+    }
+    const { exceptionDetails, result: remoteObject } = await funcCallResultP.catch(rewriteError);
     if (exceptionDetails)
       throw new Error('Evaluation failed: ' + helper.getExceptionMessage(exceptionDetails));
     return createJSHandle(this, remoteObject);
@@ -162,6 +169,29 @@ class ExecutionContext {
         throw new Error('Execution context was destroyed, most likely because of a navigation.');
       throw error;
     }
+    /**
+     * @param {!Array<*>} args
+     */
+    function warnOnNestedJSHandle(args) {
+      const alreadyTraversed = [];
+      function walk(obj, level) {
+        if (alreadyTraversed.includes(obj)) return;
+
+        if (obj instanceof JSHandle) {
+          if (level >= 1)
+            console.warn('Found JSHandle nested within an argument. JSHandles may only be passed as top-level arguments');
+        } else if (Array.isArray(obj)) {
+          alreadyTraversed.push(obj);
+          obj.forEach(elem => walk(elem, level + 1));
+        } else if (typeof obj === typeof {}) {
+          alreadyTraversed.push(obj);
+          Object.keys(obj).forEach(k => walk(obj[k], level + 1));
+        }
+      }
+
+      args.forEach(arg => walk(arg, 0));
+    }
+
   }
 
   /**

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -169,7 +169,6 @@ class ExecutionContext {
         throw new Error('Execution context was destroyed, most likely because of a navigation.');
       throw error;
     }
-
   }
 
   /**

--- a/test/jshandle.spec.js
+++ b/test/jshandle.spec.js
@@ -34,6 +34,15 @@ module.exports.addTests = function({testRunner, expect}) {
       const isFive = await page.evaluate(e => Object.is(e, 5), aHandle);
       expect(isFive).toBeTruthy();
     });
+    it('should warn on nested object handles', async({page, server}) => {
+      const aHandle = await page.evaluateHandle(() => document.body);
+      let error = null;
+      await page.evaluateHandle(
+          opts => opts.elem.querySelector('p'),
+          { elem: aHandle },
+      ).catch(e => error = e);
+      expect(error.message).toContain('Are you passing a nested JSHandle?');
+    });
   });
 
   describe('JSHandle.getProperty', function() {

--- a/test/jshandle.spec.js
+++ b/test/jshandle.spec.js
@@ -39,7 +39,7 @@ module.exports.addTests = function({testRunner, expect}) {
       let error = null;
       await page.evaluateHandle(
           opts => opts.elem.querySelector('p'),
-          { elem: aHandle },
+          { elem: aHandle }
       ).catch(e => error = e);
       expect(error.message).toContain('Are you passing a nested JSHandle?');
     });


### PR DESCRIPTION
ExecutionContext.evaluateHandle accepts arguments that are either
serializable, or JSHandles. A potential confusion is that it *does not*
accept arguments that *contain* JSHandles.

This patch adds a log message warning when it encounters that situation.

Fixes #3562