### PR TITLE
docs(troubleshooting.md): Update running on Alpine example

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -248,19 +248,20 @@ how to run this Dockerfile from a webserver running on App Engine Flex (Node).
 
 ### Running on Alpine
 
-The [newest Chromium package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium) supported on Alpine is 68, which was corresponding to [Puppeteer v1.4.0](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.4.0).
+The [newest Chromium package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium) supported on Alpine is 71, which was corresponding to [Puppeteer v1.9.0](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.9.0).
 
 Example Dockerfile:
 
 ```Dockerfile
-FROM node:9-alpine
+FROM node:10-alpine
 
-# Installs latest Chromium (68) package.
+# Installs latest Chromium (71) package.
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
     apk add --no-cache \
       chromium@edge \
+      harfbuzz@edge \
       nss@edge
 
 ...
@@ -268,8 +269,8 @@ RUN apk update && apk upgrade && \
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
-# Puppeteer v1.4.0 works with Chromium 68.
-RUN yarn add puppeteer@1.4.0
+# Puppeteer v1.9.0 works with Chromium 71.
+RUN yarn add puppeteer@1.9.0
 
 # Add user so we don't need --no-sandbox.
 RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \


### PR DESCRIPTION
Refreshes "Running on Alpine":

- Use latest LTS Node 10 on alpine in the example
- The newest Chromium package supported on Alpine `@edge` channel is now `71`
- Puppeteer corresponding to Chromium `71` is `v1.9.0`
- `harfbuzz` is now required by dynamic linking, Ref #3019