### PR TITLE
feat(browser): introduce Browser.waitForNewTarget

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,7 @@
   * [browser.targets()](#browsertargets)
   * [browser.userAgent()](#browseruseragent)
   * [browser.version()](#browserversion)
+  * [browser.waitForNewTarget(predicate[, options])](#browserwaitfornewtargetpredicate-options)
   * [browser.waitForTarget(predicate[, options])](#browserwaitfortargetpredicate-options)
   * [browser.wsEndpoint()](#browserwsendpoint)
 - [class: BrowserContext](#class-browsercontext)
@@ -66,6 +67,7 @@
   * [browserContext.overridePermissions(origin, permissions)](#browsercontextoverridepermissionsorigin-permissions)
   * [browserContext.pages()](#browsercontextpages)
   * [browserContext.targets()](#browsercontexttargets)
+  * [browserContext.waitForNewTarget(predicate[, options])](#browsercontextwaitfornewtargetpredicate-options)
   * [browserContext.waitForTarget(predicate[, options])](#browsercontextwaitfortargetpredicate-options)
 - [class: Page](#class-page)
   * [event: 'close'](#event-close)
@@ -705,6 +707,22 @@ the method will return an array with all the targets in all browser contexts.
 
 > **NOTE** the format of browser.version() might change with future releases of Chromium.
 
+#### browser.waitForNewTarget(predicate[, options])
+- `predicate` <[function]\([Target]\):[boolean]> A function to be run for every newly created target
+- `options` <[Object]>
+  - `timeout` <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
+- returns: <[Promise]<[Target]>> Promise which resolves to the first newly created target that matches the `predicate` function.
+
+This works across browser contexts, returning first new target from any browser context that satisfies the `predicate`.
+
+An example of getting a target that opens after clicking a link:
+```js
+const [target] = await Promise.all([
+  browser.waitForNewTarget(target => target.type() === 'page'),
+  page.click('a[target=_blank]'),
+]);
+```
+
 #### browser.waitForTarget(predicate[, options])
 - `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
 - `options` <[Object]>
@@ -842,6 +860,22 @@ An array of all pages inside the browser context.
 - returns: <[Array]<[Target]>>
 
 An array of all active targets inside the browser context.
+
+#### browserContext.waitForNewTarget(predicate[, options])
+- `predicate` <[function]\([Target]\):[boolean]> A function to be run for every newly created target
+- `options` <[Object]>
+  - `timeout` <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
+- returns: <[Promise]<[Target]>> Promise which resolves to the first newly created target that matches the `predicate` function.
+
+This returns first new target in this specific browser context that satisfies `predicate`.
+
+An example of getting a target that opens after clicking a link:
+```js
+const [target] = await Promise.all([
+  browserContext.waitForNewTarget(target => target.type() === 'page'),
+  page.click('a[target=_blank]'),
+]);
+```
 
 #### browserContext.waitForTarget(predicate[, options])
 - `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -198,12 +198,21 @@ class Browser extends EventEmitter {
    * @return {!Promise<!Target>}
    */
   async waitForTarget(predicate, options = {}) {
-    const {
-      timeout = 30000
-    } = options;
     const existingTarget = this.targets().find(predicate);
     if (existingTarget)
       return existingTarget;
+    return await this.waitForNewTarget(predicate, options);
+  }
+
+  /**
+   * @param {function(!Target):boolean} predicate
+   * @param {{timeout?: number}=} options
+   * @return {!Promise<!Target>}
+   */
+  async waitForNewTarget(predicate, options = {}) {
+    const {
+      timeout = 30000
+    } = options;
     let resolve;
     const targetPromise = new Promise(x => resolve = x);
     this.on(Browser.Events.TargetCreated, check);
@@ -303,6 +312,15 @@ class BrowserContext extends EventEmitter {
    */
   waitForTarget(predicate, options) {
     return this._browser.waitForTarget(target => target.browserContext() === this && predicate(target), options);
+  }
+
+  /**
+   * @param {function(!Target):boolean} predicate
+   * @param {{timeout?: number}=} options
+   * @return {!Promise<!Target>}
+   */
+  waitForNewTarget(predicate, options) {
+    return this._browser.waitForNewTarget(target => target.browserContext() === this && predicate(target), options);
   }
 
   /**

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -80,23 +80,51 @@ module.exports.addTests = function({testRunner, expect}) {
       ]);
       await context.close();
     });
-    it('should wait for a target', async function({browser, server}) {
-      const context = await browser.createIncognitoBrowserContext();
-      let resolved = false;
-      const targetPromise = context.waitForTarget(target => target.url() === server.EMPTY_PAGE);
-      targetPromise.then(() => resolved = true);
-      const page = await context.newPage();
-      expect(resolved).toBe(false);
-      await page.goto(server.EMPTY_PAGE);
-      const target = await targetPromise;
-      expect(await target.page()).toBe(page);
-      await context.close();
+    describe('BrowserContext.waitForNewTarget', () => {
+      it('should wait for a new target', async function({browser, server}) {
+        const context = await browser.createIncognitoBrowserContext();
+        let resolved = false;
+        const targetPromise = context.waitForNewTarget(target => target.url() === server.EMPTY_PAGE);
+        targetPromise.then(() => resolved = true);
+        const page = await context.newPage();
+        expect(resolved).toBe(false);
+        await page.goto(server.EMPTY_PAGE);
+        const target = await targetPromise;
+        expect(await target.page()).toBe(page);
+        await context.close();
+      });
+      it('should timeout waiting for a non-existent target', async function({browser, server}) {
+        const context = await browser.createIncognitoBrowserContext();
+        const error = await context.waitForNewTarget(target => target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
+        expect(error).toBeInstanceOf(TimeoutError);
+        await context.close();
+      });
     });
-    it('should timeout waiting for a non-existent target', async function({browser, server}) {
-      const context = await browser.createIncognitoBrowserContext();
-      const error = await context.waitForTarget(target => target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
-      expect(error).toBeInstanceOf(TimeoutError);
-      await context.close();
+    describe('BrowserContext.waitForTarget', () => {
+      it('should wait for a target', async function({browser, server}) {
+        const context = await browser.createIncognitoBrowserContext();
+        let resolved = false;
+        const targetPromise = context.waitForTarget(target => target.url() === server.EMPTY_PAGE);
+        targetPromise.then(() => resolved = true);
+        const page = await context.newPage();
+        expect(resolved).toBe(false);
+        await page.goto(server.EMPTY_PAGE);
+        const target = await targetPromise;
+        expect(await target.page()).toBe(page);
+        await context.close();
+      });
+      it('should return existing target', async function({browser, server}) {
+        const context = await browser.createIncognitoBrowserContext();
+        await context.newPage();
+        await context.waitForTarget(target => target.type() === 'page');
+        await context.close();
+      });
+      it('should timeout waiting for a non-existent target', async function({browser, server}) {
+        const context = await browser.createIncognitoBrowserContext();
+        const error = await context.waitForTarget(target => target.url() === server.EMPTY_PAGE, {timeout: 1}).catch(e => e);
+        expect(error).toBeInstanceOf(TimeoutError);
+        await context.close();
+      });
     });
     it('should isolate localStorage and cookies', async function({browser, server}) {
       // Create two incognito contexts.


### PR DESCRIPTION
This adds `browser.waitForNewTarget` and
`browserContext.waitForNewTarget` that wait for target to be
opened in future rather then search the one that currently
exists.