### PR TITLE
chore(ci): add Puppeteer-Firefox to CI

### DIFF
--- a/.ci/node8/Dockerfile.linux
+++ b/.ci/node8/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM node:8.11.3-stretch
+FROM node:8.11.3
 
 RUN apt-get update && \
     apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \

--- a/.ci/node8/Dockerfile.linux
+++ b/.ci/node8/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM node:8.11.3
+FROM node:8.11.3-stretch
 
 RUN apt-get update && \
     apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,7 @@ task:
       container:
         dockerfile: .ci/node8/Dockerfile.linux
       xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
-  install_script: cd experimental/puppeteer-firefox && npm install --unsafe-perm
+  install_script: npm install --unsafe-perm && cd experimental/puppeteer-firefox && npm install --unsafe-perm
   test_script: npm run funit
 
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ env:
 
 task:
   matrix:
-    - name: node6 (linux)
+    - name: Chromium (node6 + linux)
       container:
         dockerfile: .ci/node6/Dockerfile.linux
       xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
@@ -12,7 +12,7 @@ task:
 
 task:
   matrix:
-    - name: node8 (linux)
+    - name: Chromium (node8 + linux)
       container:
         dockerfile: .ci/node8/Dockerfile.linux
       xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
@@ -24,7 +24,7 @@ task:
 
 task:
   matrix:
-    - name: node8 Firefox (linux)
+    - name: Firefox (node8 + linux)
       container:
         dockerfile: .ci/node8/Dockerfile.linux
       xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
@@ -34,7 +34,7 @@ task:
 task:
   osx_instance:
     image: high-sierra-base
-  name: node8 (macOS)
+  name: Chromium (node8 + macOS)
   env:
     HOMEBREW_NO_AUTO_UPDATE: 1
   node_install_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,15 @@ task:
   test_types_script: npm run test-types
 
 task:
+  matrix:
+    - name: node8 Firefox (linux)
+      container:
+        dockerfile: .ci/node8/Dockerfile.linux
+      xvfb_start_background_script: Xvfb :99 -ac -screen 0 1024x768x24
+  install_script: cd experimental/puppeteer-firefox && npm install --unsafe-perm
+  test_script: npm run funit
+
+task:
   osx_instance:
     image: high-sierra-base
   name: node8 (macOS)

--- a/experimental/puppeteer-firefox/lib/Launcher.js
+++ b/experimental/puppeteer-firefox/lib/Launcher.js
@@ -72,11 +72,6 @@ class Launcher {
 
     const stdio = ['pipe', 'pipe', 'pipe'];
     const firefoxProcess = childProcess.spawn(
-        // On linux Juggler ships the libstdc++ it was linked against.
-        env: os.platform() === 'linux' ? {
-          ...process.env,
-          LD_LIBRARY_PATH: `${executablePath}:${process.env.LD_LIBRARY_PATH}`,
-        } : process.env,
         executablePath,
         firefoxArguments,
         {
@@ -84,7 +79,12 @@ class Launcher {
           // process group, making it possible to kill child process tree with `.kill(-pid)` command.
           // @see https://nodejs.org/api/child_process.html#child_process_options_detached
           detached: process.platform !== 'win32',
-          stdio
+          stdio,
+          // On linux Juggler ships the libstdc++ it was linked against.
+          env: os.platform() === 'linux' ? {
+            ...process.env,
+            LD_LIBRARY_PATH: `${executablePath}:${process.env.LD_LIBRARY_PATH}`,
+          } : process.env,
         }
     );
 

--- a/experimental/puppeteer-firefox/lib/Launcher.js
+++ b/experimental/puppeteer-firefox/lib/Launcher.js
@@ -72,6 +72,11 @@ class Launcher {
 
     const stdio = ['pipe', 'pipe', 'pipe'];
     const firefoxProcess = childProcess.spawn(
+        // On linux Juggler ships the libstdc++ it was linked against.
+        env: os.platform() === 'linux' ? {
+          ...process.env,
+          LD_LIBRARY_PATH: `${executablePath}:${process.env.LD_LIBRARY_PATH}`,
+        } : process.env,
         executablePath,
         firefoxArguments,
         {

--- a/experimental/puppeteer-firefox/lib/Launcher.js
+++ b/experimental/puppeteer-firefox/lib/Launcher.js
@@ -83,7 +83,7 @@ class Launcher {
           // On linux Juggler ships the libstdc++ it was linked against.
           env: os.platform() === 'linux' ? {
             ...process.env,
-            LD_LIBRARY_PATH: `${executablePath}:${process.env.LD_LIBRARY_PATH}`,
+            LD_LIBRARY_PATH: `${path.dirname(executablePath)}:${process.env.LD_LIBRARY_PATH}`,
           } : process.env,
         }
     );

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "d026cf7a14cb7dbe65acc4a4188c570da10a501c"
+    "firefox_revision": "74896383109c18e133bd317b7b2959ae2376f51d"
   },
   "scripts": {
     "install": "node install.js",


### PR DESCRIPTION
This patch adds Puppeteer-Firefox bot running on Linux+Node8
on Cirrus CI.