### PR TITLE
docs(troubleshooting): Puppeteer for FF on Travis

### DIFF
--- a/experimental/puppeteer-firefox/README.md
+++ b/experimental/puppeteer-firefox/README.md
@@ -2,6 +2,8 @@
 
 # Puppeteer for Firefox
 
+###### [API](#api-status) | [Troubleshooting](https://github.com/GoogleChrome/puppeteer/blob/master/experimental/puppeteer-firefox/docs/troubleshooting.md)
+
 > Use Puppeteer's API with Firefox
 
 > **BEWARE**: This project is experimental. 🐊 live here.

--- a/experimental/puppeteer-firefox/docs/troubleshooting.md
+++ b/experimental/puppeteer-firefox/docs/troubleshooting.md
@@ -1,0 +1,23 @@
+# Troubleshooting
+
+## Running Puppeteer for Firefox on Travis CI
+
+Tips-n-tricks:
+- Use the [Xenial](https://docs.travis-ci.com/user/reference/xenial/) distribution
+- The `libstdc++6` package from the `ubuntu-toolchain-r-test` repository must be installed in order to run Firefox on Ubuntu Xenial
+
+To sum up, your `.travis.yml` might look like this:
+
+```yml
+language: node_js
+dist: xenial
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test # if we don't specify this, the libstdc++6 we get is the wrong version
+    packages:
+      - libstdc++6
+cache:
+  directories:
+    - node_modules
+```


### PR DESCRIPTION
Some notes about my debugging session:

### Xenial

The following error is thrown if the `libstdc++6` is not installed:

```
XPCOMGlueLoad error for file /home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/libxul.so:
/usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.22' not found (required by /home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/libxul.so)
Couldn't load XPCOM.
```

**IMPORTANT**: The package must be installed from the `ubuntu-toolchain-r-test` repository otherwise the version is wrong :disappointed: 

### Trusty

Even with the `libstdc++6` it's not working.

##### Without the `libstdc++6`:

<details>
<pre>
/home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/firefox: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/firefox)
</pre>
</details>

##### With the `libstdc++6` from the default repository:

(same error as above)
<details>
<pre>
/home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/firefox: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/firefox)
</pre>
</details>

##### With the `libstdc++6` from the `ubuntu-toolchain-r-test` repository:

<details>
<pre>
/home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/firefox: relocation error: /home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/.local-browser/firefox-linux-e5fdeac984d4f966caafcdbc9b14da7a7f73fbed/firefox/firefox: symbol _ZTVNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEE, version GLIBCXX_3.4.21 not defined in file libstdc++.so.6 with link time reference
</pre>
</details>

### Error message

The error message returned by Puppeteer for Firefox is unhelpful:

```
Failed to launch Firefox!
    at onClose (/home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/lib/firefox/Launcher.js:174:14)
    at Interface.helper.addEventListener (/home/travis/build/Mogztter/puppeteer-firefox-travis/node_modules/puppeteer-firefox/lib/firefox/Launcher.js:163:50)
    at Interface.emit (events.js:187:15)
    at Interface.close (readline.js:379:8)
    at Socket.onend (readline.js:157:10)
    at Socket.emit (events.js:187:15)
    at endReadableNT (_stream_readable.js:1094:12)
```

I had to run the executable to get the root cause (see below).
For reference you can get the executable path by using `puppeteer.executablePath()`.