### PR TITLE
fix: ignore console messages from destroyed execution contexts

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -509,12 +509,17 @@ class Page extends EventEmitter {
    */
   async _onConsoleAPI(event) {
     if (event.executionContextId === 0) {
-      // DevTools protocol stores 1000 last console messages. These messages are
-      // reported even for removed execution contexts - in this case, they are marked with
-      // executionContextId = 0 and upon enabling Runtime agent.
+      // DevTools protocol stores the last 1000 console messages. These
+      // messages are always reported even for removed execution contexts. In
+      // this case, they are marked with executionContextId = 0 and are
+      // reported upon enabling Runtime agent.
+      //
       // Ignore these messages since:
-      // - there's no execution context we can use to operate with message arguments
-      // - these messages are reported before Puppeteer clients can subscribe to the 'console' page event.
+      // - there's no execution context we can use to operate with message
+      //   arguments
+      // - these messages are reported before Puppeteer clients can subscribe
+      //   to the 'console'
+      //   page event.
       //
       // @see https://github.com/GoogleChrome/puppeteer/issues/3865
       return;

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -508,6 +508,17 @@ class Page extends EventEmitter {
    * @param {!Protocol.Runtime.consoleAPICalledPayload} event
    */
   async _onConsoleAPI(event) {
+    if (event.executionContextId === 0) {
+      // DevTools protocol stores 1000 last console messages. These messages are
+      // reported even for removed execution contexts - in this case, they are marked with
+      // executionContextId = 0 and upon enabling Runtime agent.
+      // Ignore these messages since:
+      // - there's no execution context we can use to operate with message arguments
+      // - these messages are reported before Puppeteer clients can subscribe to the 'console' page event.
+      //
+      // @see https://github.com/GoogleChrome/puppeteer/issues/3865
+      return;
+    }
     const context = this._frameManager.executionContextById(event.executionContextId);
     const values = event.args.map(arg => createJSHandle(context, arg));
     this._addConsoleMessage(event.type, values, event.stackTrace);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -350,7 +350,7 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       });
     });
     // @see https://github.com/GoogleChrome/puppeteer/issues/3865
-    fit('should not throw when there are console messages in detached iframes', async({browser, page, server}) => {
+    it('should not throw when there are console messages in detached iframes', async({browser, page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       await page.evaluate(async () => {
         // 1. Create a popup that Puppeteer is not connected to.

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -349,6 +349,24 @@ module.exports.addTests = function({testRunner, expect, headless}) {
         columnNumber: 14,
       });
     });
+    // @see https://github.com/GoogleChrome/puppeteer/issues/3865
+    fit('should not throw when there are console messages in detached iframes', async({browser, page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(async () => {
+        // 1. Create a popup that Puppeteer is not connected to.
+        var win = window.open(window.location.href, "Title", "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=780,height=200,top=0,left=0");
+        await new Promise(x => win.onload = x);
+        // 2. In this popup, create an iframe that console.logs a message.
+        win.document.body.innerHTML = `<iframe src="/consolelog.html"></iframe>`;
+        const frame = win.document.querySelector('iframe');
+        await new Promise(x => frame.onload = x);
+        // 3. After that, remove the iframe.
+        frame.remove();
+      });
+      const popupTarget = page.browserContext().targets().find(target => target !== page.target());
+      // 4. Connect to the popup and make sure it doesn't throw.
+      const popup = await popupTarget.page();
+    });
   });
 
   describe('Page.Events.DOMContentLoaded', function() {

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -352,12 +352,12 @@ module.exports.addTests = function({testRunner, expect, headless}) {
     // @see https://github.com/GoogleChrome/puppeteer/issues/3865
     it('should not throw when there are console messages in detached iframes', async({browser, page, server}) => {
       await page.goto(server.EMPTY_PAGE);
-      await page.evaluate(async () => {
+      await page.evaluate(async() => {
         // 1. Create a popup that Puppeteer is not connected to.
-        var win = window.open(window.location.href, "Title", "toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=780,height=200,top=0,left=0");
+        const win = window.open(window.location.href, 'Title', 'toolbar=no,location=no,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=780,height=200,top=0,left=0');
         await new Promise(x => win.onload = x);
         // 2. In this popup, create an iframe that console.logs a message.
-        win.document.body.innerHTML = `<iframe src="/consolelog.html"></iframe>`;
+        win.document.body.innerHTML = `<iframe src='/consolelog.html'></iframe>`;
         const frame = win.document.querySelector('iframe');
         await new Promise(x => frame.onload = x);
         // 3. After that, remove the iframe.
@@ -365,7 +365,7 @@ module.exports.addTests = function({testRunner, expect, headless}) {
       });
       const popupTarget = page.browserContext().targets().find(target => target !== page.target());
       // 4. Connect to the popup and make sure it doesn't throw.
-      const popup = await popupTarget.page();
+      await popupTarget.page();
     });
   });
 


### PR DESCRIPTION
Fix #3865