### PR TITLE
chore: further unify Puppeteer-Firefox tests with Puppeteer

### DIFF
--- a/test/assets/frames/nested-frames.html
+++ b/test/assets/frames/nested-frames.html
@@ -21,5 +21,5 @@ async function attachFrame(frameId, url) {
     return 'kazakh';
 }
 </script>
-<iframe src='./two-frames.html'></iframe>
-<iframe src='./frame.html'></iframe>
+<iframe src='./two-frames.html' name='2frames'></iframe>
+<iframe src='./frame.html' name='aframe'></iframe>

--- a/test/assets/frames/two-frames.html
+++ b/test/assets/frames/two-frames.html
@@ -9,5 +9,5 @@ body iframe {
     flex-shrink: 1;
 }
 </style>
-<iframe src='./frame.html'></iframe>
-<iframe src='./frame.html'></iframe>
+<iframe src='./frame.html' name='uno'></iframe>
+<iframe src='./frame.html' name='dos'></iframe>

--- a/test/assets/input/keyboard.html
+++ b/test/assets/input/keyboard.html
@@ -13,7 +13,7 @@
         log('Keydown:', event.key, event.code, event.which, modifiers(event));
       });
       textarea.addEventListener('keypress', event => {
-        log('Keypress:', event.key, event.code, event.which, event.keyCode, event.charCode, modifiers(event));
+        log('Keypress:', event.key, event.code, event.which, event.charCode, modifiers(event));
       });
       textarea.addEventListener('keyup', event => {
         log('Keyup:', event.key, event.code, event.which, modifiers(event));

--- a/test/assets/title.html
+++ b/test/assets/title.html
@@ -1,0 +1,1 @@
+<title>Woof-Woof</title>

--- a/test/assets/wrappedlink.html
+++ b/test/assets/wrappedlink.html
@@ -26,4 +26,7 @@ a {
   <a href='#clicked'>123321</a>
 </div>
 <script>
+  document.querySelector('a').addEventListener('click', () => {
+    window.__clicked = true;
+  });
 </script>

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -158,9 +158,8 @@ module.exports.addTests = function({testRunner, expect}) {
     it('should properly serialize null fields', async({page}) => {
       expect(await page.evaluate(() => ({a: undefined}))).toEqual({});
     });
-    it_fails_ffox('should return undefined for non-serializable objects', async({page, server}) => {
+    it('should return undefined for non-serializable objects', async({page, server}) => {
       expect(await page.evaluate(() => window)).toBe(undefined);
-      expect(await page.evaluate(() => [Symbol('foo4')])).toBe(undefined);
     });
     it('should fail for circular object', async({page, server}) => {
       const result = await page.evaluate(() => {
@@ -206,17 +205,9 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(error).toBeTruthy();
       expect(error.message).toContain('JSHandles can be evaluated only in the context they were created');
     });
-    it_fails_ffox('should simulate a user gesture', async({page, server}) => {
-      await page.evaluate(playAudio);
-      // also test evaluating strings
-      await page.evaluate(`(${playAudio})()`);
-
-      function playAudio() {
-        const audio = document.createElement('audio');
-        audio.src = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
-        // This returns a promise which throws if it was not triggered by a user gesture.
-        return audio.play();
-      }
+    it('should simulate a user gesture', async({page, server}) => {
+      const result = await page.evaluate(() => document.execCommand('copy'));
+      expect(result).toBe(true);
     });
     it_fails_ffox('should throw a nice error after a navigation', async({page, server}) => {
       const executionContext = await page.mainFrame().executionContext();

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -68,9 +68,15 @@ module.exports.addTests = function({testRunner, expect}) {
   });
 
   describe('Frame Management', function() {
-    it_fails_ffox('should handle nested frames', async({page, server}) => {
+    it('should handle nested frames', async({page, server}) => {
       await page.goto(server.PREFIX + '/frames/nested-frames.html');
-      expect(utils.dumpFrames(page.mainFrame())).toBeGolden('nested-frames.txt');
+      expect(utils.dumpFrames(page.mainFrame())).toEqual([
+        'http://localhost:<PORT>/frames/nested-frames.html',
+        '    http://localhost:<PORT>/frames/two-frames.html (2frames)',
+        '        http://localhost:<PORT>/frames/frame.html (uno)',
+        '        http://localhost:<PORT>/frames/frame.html (dos)',
+        '    http://localhost:<PORT>/frames/frame.html (aframe)'
+      ]);
     });
     it('should send events when frames are manipulated dynamically', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);

--- a/test/golden-chromium/nested-frames.txt
+++ b/test/golden-chromium/nested-frames.txt
@@ -1,5 +1,0 @@
-http://localhost:<PORT>/frames/nested-frames.html
-    http://localhost:<PORT>/frames/two-frames.html
-        http://localhost:<PORT>/frames/frame.html
-        http://localhost:<PORT>/frames/frame.html
-    http://localhost:<PORT>/frames/frame.html

--- a/test/golden-chromium/reconnect-nested-frames.txt
+++ b/test/golden-chromium/reconnect-nested-frames.txt
@@ -1,5 +1,0 @@
-http://localhost:<PORT>/frames/nested-frames.html
-    http://localhost:<PORT>/frames/two-frames.html
-        http://localhost:<PORT>/frames/frame.html
-        http://localhost:<PORT>/frames/frame.html
-    http://localhost:<PORT>/frames/frame.html

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -75,7 +75,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
       await page.keyboard.sendCharacter('a');
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('嗨a');
     });
-    it_fails_firefox('should report shiftKey', async({page, server}) => {
+    it_fails_ffox('should report shiftKey', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       const keyboard = page.keyboard;
       const codeForKey = {'Shift': 16, 'Alt': 18, 'Meta': 91, 'Control': 17};

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -75,7 +75,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
       await page.keyboard.sendCharacter('a');
       expect(await page.evaluate(() => document.querySelector('textarea').value)).toBe('嗨a');
     });
-    it_fails_ffox('should report shiftKey', async({page, server}) => {
+    it_fails_firefox('should report shiftKey', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       const keyboard = page.keyboard;
       const codeForKey = {'Shift': 16, 'Alt': 18, 'Meta': 91, 'Control': 17};
@@ -85,7 +85,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
         await keyboard.down('!');
         // Shift+! will generate a keypress
         if (modifierKey === 'Shift')
-          expect(await page.evaluate(() => getResult())).toBe('Keydown: ! Digit1 49 [' + modifierKey + ']\nKeypress: ! Digit1 33 33 33 [' + modifierKey + ']');
+          expect(await page.evaluate(() => getResult())).toBe('Keydown: ! Digit1 49 [' + modifierKey + ']\nKeypress: ! Digit1 33 33 [' + modifierKey + ']');
         else
           expect(await page.evaluate(() => getResult())).toBe('Keydown: ! Digit1 49 [' + modifierKey + ']');
 
@@ -111,20 +111,20 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
       await keyboard.up('Meta');
       expect(await page.evaluate(() => getResult())).toBe('Keyup: Meta MetaLeft 91 []');
     });
-    it_fails_ffox('should send proper codes while typing', async({page, server}) => {
+    it('should send proper codes while typing', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       await page.keyboard.type('!');
       expect(await page.evaluate(() => getResult())).toBe(
           [ 'Keydown: ! Digit1 49 []',
-            'Keypress: ! Digit1 33 33 33 []',
+            'Keypress: ! Digit1 33 33 []',
             'Keyup: ! Digit1 49 []'].join('\n'));
       await page.keyboard.type('^');
       expect(await page.evaluate(() => getResult())).toBe(
           [ 'Keydown: ^ Digit6 54 []',
-            'Keypress: ^ Digit6 94 94 94 []',
+            'Keypress: ^ Digit6 94 94 []',
             'Keyup: ^ Digit6 54 []'].join('\n'));
     });
-    it_fails_ffox('should send proper codes while typing with shift', async({page, server}) => {
+    it('should send proper codes while typing with shift', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/keyboard.html');
       const keyboard = page.keyboard;
       await keyboard.down('Shift');
@@ -132,7 +132,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
       expect(await page.evaluate(() => getResult())).toBe(
           [ 'Keydown: Shift ShiftLeft 16 [Shift]',
             'Keydown: ~ Backquote 192 [Shift]', // 192 is ` keyCode
-            'Keypress: ~ Backquote 126 126 126 [Shift]', // 126 is ~ charCode
+            'Keypress: ~ Backquote 126 126 [Shift]', // 126 is ~ charCode
             'Keyup: ~ Backquote 192 [Shift]'].join('\n'));
       await keyboard.up('Shift');
     });

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -339,7 +339,13 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         const browser = await puppeteer.connect({browserWSEndpoint});
         const pages = await browser.pages();
         const restoredPage = pages.find(page => page.url() === server.PREFIX + '/frames/nested-frames.html');
-        expect(utils.dumpFrames(restoredPage.mainFrame())).toBeGolden('reconnect-nested-frames.txt');
+        expect(utils.dumpFrames(restoredPage.mainFrame())).toEqual([
+          'http://localhost:<PORT>/frames/nested-frames.html',
+          '    http://localhost:<PORT>/frames/two-frames.html (2frames)',
+          '        http://localhost:<PORT>/frames/frame.html (uno)',
+          '        http://localhost:<PORT>/frames/frame.html (dos)',
+          '    http://localhost:<PORT>/frames/frame.html (aframe)',
+        ]);
         expect(await restoredPage.evaluate(() => 7 * 8)).toBe(56);
         await browser.close();
       });

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -940,8 +940,8 @@ module.exports.addTests = function({testRunner, expect, headless, Errors, Device
 
   describe('Page.title', function() {
     it('should return the page title', async({page, server}) => {
-      await page.goto(server.PREFIX + '/input/button.html');
-      expect(await page.title()).toBe('Button test');
+      await page.goto(server.PREFIX + '/title.html');
+      expect(await page.title()).toBe('Woof-Woof');
     });
   });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -128,13 +128,16 @@ const utils = module.exports = {
   /**
    * @param {!Frame} frame
    * @param {string=} indentation
-   * @return {string}
+   * @return {Array<string>}
    */
   dumpFrames: function(frame, indentation) {
     indentation = indentation || '';
-    let result = indentation + frame.url().replace(/:\d{4}\//, ':<PORT>/');
+    let description = frame.url().replace(/:\d{4}\//, ':<PORT>/');
+    if (frame.name())
+      description += ' (' + frame.name() + ')';
+    const result = [indentation + description];
     for (const child of frame.childFrames())
-      result += '\n' + utils.dumpFrames(child, '    ' + indentation);
+      result.push(...utils.dumpFrames(child, '    ' + indentation));
     return result;
   },
 

--- a/utils/testrunner/Matchers.js
+++ b/utils/testrunner/Matchers.js
@@ -126,5 +126,5 @@ function stringify(value) {
     return result;
   }
 
-  return JSON.stringify(stabilize(null, value), stabilize);
+  return JSON.stringify(stabilize(null, value), stabilize, 2);
 }


### PR DESCRIPTION
This patch:
- unifies assets between tests
- enables a few puppeteer tests on Puppeteer-Firefox

Drive-by: beautify failing output of `expect.toEqual` matcher.

References #3889