### PR TITLE
feat: enable Network Service by default

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -34,6 +34,7 @@ const CHROME_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_dev_profile-');
 
 const DEFAULT_ARGS = [
   '--disable-background-networking',
+  '--enable-features=NetworkService,NetworkServiceInProcess',
   '--disable-background-timer-throttling',
   '--disable-backgrounding-occluded-windows',
   '--disable-breakpad',

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -135,7 +135,8 @@ class NetworkManager extends EventEmitter {
    * @param {!Protocol.Network.requestWillBeSentPayload} event
    */
   _onRequestWillBeSent(event) {
-    if (this._protocolRequestInterceptionEnabled) {
+    // Request interception doesn't happen for data URLs with Network Service.
+    if (this._protocolRequestInterceptionEnabled && !event.request.url.startsWith('data:')) {
       const requestHash = generateRequestHash(event.request);
       const interceptionId = this._requestHashToInterceptionIds.firstValue(requestHash);
       if (interceptionId) {
@@ -394,6 +395,9 @@ class Request {
    * @param {!{url?: string, method?:string, postData?: string, headers?: !Object}} overrides
    */
   async continue(overrides = {}) {
+    // Request interception is not supported for data: urls.
+    if (this._url.startsWith('data:'))
+      return;
     assert(this._allowInterception, 'Request Interception is not enabled!');
     assert(!this._interceptionHandled, 'Request is already handled!');
     const {
@@ -466,6 +470,9 @@ class Request {
    * @param {string=} errorCode
    */
   async abort(errorCode = 'failed') {
+    // Request interception is not supported for data: urls.
+    if (this._url.startsWith('data:'))
+      return;
     const errorReason = errorReasons[errorCode];
     assert(errorReason, 'Unknown error code: ' + errorCode);
     assert(this._allowInterception, 'Request Interception is not enabled!');

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -495,15 +495,6 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(requests.length).toBe(1);
       expect(requests[0].url()).toBe(dataURL);
     });
-    it('should abort data server', async({page, server}) => {
-      await page.setRequestInterception(true);
-      page.on('request', request => {
-        request.abort();
-      });
-      let error = null;
-      await page.goto('data:text/html,No way!').catch(err => error = err);
-      expect(error.message).toContain('net::ERR_FAILED');
-    });
     it('should navigate to URL with hash and and fire requests without hash', async({page, server}) => {
       await page.setRequestInterception(true);
       const requests = [];


### PR DESCRIPTION
**Note:** network service does not (and will not) support request interception of data URLs.

References #3471.