### PR TITLE
chore(test): remove the server.EMPTY_PAGE2 asset

### DIFF
--- a/test/elementhandle.spec.js
+++ b/test/elementhandle.spec.js
@@ -132,7 +132,7 @@ module.exports.addTests = function({testRunner, expect}) {
   describe('ElementHandle.contentFrame', function() {
     it('should work', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);
-      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE2);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
       const elementHandle = await page.$('#frame1');
       const frame = await elementHandle.contentFrame();
       expect(frame).toBe(page.frames()[1]);

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,6 @@ beforeAll(async state => {
   state.server.PREFIX = `http://localhost:${port}`;
   state.server.CROSS_PROCESS_PREFIX = `http://127.0.0.1:${port}`;
   state.server.EMPTY_PAGE = `http://localhost:${port}/empty.html`;
-  state.server.EMPTY_PAGE2 = `http://localhost:${port}/empty2.html`;
 
   const httpsPort = port + 1;
   state.httpsServer = await TestServer.createHTTPS(assetsPath, httpsPort);
@@ -55,7 +54,6 @@ beforeAll(async state => {
   state.httpsServer.PREFIX = `https://localhost:${httpsPort}`;
   state.httpsServer.CROSS_PROCESS_PREFIX = `https://127.0.0.1:${httpsPort}`;
   state.httpsServer.EMPTY_PAGE = `https://localhost:${httpsPort}/empty.html`;
-  state.httpsServer.EMPTY_PAGE2 = `https://localhost:${httpsPort}/empty2.html`;
 });
 
 afterAll(async({server, httpsServer}) => {

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -253,7 +253,7 @@ module.exports.addTests = function({testRunner, expect, product, Errors}) {
 
     it('Page.waitForSelector is shortcut for main frame', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
-      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE2);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
       const otherFrame = page.frames()[1];
       const watchdog = page.waitForSelector('div');
       await otherFrame.evaluate(addElement, 'div');
@@ -263,8 +263,8 @@ module.exports.addTests = function({testRunner, expect, product, Errors}) {
     });
 
     it('should run in specified frame', async({page, server}) => {
-      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE2);
-      await utils.attachFrame(page, 'frame2', server.EMPTY_PAGE2);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'frame2', server.EMPTY_PAGE);
       const frame1 = page.frames()[1];
       const frame2 = page.frames()[2];
       const waitForSelectorPromise = frame2.waitForSelector('div');


### PR DESCRIPTION
Firefox used to have a bug that prevented adding iframes with the
same URL as main frame. In this case, we used the EMPTY_PAGE2
so that it doesn't clash with top-level EMPTY_PAGE.

The bug seems to be fixed after we rolled onto a fresh Firefox;
there's no more need for this test asset.