### PR TITLE
test(firefox): introduce vendor-specific specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules/
-/test/output
+/test/output-chromium
+/test/output-firefox
 /test/test-user-data-dir*
 /.local-chromium/
 /.dev_profile*

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -14,26 +14,10 @@
  * limitations under the License.
  */
 
-module.exports.addTests = function({testRunner, expect, headless, puppeteer}) {
+module.exports.addTests = function({testRunner, expect, headless, puppeteer, FFOX}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
-
-  describe('Browser.version', function() {
-    it('should return whether we are in headless', async({browser}) => {
-      const version = await browser.version();
-      expect(version.length).toBeGreaterThan(0);
-      expect(version.startsWith('Headless')).toBe(headless);
-    });
-  });
-
-  describe('Browser.userAgent', function() {
-    it('should include WebKit', async({browser}) => {
-      const userAgent = await browser.userAgent();
-      expect(userAgent.length).toBeGreaterThan(0);
-      expect(userAgent).toContain('WebKit');
-    });
-  });
 
   describe('Browser.target', function() {
     it('should return browser target', async({browser}) => {
@@ -46,6 +30,8 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer}) {
     it('should return child_process instance', async function({browser}) {
       const process = await browser.process();
       expect(process.pid).toBeGreaterThan(0);
+    });
+    (FFOX ? xit : it)('should not return child_process for remote browser', async function({browser}) {
       const browserWSEndpoint = browser.wsEndpoint();
       const remoteBrowser = await puppeteer.connect({browserWSEndpoint});
       expect(remoteBrowser.process()).toBe(null);

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports.addTests = function({testRunner, expect, product}) {
+  const {describe, xdescribe, fdescribe} = testRunner;
+  const {it, fit, xit} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe('Chromium-specific tests', function() {
+    describe('Browser.version', function() {
+      xit('should return whether we are in headless', async({browser}) => {
+        const version = await browser.version();
+        expect(version.length).toBeGreaterThan(0);
+        expect(version.startsWith('Headless')).toBe(headless);
+      });
+    });
+
+    describe('Browser.userAgent', function() {
+      it('should include WebKit', async({browser}) => {
+        const userAgent = await browser.userAgent();
+        expect(userAgent.length).toBeGreaterThan(0);
+        expect(userAgent).toContain('WebKit');
+      });
+    });
+  });
+};
+

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module.exports.addTests = function({testRunner, expect, product}) {
+module.exports.addTests = function({testRunner, expect, product, headless}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Chromium-specific tests', function() {
     describe('Browser.version', function() {
-      xit('should return whether we are in headless', async({browser}) => {
+      it('should return whether we are in headless', async({browser}) => {
         const version = await browser.version();
         expect(version.length).toBeGreaterThan(0);
         expect(version.startsWith('Headless')).toBe(headless);

--- a/test/firefoxonly.spec.js
+++ b/test/firefoxonly.spec.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports.addTests = function({testRunner, expect, product}) {
+  const {describe, xdescribe, fdescribe} = testRunner;
+  const {it, fit, xit} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe('Firefox-specific tests', function() {
+    describe('Browser.version', function() {
+      it('should return whether we are in headless', async({browser}) => {
+        const version = await browser.version();
+        expect(version.length).toBeGreaterThan(0);
+        expect(version.startsWith('Firefox/')).toBe(true);
+      });
+    });
+
+    describe('Browser.userAgent', function() {
+      it('should include WebKit', async({browser}) => {
+        const userAgent = await browser.userAgent();
+        expect(userAgent.length).toBeGreaterThan(0);
+        expect(userAgent).toContain('Gecko');
+      });
+    });
+  });
+};
+

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -28,6 +28,7 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   const CHROME = product === 'Chromium';
+  const FFOX = product === 'Firefox';
 
   if (defaultBrowserOptions.executablePath) {
     console.warn(`${YELLOW_COLOR}WARN: running ${product} tests with ${defaultBrowserOptions.executablePath}${RESET_COLOR}`);
@@ -48,6 +49,8 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
   const testOptions = {
     testRunner,
     product,
+    FFOX,
+    CHROME,
     puppeteer,
     expect,
     defaultBrowserOptions,
@@ -121,6 +124,9 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
         require('./coverage.spec.js').addTests(testOptions);
         require('./network.spec.js').addTests(testOptions);
         require('./worker.spec.js').addTests(testOptions);
+        require('./chromiumonly.spec.js').addTests(testOptions);
+      } else {
+        require('./firefoxonly.spec.js').addTests(testOptions);
       }
     });
 


### PR DESCRIPTION
Certain Puppeteer methods do expose the inner browser - e.g.
`browser.version()` depends on the browser we run.

Split out these tests into a vendor-specific test suites.

References #3889