### PR TITLE
chore: bump version to v1.11.0-post

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,8 @@
-# Puppeteer API <!-- GEN:version -->v1.11.0<!-- GEN:stop-->
+# Puppeteer API <!-- GEN:version -->Tip-Of-Tree<!-- GEN:stop-->
 
-<!-- GEN:empty-if-release --><!-- GEN:stop -->
+<!-- GEN:empty-if-release -->
+> Next Release: **Jan 31, 2019**
+<!-- GEN:stop -->
 - API Translations: [中文|Chinese](https://zhaoqize.github.io/puppeteer-api-zh_CN/#/)
 - Releases per Chromium Version:
   * Chromium 72.0.3582.0 - [Puppeteer v1.10.0](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppeteer",
-  "version": "1.11.0",
+  "version": "1.11.0-post",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol",
   "main": "index.js",
   "repository": "github:GoogleChrome/puppeteer",


### PR DESCRIPTION
Tentatively setting next release date to **Jan 31, 2019** so that we have time to polish all the planned changes for the v2.0.0.