### PR TITLE
chore(firefox): run Puppeteer-Firefox against Puppeteer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "unit": "node test/test.js",
+    "funit": "BROWSER=firefox node test/test.js",
     "debug-unit": "node --inspect-brk test/test.js",
     "test-doclint": "node utils/doclint/check_public_api/test/test.js && node utils/doclint/preprocessor/test.js",
     "test": "npm run lint --silent && npm run coverage && npm run test-doclint && npm run test-node6-transformer && npm run test-types",

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -27,6 +27,8 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
+  const CHROME = product === 'Chromium';
+
   if (defaultBrowserOptions.executablePath) {
     console.warn(`${YELLOW_COLOR}WARN: running ${product} tests with ${defaultBrowserOptions.executablePath}${RESET_COLOR}`);
   } else {
@@ -94,30 +96,32 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
 
       // Page-level tests that are given a browser, a context and a page.
       // Each test is launched in a new browser context.
-      require('./CDPSession.spec.js').addTests(testOptions);
-      require('./accessibility.spec.js').addTests(testOptions);
       require('./browser.spec.js').addTests(testOptions);
-      require('./cookies.spec.js').addTests(testOptions);
-      require('./coverage.spec.js').addTests(testOptions);
+      require('./click.spec.js').addTests(testOptions);
+      require('./dialog.spec.js').addTests(testOptions);
       require('./elementhandle.spec.js').addTests(testOptions);
-      require('./queryselector.spec.js').addTests(testOptions);
-      require('./waittask.spec.js').addTests(testOptions);
+      require('./emulation.spec.js').addTests(testOptions);
+      require('./evaluation.spec.js').addTests(testOptions);
       require('./frame.spec.js').addTests(testOptions);
       require('./input.spec.js').addTests(testOptions);
-      require('./mouse.spec.js').addTests(testOptions);
-      require('./keyboard.spec.js').addTests(testOptions);
-      require('./touchscreen.spec.js').addTests(testOptions);
-      require('./click.spec.js').addTests(testOptions);
       require('./jshandle.spec.js').addTests(testOptions);
-      require('./network.spec.js').addTests(testOptions);
-      require('./page.spec.js').addTests(testOptions);
-      require('./dialog.spec.js').addTests(testOptions);
+      require('./keyboard.spec.js').addTests(testOptions);
+      require('./mouse.spec.js').addTests(testOptions);
       require('./navigation.spec.js').addTests(testOptions);
-      require('./evaluation.spec.js').addTests(testOptions);
-      require('./emulation.spec.js').addTests(testOptions);
+      require('./page.spec.js').addTests(testOptions);
       require('./screenshot.spec.js').addTests(testOptions);
+      require('./queryselector.spec.js').addTests(testOptions);
       require('./target.spec.js').addTests(testOptions);
-      require('./worker.spec.js').addTests(testOptions);
+      require('./touchscreen.spec.js').addTests(testOptions);
+      require('./waittask.spec.js').addTests(testOptions);
+      if (CHROME) {
+        require('./CDPSession.spec.js').addTests(testOptions);
+        require('./accessibility.spec.js').addTests(testOptions);
+        require('./cookies.spec.js').addTests(testOptions);
+        require('./coverage.spec.js').addTests(testOptions);
+        require('./network.spec.js').addTests(testOptions);
+        require('./worker.spec.js').addTests(testOptions);
+      }
     });
 
     // Browser-level tests that are given a browser.
@@ -127,6 +131,8 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
   // Top-level tests that launch Browser themselves.
   require('./ignorehttpserrors.spec.js').addTests(testOptions);
   require('./launcher.spec.js').addTests(testOptions);
-  require('./headful.spec.js').addTests(testOptions);
-  require('./tracing.spec.js').addTests(testOptions);
+  if (CHROME) {
+    require('./headful.spec.js').addTests(testOptions);
+    require('./tracing.spec.js').addTests(testOptions);
+  }
 };


### PR DESCRIPTION
Introduce a `npm run funit` script that runs puppeteer tests
against Puppeteer-Firefox.

Next steps:
- bring Puppeteer-Firefox unique tests to Puppeteer
- skip failing tests and enable Puppeteer-Firefox on CI
- work through tests to pass them all with Puppeteer-Firefox

References #3889 