### PR TITLE
feat(chromium): roll chromium to r624492

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "624487"
+    "chromium_revision": "624492"
   },
   "scripts": {
     "unit": "node test/test.js",


### PR DESCRIPTION
The previous Chromium revision broke a bunch of big sites with TLS errors.
Fixes #3893 
Might be related to #3880