### PR TITLE
fix(types): disable shipping our own d.ts file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -34,3 +34,6 @@ yarn.lock
 README.md
 tsconfig.json
 experimental
+
+# exclude types, see https://github.com/GoogleChrome/puppeteer/issues/3878
+/index.d.ts


### PR DESCRIPTION
It looks like this was a breaking change for people using DefinitelyTyped's definitions. Let's revert, and revisit it for 2.0
#3878, #2079