### PR TITLE
test: move tracing tests to one-per-browser

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -167,7 +167,6 @@ describe('Browser', function() {
     require('./emulation.spec.js').addTests({testRunner, expect, headless});
     require('./screenshot.spec.js').addTests({testRunner, expect});
     require('./target.spec.js').addTests({testRunner, expect});
-    require('./tracing.spec.js').addTests({testRunner, expect});
     require('./worker.spec.js').addTests({testRunner, expect});
   });
 
@@ -179,6 +178,7 @@ describe('Browser', function() {
 require('./ignorehttpserrors.spec.js').addTests({testRunner, expect, defaultBrowserOptions});
 require('./puppeteer.spec.js').addTests({testRunner, expect, defaultBrowserOptions});
 require('./headful.spec.js').addTests({testRunner, expect, defaultBrowserOptions});
+require('./tracing.spec.js').addTests({testRunner, expect, defaultBrowserOptions});
 
 if (process.env.COVERAGE) {
   describe('COVERAGE', function() {

--- a/test/tracing.spec.js
+++ b/test/tracing.spec.js
@@ -16,17 +16,24 @@
 
 const fs = require('fs');
 const path = require('path');
+const utils = require('./utils');
+const puppeteer = utils.requireRoot('index');
 
-module.exports.addTests = function({testRunner, expect}) {
+module.exports.addTests = function({testRunner, expect, defaultBrowserOptions}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Tracing', function() {
-    beforeEach(function(state) {
+    beforeEach(async function(state) {
       state.outputFile = path.join(__dirname, 'assets', `trace-${state.parallelIndex}.json`);
+      state.browser = await puppeteer.launch(defaultBrowserOptions);
+      state.page = await state.browser.newPage();
     });
-    afterEach(function(state) {
+    afterEach(async function(state) {
+      await state.browser.close();
+      state.browser = null;
+      state.page = null;
       if (fs.existsSync(state.outputFile)) {
         fs.unlinkSync(state.outputFile);
         state.outputFile = null;


### PR DESCRIPTION
Tracing is working on a per-browser level, not per-page. In order
to paralellize these tests effectively and properly, each should run
a designated browser.