### PR TITLE
feat(serviceworkers): add basic support for Service Workers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -87,6 +87,9 @@
   * [event: 'response'](#event-response)
   * [event: 'serviceworkercreated'](#event-serviceworkercreated)
   * [event: 'serviceworkerdestroyed'](#event-serviceworkerdestroyed)
+  * [event: 'serviceworkerregistrationcreated'](#event-serviceworkerregistrationcreated)
+  * [event: 'serviceworkerregistrationdeleted'](#event-serviceworkerregistrationdeleted)
+  * [event: 'serviceworkerstatuschanged'](#event-serviceworkerstatuschanged)
   * [event: 'workercreated'](#event-workercreated)
   * [event: 'workerdestroyed'](#event-workerdestroyed)
   * [page.$(selector)](#pageselector)
@@ -173,6 +176,16 @@
   * [serviceWorker.pages()](#serviceworkerpages)
   * [serviceWorker.target()](#serviceworkertarget)
   * [serviceWorker.url()](#serviceworkerurl)
+- [class: ServiceWorkerRegistration](#class-serviceworkerregistration)
+  * [serviceWorkerRegistration.page()](#serviceworkerregistrationpage)
+  * [serviceWorkerRegistration.push([data])](#serviceworkerregistrationpushdata)
+  * [serviceWorkerRegistration.runningStatus()](#serviceworkerregistrationrunningstatus)
+  * [serviceWorkerRegistration.scope()](#serviceworkerregistrationscope)
+  * [serviceWorkerRegistration.serviceWorker()](#serviceworkerregistrationserviceworker)
+  * [serviceWorkerRegistration.skipWaiting()](#serviceworkerregistrationskipwaiting)
+  * [serviceWorkerRegistration.status()](#serviceworkerregistrationstatus)
+  * [serviceWorkerRegistration.sync([tag], [lastChance])](#serviceworkerregistrationsynctag-lastchance)
+  * [serviceWorkerRegistration.target()](#serviceworkerregistrationtarget)
 - [class: Accessibility](#class-accessibility)
   * [accessibility.snapshot([options])](#accessibilitysnapshotoptions)
 - [class: Keyboard](#class-keyboard)
@@ -1020,6 +1033,21 @@ Emitted when a dedicated [ServiceWorker](https://developer.mozilla.org/en-US/doc
 - <[ServiceWorker]>
 
 Emitted when a dedicated [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is terminated.
+
+#### event: 'serviceworkerregistrationcreated'
+- <[ServiceWorkerRegistration]>
+
+Emitted when a [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) is created
+
+#### event: 'serviceworkerregistrationdeleted'
+- <[ServiceWorkerRegistration]>
+
+Emitted when a [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) is deleted.
+
+#### event: 'serviceworkerstatuschanged'
+- <[ServiceWorkerRegistration]>
+
+Emitted when the status of a [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) has changed.    
 
 #### event: 'workercreated'
 - <[Worker]>
@@ -2116,6 +2144,73 @@ Get the target this ServiceWorker was created from.
 
 Returns this Service Worker's script URL.
 This is a shortcut for [page.target().url()](#targeturl).
+
+### class: ServiceWorkerRegistration
+
+The [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) class represents a Service Worker's registration on a page.
+
+You can get ServiceWorkerRegistrations by listening on the `serviceworkerregistrationcreated` event:
+```js
+const puppeteer = require('puppeteer');
+
+puppeteer.launch().then(async browser => {
+  const page = await browser.newPage();
+  page.on('serviceworkerregistrationcreated', registration => {
+    console.log('Registration with scope: ' + registration.scope());
+  });
+  
+  await page.goto('https://service-worker-example.org/');
+  await browser.close();
+});
+```
+
+#### serviceWorkerRegistration.page()
+- returns: <[Page]>
+
+Get the page associated with this ServiceWorker registration.
+
+#### serviceWorkerRegistration.push([data])
+- `data` <[string]> The data to push by the ServiceWorker.
+- returns: <[Promise]>
+
+Deliver a push message by the ServiceWorker.
+
+#### serviceWorkerRegistration.runningStatus()
+- returns: <[string]>
+
+Get the running status of this ServiceWorker registration.
+
+#### serviceWorkerRegistration.scope()
+- returns: <[string]>
+
+Get the [scope](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/scope) this ServiceWorker registration can affect. 
+
+#### serviceWorkerRegistration.serviceWorker()
+- returns: <[Promise]<[ServiceWorker]>>
+
+Get the ServiceWorker associated with this registration.
+
+#### serviceWorkerRegistration.skipWaiting()
+- returns: <[Promise]>
+
+Force the waiting ServiceWorker to become the active ServiceWorker.
+
+#### serviceWorkerRegistration.status()
+- returns: <[string]>
+
+Get the status of this ServiceWorker registration.
+
+#### serviceWorkerRegistration.sync([tag], [lastChance])
+- `tag` <[string]> The tag to dispatch the sync event with.
+- `lastChance` <[boolean]> `true` if the user agent will not make further synchronization attempts after the current attempt.
+- returns: <[Promise]>
+
+Dispatch a [SyncEvent](https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent) by the ServiceWorker.
+
+#### serviceWorkerRegistration.target()
+- returns: <[Promise]<[Target]>>
+
+Get the ServiceWorker's target associated with this registration.
 
 ### class: Accessibility
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,24 +170,36 @@
   * [worker.executionContext()](#workerexecutioncontext)
   * [worker.url()](#workerurl)
 - [class: ServiceWorker](#class-serviceworker)
+  * [event: 'active'](#event-active)
+  * [event: 'clientattached'](#event-clientattached)
+  * [event: 'clientdetached'](#event-clientdetached)
   * [event: 'detached'](#event-detached)
+  * [event: 'installing'](#event-installing)
+  * [event: 'redundant'](#event-redundant)
   * [event: 'request'](#event-request-1)
   * [event: 'requestfailed'](#event-requestfailed-1)
   * [event: 'requestfinished'](#event-requestfinished-1)
   * [event: 'response'](#event-response-1)
+  * [event: 'waiting'](#event-waiting)
   * [serviceWorker.browser()](#serviceworkerbrowser)
+  * [serviceWorker.clients()](#serviceworkerclients)
   * [serviceWorker.detach()](#serviceworkerdetach)
-  * [serviceWorker.pages()](#serviceworkerpages)
+  * [serviceWorker.isRunning()](#serviceworkerisrunning)
+  * [serviceWorker.status()](#serviceworkerstatus)
   * [serviceWorker.target()](#serviceworkertarget)
   * [serviceWorker.url()](#serviceworkerurl)
 - [class: ServiceWorkerRegistration](#class-serviceworkerregistration)
+  * [event: 'active'](#event-active-1)
+  * [event: 'installing'](#event-installing-1)
+  * [event: 'redundant'](#event-redundant-1)
+  * [event: 'waiting'](#event-waiting-1)
   * [serviceWorkerRegistration.active()](#serviceworkerregistrationactive)
+  * [serviceWorkerRegistration.browserContext()](#serviceworkerregistrationbrowsercontext)
   * [serviceWorkerRegistration.installing()](#serviceworkerregistrationinstalling)
-  * [serviceWorkerRegistration.page()](#serviceworkerregistrationpage)
-  * [serviceWorkerRegistration.push([data])](#serviceworkerregistrationpushdata)
+  * [serviceWorkerRegistration.push([data], [origin])](#serviceworkerregistrationpushdata-origin)
   * [serviceWorkerRegistration.scope()](#serviceworkerregistrationscope)
   * [serviceWorkerRegistration.skipWaiting()](#serviceworkerregistrationskipwaiting)
-  * [serviceWorkerRegistration.sync([tag], [lastChance])](#serviceworkerregistrationsynctag-lastchance)
+  * [serviceWorkerRegistration.sync([tag], [origin], [lastChance])](#serviceworkerregistrationsynctag-origin-lastchance)
   * [serviceWorkerRegistration.unregister()](#serviceworkerregistrationunregister)
   * [serviceWorkerRegistration.waiting()](#serviceworkerregistrationwaiting)
 - [class: Accessibility](#class-accessibility)
@@ -2124,10 +2136,35 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
+#### event: 'active'
+- <[ServiceWorker]>
+
+Emitted when the service worker becomes active.
+
+#### event: 'clientattached'
+- <[Target]>
+
+Emitted when a target attached to the service worker.
+
+#### event: 'clientdetached'
+- <[Target]>
+
+Emitted when a target detached from the service worker.
+
 #### event: 'detached'
 - <[ServiceWorker]>
 
 Emitted when a service worker has been detached.
+
+#### event: 'installing'
+- <[ServiceWorker]>
+
+Emitted when the service worker becomes installing.
+
+#### event: 'redundant'
+- <[ServiceWorker]>
+
+Emitted when the service worker becomes redundant.
 
 #### event: 'request'
 - <[Request]>
@@ -2149,20 +2186,35 @@ Emitted when a request finishes successfully.
 
 Emitted when a [response] is received.
 
+#### event: 'waiting'
+- <[ServiceWorker]>
+
+Emitted when the service worker becomes waiting.
+
 #### serviceWorker.browser()
 - returns: <[Browser]>
 
 Get the browser the service worker belongs to.
+
+#### serviceWorker.clients()
+- returns: <[Array]<[Target]>>
+
+Returns all targets attached to the service worker.
 
 #### serviceWorker.detach()
 - returns: <[Promise]>
 
 Detach the service worker. 
 
-#### serviceWorker.pages()
-- returns: <[Array]<[Page]>>
+#### serviceWorker.isRunning()
+- returns: <[boolean]>
 
-Returns all pages associated with this SerivceWorker.
+Determine whether the service worker is running. 
+
+#### serviceWorker.status()
+- returns: <"new"|"installing"|"waiting"|"active"|"redundant">
+
+Determine the service worker's status within the [service worker lifecycle](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle).
 
 #### serviceWorker.target()
 - returns: <[Target]> 
@@ -2194,23 +2246,44 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
+#### event: 'active'
+- <[ServiceWorker]>
+
+Emitted when a service worker of the registration becomes active.
+
+#### event: 'installing'
+- <[ServiceWorker]>
+
+Emitted when a service worker of the registration becomes installing.
+
+#### event: 'redundant'
+- <[ServiceWorker]>
+
+Emitted when a service worker of the registration becomes redundant.
+
+#### event: 'waiting'
+- <[ServiceWorker]>
+
+Emitted when a service worker of the registration becomes waiting.
+
 #### serviceWorkerRegistration.active()
-- returns: <[Promise]<[ServiceWorker]>>
+- returns: <?[ServiceWorker]>
 
 Get the [active service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/active) of this registration.
 
+#### serviceWorkerRegistration.browserContext()
+- returns: <[BrowserContext]>
+
+Get the browser context associated with this service worker registration.
+
 #### serviceWorkerRegistration.installing()
-- returns: <[Promise]<[ServiceWorker]>>
+- returns: <?[ServiceWorker]>
 
 Get the [installing service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/installing) of this registration.
 
-#### serviceWorkerRegistration.page()
-- returns: <[Page]>
-
-Get the page associated with this ServiceWorker registration.
-
-#### serviceWorkerRegistration.push([data])
-- `data` <[string]> The data to push by the ServiceWorker.
+#### serviceWorkerRegistration.push([data], [origin])
+- `data` <[string]> The data to push by the service worker.
+- `origin` <[string]> The origin to push the data for.
 - returns: <[Promise]>
 
 Deliver a push message by the ServiceWorker.
@@ -2225,8 +2298,9 @@ Get the [scope](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRe
 
 Force the waiting ServiceWorker to become the active ServiceWorker.
 
-#### serviceWorkerRegistration.sync([tag], [lastChance])
+#### serviceWorkerRegistration.sync([tag], [origin], [lastChance])
 - `tag` <[string]> The tag to dispatch the sync event with.
+- `origin` <[string]> The origin to sync for.
 - `lastChance` <[boolean]> `true` if the user agent will not make further synchronization attempts after the current attempt.
 - returns: <[Promise]>
 
@@ -2238,7 +2312,7 @@ Dispatch a [SyncEvent](https://developer.mozilla.org/en-US/docs/Web/API/SyncEven
 Unregisters this ServiceWorker registration from the Browser.
 
 #### serviceWorkerRegistration.waiting()
-- returns: <[Promise]<[ServiceWorker]>>
+- returns: <?[ServiceWorker]>
 
 Get the [waiting service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/waiting) of this registration.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -185,7 +185,9 @@
   * [serviceWorker.clients()](#serviceworkerclients)
   * [serviceWorker.detach()](#serviceworkerdetach)
   * [serviceWorker.isRunning()](#serviceworkerisrunning)
+  * [serviceWorker.registration()](#serviceworkerregistration)
   * [serviceWorker.status()](#serviceworkerstatus)
+  * [serviceWorker.stop()](#serviceworkerstop)
   * [serviceWorker.target()](#serviceworkertarget)
   * [serviceWorker.url()](#serviceworkerurl)
 - [class: ServiceWorkerRegistration](#class-serviceworkerregistration)
@@ -2211,10 +2213,20 @@ Detach the service worker.
 
 Determine whether the service worker is running. 
 
+#### serviceWorker.registration()
+- returns: <[Promise]<[ServiceWorkerRegistration]>>
+
+Get the service worker registration associated with the service worker.
+
 #### serviceWorker.status()
 - returns: <"new"|"installing"|"waiting"|"active"|"redundant">
 
 Determine the service worker's status within the [service worker lifecycle](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle).
+
+#### serviceWorker.stop()
+- returns: <[Promise]>
+
+Stop the service worker. Afterwards, [serviceWorker.isRunning()](#serviceworkerisrunning) returns false.
 
 #### serviceWorker.target()
 - returns: <[Target]> 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,8 @@
   * [browserFetcher.revisionInfo(revision)](#browserfetcherrevisioninforevision)
 - [class: Browser](#class-browser)
   * [event: 'disconnected'](#event-disconnected)
+  * [event: 'serviceworkercreated'](#event-serviceworkercreated)
+  * [event: 'serviceworkerdestroyed'](#event-serviceworkerdestroyed)
   * [event: 'targetchanged'](#event-targetchanged)
   * [event: 'targetcreated'](#event-targetcreated)
   * [event: 'targetdestroyed'](#event-targetdestroyed)
@@ -56,6 +58,8 @@
   * [browser.waitForTarget(predicate[, options])](#browserwaitfortargetpredicate-options)
   * [browser.wsEndpoint()](#browserwsendpoint)
 - [class: BrowserContext](#class-browsercontext)
+  * [event: 'serviceworkercreated'](#event-serviceworkercreated-1)
+  * [event: 'serviceworkerdestroyed'](#event-serviceworkerdestroyed-1)
   * [event: 'targetchanged'](#event-targetchanged-1)
   * [event: 'targetcreated'](#event-targetcreated-1)
   * [event: 'targetdestroyed'](#event-targetdestroyed-1)
@@ -85,11 +89,11 @@
   * [event: 'requestfailed'](#event-requestfailed)
   * [event: 'requestfinished'](#event-requestfinished)
   * [event: 'response'](#event-response)
-  * [event: 'serviceworkercreated'](#event-serviceworkercreated)
-  * [event: 'serviceworkerdestroyed'](#event-serviceworkerdestroyed)
-  * [event: 'serviceworkerregistrationcreated'](#event-serviceworkerregistrationcreated)
-  * [event: 'serviceworkerregistrationdeleted'](#event-serviceworkerregistrationdeleted)
-  * [event: 'serviceworkerstatuschanged'](#event-serviceworkerstatuschanged)
+  * [event: 'serviceworkeractive'](#event-serviceworkeractive)
+  * [event: 'serviceworkerinstalling'](#event-serviceworkerinstalling)
+  * [event: 'serviceworkerregistered'](#event-serviceworkerregistered)
+  * [event: 'serviceworkerunregistered'](#event-serviceworkerunregistered)
+  * [event: 'serviceworkerwaiting'](#event-serviceworkerwaiting)
   * [event: 'workercreated'](#event-workercreated)
   * [event: 'workerdestroyed'](#event-workerdestroyed)
   * [page.$(selector)](#pageselector)
@@ -166,26 +170,26 @@
   * [worker.executionContext()](#workerexecutioncontext)
   * [worker.url()](#workerurl)
 - [class: ServiceWorker](#class-serviceworker)
-  * [event: 'pagecreated'](#event-pagecreated)
-  * [event: 'pagedestroyed'](#event-pagedestroyed)
+  * [event: 'detached'](#event-detached)
   * [event: 'request'](#event-request-1)
   * [event: 'requestfailed'](#event-requestfailed-1)
   * [event: 'requestfinished'](#event-requestfinished-1)
   * [event: 'response'](#event-response-1)
   * [serviceWorker.browser()](#serviceworkerbrowser)
+  * [serviceWorker.detach()](#serviceworkerdetach)
   * [serviceWorker.pages()](#serviceworkerpages)
   * [serviceWorker.target()](#serviceworkertarget)
   * [serviceWorker.url()](#serviceworkerurl)
 - [class: ServiceWorkerRegistration](#class-serviceworkerregistration)
+  * [serviceWorkerRegistration.active()](#serviceworkerregistrationactive)
+  * [serviceWorkerRegistration.installing()](#serviceworkerregistrationinstalling)
   * [serviceWorkerRegistration.page()](#serviceworkerregistrationpage)
   * [serviceWorkerRegistration.push([data])](#serviceworkerregistrationpushdata)
-  * [serviceWorkerRegistration.runningStatus()](#serviceworkerregistrationrunningstatus)
   * [serviceWorkerRegistration.scope()](#serviceworkerregistrationscope)
-  * [serviceWorkerRegistration.serviceWorker()](#serviceworkerregistrationserviceworker)
   * [serviceWorkerRegistration.skipWaiting()](#serviceworkerregistrationskipwaiting)
-  * [serviceWorkerRegistration.status()](#serviceworkerregistrationstatus)
   * [serviceWorkerRegistration.sync([tag], [lastChance])](#serviceworkerregistrationsynctag-lastchance)
-  * [serviceWorkerRegistration.target()](#serviceworkerregistrationtarget)
+  * [serviceWorkerRegistration.unregister()](#serviceworkerregistrationunregister)
+  * [serviceWorkerRegistration.waiting()](#serviceworkerregistrationwaiting)
 - [class: Accessibility](#class-accessibility)
   * [accessibility.snapshot([options])](#accessibilitysnapshotoptions)
 - [class: Keyboard](#class-keyboard)
@@ -643,6 +647,16 @@ Emitted when Puppeteer gets disconnected from the Chromium instance. This might 
 - Chromium is closed or crashed
 - The [`browser.disconnect`](#browserdisconnect) method was called
 
+#### event: 'serviceworkercreated'
+- <[ServiceWorker]>
+
+Emitted when a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is created in this browser.
+
+#### event: 'serviceworkerdestroyed'
+- <[ServiceWorker]>
+
+Emitted when a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is destroyed in this browser.
+
 #### event: 'targetchanged'
 - <[Target]>
 
@@ -786,6 +800,16 @@ await page.goto('https://example.com');
 // Dispose context once it's no longer needed.
 await context.close();
 ```
+
+#### event: 'serviceworkercreated'
+- <[ServiceWorker]>
+
+Emitted when a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is created in this browser context.
+
+#### event: 'serviceworkerdestroyed'
+- <[ServiceWorker]>
+
+Emitted when a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is destroyed in this browser context.
 
 #### event: 'targetchanged'
 - <[Target]>
@@ -1024,30 +1048,30 @@ Emitted when a request finishes successfully.
 
 Emitted when a [response] is received.
 
-#### event: 'serviceworkercreated'
+#### event: 'serviceworkeractive'
 - <[ServiceWorker]>
 
-Emitted when a dedicated [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is spawned by the page.
+Emitted when a dedicated [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is active.
 
-#### event: 'serviceworkerdestroyed'
+#### event: 'serviceworkerinstalling'
 - <[ServiceWorker]>
 
-Emitted when a dedicated [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is terminated.
+Emitted when a dedicated [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is installing.
 
-#### event: 'serviceworkerregistrationcreated'
+#### event: 'serviceworkerregistered'
 - <[ServiceWorkerRegistration]>
 
-Emitted when a [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) is created
+Emitted when a dedicated [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is registered on the page.
 
-#### event: 'serviceworkerregistrationdeleted'
+#### event: 'serviceworkerunregistered'
 - <[ServiceWorkerRegistration]>
 
-Emitted when a [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) is deleted.
+Emitted when a dedicated [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is unregistered from the page.
 
-#### event: 'serviceworkerstatuschanged'
-- <[ServiceWorkerRegistration]>
+#### event: 'serviceworkerwaiting'
+- <[ServiceWorker]>
 
-Emitted when the status of a [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) has changed.    
+Emitted when a dedicated [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is waiting.
 
 #### event: 'workercreated'
 - <[Worker]>
@@ -2072,37 +2096,38 @@ Shortcut for [(await worker.executionContext()).evaluateHandle(pageFunction, ...
 
 * extends: [`EventEmitter`](https://nodejs.org/api/events.html#events_class_eventemitter)
 
-The ServiceWorker class represents a [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API).
-The events `serviceworkercreated` and `serviceworkerdestroyed` are emitted on the page object to signal the ServiceWorker registration lifecycle.
+The ServiceWorker class represents a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API).
+The events `serviceworkercreated` and `serviceworkerdestroyed` are emitted on the page object to signal the service worker registration lifecycle.
 
-You can listen to a ServiceWorkers' requests:
+You can listen to a service workers' requests:
 ```js
 const puppeteer = require('puppeteer');
 
 function logRequest(interceptedRequest) {
-  console.log('A request was made by the ServiceWorker:', interceptedRequest.url());
+  console.log('A request was made by the service worker:', interceptedRequest.url());
 }
 
 puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
-  page.on('serviceworkercreated', serviceWorker => {
-    serviceWorker.on('request', logRequest);
+  page.on('serviceworkerregistered', serviceWorkerRegistration => {
+    serviceWorkerRegistration.installing(); // ServiceWorker
+    serviceWorkerRegistration.waiting(); // null
+    serviceWorkerRegistration.active(); // null
+    
+    // serviceWorker.on('request', logRequest);
   });
+  
+  page.on('serviceworkerunregistered', serviceWorkerRegistration => {
   
   await page.goto('https://service-worker-example.org/');
   await browser.close();
 });
 ```
 
-#### event: 'pagecreated'
-- <[Page]>
+#### event: 'detached'
+- <[ServiceWorker]>
 
-Emitted when a new page is associated with this ServiceWorker.
-
-#### event: 'pagedestroyed'
-- <[Page]>
-
-Emitted when an associated page is destroyed.
+Emitted when a service worker has been detached.
 
 #### event: 'request'
 - <[Request]>
@@ -2127,7 +2152,12 @@ Emitted when a [response] is received.
 #### serviceWorker.browser()
 - returns: <[Browser]>
 
-Get the browser the ServiceWorker belongs to.
+Get the browser the service worker belongs to.
+
+#### serviceWorker.detach()
+- returns: <[Promise]>
+
+Detach the service worker. 
 
 #### serviceWorker.pages()
 - returns: <[Array]<[Page]>>
@@ -2137,7 +2167,7 @@ Returns all pages associated with this SerivceWorker.
 #### serviceWorker.target()
 - returns: <[Target]> 
 
-Get the target this ServiceWorker was created from.
+Get the target this service worker was created from.
 
 #### serviceWorker.url()
 - returns: <[string]>
@@ -2164,6 +2194,16 @@ puppeteer.launch().then(async browser => {
 });
 ```
 
+#### serviceWorkerRegistration.active()
+- returns: <[Promise]<[ServiceWorker]>>
+
+Get the [active service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/active) of this registration.
+
+#### serviceWorkerRegistration.installing()
+- returns: <[Promise]<[ServiceWorker]>>
+
+Get the [installing service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/installing) of this registration.
+
 #### serviceWorkerRegistration.page()
 - returns: <[Page]>
 
@@ -2175,30 +2215,15 @@ Get the page associated with this ServiceWorker registration.
 
 Deliver a push message by the ServiceWorker.
 
-#### serviceWorkerRegistration.runningStatus()
-- returns: <[string]>
-
-Get the running status of this ServiceWorker registration.
-
 #### serviceWorkerRegistration.scope()
 - returns: <[string]>
 
 Get the [scope](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/scope) this ServiceWorker registration can affect. 
 
-#### serviceWorkerRegistration.serviceWorker()
-- returns: <[Promise]<[ServiceWorker]>>
-
-Get the ServiceWorker associated with this registration.
-
 #### serviceWorkerRegistration.skipWaiting()
 - returns: <[Promise]>
 
 Force the waiting ServiceWorker to become the active ServiceWorker.
-
-#### serviceWorkerRegistration.status()
-- returns: <[string]>
-
-Get the status of this ServiceWorker registration.
 
 #### serviceWorkerRegistration.sync([tag], [lastChance])
 - `tag` <[string]> The tag to dispatch the sync event with.
@@ -2207,10 +2232,15 @@ Get the status of this ServiceWorker registration.
 
 Dispatch a [SyncEvent](https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent) by the ServiceWorker.
 
-#### serviceWorkerRegistration.target()
-- returns: <[Promise]<[Target]>>
+#### serviceWorkerRegistration.unregister()
+- returns: <[Promise]>
 
-Get the ServiceWorker's target associated with this registration.
+Unregisters this ServiceWorker registration from the Browser.
+
+#### serviceWorkerRegistration.waiting()
+- returns: <[Promise]<[ServiceWorker]>>
+
+Get the [waiting service worker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/waiting) of this registration.
 
 ### class: Accessibility
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -236,6 +236,15 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @return {!Promise<!Array<!Puppeteer.ServiceWorker>>}
+   */
+  async serviceWorkers() {
+    const contextServiceWorkers = await Promise.all(this.browserContexts().map(context => context.serviceWorkers()));
+    // Flatten array.
+    return contextServiceWorkers.reduce((acc, x) => acc.concat(x), []);
+  }
+
+  /**
    * @return {!Promise<string>}
    */
   async version() {
@@ -315,6 +324,18 @@ class BrowserContext extends EventEmitter {
             .map(target => target.page())
     );
     return pages.filter(page => !!page);
+  }
+
+  /**
+   * @return {!Promise<!Array<!Puppeteer.ServiceWorker>>}
+   */
+  async serviceWorkers() {
+    const serviceWorkers = await Promise.all(
+        this.targets()
+            .filter(target => target.type() === 'service_worker')
+            .map(target => target.serviceWorker())
+    );
+    return serviceWorkers.filter(serviceWorker => !!serviceWorker);
   }
 
   /**

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -121,6 +121,12 @@ class Browser extends EventEmitter {
       this.emit(Browser.Events.TargetCreated, target);
       context.emit(BrowserContext.Events.TargetCreated, target);
     }
+
+    if (targetInfo.type === 'service_worker') {
+      const serviceWorker = await target.serviceWorker();
+      this.emit(Browser.Events.ServiceWorkerCreated, serviceWorker);
+      context.emit(BrowserContext.Events.ServiceWorkerCreated, serviceWorker);
+    }
   }
 
   /**
@@ -132,6 +138,12 @@ class Browser extends EventEmitter {
     this._targets.delete(event.targetId);
     target._closedCallback();
     if (await target._initializedPromise) {
+      if (target.type() === 'service_worker') {
+        const serviceWorker = await target.serviceWorker();
+        this.emit(Browser.Events.ServiceWorkerDestroyed, serviceWorker);
+        target.browserContext().emit(BrowserContext.Events.ServiceWorkerDestroyed, serviceWorker);
+      }
+
       this.emit(Browser.Events.TargetDestroyed, target);
       target.browserContext().emit(BrowserContext.Events.TargetDestroyed, target);
     }
@@ -282,7 +294,9 @@ Browser.Events = {
   TargetCreated: 'targetcreated',
   TargetDestroyed: 'targetdestroyed',
   TargetChanged: 'targetchanged',
-  Disconnected: 'disconnected'
+  Disconnected: 'disconnected',
+  ServiceWorkerCreated: 'serviceworkercreated',
+  ServiceWorkerDestroyed: 'serviceworkerdestroyed',
 };
 
 class BrowserContext extends EventEmitter {
@@ -407,6 +421,8 @@ BrowserContext.Events = {
   TargetCreated: 'targetcreated',
   TargetDestroyed: 'targetdestroyed',
   TargetChanged: 'targetchanged',
+  ServiceWorkerCreated: 'serviceworkercreated',
+  ServiceWorkerDestroyed: 'serviceworkerdestroyed',
 };
 
 helper.tracePublicAPI(BrowserContext);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -46,7 +46,7 @@ class Page extends EventEmitter {
     const page = new Page(client, target, frameTree, ignoreHTTPSErrors, screenshotTaskQueue);
 
     await Promise.all([
-      client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false}),
+      client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: true}),
       client.send('Page.setLifecycleEventsEnabled', { enabled: true }),
       client.send('Network.enable', {}),
       client.send('Runtime.enable', {}),
@@ -97,27 +97,8 @@ class Page extends EventEmitter {
 
     /** @type {!Map<string, Worker>} */
     this._workers = new Map();
-    client.on('Target.attachedToTarget', event => {
-      if (event.targetInfo.type !== 'worker') {
-        // If we don't detach from service workers, they will never die.
-        client.send('Target.detachFromTarget', {
-          sessionId: event.sessionId
-        }).catch(debugError);
-        return;
-      }
-      const session = client._createSession(event.targetInfo.type, event.sessionId);
-      const worker = new Worker(session, event.targetInfo.url, this._addConsoleMessage.bind(this), this._handleException.bind(this));
-      this._workers.set(event.sessionId, worker);
-      this.emit(Page.Events.WorkerCreated, worker);
-
-    });
-    client.on('Target.detachedFromTarget', event => {
-      const worker = this._workers.get(event.sessionId);
-      if (!worker)
-        return;
-      this.emit(Page.Events.WorkerDestroyed, worker);
-      this._workers.delete(event.sessionId);
-    });
+    client.on('Target.attachedToTarget', this._onAttachedToTarget.bind(this));
+    client.on('Target.detachedFromTarget', this._onDetachedFromTarget.bind(this));
 
     this._frameManager.on(FrameManager.Events.FrameAttached, event => this.emit(Page.Events.FrameAttached, event));
     this._frameManager.on(FrameManager.Events.FrameDetached, event => this.emit(Page.Events.FrameDetached, event));
@@ -170,6 +151,37 @@ class Page extends EventEmitter {
    */
   browser() {
     return this._target.browser();
+  }
+
+  /**
+   * @param {!Protocol.Target.attachedToTargetPayload} event
+   */
+  async _onAttachedToTarget(event) {
+    const session = this._client._createSession(event.targetInfo.type, event.sessionId);
+    if (event.targetInfo.type === 'worker') {
+      const worker = new Worker(session, event.targetInfo.url, this._addConsoleMessage.bind(this), this._handleException.bind(this));
+      this._workers.set(event.sessionId, worker);
+      this.emit(Page.Events.WorkerCreated, worker);
+      await session.send('Runtime.runIfWaitingForDebugger', {});
+      return;
+    }
+
+    // If we don't detach from service workers, they will never die.
+    await session.send('Runtime.runIfWaitingForDebugger', {});
+    await this._client.send('Target.detachFromTarget', {
+      sessionId: event.sessionId
+    }).catch(debugError);
+  }
+
+  /**
+   * @param {!Protocol.Target.detachedFromTargetPayload} event
+   */
+  _onDetachedFromTarget(event) {
+    const worker = this._workers.get(event.sessionId);
+    if (worker) {
+      this.emit(Page.Events.WorkerDestroyed, worker);
+      this._workers.delete(event.sessionId);
+    }
   }
 
   _onTargetCrashed() {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -114,9 +114,11 @@ class Page extends EventEmitter {
     this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(Page.Events.RequestFailed, event));
     this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(Page.Events.RequestFinished, event));
 
-    this._serviceWorkerManager.on(ServiceWorkerManager.Events.RegistrationCreated, event => this.emit(Page.Events.ServiceWorkerRegistrationCreated, event));
-    this._serviceWorkerManager.on(ServiceWorkerManager.Events.RegistrationDeleted, event => this.emit(Page.Events.ServiceWorkerRegistrationDeleted, event));
-    this._serviceWorkerManager.on(ServiceWorkerManager.Events.StatusChanged, event => this.emit(Page.Events.ServiceWorkerStatusChanged, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.Registered, event => this.emit(Page.Events.ServiceWorkerRegistered, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.Unregistered, event => this.emit(Page.Events.ServiceWorkerUnregistered, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.Installing, event => this.emit(Page.Events.ServiceWorkerInstalling, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.Waiting, event => this.emit(Page.Events.ServiceWorkerWaiting, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.Active, event => this.emit(Page.Events.ServiceWorkerActive, event));
 
     client.on('Page.domContentEventFired', event => this.emit(Page.Events.DOMContentLoaded));
     client.on('Page.loadEventFired', event => this.emit(Page.Events.Load));
@@ -175,23 +177,20 @@ class Page extends EventEmitter {
     } else if (event.targetInfo.type === 'service_worker') {
       const target = this.browser()._targets.get(event.targetInfo.targetId);
       assert(!!target, 'Service Worker Target should already exist');
+
       const serviceWorker = await target.serviceWorker();
+      serviceWorker.on(ServiceWorker.Events.Detached, async() => {
+        // If we don't detach from service workers, they will never die.
+        if (event.targetInfo.type === 'service_worker') {
+          await this._client.send('Target.detachFromTarget', {
+            sessionId: event.sessionId
+          }).catch(debugError);
+        }
+      });
+
       this._serviceWorkers.set(event.sessionId, serviceWorker);
-      serviceWorker._pages.set(event.sessionId, this);
-      this.emit(Page.Events.ServiceWorkerCreated, serviceWorker);
-      serviceWorker.emit(ServiceWorker.Events.PageCreated, this);
-
-      await session.send('Network.enable', {});
-
-      const serviceWorkerNetworkManager = new NetworkManager(session);
-      serviceWorkerNetworkManager.on(NetworkManager.Events.Request, event => serviceWorker.emit(ServiceWorker.Events.Request, event));
-      serviceWorkerNetworkManager.on(NetworkManager.Events.Response, event => serviceWorker.emit(ServiceWorker.Events.Response, event));
-      serviceWorkerNetworkManager.on(NetworkManager.Events.RequestFailed, event => serviceWorker.emit(ServiceWorker.Events.RequestFailed, event));
-      serviceWorkerNetworkManager.on(NetworkManager.Events.RequestFinished, event => serviceWorker.emit(ServiceWorker.Events.RequestFinished, event));
+      await serviceWorker._attach(session);
     }
-
-    // If we don't detach from service workers, they will never die.
-    await session.send('Runtime.runIfWaitingForDebugger', {});
   }
 
   /**
@@ -205,8 +204,6 @@ class Page extends EventEmitter {
     }
     const serviceWorker = this._serviceWorkers.get(event.sessionId);
     if (serviceWorker) {
-      this.emit(Page.Events.ServiceWorkerDestroyed, serviceWorker);
-      serviceWorker.emit(ServiceWorker.Events.PageDestroyed, this);
       this._serviceWorkers.delete(event.sessionId);
       serviceWorker._pages.delete(event.sessionId);
     }
@@ -284,10 +281,10 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @return {!Array<!ServiceWorker>}
+   * @return {!Array<!ServiceWorkerRegistration>}
    */
   serviceWorkers() {
-    return Array.from(this._serviceWorkers.values());
+    return this._serviceWorkerManager.registrations();
   }
 
   /**
@@ -1234,11 +1231,16 @@ Page.Events = {
   Metrics: 'metrics',
   WorkerCreated: 'workercreated',
   WorkerDestroyed: 'workerdestroyed',
-  ServiceWorkerCreated: 'serviceworkercreated',
-  ServiceWorkerDestroyed: 'serviceworkerdestroyed',
-  ServiceWorkerRegistrationCreated: 'serviceworkerregistrationcreated',
-  ServiceWorkerRegistrationDeleted: 'serviceworkerregistrationdeleted',
-  ServiceWorkerStatusChanged: 'serviceworkerstatuschanged',
+  ServiceWorkerActive: 'serviceworkeractive',
+  ServiceWorkerInstalling: 'serviceworkerinstalling',
+  ServiceWorkerRegistered: 'serviceworkerregistered',
+  ServiceWorkerUnregistered: 'serviceworkerunregistered',
+  ServiceWorkerWaiting: 'serviceworkerwaiting',
+
+  // ServiceWorkerDestroyed: 'serviceworkerdestroyed',
+  // ServiceWorkerRegistrationCreated: 'serviceworkerregistrationcreated',
+  // ServiceWorkerRegistrationDeleted: 'serviceworkerregistrationdeleted',
+  // ServiceWorkerStatusChanged: 'serviceworkerstatuschanged',
 };
 
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -26,6 +26,7 @@ const Tracing = require('./Tracing');
 const {helper, debugError, assert} = require('./helper');
 const {Coverage} = require('./Coverage');
 const {Worker} = require('./Worker');
+const {ServiceWorker} = require('./ServiceWorker');
 const {createJSHandle} = require('./ExecutionContext');
 const {Accessibility} = require('./Accessibility');
 const writeFileAsync = helper.promisify(fs.writeFile);
@@ -97,6 +98,8 @@ class Page extends EventEmitter {
 
     /** @type {!Map<string, Worker>} */
     this._workers = new Map();
+    /** @type {!Map<string, ServiceWorker>} */
+    this._serviceWorkers = new Map();
     client.on('Target.attachedToTarget', this._onAttachedToTarget.bind(this));
     client.on('Target.detachedFromTarget', this._onDetachedFromTarget.bind(this));
 
@@ -163,14 +166,26 @@ class Page extends EventEmitter {
       this._workers.set(event.sessionId, worker);
       this.emit(Page.Events.WorkerCreated, worker);
       await session.send('Runtime.runIfWaitingForDebugger', {});
-      return;
+    } else if (event.targetInfo.type === 'service_worker') {
+      const target = this.browser()._targets.get(event.targetInfo.targetId);
+      assert(!!target, 'Service Worker Target should already exist');
+      const serviceWorker = await target.serviceWorker();
+      this._serviceWorkers.set(event.sessionId, serviceWorker);
+      serviceWorker._pages.set(event.sessionId, this);
+      this.emit(Page.Events.ServiceWorkerCreated, serviceWorker);
+      serviceWorker.emit(ServiceWorker.Events.PageCreated, this);
+
+      await session.send('Network.enable', {});
+
+      const serviceWorkerNetworkManager = new NetworkManager(session);
+      serviceWorkerNetworkManager.on(NetworkManager.Events.Request, event => serviceWorker.emit(ServiceWorker.Events.Request, event));
+      serviceWorkerNetworkManager.on(NetworkManager.Events.Response, event => serviceWorker.emit(ServiceWorker.Events.Response, event));
+      serviceWorkerNetworkManager.on(NetworkManager.Events.RequestFailed, event => serviceWorker.emit(ServiceWorker.Events.RequestFailed, event));
+      serviceWorkerNetworkManager.on(NetworkManager.Events.RequestFinished, event => serviceWorker.emit(ServiceWorker.Events.RequestFinished, event));
     }
 
     // If we don't detach from service workers, they will never die.
     await session.send('Runtime.runIfWaitingForDebugger', {});
-    await this._client.send('Target.detachFromTarget', {
-      sessionId: event.sessionId
-    }).catch(debugError);
   }
 
   /**
@@ -181,6 +196,13 @@ class Page extends EventEmitter {
     if (worker) {
       this.emit(Page.Events.WorkerDestroyed, worker);
       this._workers.delete(event.sessionId);
+    }
+    const serviceWorker = this._serviceWorkers.get(event.sessionId);
+    if (serviceWorker) {
+      this.emit(Page.Events.ServiceWorkerDestroyed, serviceWorker);
+      serviceWorker.emit(ServiceWorker.Events.PageDestroyed, this);
+      this._serviceWorkers.delete(event.sessionId);
+      serviceWorker._pages.delete(event.sessionId);
     }
   }
 
@@ -253,6 +275,13 @@ class Page extends EventEmitter {
    */
   workers() {
     return Array.from(this._workers.values());
+  }
+
+  /**
+   * @return {!Array<!ServiceWorker>}
+   */
+  serviceWorkers() {
+    return Array.from(this._serviceWorkers.values());
   }
 
   /**
@@ -1199,6 +1228,8 @@ Page.Events = {
   Metrics: 'metrics',
   WorkerCreated: 'workercreated',
   WorkerDestroyed: 'workerdestroyed',
+  ServiceWorkerCreated: 'serviceworkercreated',
+  ServiceWorkerDestroyed: 'serviceworkerdestroyed',
 };
 
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -203,10 +203,8 @@ class Page extends EventEmitter {
       this._workers.delete(event.sessionId);
     }
     const serviceWorker = this._serviceWorkers.get(event.sessionId);
-    if (serviceWorker) {
+    if (serviceWorker)
       this._serviceWorkers.delete(event.sessionId);
-      serviceWorker._pages.delete(event.sessionId);
-    }
   }
 
   _onTargetCrashed() {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -26,7 +26,7 @@ const Tracing = require('./Tracing');
 const {helper, debugError, assert} = require('./helper');
 const {Coverage} = require('./Coverage');
 const {Worker} = require('./Worker');
-const {ServiceWorker} = require('./ServiceWorker');
+const {ServiceWorker, ServiceWorkerManager} = require('./ServiceWorker');
 const {createJSHandle} = require('./ExecutionContext');
 const {Accessibility} = require('./Accessibility');
 const writeFileAsync = helper.promisify(fs.writeFile);
@@ -54,6 +54,7 @@ class Page extends EventEmitter {
       client.send('Security.enable', {}),
       client.send('Performance.enable', {}),
       client.send('Log.enable', {}),
+      client.send('ServiceWorker.enable', {}),
     ]);
     if (ignoreHTTPSErrors)
       await client.send('Security.setOverrideCertificateErrors', {override: true});
@@ -85,6 +86,7 @@ class Page extends EventEmitter {
     this._frameManager = new FrameManager(client, frameTree, this, this._networkManager);
     this._networkManager.setFrameManager(this._frameManager);
     this._emulationManager = new EmulationManager(client);
+    this._serviceWorkerManager = new ServiceWorkerManager(client, this);
     this._tracing = new Tracing(client);
     /** @type {!Map<string, Function>} */
     this._pageBindings = new Map();
@@ -111,6 +113,10 @@ class Page extends EventEmitter {
     this._networkManager.on(NetworkManager.Events.Response, event => this.emit(Page.Events.Response, event));
     this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(Page.Events.RequestFailed, event));
     this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(Page.Events.RequestFinished, event));
+
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.RegistrationCreated, event => this.emit(Page.Events.ServiceWorkerRegistrationCreated, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.RegistrationDeleted, event => this.emit(Page.Events.ServiceWorkerRegistrationDeleted, event));
+    this._serviceWorkerManager.on(ServiceWorkerManager.Events.StatusChanged, event => this.emit(Page.Events.ServiceWorkerStatusChanged, event));
 
     client.on('Page.domContentEventFired', event => this.emit(Page.Events.DOMContentLoaded));
     client.on('Page.loadEventFired', event => this.emit(Page.Events.Load));
@@ -1230,6 +1236,9 @@ Page.Events = {
   WorkerDestroyed: 'workerdestroyed',
   ServiceWorkerCreated: 'serviceworkercreated',
   ServiceWorkerDestroyed: 'serviceworkerdestroyed',
+  ServiceWorkerRegistrationCreated: 'serviceworkerregistrationcreated',
+  ServiceWorkerRegistrationDeleted: 'serviceworkerregistrationdeleted',
+  ServiceWorkerStatusChanged: 'serviceworkerstatuschanged',
 };
 
 

--- a/lib/ServiceWorker.js
+++ b/lib/ServiceWorker.js
@@ -16,7 +16,6 @@
 
 const {helper, assert} = require('./helper');
 const {NetworkManager} = require('./NetworkManager');
-const {parse} = require('url');
 const EventEmitter = require('events');
 
 class ServiceWorker extends EventEmitter {
@@ -44,9 +43,14 @@ class ServiceWorker extends EventEmitter {
     this._closed = false;
     this._client = client;
     this._target = target;
+    /** @type {?string} */
+    this._versionId = null;
+    /** @type {string} */
+    this._status = 'new';
+    this._running = false;
 
-    /** @type {!Map<!string, !Puppeteer.Page>} */
-    this._pages = new Map();
+    /** @type {!Map<!string, !Puppeteer.Target>} */
+    this._clients = new Map();
 
     client.on('Target.attachedToTarget', async event => {
       assert(event.targetInfo.type === 'worker', 'First attaching target should be the inner worker.');
@@ -98,10 +102,78 @@ class ServiceWorker extends EventEmitter {
   }
 
   /**
-   * @return {!Array<!Puppeteer.Page>}
+   * @return {!Array<!Puppeteer.Target>}
    */
-  pages() {
-    return Array.from(this._pages.values());
+  clients() {
+    return Array.from(this._clients.values());
+  }
+
+  /**
+   * @return {boolean}
+   */
+  isRunning() {
+    return this._running;
+  }
+
+  /**
+   * @return {string}
+   */
+  status() {
+    return this._status;
+  }
+
+  /**
+   * @param {!Protocol.ServiceWorker.ServiceWorkerVersion} version
+   */
+  _updateVersionInfo(version) {
+    if (this._versionId !== version.versionId)
+      this._versionId = version.versionId;
+    if (this._status !== this._statusToState(version.status)) {
+      this._status = this._statusToState(version.status);
+      if (this._status === 'installing')
+        this.emit(ServiceWorker.Events.Installing, this);
+      else if (this._status === 'waiting')
+        this.emit(ServiceWorker.Events.Waiting, this);
+      else if (this._status === 'active')
+        this.emit(ServiceWorker.Events.Active, this);
+      else if (this._status === 'redundant')
+        this.emit(ServiceWorker.Events.Redundant, this);
+    }
+    if ((this._running && version.runningStatus !== 'running') || (!this._running && version.runningStatus === 'running'))
+      this._running = version.runningStatus === 'running';
+    for (const [targetId, client] of Array.from(this._clients)) {
+      if (version.controlledClients.indexOf(targetId) < 0) {
+        this.emit(ServiceWorker.Events.ClientDetached, client);
+        this._clients.delete(targetId);
+      }
+    }
+    for (const targetId of version.controlledClients) {
+      if (!this._clients.has(targetId)) {
+        const client = this._target.browser()._targets.get(targetId);
+        this._clients.set(targetId, client);
+        this.emit(ServiceWorker.Events.ClientAttached, client);
+      }
+    }
+  }
+
+  /**
+   * @param {!string} status
+   * @returns {!string}
+   */
+  _statusToState(status) {
+    switch (status) {
+      case 'installing':
+        return 'installing';
+      case 'installed':
+        return 'waiting';
+      case 'activating':
+      case 'activated':
+        return 'active';
+      case 'redundant':
+        return 'redundant';
+      default:
+        return 'new';
+    }
   }
 }
 
@@ -111,6 +183,12 @@ ServiceWorker.Events = {
   RequestFailed: 'requestfailed',
   RequestFinished: 'requestfinished',
   Detached: 'detached',
+  Installing: 'installing',
+  Waiting: 'waiting',
+  Active: 'active',
+  Redundant: 'redundant',
+  ClientAttached: 'clientattached',
+  ClientDetached: 'clientdetached',
 };
 
 class ServiceWorkerManager extends EventEmitter {
@@ -139,7 +217,7 @@ class ServiceWorkerManager extends EventEmitter {
   /**
    * @param {!Protocol.ServiceWorker.workerRegistrationUpdatedPayload} event
    */
-  _onWorkerRegistrationUpdated(event) {
+  async _onWorkerRegistrationUpdated(event) {
     for (const payload of event.registrations) {
       const registration = this._registrationIdToRegistration.get(payload.registrationId);
       if (payload.isDeleted) {
@@ -148,11 +226,16 @@ class ServiceWorkerManager extends EventEmitter {
 
         this.emit(ServiceWorkerManager.Events.Unregistered, registration);
         this._registrationIdToRegistration.delete(payload.registrationId);
+        await registration._delete();
         return;
       }
 
       if (!registration) {
-        const registration = new ServiceWorkerRegistration(this._client, this._page, payload);
+        const registration = new ServiceWorkerRegistration(this._client, this._page._target._browserContext, payload);
+        registration.on(ServiceWorkerRegistration.Events.Installing, event => this.emit(ServiceWorkerManager.Events.Installing, event));
+        registration.on(ServiceWorkerRegistration.Events.Waiting, event => this.emit(ServiceWorkerManager.Events.Waiting, event));
+        registration.on(ServiceWorkerRegistration.Events.Active, event => this.emit(ServiceWorkerManager.Events.Active, event));
+        registration.on(ServiceWorkerRegistration.Events.Redundant, event => this.emit(ServiceWorkerManager.Events.Redundant, event));
         this._registrationIdToRegistration.set(payload.registrationId, registration);
         this.emit(ServiceWorkerManager.Events.Registered, registration);
         return;
@@ -168,49 +251,10 @@ class ServiceWorkerManager extends EventEmitter {
   async _onWorkerVersionUpdated(event) {
     for (const version of event.versions) {
       const registration = this._registrationIdToRegistration.get(version.registrationId);
-      if (!registration)
+      if (!registration || !version.targetId)
         return;
 
-      const oldVersion = registration._versions.get(version.versionId);
-      registration._versions.set(version.versionId, version);
-
-      if (this._statusToState(version.status) !== this._statusToState(oldVersion && oldVersion.status)) {
-        switch (this._statusToState(version.status)) {
-          case 'installing':
-            this.emit(ServiceWorkerManager.Events.Installing, await registration.installing());
-            return;
-          case 'waiting':
-            this.emit(ServiceWorkerManager.Events.Waiting, await registration.waiting());
-            return;
-          case 'active':
-            this.emit(ServiceWorkerManager.Events.Active, await registration.active());
-          case 'redundant':
-            const serviceWorker = await registration._findServiceWorker(other => other.versionId === version.versionId);
-            // If we don't detach from service workers, they will never die.
-            await serviceWorker.detach();
-            this.emit(ServiceWorkerManager.Events.Redundant, serviceWorker);
-        }
-      }
-    }
-  }
-
-  /**
-   * @param {!string} status
-   * @returns {!string}
-   */
-  _statusToState(status) {
-    switch (status) {
-      case 'installing':
-        return 'installing';
-      case 'installed':
-        return 'waiting';
-      case 'activating':
-      case 'activated':
-        return 'active';
-      case 'redundant':
-        return 'redundant';
-      default:
-        return 'new';
+      await registration._updateVersionInfo(version);
     }
   }
 }
@@ -224,21 +268,19 @@ ServiceWorkerManager.Events = {
   Redundant: 'redundant',
 };
 
-class ServiceWorkerRegistration {
+class ServiceWorkerRegistration extends EventEmitter {
   /**
    * @param {!Puppeteer.CDPSession} client
-   * @param {!Puppeteer.Page} page
+   * @param {!Puppeteer.BrowserContext} browserContext
    * @param {!Protocol.ServiceWorker.ServiceWorkerRegistration} registration
    */
-  constructor(client, page, registration) {
+  constructor(client, browserContext, registration) {
+    super();
     this._client = client;
-    this._page = page;
+    this._browserContext = browserContext;
     this._registration = registration;
-    /** @type {!Map<!string, !Protocol.ServiceWorker.ServiceWorkerVersion>} */
-    this._versions = new Map();
-
-    const url = parse(page.url());
-    this._origin = url.protocol + '//' + url.host;
+    /** @type {!Map<string, !ServiceWorker>} */
+    this._targetIdToServiceWorker = new Map();
   }
 
   async skipWaiting() {
@@ -251,79 +293,105 @@ class ServiceWorkerRegistration {
 
   /**
    * @param {!string} tag
+   * @param {!string} origin
    * @param {!boolean=} lastChance
    */
-  async sync(tag, lastChance = false) {
+  async sync(tag, origin, lastChance = false) {
     await this._client.send('ServiceWorker.dispatchSyncEvent', {
       tag,
       lastChance,
-      origin: this._origin,
+      origin,
       registrationId: this._registration.registrationId,
     });
   }
 
   /**
    * @param {!string} data
+   * @param {!string} origin
    */
-  async push(data) {
+  async push(data, origin) {
     await this._client.send('ServiceWorker.deliverPushMessage', {
       data,
-      origin: this._origin,
+      origin,
       registrationId: this._registration.registrationId,
     });
   }
 
   /**
-   * @returns {!Promise<?ServiceWorker>}
+   * @return {?ServiceWorker}
    */
   installing() {
-    return this._findServiceWorker(version => version.status === 'installing');
+    return this._findServiceWorker(serviceWorker => serviceWorker.status() === 'installing');
   }
 
   /**
-   * @returns {!Promise<?ServiceWorker>}
+   * @return {?ServiceWorker}
    */
   waiting() {
-    return this._findServiceWorker(version => version.status === 'installed');
+    return this._findServiceWorker(serviceWorker => serviceWorker.status() === 'waiting');
   }
 
   /**
-   * @returns {!Promise<?ServiceWorker>}
+   * @return {?ServiceWorker}
    */
   active() {
-    return this._findServiceWorker(version => version.status === 'activating' || version.status === 'activated');
+    return this._findServiceWorker(serviceWorker => serviceWorker.status() === 'active');
   }
 
   /**
-   * @param {!function(!Protocol.ServiceWorker.ServiceWorkerVersion): !boolean} predicate
-   * @returns {!Promise<?ServiceWorker>}
+   * @param {!function(!ServiceWorker): !boolean} predicate
+   * @return {?ServiceWorker}
    */
-  async _findServiceWorker(predicate) {
-    const version = Array.from(this._versions.values())
-        .filter(version => version.targetId)
-        .find(predicate);
+  _findServiceWorker(predicate) {
+    const serviceWorker = Array.from(this._targetIdToServiceWorker.values()).find(predicate);
+    if (serviceWorker)
+      return serviceWorker;
 
-    if (!version)
-      return null;
-
-    const target = await this._page._target._browserContext.waitForTarget(target => target._targetId === version.targetId);
-    return target.serviceWorker();
+    return null;
   }
 
   /**
-   * @returns {string}
+   * @return {string}
    */
   scope() {
     return this._registration.scopeURL;
   }
 
   /**
-   * @returns {!Puppeteer.Page}
+   * @return {!Puppeteer.BrowserContext}
    */
-  page() {
-    return this._page;
+  browserContext() {
+    return this._browserContext;
+  }
+
+  async _delete() {
+    await Promise.all(Array.from(this._targetIdToServiceWorker.values()).map(serviceWorker => serviceWorker.detach()));
+  }
+
+  /**
+   * @param {!Protocol.ServiceWorker.ServiceWorkerVersion} version
+   */
+  async _updateVersionInfo(version) {
+    let serviceWorker = this._targetIdToServiceWorker.get(version.targetId);
+    if (!serviceWorker) {
+      const target = await this._browserContext.waitForTarget(target => target._targetId === version.targetId);
+      serviceWorker = await target.serviceWorker();
+      serviceWorker.on(ServiceWorker.Events.Installing, event => this.emit(ServiceWorkerRegistration.Events.Installing, event));
+      serviceWorker.on(ServiceWorker.Events.Waiting, event => this.emit(ServiceWorkerRegistration.Events.Waiting, event));
+      serviceWorker.on(ServiceWorker.Events.Active, event => this.emit(ServiceWorkerRegistration.Events.Active, event));
+      serviceWorker.on(ServiceWorker.Events.Redundant, event => this.emit(ServiceWorkerRegistration.Events.Redundant, event));
+      this._targetIdToServiceWorker.set(target._targetId, serviceWorker);
+    }
+    serviceWorker._updateVersionInfo(version);
   }
 }
+
+ServiceWorkerRegistration.Events = {
+  Installing: 'installing',
+  Waiting: 'waiting',
+  Active: 'active',
+  Redundant: 'redundant',
+};
 
 helper.tracePublicAPI(ServiceWorker);
 helper.tracePublicAPI(ServiceWorkerRegistration);

--- a/lib/ServiceWorker.js
+++ b/lib/ServiceWorker.js
@@ -47,23 +47,33 @@ class ServiceWorker extends EventEmitter {
 
     /** @type {!Map<!string, !Puppeteer.Page>} */
     this._pages = new Map();
-    this._networkManager = null;
-    this._initializedPromise = new Promise(fulfill => {
-      client.once('Target.attachedToTarget', async event => {
-        assert(event.targetInfo.type === 'worker', 'First attaching target should be the inner worker.');
-        const session = client._createSession(event.targetInfo.type, event.sessionId);
-        await session.send('Network.enable', {});
-        this._networkManager = new NetworkManager(session);
 
-        this._networkManager.on(NetworkManager.Events.Request, event => this.emit(ServiceWorker.Events.Request, event));
-        this._networkManager.on(NetworkManager.Events.Response, event => this.emit(ServiceWorker.Events.Response, event));
-        this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(ServiceWorker.Events.RequestFailed, event));
-        this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(ServiceWorker.Events.RequestFinished, event));
-
-        await session.send('Runtime.runIfWaitingForDebugger', {});
-        fulfill();
-      });
+    client.on('Target.attachedToTarget', async event => {
+      assert(event.targetInfo.type === 'worker', 'First attaching target should be the inner worker.');
+      const session = client._createSession(event.targetInfo.type, event.sessionId);
+      await this._attach(session);
     });
+  }
+
+  /**
+   * @param {!Puppeteer.CDPSession} session
+   * @returns {!Promise}
+   */
+  async _attach(session) {
+    await session.send('Network.enable', {});
+    const networkManager = new NetworkManager(session);
+
+    networkManager.on(NetworkManager.Events.Request, event => this.emit(ServiceWorker.Events.Request, event));
+    networkManager.on(NetworkManager.Events.Response, event => this.emit(ServiceWorker.Events.Response, event));
+    networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(ServiceWorker.Events.RequestFailed, event));
+    networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(ServiceWorker.Events.RequestFinished, event));
+
+    await session.send('Runtime.runIfWaitingForDebugger', {});
+  }
+
+  async detach() {
+    await this._client.detach();
+    this.emit(ServiceWorker.Events.Detached, this);
   }
 
   /**
@@ -100,8 +110,7 @@ ServiceWorker.Events = {
   Response: 'response',
   RequestFailed: 'requestfailed',
   RequestFinished: 'requestfinished',
-  PageCreated: 'pagecreated',
-  PageDestroyed: 'pagedestroyed',
+  Detached: 'detached',
 };
 
 class ServiceWorkerManager extends EventEmitter {
@@ -121,24 +130,31 @@ class ServiceWorkerManager extends EventEmitter {
   }
 
   /**
+   * @returns {!Array<!ServiceWorkerRegistration>}
+   */
+  registrations() {
+    return Array.from(this._registrationIdToRegistration.values());
+  }
+
+  /**
    * @param {!Protocol.ServiceWorker.workerRegistrationUpdatedPayload} event
    */
   _onWorkerRegistrationUpdated(event) {
     for (const payload of event.registrations) {
-      let registration = this._registrationIdToRegistration.get(payload.registrationId);
+      const registration = this._registrationIdToRegistration.get(payload.registrationId);
       if (payload.isDeleted) {
         if (!registration)
           return;
 
-        this.emit(ServiceWorkerManager.Events.RegistrationDeleted, registration);
+        this.emit(ServiceWorkerManager.Events.Unregistered, registration);
         this._registrationIdToRegistration.delete(payload.registrationId);
         return;
       }
 
       if (!registration) {
-        registration = new ServiceWorkerRegistration(this._client, this._page, payload);
+        const registration = new ServiceWorkerRegistration(this._client, this._page, payload);
         this._registrationIdToRegistration.set(payload.registrationId, registration);
-        this.emit(ServiceWorkerManager.Events.RegistrationCreated, registration);
+        this.emit(ServiceWorkerManager.Events.Registered, registration);
         return;
       }
 
@@ -149,25 +165,63 @@ class ServiceWorkerManager extends EventEmitter {
   /**
    * @param {!Protocol.ServiceWorker.workerVersionUpdatedPayload} event
    */
-  _onWorkerVersionUpdated(event) {
+  async _onWorkerVersionUpdated(event) {
     for (const version of event.versions) {
       const registration = this._registrationIdToRegistration.get(version.registrationId);
       if (!registration)
         return;
 
-      const status = registration.status();
-      registration._version = version;
+      const oldVersion = registration._versions.get(version.versionId);
+      registration._versions.set(version.versionId, version);
 
-      if (registration.status() !== status)
-        this.emit(ServiceWorkerManager.Events.StatusChanged, registration);
+      if (this._statusToState(version.status) !== this._statusToState(oldVersion && oldVersion.status)) {
+        switch (this._statusToState(version.status)) {
+          case 'installing':
+            this.emit(ServiceWorkerManager.Events.Installing, await registration.installing());
+            return;
+          case 'waiting':
+            this.emit(ServiceWorkerManager.Events.Waiting, await registration.waiting());
+            return;
+          case 'active':
+            this.emit(ServiceWorkerManager.Events.Active, await registration.active());
+          case 'redundant':
+            const serviceWorker = await registration._findServiceWorker(other => other.versionId === version.versionId);
+            // If we don't detach from service workers, they will never die.
+            await serviceWorker.detach();
+            this.emit(ServiceWorkerManager.Events.Redundant, serviceWorker);
+        }
+      }
+    }
+  }
+
+  /**
+   * @param {!string} status
+   * @returns {!string}
+   */
+  _statusToState(status) {
+    switch (status) {
+      case 'installing':
+        return 'installing';
+      case 'installed':
+        return 'waiting';
+      case 'activating':
+      case 'activated':
+        return 'active';
+      case 'redundant':
+        return 'redundant';
+      default:
+        return 'new';
     }
   }
 }
 
 ServiceWorkerManager.Events = {
-  RegistrationCreated: 'registrationcreated',
-  RegistrationDeleted: 'registrationdeleted',
-  StatusChanged: 'statuschanged',
+  Registered: 'registered',
+  Unregistered: 'unregistered',
+  Installing: 'installing',
+  Waiting: 'waiting',
+  Active: 'active',
+  Redundant: 'redundant',
 };
 
 class ServiceWorkerRegistration {
@@ -180,8 +234,8 @@ class ServiceWorkerRegistration {
     this._client = client;
     this._page = page;
     this._registration = registration;
-    /** @type {?Protocol.ServiceWorker.ServiceWorkerVersion} */
-    this._version = null;
+    /** @type {!Map<!string, !Protocol.ServiceWorker.ServiceWorkerVersion>} */
+    this._versions = new Map();
 
     const url = parse(page.url());
     this._origin = url.protocol + '//' + url.host;
@@ -191,9 +245,13 @@ class ServiceWorkerRegistration {
     await this._client.send('ServiceWorker.skipWaiting', {scopeURL: this._registration.scopeURL});
   }
 
+  async unregister() {
+    await this._client.send('ServiceWorker.unregister', {scopeURL: this._registration.scopeURL});
+  }
+
   /**
-   * @param {string} tag
-   * @param {boolean} lastChance
+   * @param {!string} tag
+   * @param {!boolean=} lastChance
    */
   async sync(tag, lastChance = false) {
     await this._client.send('ServiceWorker.dispatchSyncEvent', {
@@ -205,7 +263,7 @@ class ServiceWorkerRegistration {
   }
 
   /**
-   * @param {string} data
+   * @param {!string} data
    */
   async push(data) {
     await this._client.send('ServiceWorker.deliverPushMessage', {
@@ -216,6 +274,43 @@ class ServiceWorkerRegistration {
   }
 
   /**
+   * @returns {!Promise<?ServiceWorker>}
+   */
+  installing() {
+    return this._findServiceWorker(version => version.status === 'installing');
+  }
+
+  /**
+   * @returns {!Promise<?ServiceWorker>}
+   */
+  waiting() {
+    return this._findServiceWorker(version => version.status === 'installed');
+  }
+
+  /**
+   * @returns {!Promise<?ServiceWorker>}
+   */
+  active() {
+    return this._findServiceWorker(version => version.status === 'activating' || version.status === 'activated');
+  }
+
+  /**
+   * @param {!function(!Protocol.ServiceWorker.ServiceWorkerVersion): !boolean} predicate
+   * @returns {!Promise<?ServiceWorker>}
+   */
+  async _findServiceWorker(predicate) {
+    const version = Array.from(this._versions.values())
+        .filter(version => version.targetId)
+        .find(predicate);
+
+    if (!version)
+      return null;
+
+    const target = await this._page._target._browserContext.waitForTarget(target => target._targetId === version.targetId);
+    return target.serviceWorker();
+  }
+
+  /**
    * @returns {string}
    */
   scope() {
@@ -223,45 +318,10 @@ class ServiceWorkerRegistration {
   }
 
   /**
-   * @returns {?Protocol.ServiceWorker.ServiceWorkerVersionStatus}
-   */
-  status() {
-    return this._version ? this._version.status : null;
-  }
-
-  /**
-   * @returns {?Protocol.ServiceWorker.ServiceWorkerVersionRunningStatus}
-   */
-  runningStatus() {
-    return this._version ? this._version.runningStatus : null;
-  }
-
-  /**
    * @returns {!Puppeteer.Page}
    */
   page() {
     return this._page;
-  }
-
-  /**
-   * @returns {?Puppeteer.Target}
-   */
-  target() {
-    if (this._version && this._version.targetId)
-      return this._page.browser()._targets.get(this._version.targetId);
-
-    return null;
-  }
-
-  /**
-   * @returns {!Promise<?ServiceWorker>}
-   */
-  async serviceWorker() {
-    const target = this.target();
-    if (target)
-      return target.serviceWorker();
-
-    return null;
   }
 }
 

--- a/lib/ServiceWorker.js
+++ b/lib/ServiceWorker.js
@@ -16,6 +16,7 @@
 
 const {helper, assert} = require('./helper');
 const {NetworkManager} = require('./NetworkManager');
+const {parse} = require('url');
 const EventEmitter = require('events');
 
 class ServiceWorker extends EventEmitter {
@@ -103,6 +104,168 @@ ServiceWorker.Events = {
   PageDestroyed: 'pagedestroyed',
 };
 
-helper.tracePublicAPI(ServiceWorker);
+class ServiceWorkerManager extends EventEmitter {
+  /**
+   * @param {!Puppeteer.CDPSession} client
+   * @param {!Puppeteer.Page} page
+   */
+  constructor(client, page) {
+    super();
+    this._client = client;
+    this._page = page;
+    /** @type {!Map<string, !ServiceWorkerRegistration>} */
+    this._registrationIdToRegistration = new Map();
 
-module.exports = {ServiceWorker};
+    client.on('ServiceWorker.workerRegistrationUpdated', this._onWorkerRegistrationUpdated.bind(this));
+    client.on('ServiceWorker.workerVersionUpdated', this._onWorkerVersionUpdated.bind(this));
+  }
+
+  /**
+   * @param {!Protocol.ServiceWorker.workerRegistrationUpdatedPayload} event
+   */
+  _onWorkerRegistrationUpdated(event) {
+    for (const payload of event.registrations) {
+      let registration = this._registrationIdToRegistration.get(payload.registrationId);
+      if (payload.isDeleted) {
+        if (!registration)
+          return;
+
+        this.emit(ServiceWorkerManager.Events.RegistrationDeleted, registration);
+        this._registrationIdToRegistration.delete(payload.registrationId);
+        return;
+      }
+
+      if (!registration) {
+        registration = new ServiceWorkerRegistration(this._client, this._page, payload);
+        this._registrationIdToRegistration.set(payload.registrationId, registration);
+        this.emit(ServiceWorkerManager.Events.RegistrationCreated, registration);
+        return;
+      }
+
+      registration._registration = payload;
+    }
+  }
+
+  /**
+   * @param {!Protocol.ServiceWorker.workerVersionUpdatedPayload} event
+   */
+  _onWorkerVersionUpdated(event) {
+    for (const version of event.versions) {
+      const registration = this._registrationIdToRegistration.get(version.registrationId);
+      if (!registration)
+        return;
+
+      const status = registration.status();
+      registration._version = version;
+
+      if (registration.status() !== status)
+        this.emit(ServiceWorkerManager.Events.StatusChanged, registration);
+    }
+  }
+}
+
+ServiceWorkerManager.Events = {
+  RegistrationCreated: 'registrationcreated',
+  RegistrationDeleted: 'registrationdeleted',
+  StatusChanged: 'statuschanged',
+};
+
+class ServiceWorkerRegistration {
+  /**
+   * @param {!Puppeteer.CDPSession} client
+   * @param {!Puppeteer.Page} page
+   * @param {!Protocol.ServiceWorker.ServiceWorkerRegistration} registration
+   */
+  constructor(client, page, registration) {
+    this._client = client;
+    this._page = page;
+    this._registration = registration;
+    /** @type {?Protocol.ServiceWorker.ServiceWorkerVersion} */
+    this._version = null;
+
+    const url = parse(page.url());
+    this._origin = url.protocol + '//' + url.host;
+  }
+
+  async skipWaiting() {
+    await this._client.send('ServiceWorker.skipWaiting', {scopeURL: this._registration.scopeURL});
+  }
+
+  /**
+   * @param {string} tag
+   * @param {boolean} lastChance
+   */
+  async sync(tag, lastChance = false) {
+    await this._client.send('ServiceWorker.dispatchSyncEvent', {
+      tag,
+      lastChance,
+      origin: this._origin,
+      registrationId: this._registration.registrationId,
+    });
+  }
+
+  /**
+   * @param {string} data
+   */
+  async push(data) {
+    await this._client.send('ServiceWorker.deliverPushMessage', {
+      data,
+      origin: this._origin,
+      registrationId: this._registration.registrationId,
+    });
+  }
+
+  /**
+   * @returns {string}
+   */
+  scope() {
+    return this._registration.scopeURL;
+  }
+
+  /**
+   * @returns {?Protocol.ServiceWorker.ServiceWorkerVersionStatus}
+   */
+  status() {
+    return this._version ? this._version.status : null;
+  }
+
+  /**
+   * @returns {?Protocol.ServiceWorker.ServiceWorkerVersionRunningStatus}
+   */
+  runningStatus() {
+    return this._version ? this._version.runningStatus : null;
+  }
+
+  /**
+   * @returns {!Puppeteer.Page}
+   */
+  page() {
+    return this._page;
+  }
+
+  /**
+   * @returns {?Puppeteer.Target}
+   */
+  target() {
+    if (this._version && this._version.targetId)
+      return this._page.browser()._targets.get(this._version.targetId);
+
+    return null;
+  }
+
+  /**
+   * @returns {!Promise<?ServiceWorker>}
+   */
+  async serviceWorker() {
+    const target = this.target();
+    if (target)
+      return target.serviceWorker();
+
+    return null;
+  }
+}
+
+helper.tracePublicAPI(ServiceWorker);
+helper.tracePublicAPI(ServiceWorkerRegistration);
+
+module.exports = {ServiceWorker, ServiceWorkerManager, ServiceWorkerRegistration};

--- a/lib/ServiceWorker.js
+++ b/lib/ServiceWorker.js
@@ -48,6 +48,8 @@ class ServiceWorker extends EventEmitter {
     /** @type {string} */
     this._status = 'new';
     this._running = false;
+    /** @type {!Promise<!ServiceWorkerRegistration>} */
+    this._registration = new Promise(fulfill => this._registrationCallback = fulfill);
 
     /** @type {!Map<!string, !Puppeteer.Target>} */
     this._clients = new Map();
@@ -78,6 +80,13 @@ class ServiceWorker extends EventEmitter {
   async detach() {
     await this._client.detach();
     this.emit(ServiceWorker.Events.Detached, this);
+  }
+
+  /**
+   * @return {!Promise<!ServiceWorkerRegistration>}
+   */
+  registration() {
+    return this._registration;
   }
 
   /**
@@ -120,6 +129,13 @@ class ServiceWorker extends EventEmitter {
    */
   status() {
     return this._status;
+  }
+
+  async stop() {
+    if (!this._versionId)
+      return;
+    const registration = await this.registration();
+    await registration._stopWorker(this._versionId);
   }
 
   /**
@@ -376,6 +392,7 @@ class ServiceWorkerRegistration extends EventEmitter {
     if (!serviceWorker) {
       const target = await this._browserContext.waitForTarget(target => target._targetId === version.targetId);
       serviceWorker = await target.serviceWorker();
+      serviceWorker._registrationCallback(this);
       serviceWorker.on(ServiceWorker.Events.Installing, event => this.emit(ServiceWorkerRegistration.Events.Installing, event));
       serviceWorker.on(ServiceWorker.Events.Waiting, event => this.emit(ServiceWorkerRegistration.Events.Waiting, event));
       serviceWorker.on(ServiceWorker.Events.Active, event => this.emit(ServiceWorkerRegistration.Events.Active, event));
@@ -383,6 +400,13 @@ class ServiceWorkerRegistration extends EventEmitter {
       this._targetIdToServiceWorker.set(target._targetId, serviceWorker);
     }
     serviceWorker._updateVersionInfo(version);
+  }
+
+  /**
+   * @param {!string} versionId
+   */
+  async _stopWorker(versionId) {
+    await this._client.send('ServiceWorker.stopWorker', {versionId});
   }
 }
 

--- a/lib/ServiceWorker.js
+++ b/lib/ServiceWorker.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {helper, assert} = require('./helper');
+const {NetworkManager} = require('./NetworkManager');
+const EventEmitter = require('events');
+
+class ServiceWorker extends EventEmitter {
+  /**
+   * @param {!Puppeteer.CDPSession} client
+   * @param {!Puppeteer.Target} target
+   * @return {!Promise<!ServiceWorker>}
+   */
+  static async create(client, target) {
+    const serviceWorker = new ServiceWorker(client, target);
+
+    await Promise.all([
+      client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: true}),
+    ]);
+
+    return serviceWorker;
+  }
+
+  /**
+   * @param {!Puppeteer.CDPSession} client
+   * @param {!Puppeteer.Target} target
+   */
+  constructor(client, target) {
+    super();
+    this._closed = false;
+    this._client = client;
+    this._target = target;
+
+    /** @type {!Map<!string, !Puppeteer.Page>} */
+    this._pages = new Map();
+    this._networkManager = null;
+    this._initializedPromise = new Promise(fulfill => {
+      client.once('Target.attachedToTarget', async event => {
+        assert(event.targetInfo.type === 'worker', 'First attaching target should be the inner worker.');
+        const session = client._createSession(event.targetInfo.type, event.sessionId);
+        await session.send('Network.enable', {});
+        this._networkManager = new NetworkManager(session);
+
+        this._networkManager.on(NetworkManager.Events.Request, event => this.emit(ServiceWorker.Events.Request, event));
+        this._networkManager.on(NetworkManager.Events.Response, event => this.emit(ServiceWorker.Events.Response, event));
+        this._networkManager.on(NetworkManager.Events.RequestFailed, event => this.emit(ServiceWorker.Events.RequestFailed, event));
+        this._networkManager.on(NetworkManager.Events.RequestFinished, event => this.emit(ServiceWorker.Events.RequestFinished, event));
+
+        await session.send('Runtime.runIfWaitingForDebugger', {});
+        fulfill();
+      });
+    });
+  }
+
+  /**
+   * @return {!Puppeteer.Target}
+   */
+  target() {
+    return this._target;
+  }
+
+  /**
+   * @return {!Puppeteer.Browser}
+   */
+  browser() {
+    return this._target.browser();
+  }
+
+  /**
+   * @return {!string}
+   */
+  url() {
+    return this._target.url();
+  }
+
+  /**
+   * @return {!Array<!Puppeteer.Page>}
+   */
+  pages() {
+    return Array.from(this._pages.values());
+  }
+}
+
+ServiceWorker.Events = {
+  Request: 'request',
+  Response: 'response',
+  RequestFailed: 'requestfailed',
+  RequestFinished: 'requestfinished',
+  PageCreated: 'pagecreated',
+  PageDestroyed: 'pagedestroyed',
+};
+
+helper.tracePublicAPI(ServiceWorker);
+
+module.exports = {ServiceWorker};

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -1,4 +1,5 @@
 const {Page} = require('./Page');
+const {ServiceWorker} = require('./ServiceWorker');
 const {helper} = require('./helper');
 
 class Target {
@@ -20,6 +21,8 @@ class Target {
     this._screenshotTaskQueue = screenshotTaskQueue;
     /** @type {?Promise<!Puppeteer.Page>} */
     this._pagePromise = null;
+    /** @type {?Promise<!Puppeteer.ServiceWorker>} */
+    this._serviceWorkerPromise = null;
     this._initializedPromise = new Promise(fulfill => this._initializedCallback = fulfill);
     this._isClosedPromise = new Promise(fulfill => this._closedCallback = fulfill);
     this._isInitialized = this._targetInfo.type !== 'page' || this._targetInfo.url !== '';
@@ -43,6 +46,17 @@ class Target {
           .then(client => Page.create(client, this, this._ignoreHTTPSErrors, this._defaultViewport, this._screenshotTaskQueue));
     }
     return this._pagePromise;
+  }
+
+  /**
+   * @return {!Promise<?ServiceWorker>}
+   */
+  async serviceWorker() {
+    if (this._targetInfo.type === 'service_worker' && !this._serviceWorkerPromise) {
+      this._serviceWorkerPromise = this._sessionFactory()
+          .then(client => ServiceWorker.create(client, this));
+    }
+    return this._serviceWorkerPromise;
   }
 
   /**

--- a/lib/externs.d.ts
+++ b/lib/externs.d.ts
@@ -2,7 +2,7 @@ import { Connection as RealConnection, CDPSession as RealCDPSession } from './Co
 import { Browser as RealBrowser, BrowserContext as RealBrowserContext} from './Browser.js';
 import {Target as RealTarget} from './Target.js';
 import {Page as RealPage} from './Page.js';
-import {ServiceWorker as RealServiceWorker} from './ServiceWorker.js';
+import {ServiceWorker as RealServiceWorker, ServiceWorkerManager as RealServiceWorkerManager, ServiceWorkerRegistration as RealServiceWorkerRegistration} from './ServiceWorker.js';
 import {TaskQueue as RealTaskQueue} from './TaskQueue.js';
 import {Mouse as RealMouse, Keyboard as RealKeyboard, Touchscreen as RealTouchscreen}  from './Input.js';
 import {Frame as RealFrame, FrameManager as RealFrameManager}  from './FrameManager.js';
@@ -31,6 +31,8 @@ declare global {
     export class ExecutionContext extends RealExecutionContext {}
     export class Page extends RealPage { }
     export class ServiceWorker extends RealServiceWorker { }
+    export class ServiceWorkerManager extends RealServiceWorkerManager { }
+    export class ServiceWorkerRegistration extends RealServiceWorkerRegistration { }
     export class Response extends RealResponse { }
     export class Request extends RealRequest { }
 

--- a/lib/externs.d.ts
+++ b/lib/externs.d.ts
@@ -2,6 +2,7 @@ import { Connection as RealConnection, CDPSession as RealCDPSession } from './Co
 import { Browser as RealBrowser, BrowserContext as RealBrowserContext} from './Browser.js';
 import {Target as RealTarget} from './Target.js';
 import {Page as RealPage} from './Page.js';
+import {ServiceWorker as RealServiceWorker} from './ServiceWorker.js';
 import {TaskQueue as RealTaskQueue} from './TaskQueue.js';
 import {Mouse as RealMouse, Keyboard as RealKeyboard, Touchscreen as RealTouchscreen}  from './Input.js';
 import {Frame as RealFrame, FrameManager as RealFrameManager}  from './FrameManager.js';
@@ -29,6 +30,7 @@ declare global {
     export class JSHandle extends RealJSHandle {}
     export class ExecutionContext extends RealExecutionContext {}
     export class Page extends RealPage { }
+    export class ServiceWorker extends RealServiceWorker { }
     export class Response extends RealResponse { }
     export class Request extends RealRequest { }
 

--- a/test/serviceworker.spec.js
+++ b/test/serviceworker.spec.js
@@ -51,7 +51,19 @@ module.exports.addTests = function({testRunner, expect}) {
 
       await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
     });
+    it('can be stopped', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const activeServiceWorker = new Promise(fulfill => page.on('serviceworkeractive', fulfill));
 
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      const serviceWorker = await activeServiceWorker;
+      expect(serviceWorker.isRunning()).toBe(true);
+      await serviceWorker.stop();
+      expect(serviceWorker.isRunning()).toBe(false);
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
     it('should report when a service worker is installing', async({page, server, context}) => {
       await page.goto(server.EMPTY_PAGE);
       const installing = new Promise(fulfill => page.on('serviceworkerinstalling', fulfill));

--- a/test/serviceworker.spec.js
+++ b/test/serviceworker.spec.js
@@ -51,35 +51,7 @@ module.exports.addTests = function({testRunner, expect}) {
 
       await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
     });
-  });
 
-  describe('ServiceWorkerRegistration', function() {
-    it('should report when a service worker registration is registered and unregistered', async({page, server, context}) => {
-      await page.goto(server.EMPTY_PAGE);
-      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
-
-      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
-
-      expect((await registered).scope()).toBe(server.PREFIX + '/serviceworkers/empty/');
-      expect((await registered).page()).toBe(page);
-
-      const unregistered = new Promise(fulfill => page.on('serviceworkerunregistered', fulfill));
-      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
-      expect(await unregistered).toBe(await registered);
-    });
-    it('can enforce to unregister', async({page, server, context}) => {
-      await page.goto(server.EMPTY_PAGE);
-      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
-
-      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
-
-      expect((await registered).scope()).toBe(server.PREFIX + '/serviceworkers/empty/');
-      expect((await registered).page()).toBe(page);
-
-      const unregistered = new Promise(fulfill => page.on('serviceworkerunregistered', fulfill));
-      await (await registered).unregister();
-      expect(await unregistered).toBe(await registered);
-    });
     it('should report when a service worker is installing', async({page, server, context}) => {
       await page.goto(server.EMPTY_PAGE);
       const installing = new Promise(fulfill => page.on('serviceworkerinstalling', fulfill));
@@ -107,6 +79,68 @@ module.exports.addTests = function({testRunner, expect}) {
       await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
 
       expect((await active).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+  });
+
+  describe('ServiceWorkerRegistration', function() {
+    it('should report when a service worker registration is registered and unregistered', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await registered).scope()).toBe(server.PREFIX + '/serviceworkers/empty/');
+      expect((await registered).browserContext()).toBe(context);
+
+      const unregistered = new Promise(fulfill => page.on('serviceworkerunregistered', fulfill));
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+      expect(await unregistered).toBe(await registered);
+    });
+    it('can enforce to unregister', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await registered).scope()).toBe(server.PREFIX + '/serviceworkers/empty/');
+      expect((await registered).browserContext()).toBe(context);
+
+      const unregistered = new Promise(fulfill => page.on('serviceworkerunregistered', fulfill));
+      await (await registered).unregister();
+      expect(await unregistered).toBe(await registered);
+    });
+    it('should report when a service worker is installing', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+      const installingServiceWorker = registered.then(registration => new Promise(fulfill => registration.once('installing', fulfill)));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await installingServiceWorker).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+    it('should report when a service worker is waiting', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+      const waitingServiceWorker = registered.then(registration => new Promise(fulfill => registration.once('waiting', fulfill)));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await waitingServiceWorker).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+    it('should report when a service worker is active', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+      const activeServiceWorker = registered.then(registration => new Promise(fulfill => registration.once('active', fulfill)));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await activeServiceWorker).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
 
       await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
     });

--- a/test/serviceworker.spec.js
+++ b/test/serviceworker.spec.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const utils = require('./utils');
+const {waitEvent} = utils;
+
+module.exports.addTests = function({testRunner, expect}) {
+  const {describe, xdescribe, fdescribe} = testRunner;
+  const {it, fit, xit} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe('Browser', function() {
+    it('should report when a service worker is created and destroyed', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const createdServiceWorker = new Promise(fulfill => context.on('serviceworkercreated', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await createdServiceWorker).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      const destroyedServiceWorker = new Promise(fulfill => context.on('serviceworkerdestroyed', fulfill));
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+
+      expect(await destroyedServiceWorker).toBe(await createdServiceWorker);
+    });
+  });
+
+  describe('ServiceWorker', function() {
+    it('should report the sw.js request', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const createdServiceWorker = new Promise(fulfill => context.on('serviceworkercreated', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+      const serviceWorker = await createdServiceWorker;
+
+      const firstRequest = new Promise(fulfill => serviceWorker.once('request', fulfill));
+      expect((await firstRequest).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+  });
+
+  describe('ServiceWorkerRegistration', function() {
+    it('should report when a service worker registration is registered and unregistered', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await registered).scope()).toBe(server.PREFIX + '/serviceworkers/empty/');
+      expect((await registered).page()).toBe(page);
+
+      const unregistered = new Promise(fulfill => page.on('serviceworkerunregistered', fulfill));
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+      expect(await unregistered).toBe(await registered);
+    });
+    it('can enforce to unregister', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const registered = new Promise(fulfill => page.on('serviceworkerregistered', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await registered).scope()).toBe(server.PREFIX + '/serviceworkers/empty/');
+      expect((await registered).page()).toBe(page);
+
+      const unregistered = new Promise(fulfill => page.on('serviceworkerunregistered', fulfill));
+      await (await registered).unregister();
+      expect(await unregistered).toBe(await registered);
+    });
+    it('should report when a service worker is installing', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const installing = new Promise(fulfill => page.on('serviceworkerinstalling', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await installing).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+    it('should report when a service worker is waiting', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const waiting = new Promise(fulfill => page.on('serviceworkerwaiting', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await waiting).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+    it('should report when a service worker is active', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      const active = new Promise(fulfill => page.on('serviceworkeractive', fulfill));
+
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      expect((await active).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
+
+      await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
+    });
+  });
+};

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -79,7 +79,7 @@ module.exports.addTests = function({testRunner, expect}) {
       expect((await createdTarget).type()).toBe('service_worker');
       expect((await createdTarget).url()).toBe(server.PREFIX + '/serviceworkers/empty/sw.js');
 
-      const destroyedTarget = new Promise(fulfill => context.once('targetdestroyed', target => fulfill(target)));
+      const destroyedTarget = new Promise(fulfill => context.on('targetdestroyed', target => target.type() === 'service_worker' && fulfill(target)));
       await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
       expect(await destroyedTarget).toBe(await createdTarget);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,7 @@ describe('Browser', function() {
     require('./target.spec.js').addTests({testRunner, expect});
     require('./tracing.spec.js').addTests({testRunner, expect});
     require('./worker.spec.js').addTests({testRunner, expect});
+    require('./serviceworker.spec').addTests({testRunner, expect});
   });
 
   // Browser-level tests that are given a browser.

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -32,6 +32,7 @@ const EXCLUDE_CLASSES = new Set([
   'Multimap',
   'LifecycleWatcher',
   'NetworkManager',
+  'ServiceWorkerManager',
   'PipeTransport',
   'TaskQueue',
   'WaitTask',


### PR DESCRIPTION
After figuring out how Service Workers are being handeld by Chrome DevTools, I created this PR which adds basic support for Service Workers. It allows users to get all Service Workers running in the browser, receive all requests which the Service Worker performs (including his own `sw.js` request), and listen for ServiceWorkerRegistration's `scopeURL` and `status`.

Example:
```js
const puppeteer = require('puppeteer');

function logRequest(interceptedRequest) {
  console.log('A request was made by the ServiceWorker:', interceptedRequest.url());
}

puppeteer.launch().then(async browser => {
  const page = await browser.newPage();
  page.on('serviceworkercreated', serviceWorker => {
    serviceWorker.on('request', logRequest);
  });
  
  await page.goto('https://service-worker-example.org/');
  await browser.close();
});
```

Unfortunately, I was not sure how to test this feature and would appreciate help with it. Also, I did not implement code coverage or stopping.

Addresses #2634.