### PR TITLE
feat: introduce target.title()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -296,6 +296,7 @@
   * [target.createCDPSession()](#targetcreatecdpsession)
   * [target.opener()](#targetopener)
   * [target.page()](#targetpage)
+  * [target.title()](#targettitle)
   * [target.type()](#targettype)
   * [target.url()](#targeturl)
 - [class: CDPSession](#class-cdpsession)
@@ -3412,6 +3413,9 @@ Get the target that opened this target. Top-level targets return `null`.
 - returns: <[Promise]<?[Page]>>
 
 If the target is not of type `"page"` or `"background_page"`, returns `null`.
+
+#### target.title()
+- returns: <[string]> Returns target's title.
 
 #### target.type()
 - returns: <"page"|"background_page"|"service_worker"|"other"|"browser">

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -75,6 +75,13 @@ class Target {
   }
 
   /**
+   * @return {string}
+   */
+  title() {
+    return this._targetInfo.title;
+  }
+
+  /**
    * @return {!Puppeteer.Browser}
    */
   browser() {

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -76,6 +76,14 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions}) 
       expect(await page.evaluate(() => 2 * 3)).toBe(6);
       await browserWithExtension.close();
     });
+    it('target.title() should return extension title', async({}) => {
+      const browserWithExtension = await puppeteer.launch(extensionOptions);
+      const backgroundPageTarget = await waitForBackgroundPageTarget(browserWithExtension);
+      const backgroundPageTitle = backgroundPageTarget.title();
+      expect(backgroundPageTitle === 'Simple extension' ||
+        backgroundPageTitle === 'CryptoTokenExtension').toBeTruthy();
+      await browserWithExtension.close();
+    });
     it('should have default url when launching browser', async function() {
       const browser = await puppeteer.launch(extensionOptions);
       const pages = (await browser.pages()).map(page => page.url());

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -141,5 +141,15 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(createdTarget.opener()).toBe(page.target());
       expect(page.target().opener()).toBe(null);
     });
+
+    describe('Target.title', function() {
+      it('should return target titles', async({browser}) => {
+        const aboutBlankTargets = browser.targets().filter(target => target.url() === 'about:blank');
+        const aboutBlankTitles = aboutBlankTargets.map(target => target.title());
+        expect(aboutBlankTitles.length).toBeGreaterThan(0);
+        for (const title of aboutBlankTitles)
+          expect(title).toBe('about:blank');
+      });
+    });
   });
 };


### PR DESCRIPTION
Talked to @JoelEinbinder about this and he suggested the change.

When looking at `background_page` targets of extensions, there's not really any way to tell which extension is the one you want without knowing the hash (the url is just something like `chrome-extension://kmendfapggjehodndflmmgagdbamhnfd/_generated_background_page.html`), which is a problem if you're dynamically loading the extension for testing.

The problem is compounded since `--disable-extensions-except` doesn't actually load *only* the extension specified. Currently, at least the 2FA `CryptoTokenExtension` is always loaded (at least on my machine) in addition to the extension path passed in.

`_targetInfo.title` looks like it's a stable part of the protocol and I can't see any other way to get this string, so hopefully this change seems reasonable.