### PR TITLE
test(firefox): support Puppeteer-Firefox specific env variables

### DIFF
--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -22,13 +22,21 @@ const {Matchers} = require('../utils/testrunner/');
 const YELLOW_COLOR = '\x1b[33m';
 const RESET_COLOR = '\x1b[0m';
 
-module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescriptors, defaultBrowserOptions}) => {
+module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescriptors, slowMo, headless}) => {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   const CHROME = product === 'Chromium';
   const FFOX = product === 'Firefox';
+
+  const defaultBrowserOptions = {
+    handleSIGINT: false,
+    executablePath: CHROME ? process.env.CHROME : process.env.FFOX,
+    slowMo,
+    headless,
+    dumpio: (process.env.DUMPIO || 'false').trim().toLowerCase() === 'true',
+  };
 
   if (defaultBrowserOptions.executablePath) {
     console.warn(`${YELLOW_COLOR}WARN: running ${product} tests with ${defaultBrowserOptions.executablePath}${RESET_COLOR}`);
@@ -58,6 +66,11 @@ module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescri
     defaultBrowserOptions,
     headless: !!defaultBrowserOptions.headless,
   };
+
+  beforeAll(async () => {
+    if (FFOX && defaultBrowserOptions.executablePath)
+      await require('../experimental/puppeteer-firefox/misc/install-preferences')(defaultBrowserOptions.executablePath);
+  });
 
   describe('Browser', function() {
     beforeAll(async state => {

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -67,7 +67,7 @@ module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescri
     headless: !!defaultBrowserOptions.headless,
   };
 
-  beforeAll(async () => {
+  beforeAll(async() => {
     if (FFOX && defaultBrowserOptions.executablePath)
       await require('../experimental/puppeteer-firefox/misc/install-preferences')(defaultBrowserOptions.executablePath);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -20,13 +20,6 @@ const utils = require('./utils');
 
 const headless = (process.env.HEADLESS || 'true').trim().toLowerCase() === 'true';
 const slowMo = parseInt((process.env.SLOW_MO || '0').trim(), 10);
-const defaultBrowserOptions = {
-  handleSIGINT: false,
-  executablePath: process.env.CHROME,
-  slowMo,
-  headless,
-  dumpio: (process.env.DUMPIO || 'false').trim().toLowerCase() === 'true',
-};
 
 let parallel = 1;
 if (process.env.PPTR_PARALLEL_TESTS)
@@ -93,8 +86,9 @@ if (process.env.BROWSER !== 'firefox') {
       puppeteer: utils.requireRoot('index'),
       Errors: utils.requireRoot('Errors'),
       DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
-      defaultBrowserOptions,
       testRunner,
+      slowMo,
+      headless,
     });
     if (process.env.COVERAGE)
       utils.recordAPICoverage(testRunner, require('../lib/api'), CHROMIUM_NO_COVERAGE);
@@ -106,8 +100,9 @@ if (process.env.BROWSER !== 'firefox') {
       puppeteer: require('../experimental/puppeteer-firefox'),
       Errors: require('../experimental/puppeteer-firefox/Errors'),
       DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
-      defaultBrowserOptions,
       testRunner,
+      slowMo,
+      headless,
     });
   });
 }


### PR DESCRIPTION
This patch:
- adds support to `FFOX` env variable for Puppeteer testsuite
- install Firefox preferences when running tests with custom firefox
  executable

References #3889