### PR TITLE
feat(firefox): Page.waitForRequest/Page.waitForResponse

### DIFF
--- a/experimental/puppeteer-firefox/lib/NetworkManager.js
+++ b/experimental/puppeteer-firefox/lib/NetworkManager.js
@@ -19,11 +19,11 @@ class NetworkManager extends EventEmitter {
   }
 
   _onRequestWillBeSent(event) {
-    const frame = this._frameManager && event.frameId ? this._frameManager.frame(event.frameId) : null;
+    const redirected = event.redirectedFrom ? this._requests.get(event.redirectedFrom) : null;
+    const frame = redirected ? redirected.frame() : (this._frameManager && event.frameId ? this._frameManager.frame(event.frameId) : null);
     if (!frame)
       return;
     let redirectChain = [];
-    const redirected = event.redirectedFrom ? this._requests.get(event.redirectedFrom) : null;
     if (redirected) {
       redirectChain = redirected._redirectChain;
       redirectChain.push(redirected);

--- a/experimental/puppeteer-firefox/lib/Page.js
+++ b/experimental/puppeteer-firefox/lib/Page.js
@@ -95,6 +95,42 @@ class Page extends EventEmitter {
   }
 
   /**
+   * @param {(string|Function)} urlOrPredicate
+   * @param {!{timeout?: number}=} options
+   * @return {!Promise<!Puppeteer.Request>}
+   */
+  async waitForRequest(urlOrPredicate, options = {}) {
+    const {
+      timeout = this._timeoutSettings.timeout(),
+    } = options;
+    return helper.waitForEvent(this._networkManager, Events.NetworkManager.Request, request => {
+      if (helper.isString(urlOrPredicate))
+        return (urlOrPredicate === request.url());
+      if (typeof urlOrPredicate === 'function')
+        return !!(urlOrPredicate(request));
+      return false;
+    }, timeout);
+  }
+
+  /**
+   * @param {(string|Function)} urlOrPredicate
+   * @param {!{timeout?: number}=} options
+   * @return {!Promise<!Puppeteer.Response>}
+   */
+  async waitForResponse(urlOrPredicate, options = {}) {
+    const {
+      timeout = this._timeoutSettings.timeout(),
+    } = options;
+    return helper.waitForEvent(this._networkManager, Events.NetworkManager.Response, response => {
+      if (helper.isString(urlOrPredicate))
+        return (urlOrPredicate === response.url());
+      if (typeof urlOrPredicate === 'function')
+        return !!(urlOrPredicate(response));
+      return false;
+    }, timeout);
+  }
+
+  /**
    * @param {number} timeout
    */
   setDefaultNavigationTimeout(timeout) {

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "668e06245e539adf0d453b447401b8eb6e9acb44"
+    "firefox_revision": "ad27e01304952cb0ff0b2817016b0e9f31d7f8fa"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -280,7 +280,7 @@ module.exports.addTests = function({testRunner, expect, Errors, CHROME}) {
     });
     it_fails_ffox('should navigate to dataURL and fire dataURL requests', async({page, server}) => {
       const requests = [];
-      page.on('request', request => requests.push(request));
+      page.on('request', request => !utils.isFavicon(request) && requests.push(request));
       const dataURL = 'data:text/html,<div>yo</div>';
       const response = await page.goto(dataURL);
       expect(response.status()).toBe(200);
@@ -289,7 +289,7 @@ module.exports.addTests = function({testRunner, expect, Errors, CHROME}) {
     });
     it_fails_ffox('should navigate to URL with hash and fire requests without hash', async({page, server}) => {
       const requests = [];
-      page.on('request', request => requests.push(request));
+      page.on('request', request => !utils.isFavicon(request) && requests.push(request));
       const response = await page.goto(server.EMPTY_PAGE + '#hash');
       expect(response.status()).toBe(200);
       expect(response.url()).toBe(server.EMPTY_PAGE);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -423,7 +423,7 @@ module.exports.addTests = function({testRunner, expect, headless, Errors, Device
     }
   });
 
-  describe_fails_ffox('Page.waitForRequest', function() {
+  describe('Page.waitForRequest', function() {
     it('should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [request] = await Promise.all([
@@ -473,7 +473,7 @@ module.exports.addTests = function({testRunner, expect, headless, Errors, Device
     });
   });
 
-  describe_fails_ffox('Page.waitForResponse', function() {
+  describe('Page.waitForResponse', function() {
     it('should work', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
       const [response] = await Promise.all([

--- a/test/utils.js
+++ b/test/utils.js
@@ -97,6 +97,10 @@ const utils = module.exports = {
     }
   },
 
+  isFavicon: function(request) {
+    return request.url().includes('favicon.ico');
+  },
+
   /**
    * @param {!Page} page
    * @param {string} frameId


### PR DESCRIPTION
Drive-by: refactor `Request.frame()` tests into a separate test suite.