### PR TITLE
fix(browser): Close browser targets before closing browser itself

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -252,6 +252,10 @@ class Browser extends EventEmitter {
   }
 
   async close() {
+    await Promise.all(this.targets().map(async target => {
+      await this._connection.send('Target.closeTarget', { targetId: target._targetId });
+    }));
+
     await this._closeCallback.call(null);
     this.disconnect();
   }

--- a/test/test.js
+++ b/test/test.js
@@ -146,7 +146,7 @@ describe('Browser', function() {
     // Each test is launched in a new browser context.
     require('./CDPSession.spec.js').addTests({testRunner, expect});
     require('./accessibility.spec.js').addTests({testRunner, expect});
-    require('./browser.spec.js').addTests({testRunner, expect, headless});
+    require('./browser.spec.js').addTests({testRunner, expect, headless, defaultBrowserOptions});
     require('./cookies.spec.js').addTests({testRunner, expect});
     require('./coverage.spec.js').addTests({testRunner, expect});
     require('./elementhandle.spec.js').addTests({testRunner, expect});


### PR DESCRIPTION
This PR fixes #3673 by adding logic to [browser.close](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#browserclose) to close the browser targets first before the browser. This seems to ignore the beforeunload dialog on the page and succesfully closes the browser.