### PR TITLE
fix(network): relax request matching heuristic

### DIFF
--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -651,6 +651,8 @@ class Response {
 }
 helper.tracePublicAPI(Response);
 
+const IGNORED_HEADERS = new Set(['accept', 'referer', 'x-devtools-emulate-network-conditions-client-id', 'cookie', 'origin', 'content-type']);
+
 /**
  * @param {!Protocol.Network.Request} request
  * @return {string}
@@ -677,7 +679,7 @@ function generateRequestHash(request) {
     for (let header of headers) {
       const headerValue = request.headers[header];
       header = header.toLowerCase();
-      if (header === 'accept' || header === 'referer' || header === 'x-devtools-emulate-network-conditions-client-id' || header === 'cookie' || header === 'origin' || header === 'content-type')
+      if (IGNORED_HEADERS.has(header))
         continue;
       hash.headers[header] = headerValue;
     }

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -677,7 +677,7 @@ function generateRequestHash(request) {
     for (let header of headers) {
       const headerValue = request.headers[header];
       header = header.toLowerCase();
-      if (header === 'accept' || header === 'referer' || header === 'x-devtools-emulate-network-conditions-client-id' || header === 'cookie')
+      if (header === 'accept' || header === 'referer' || header === 'x-devtools-emulate-network-conditions-client-id' || header === 'cookie' || header === 'origin' || header === 'content-type')
         continue;
       hash.headers[header] = headerValue;
     }

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -266,7 +266,7 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(response.ok()).toBe(true);
       expect(response.remoteAddress().port).toBe(server.PORT);
     });
-    xit('should work when POST is redirected with 302', async({page, server}) => {
+    it('should work when POST is redirected with 302', async({page, server}) => {
       server.setRedirect('/rredirect', '/empty.html');
       await page.goto(server.EMPTY_PAGE);
       await page.setRequestInterception(true);


### PR DESCRIPTION
Drop requirement for matching "origin" and "content-type" headers
in requests and request interceptions. This way javascript redirects
that use form submission start working.

Fix #3684.