### PR TITLE
test(firefox): further unify Puppeteer-Firefox and Puppeteer tests

### DIFF
--- a/experimental/puppeteer-firefox/test/assets/consolelog.html
+++ b/experimental/puppeteer-firefox/test/assets/consolelog.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>console.log test</title>
+  </head>
+  <body>
+    <script>
+      console.log('yellow')
+    </script>
+  </body>
+</html>

--- a/experimental/puppeteer-firefox/test/ignorehttpserrors.spec.js
+++ b/experimental/puppeteer-firefox/test/ignorehttpserrors.spec.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-module.exports.addTests = function({testRunner, expect, product, puppeteer}) {
+module.exports.addTests = function({testRunner, expect, product, puppeteer, defaultBrowserOptions}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
@@ -23,7 +23,7 @@ module.exports.addTests = function({testRunner, expect, product, puppeteer}) {
 
   describe('ignoreHTTPSErrors', function() {
     beforeAll(async state => {
-      const options = Object.assign({ignoreHTTPSErrors: true}, state.defaultBrowserOptions);
+      const options = Object.assign({ignoreHTTPSErrors: true}, defaultBrowserOptions);
       state.browser = await puppeteer.launch(options);
     });
     afterAll(async state => {

--- a/experimental/puppeteer-firefox/test/keyboard.spec.js
+++ b/experimental/puppeteer-firefox/test/keyboard.spec.js
@@ -66,7 +66,7 @@ module.exports.addTests = function({testRunner, expect, product}) {
       await page.keyboard.sendCharacter('a');
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('嗨a');
     });
-    it('should press the metaKey', async ({page}) => {
+    it('should press the metaKey', async({page}) => {
       await page.evaluate(() => {
         window.keyPromise = new Promise(resolve => document.addEventListener('keydown', event => resolve(event.key)));
       });

--- a/experimental/puppeteer-firefox/test/launcher.spec.js
+++ b/experimental/puppeteer-firefox/test/launcher.spec.js
@@ -15,7 +15,7 @@
  */
 const fs = require('fs');
 
-module.exports.addTests = function({testRunner, expect, product, puppeteer}) {
+module.exports.addTests = function({testRunner, expect, product, puppeteer, defaultBrowserOptions}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
@@ -23,14 +23,14 @@ module.exports.addTests = function({testRunner, expect, product, puppeteer}) {
   const FFOX = product === 'firefox';
   const CHROME = product === 'chromium';
   describe('Launcher.executablePath', function() {
-    it('should work', async() => {
-      const executablePath = puppeteer.executablePath({product});
+    it('should work', async({server}) => {
+      const executablePath = puppeteer.executablePath();
       expect(fs.existsSync(executablePath)).toBe(true);
     });
   });
 
   describe('Launcher.launch', () => {
-    it('should set the default viewport', async({defaultBrowserOptions}) => {
+    it('should set the default viewport', async() => {
       const options = Object.assign({}, defaultBrowserOptions, {
         defaultViewport: {
           width: 456,
@@ -43,7 +43,7 @@ module.exports.addTests = function({testRunner, expect, product, puppeteer}) {
       expect(await page.evaluate('window.innerHeight')).toBe(789);
       await browser.close();
     });
-    it('should disable the default viewport', async({defaultBrowserOptions}) => {
+    it('should disable the default viewport', async() => {
       const options = Object.assign({}, defaultBrowserOptions, {
         defaultViewport: null
       });

--- a/experimental/puppeteer-firefox/test/page.spec.js
+++ b/experimental/puppeteer-firefox/test/page.spec.js
@@ -75,12 +75,11 @@ module.exports.addTests = function({testRunner, expect, product}) {
       await newPage.close();
       expect(newPage.isClosed()).toBe(true);
     });
-    it('should emit the close event', async({browser}) => {
-      const newPage = await browser.newPage();
-      let gotClosedEvent = false;
-      newPage.on('close', () => gotClosedEvent = true);
+    it('should work with page.close', async function({ page, context, server }) {
+      const newPage = await context.newPage();
+      const closedPromise = new Promise(x => newPage.on('close', x));
       await newPage.close();
-      expect(gotClosedEvent).toBe(true);
+      await closedPromise;
     });
   });
 

--- a/experimental/puppeteer-firefox/test/puppeteer.spec.js
+++ b/experimental/puppeteer-firefox/test/puppeteer.spec.js
@@ -28,29 +28,28 @@ module.exports.addTests = ({testRunner, product, puppeteer}) => testRunner.descr
     toBeGolden: GoldenUtils.compare.bind(null, GOLDEN_DIR, OUTPUT_DIR)
   });
 
+  const defaultBrowserOptions = {
+    handleSIGINT: false,
+    executablePath: product === 'chromium' ? process.env.CHROME : process.env.FFOX,
+    dumpio: !!process.env.DUMPIO,
+    args: product === 'chromium' ? ['--no-sandbox'] : [],
+  };
 
-  beforeAll(async state => {
-    state.defaultBrowserOptions = {
-      handleSIGINT: false,
-      executablePath: product === 'chromium' ? process.env.CHROME : process.env.FFOX,
-      dumpio: !!process.env.DUMPIO,
-      args: product === 'chromium' ? ['--no-sandbox'] : [],
-    };
-    if (product === 'firefox' && state.defaultBrowserOptions.executablePath) {
-      await require('../misc/install-preferences')(state.defaultBrowserOptions.executablePath);
-      console.log('RUNNING CUSTOM FIREFOX: ' + state.defaultBrowserOptions.executablePath);
-    }
-  });
-  afterAll(state => {
-    state.defaultBrowserOptions = undefined;
-  });
+  const testOptions = {testRunner, expect, product, puppeteer, defaultBrowserOptions};
 
-  require('./launcher.spec.js').addTests({testRunner, expect, product, puppeteer});
-  require('./ignorehttpserrors.spec.js').addTests({testRunner, expect, product, puppeteer});
+  if (product === 'firefox' && defaultBrowserOptions.executablePath) {
+    beforeAll(async () => {
+      await require('../misc/install-preferences')(defaultBrowserOptions.executablePath);
+      console.log('RUNNING CUSTOM FIREFOX: ' + defaultBrowserOptions.executablePath);
+    });
+  }
+
+  require('./launcher.spec.js').addTests(testOptions);
+  require('./ignorehttpserrors.spec.js').addTests(testOptions);
 
   describe('Browser', () => {
     beforeAll(async state => {
-      state.browser = await puppeteer.launch(state.defaultBrowserOptions);
+      state.browser = await puppeteer.launch(defaultBrowserOptions);
     });
 
     afterAll(async state => {
@@ -58,8 +57,8 @@ module.exports.addTests = ({testRunner, product, puppeteer}) => testRunner.descr
       state.browser = null;
     });
 
-    require('./browser.spec.js').addTests({testRunner, expect, product, puppeteer});
-    require('./browsercontext.spec.js').addTests({testRunner, expect, product, puppeteer});
+    require('./browser.spec.js').addTests(testOptions);
+    require('./browsercontext.spec.js').addTests(testOptions);
 
     describe('Page', () => {
       beforeEach(async state => {
@@ -73,31 +72,31 @@ module.exports.addTests = ({testRunner, product, puppeteer}) => testRunner.descr
         state.page = null;
       });
 
-      require('./page.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./evaluation.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./navigation.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./dialog.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./frame.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./jshandle.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./elementhandle.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./target.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./waittask.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./queryselector.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./emulation.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./screenshot.spec.js').addTests({testRunner, expect, product, puppeteer});
+      require('./page.spec.js').addTests(testOptions);
+      require('./evaluation.spec.js').addTests(testOptions);
+      require('./navigation.spec.js').addTests(testOptions);
+      require('./dialog.spec.js').addTests(testOptions);
+      require('./frame.spec.js').addTests(testOptions);
+      require('./jshandle.spec.js').addTests(testOptions);
+      require('./elementhandle.spec.js').addTests(testOptions);
+      require('./target.spec.js').addTests(testOptions);
+      require('./waittask.spec.js').addTests(testOptions);
+      require('./queryselector.spec.js').addTests(testOptions);
+      require('./emulation.spec.js').addTests(testOptions);
+      require('./screenshot.spec.js').addTests(testOptions);
 
       // Input tests
-      require('./keyboard.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./mouse.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./click.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./type.spec.js').addTests({testRunner, expect, product, puppeteer});
-      require('./hover.spec.js').addTests({testRunner, expect, product, puppeteer});
+      require('./keyboard.spec.js').addTests(testOptions);
+      require('./mouse.spec.js').addTests(testOptions);
+      require('./click.spec.js').addTests(testOptions);
+      require('./type.spec.js').addTests(testOptions);
+      require('./hover.spec.js').addTests(testOptions);
 
       // Browser-specific page tests
       if (product === 'firefox')
-        require('./firefoxonly.spec.js').addTests({testRunner, expect, product, puppeteer});
+        require('./firefoxonly.spec.js').addTests(testOptions);
       else
-        require('./chromiumonly.spec.js').addTests({testRunner, expect, product, puppeteer});
+        require('./chromiumonly.spec.js').addTests(testOptions);
     });
   });
 });

--- a/experimental/puppeteer-firefox/test/target.spec.js
+++ b/experimental/puppeteer-firefox/test/target.spec.js
@@ -80,18 +80,18 @@ module.exports.addTests = function({testRunner, expect, product}) {
   describe('Browser.waitForTarget', () => {
     it('should wait for a target', async function({browser, server}) {
       let resolved = false;
-      const targetPromise = browser.waitForTarget(target => target.url() === server.EMPTY_PAGE2);
+      const targetPromise = browser.waitForTarget(target => target.url() === server.EMPTY_PAGE);
       targetPromise.then(() => resolved = true);
       const page = await browser.newPage();
       expect(resolved).toBe(false);
-      await page.goto(server.EMPTY_PAGE2);
+      await page.goto(server.EMPTY_PAGE);
       const target = await targetPromise;
       expect(await target.page()).toBe(page);
       await page.close();
     });
     it('should timeout waiting for a non-existent target', async function({browser, server}) {
       let error = null;
-      await browser.waitForTarget(target => target.url() === server.EMPTY_PAGE2, {
+      await browser.waitForTarget(target => target.url() === server.EMPTY_PAGE, {
         timeout: 1
       }).catch(e => error = e);
       expect(error).toBeInstanceOf(TimeoutError);

--- a/experimental/puppeteer-firefox/test/waittask.spec.js
+++ b/experimental/puppeteer-firefox/test/waittask.spec.js
@@ -123,11 +123,9 @@ module.exports.addTests = function({testRunner, expect, product}) {
       await watchdog;
     });
     it('should survive navigations', async({page, server}) => {
-      const watchdog = page.waitForFunction(() => {
-        return window.__done;
-      });
+      const watchdog = page.waitForFunction(() => window.__done);
       await page.goto(server.EMPTY_PAGE);
-      await page.goto(server.EMPTY_PAGE2);
+      await page.goto(server.PREFIX + '/consolelog.html');
       await page.evaluate(() => window.__done = true);
       await watchdog;
     });

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -15,12 +15,12 @@
  */
 
 const utils = require('./utils');
-const {TimeoutError} = utils.requireRoot('Errors');
 
-module.exports.addTests = function({testRunner, expect, puppeteer}) {
+module.exports.addTests = function({testRunner, expect, puppeteer, Errors}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+  const {TimeoutError} = Errors;
 
   describe('BrowserContext', function() {
     it('should have default context', async function({browser, server}) {

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -15,19 +15,30 @@
  */
 
 const utils = require('./utils');
+const os = require('os');
 
-module.exports.addTests = function({testRunner, expect}) {
+module.exports.addTests = function({testRunner, expect, FFOX}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Keyboard', function() {
-    it('should type into the textarea', async({page, server}) => {
-      await page.goto(server.PREFIX + '/input/textarea.html');
-
-      const textarea = await page.$('textarea');
-      await textarea.type('Type in this text!');
-      expect(await page.evaluate(() => result)).toBe('Type in this text!');
+    it('should type into a textarea', async({page, server}) => {
+      await page.evaluate(() => {
+        const textarea = document.createElement('textarea');
+        document.body.appendChild(textarea);
+        textarea.focus();
+      });
+      const text = 'Hello world. I am the text that was typed!';
+      await page.keyboard.type(text);
+      expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe(text);
+    });
+    it('should press the metaKey', async({page}) => {
+      await page.evaluate(() => {
+        window.keyPromise = new Promise(resolve => document.addEventListener('keydown', event => resolve(event.key)));
+      });
+      await page.keyboard.press('Meta');
+      expect(await page.evaluate('keyPromise')).toBe(FFOX && os.platform() !== 'darwin' ? 'OS' : 'Meta');
     });
     it('should move with the arrow keys', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/textarea.html');

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -15,14 +15,24 @@
  */
 
 const utils = require('./utils');
-const {TimeoutError} = utils.requireRoot('Errors');
 
-module.exports.addTests = function({testRunner, expect}) {
+module.exports.addTests = function({testRunner, expect, Errors}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+  const {TimeoutError} = Errors;
 
   describe('Page.goto', function() {
+    it('should work', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      expect(page.url()).toBe(server.EMPTY_PAGE);
+    });
+    it('should work with redirects', async({page, server}) => {
+      server.setRedirect('/redirect/1.html', '/redirect/2.html');
+      server.setRedirect('/redirect/2.html', '/empty.html');
+      await page.goto(server.PREFIX + '/redirect/1.html');
+      expect(page.url()).toBe(server.EMPTY_PAGE);
+    });
     it('should navigate to about:blank', async({page, server}) => {
       const response = await page.goto('about:blank');
       expect(response).toBe(null);
@@ -521,6 +531,15 @@ module.exports.addTests = function({testRunner, expect}) {
       ]);
       await page.$eval('iframe', frame => frame.remove());
       await navigationPromise;
+    });
+  });
+
+  describe('Page.reload', function() {
+    it('should work', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => window._foo = 10);
+      await page.reload();
+      expect(await page.evaluate(() => window._foo)).toBe(undefined);
     });
   });
 };

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -17,10 +17,6 @@ const fs = require('fs');
 const path = require('path');
 const utils = require('./utils');
 const {waitEvent} = utils;
-const {TimeoutError} = utils.requireRoot('Errors');
-
-const DeviceDescriptors = utils.requireRoot('DeviceDescriptors');
-const iPhone = DeviceDescriptors['iPhone 6'];
 
 let asyncawait = true;
 try {
@@ -29,10 +25,13 @@ try {
   asyncawait = false;
 }
 
-module.exports.addTests = function({testRunner, expect, headless}) {
+module.exports.addTests = function({testRunner, expect, headless, Errors, DeviceDescriptors}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  const {TimeoutError} = Errors;
+  const iPhone = DeviceDescriptors['iPhone 6'];
 
   describe('Page.close', function() {
     it('should reject all promises when page is closed', async({context}) => {

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -22,7 +22,7 @@ const {Matchers} = require('../utils/testrunner/');
 const YELLOW_COLOR = '\x1b[33m';
 const RESET_COLOR = '\x1b[0m';
 
-module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOptions}) => {
+module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescriptors, defaultBrowserOptions}) => {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
@@ -52,6 +52,8 @@ module.exports.addTests = ({testRunner, product, puppeteer, defaultBrowserOption
     FFOX,
     CHROME,
     puppeteer,
+    Errors,
+    DeviceDescriptors,
     expect,
     defaultBrowserOptions,
     headless: !!defaultBrowserOptions.headless,

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,7 @@ beforeAll(async state => {
   state.server.PREFIX = `http://localhost:${port}`;
   state.server.CROSS_PROCESS_PREFIX = `http://127.0.0.1:${port}`;
   state.server.EMPTY_PAGE = `http://localhost:${port}/empty.html`;
+  state.server.EMPTY_PAGE2 = `http://localhost:${port}/empty2.html`;
 
   const httpsPort = port + 1;
   state.httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort);
@@ -61,6 +62,7 @@ beforeAll(async state => {
   state.httpsServer.PREFIX = `https://localhost:${httpsPort}`;
   state.httpsServer.CROSS_PROCESS_PREFIX = `https://127.0.0.1:${httpsPort}`;
   state.httpsServer.EMPTY_PAGE = `https://localhost:${httpsPort}/empty.html`;
+  state.httpsServer.EMPTY_PAGE2 = `https://localhost:${httpsPort}/empty2.html`;
 });
 
 afterAll(async({server, httpsServer}) => {
@@ -89,6 +91,8 @@ if (process.env.BROWSER !== 'firefox') {
     require('./puppeteer.spec.js').addTests({
       product: 'Chromium',
       puppeteer: utils.requireRoot('index'),
+      Errors: utils.requireRoot('Errors'),
+      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
       defaultBrowserOptions,
       testRunner,
     });
@@ -100,6 +104,8 @@ if (process.env.BROWSER !== 'firefox') {
     require('./puppeteer.spec.js').addTests({
       product: 'Firefox',
       puppeteer: require('../experimental/puppeteer-firefox'),
+      Errors: require('../experimental/puppeteer-firefox/Errors'),
+      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
       defaultBrowserOptions,
       testRunner,
     });


### PR DESCRIPTION
This patch:
- changes Puppeteer-Firefox plumbing of defaultBrowserOptions to align
  with the way we do it for Puppeteer.
- plumbs puppeeteer-dependent Errors and DeviceDescriptors down to every
  test.
- unifies a few tests between Puppeteer-Firefox and Puppeteer.

**Note:** in future, we should expose errors as `puppeteer.errors` and
device descriptors as `puppeteer.devices` to make it easy to pass around
Puppeteer/Puppeteer-Firefox instance.

References #3889.