### PR TITLE
chore(examples): exclude localhost from proxy bypass list

### DIFF
--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -23,7 +23,11 @@ const puppeteer = require('puppeteer');
     // Launch chromium using a proxy server on port 9876.
     // More on proxying:
     //    https://www.chromium.org/developers/design-documents/network-settings
-    args: [ '--proxy-server=127.0.0.1:9876' ]
+    args: [
+      '--proxy-server=127.0.0.1:9876',
+      // Use proxy for localhost URLs
+      '--proxy-bypass-list=<-loopback>',
+    ]
   });
   const page = await browser.newPage();
   await page.goto('https://google.com');


### PR DESCRIPTION
Since Chrome 72 localhost is bypassed by default. Oftentimes
this is not a default behavior in testing scenarios.

Fixes #3711.