### PR TITLE
test(firefox): run puppeteer-firefox tests in browser contexts

### DIFF
--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -8,7 +8,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "2a2b2cd2c5e5b7062e7ede93b235a5a062d4dc9a"
+    "firefox_revision": "ca4758c475a9c05dc88b7b8811fbbb7e5acf95b4"
   },
   "scripts": {
     "install": "node install.js",

--- a/experimental/puppeteer-firefox/test/puppeteer.spec.js
+++ b/experimental/puppeteer-firefox/test/puppeteer.spec.js
@@ -63,11 +63,13 @@ module.exports.addTests = ({testRunner, product, puppeteer}) => testRunner.descr
 
     describe('Page', () => {
       beforeEach(async state => {
-        state.page = await state.browser.newPage();
+        state.context = await state.browser.createIncognitoBrowserContext();
+        state.page = await state.context.newPage();
       });
 
       afterEach(async state => {
-        await state.page.close();
+        await state.context.close();
+        state.context = null;
         state.page = null;
       });
 


### PR DESCRIPTION
This patch starts running all Puppeteer-Firefox tests in separate
browser contexts.