### PR TITLE
docs(api.md): expand puppeteer-core explanation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -357,6 +357,7 @@ When using `puppeteer-core`, remember to change the *include* line:
 const puppeteer = require('puppeteer-core');
 ```
 
+You will then need to call [`puppeteer.connect([options])`](#puppeteerconnectoptions) or [`puppeteer.launch([options])`](#puppeteerlaunchoptions) with an explicit `executablePath` option.
 
 ### Environment Variables
 


### PR DESCRIPTION
Per the discussion at https://github.com/GoogleChrome/puppeteer/issues/3157.  It may help to mention that developers will need to use the executable path (or connect).