### PR TITLE
chore(test): remove --firefox-status flag from tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -78,7 +78,19 @@ const CHROMIUM_NO_COVERAGE = new Set([
   'securityDetails.validTo',
 ]);
 
-if (process.env.BROWSER !== 'firefox') {
+if (process.env.BROWSER === 'firefox') {
+  testRunner.addTestDSL('it_fails_ffox', 'skip');
+  testRunner.addSuiteDSL('describe_fails_ffox', 'skip');
+  describe('Firefox', () => {
+    require('./puppeteer.spec.js').addTests({
+      product: 'Firefox',
+      puppeteer: require('../experimental/puppeteer-firefox'),
+      Errors: require('../experimental/puppeteer-firefox/Errors'),
+      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
+      testRunner,
+    });
+  });
+} else {
   testRunner.addTestDSL('it_fails_ffox', 'run');
   testRunner.addSuiteDSL('describe_fails_ffox', 'run');
   describe('Chromium', () => {
@@ -92,37 +104,6 @@ if (process.env.BROWSER !== 'firefox') {
     if (process.env.COVERAGE)
       utils.recordAPICoverage(testRunner, require('../lib/api'), CHROMIUM_NO_COVERAGE);
   });
-} else {
-  const FFOX_SKIPPED_TESTS = Symbol('FFOX_SKIPPED_TESTS');
-  testRunner.addTestDSL('it_fails_ffox', 'skip', FFOX_SKIPPED_TESTS);
-  testRunner.addSuiteDSL('describe_fails_ffox', 'skip', FFOX_SKIPPED_TESTS);
-  describe('Firefox', () => {
-    require('./puppeteer.spec.js').addTests({
-      product: 'Firefox',
-      puppeteer: require('../experimental/puppeteer-firefox'),
-      Errors: require('../experimental/puppeteer-firefox/Errors'),
-      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
-      testRunner,
-    });
-  });
-
-  if (process.argv.indexOf('--firefox-status') !== -1) {
-    const allTests = testRunner.tests();
-    const ffoxTests = allTests.filter(test => {
-      if (test.comment === FFOX_SKIPPED_TESTS)
-        return false;
-      for (let suite = test.suite; suite; suite = suite.parentSuite) {
-        if (suite.comment === FFOX_SKIPPED_TESTS)
-          return false;
-      }
-      return true;
-    });
-    console.log(JSON.stringify({
-      allTests: allTests.length,
-      firefoxTests: ffoxTests.length
-    }));
-    process.exit(0);
-  }
 }
 
 if (process.env.CI && testRunner.hasFocusedTestsOrSuites()) {


### PR DESCRIPTION
The [IsPuppeteerFirefoxReady?](https://aslushnikov.github.io/ispuppeteerfirefoxready/)
website now has its own script to compute test and api coverage.