### PR TITLE
feat(page):  retrieve all the cookies on a page by default

### DIFF
--- a/examples/cookies-url.js
+++ b/examples/cookies-url.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const puppeteer = require('puppeteer');
+
+(async() => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto('https://www.nytimes.com');
+  const cookies = await page.cookies('https://www.nytimes.com');
+  console.log(JSON.stringify(cookies, null, cookies.length));
+  await browser.close();
+})();

--- a/examples/cookies.js
+++ b/examples/cookies.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const puppeteer = require('puppeteer');
+
+(async() => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto('https://www.nytimes.com');
+  const cookies = await page.cookies();
+  console.log(JSON.stringify(cookies, null, cookies.length));
+  await browser.close();
+})();

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -351,8 +351,9 @@ class Page extends EventEmitter {
    * @return {!Promise<!Array<Network.Cookie>>}
    */
   async cookies(...urls) {
-    return (await this._client.send('Network.getCookies', {
-      urls: urls.length ? urls : [this.url()]
+    const message = urls.length ? 'Network.getCookies' : 'Network.getAllCookies';
+    return (await this._client.send(message, {
+      urls: urls.length ? urls : []
     })).cookies;
   }
 

--- a/test/cookies.spec.js
+++ b/test/cookies.spec.js
@@ -91,7 +91,7 @@ module.exports.addTests = function({testRunner, expect}) {
       }]);
       expect(await page.evaluate('document.cookie')).toBe('gridcookie=GRID');
       await page.goto(server.PREFIX + '/empty.html');
-      expect(await page.cookies()).toEqual([]);
+      expect(await page.cookies(server.PREFIX)).toEqual([]);
       expect(await page.evaluate('document.cookie')).toBe('');
       await page.goto(server.PREFIX + '/grid.html');
       expect(await page.evaluate('document.cookie')).toBe('gridcookie=GRID');
@@ -162,7 +162,7 @@ module.exports.addTests = function({testRunner, expect}) {
       await page.goto(server.PREFIX + '/grid.html');
       await page.setCookie({name: 'example-cookie', value: 'best',  url: 'https://www.example.com'});
       expect(await page.evaluate('document.cookie')).toBe('');
-      expect(await page.cookies()).toEqual([]);
+      expect(await page.cookies(server.PREFIX)).toEqual([]);
       expect(await page.cookies('https://www.example.com')).toEqual([{
         name: 'example-cookie',
         value: 'best',
@@ -192,7 +192,36 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(await page.evaluate('document.cookie')).toBe('localhost-cookie=best');
       expect(await page.frames()[1].evaluate('document.cookie')).toBe('127-cookie=worst');
 
-      expect(await page.cookies()).toEqual([{
+      expect((await page.cookies()).sort((a,b) => {
+        if (a.name < b.name)
+          return -1;
+        if (a.name > b.name)
+          return 1;
+        return 0;
+      })).toEqual([{
+        name: '127-cookie',
+        value: 'worst',
+        domain: '127.0.0.1',
+        path: '/',
+        expires: -1,
+        size: 15,
+        httpOnly: false,
+        secure: false,
+        session: true
+      },
+      {
+        name: 'localhost-cookie',
+        value: 'best',
+        domain: 'localhost',
+        path: '/',
+        expires: -1,
+        size: 20,
+        httpOnly: false,
+        secure: false,
+        session: true
+      }]);
+
+      expect(await page.cookies(server.PREFIX)).toEqual([{
         name: 'localhost-cookie',
         value: 'best',
         domain: 'localhost',


### PR DESCRIPTION
This patch fixes `page.cookies` so that by default it can retrieve all the cookies on a page (1st and third party cookies).
Refer: examples/cookies.js and examples/cookies-url.js

Fixes #3728

BREAKING CHANGE: page.cookies now retrieve all the cookies on a page (1st and third party cookies) by default.
To retrieve cookie for specific url(s), pass url(s) as parameter:
  `page.cookie('https://www.nytimes.com')`.