### PR TITLE
fix(page): include event context on 'load' and 'domcontentloaded'

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -129,8 +129,8 @@ class Page extends EventEmitter {
     this._networkManager.on(Events.NetworkManager.RequestFailed, event => this.emit(Events.Page.RequestFailed, event));
     this._networkManager.on(Events.NetworkManager.RequestFinished, event => this.emit(Events.Page.RequestFinished, event));
 
-    client.on('Page.domContentEventFired', event => this.emit(Events.Page.DOMContentLoaded));
-    client.on('Page.loadEventFired', event => this.emit(Events.Page.Load));
+    client.on('Page.domContentEventFired', event => this.emit(Events.Page.DOMContentLoaded, event));
+    client.on('Page.loadEventFired', event => this.emit(Events.Page.Load, event));
     client.on('Runtime.consoleAPICalled', event => this._onConsoleAPI(event));
     client.on('Runtime.bindingCalled', event => this._onBindingCalled(event));
     client.on('Page.javascriptDialogOpening', event => this._onDialog(event));


### PR DESCRIPTION
For both the 'load' and 'domcontentloaded' events, we were just emitting the event without any context about the event. The [event from dev tools](https://chromedevtools.github.io/devtools-protocol/tot/Page#event-loadEventFired) includes the timestamp which is fairly useful for any timing measurements.  This change adds those events to the emitted context.

On a side note, it's a little odd that the `load` event doesn't include any context about the frame (like [lifecycle events](https://chromedevtools.github.io/devtools-protocol/tot/Page#event-lifecycleEvent) do), but I think that's more an issue for dev tools.

*Note: this was originally submitted in #3803 but resubmitted to be in alignment with our CLA*