### PR TITLE
feat(firefox): introduce async stacks for Puppeteer-Firefox

### DIFF
--- a/experimental/puppeteer-firefox/index.js
+++ b/experimental/puppeteer-firefox/index.js
@@ -13,44 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const FirefoxLauncher = require('./lib/Launcher.js').Launcher;
-const BrowserFetcher = require('./lib/BrowserFetcher.js');
 
-class Puppeteer {
-  constructor() {
-    this._firefoxLauncher = new FirefoxLauncher();
-  }
+const {helper} = require('./lib/helper');
+const api = require('./lib/api');
+for (const className in api)
+  helper.installAsyncStackHooks(api[className]);
 
-  async launch(options = {}) {
-    const {
-      args = [],
-      dumpio = !!process.env.DUMPIO,
-      handleSIGHUP = true,
-      handleSIGINT = true,
-      handleSIGTERM = true,
-      headless = (process.env.HEADLESS || 'true').trim().toLowerCase() === 'true',
-      defaultViewport = {width: 800, height: 600},
-      ignoreHTTPSErrors = false,
-      slowMo = 0,
-      executablePath = this.executablePath(),
-    } = options;
-    options = {
-      args, slowMo, dumpio, executablePath, handleSIGHUP, handleSIGINT, handleSIGTERM, headless, defaultViewport,
-      ignoreHTTPSErrors
-    };
-    return await this._firefoxLauncher.launch(options);
-  }
-
-  createBrowserFetcher(options) {
-    return new BrowserFetcher(__dirname, options);
-  }
-
-  executablePath() {
-    const browserFetcher = new BrowserFetcher(__dirname, { product: 'firefox' });
-    const revision = require('./package.json').puppeteer.firefox_revision;
-    const revisionInfo = browserFetcher.revisionInfo(revision);
-    return revisionInfo.executablePath;
-  }
-}
-
-module.exports = new Puppeteer();
+const {Puppeteer} = require('./lib/Puppeteer');
+const packageJson = require('./package.json');
+const preferredRevision = packageJson.puppeteer.firefox_revision;
+module.exports = new Puppeteer(__dirname, preferredRevision);

--- a/experimental/puppeteer-firefox/lib/Browser.js
+++ b/experimental/puppeteer-firefox/lib/Browser.js
@@ -312,4 +312,4 @@ BrowserContext.Events = {
   TargetDestroyed: 'targetdestroyed'
 }
 
-module.exports = {Browser, Target};
+module.exports = {Browser, BrowserContext, Target};

--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -228,7 +228,7 @@ class BrowserFetcher {
   }
 }
 
-module.exports = BrowserFetcher;
+module.exports = {BrowserFetcher};
 
 /**
  * @param {string} folderPath

--- a/experimental/puppeteer-firefox/lib/Launcher.js
+++ b/experimental/puppeteer-firefox/lib/Launcher.js
@@ -19,6 +19,7 @@ const removeFolder = require('rimraf');
 const childProcess = require('child_process');
 const {Connection} = require('./Connection');
 const {Browser} = require('./Browser');
+const {BrowserFetcher} = require('./BrowserFetcher');
 const readline = require('readline');
 const fs = require('fs');
 const util = require('util');
@@ -35,6 +36,11 @@ const FIREFOX_PROFILE_PATH = path.join(os.tmpdir(), 'puppeteer_firefox_profile-'
  * @internal
  */
 class Launcher {
+  constructor(projectRoot, preferredRevision) {
+    this._projectRoot = projectRoot;
+    this._preferredRevision = preferredRevision;
+  }
+
   /**
    * @param {Object} options
    * @return {!Promise<!Browser>}
@@ -43,7 +49,7 @@ class Launcher {
     const {
       args = [],
       dumpio = false,
-      executablePath = null,
+      executablePath = this.executablePath(),
       handleSIGHUP = true,
       handleSIGINT = true,
       handleSIGTERM = true,
@@ -52,9 +58,6 @@ class Launcher {
       defaultViewport = {width: 800, height: 600},
       slowMo = 0,
     } = options;
-
-    if (!executablePath)
-      throw new Error('Firefox launching is only supported with local version of firefox!');
 
     const firefoxArguments = args.slice();
     firefoxArguments.push('-no-remote');
@@ -151,6 +154,15 @@ class Launcher {
         removeFolder.sync(temporaryProfileDir);
       } catch (e) { }
     }
+  }
+
+  /**
+   * @return {string}
+   */
+  executablePath() {
+    const browserFetcher = new BrowserFetcher(this._projectRoot, { product: 'firefox' });
+    const revisionInfo = browserFetcher.revisionInfo(this._preferredRevision);
+    return revisionInfo.executablePath;
   }
 }
 

--- a/experimental/puppeteer-firefox/lib/Page.js
+++ b/experimental/puppeteer-firefox/lib/Page.js
@@ -1446,4 +1446,4 @@ class NavigationWatchdog {
   }
 }
 
-module.exports = {Page};
+module.exports = {Page, Frame, ConsoleMessage};

--- a/experimental/puppeteer-firefox/lib/Puppeteer.js
+++ b/experimental/puppeteer-firefox/lib/Puppeteer.js
@@ -1,0 +1,27 @@
+const {Launcher} = require('./Launcher.js');
+const {BrowserFetcher} = require('./BrowserFetcher.js');
+
+class Puppeteer {
+  /**
+   * @param {string} projectRoot
+   * @param {string} preferredRevision
+   */
+  constructor(projectRoot, preferredRevision) {
+    this._projectRoot = projectRoot;
+    this._launcher = new Launcher(projectRoot, preferredRevision);
+  }
+
+  async launch(options = {}) {
+    return this._launcher.launch(options);
+  }
+
+  createBrowserFetcher(options) {
+    return new BrowserFetcher(this._projectRoot, options);
+  }
+
+  executablePath() {
+    return this._launcher.executablePath();
+  }
+}
+
+module.exports = {Puppeteer};

--- a/experimental/puppeteer-firefox/lib/api.js
+++ b/experimental/puppeteer-firefox/lib/api.js
@@ -1,0 +1,16 @@
+module.exports = {
+  Browser: require('./Browser').Browser,
+  BrowserContext: require('./Browser').BrowserContext,
+  BrowserFetcher: require('./BrowserFetcher').BrowserFetcher,
+  ConsoleMessage: require('./Page').ConsoleMessage,
+  Dialog: require('./Dialog').Dialog,
+  ElementHandle: require('./JSHandle').ElementHandle,
+  Frame: require('./Page').Frame,
+  JSHandle: require('./JSHandle').JSHandle,
+  Keyboard: require('./Input').Keyboard,
+  Mouse: require('./Input').Mouse,
+  Page: require('./Page').Page,
+  Puppeteer: require('./Puppeteer').Puppeteer,
+  Target: require('./Browser').Target,
+  TimeoutError: require('./Errors').TimeoutError,
+};

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -79,7 +79,7 @@ module.exports.addTests = function({testRunner, expect, headless, Errors, Device
     });
   });
 
-  (asyncawait ? describe_fails_ffox : xdescribe)('Async stacks', () => {
+  (asyncawait ? describe : xdescribe)('Async stacks', () => {
     it('should work', async({page, server}) => {
       server.setRoute('/empty.html', (req, res) => {
         res.statusCode = 204;
@@ -88,7 +88,7 @@ module.exports.addTests = function({testRunner, expect, headless, Errors, Device
       let error = null;
       await page.goto(server.EMPTY_PAGE).catch(e => error = e);
       expect(error).not.toBe(null);
-      expect(error.message).toContain('net::ERR_ABORTED');
+      expect(error.stack).toContain(__filename);
     });
   });
 


### PR DESCRIPTION
This patch refactors Puppeteer-Firefox code to declare public
API in `/lib/api.js` and use it to setup async stack hooks
over the public API method calls.
