### PR TITLE
docs(troubleshooting): Update docs about copying file for setuid sandbox

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,7 +123,7 @@ cd <project-dir-path>/node_modules/puppeteer/.local-chromium/linux-<revision>/ch
 sudo chown root:root chrome_sandbox
 sudo chmod 4755 chrome_sandbox
 # copy sandbox executable to a shared location
-sudo cp chrome_sandbox /usr/local/sbin/chrome-devel-sandbox
+sudo cp -p chrome_sandbox /usr/local/sbin/chrome-devel-sandbox
 # export CHROME_DEVEL_SANDBOX env variable
 export CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox
 ```


### PR DESCRIPTION
Very small change in light of operational experience while getting it running on Centos in Jenkins pipeline.

Without the `-p`, the permissions set in the `chmod` before this command are not carried over chrome cannot start.