### PR TITLE
fix: Respect the loglevel for logging

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,15 +21,15 @@ if (require('./package.json').name === 'puppeteer-core')
 buildNode6IfNecessary();
 
 if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
-  console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
+  log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;
 }
 if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_config_puppeteer_skip_chromium_download) {
-  console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in npm config.');
+  log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in npm config.');
   return;
 }
 if (process.env.NPM_PACKAGE_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_package_config_puppeteer_skip_chromium_download) {
-  console.log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in project config.');
+  log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in project config.');
   return;
 }
 
@@ -71,7 +71,7 @@ browserFetcher.download(revisionInfo.revision, onProgress)
  * @return {!Promise}
  */
 function onSuccess(localRevisions) {
-  console.log('Chromium downloaded to ' + revisionInfo.folderPath);
+  log('Chromium downloaded to ' + revisionInfo.folderPath);
   localRevisions = localRevisions.filter(revision => revision !== revisionInfo.revision);
   // Remove previous chromium revisions.
   const cleanupOldVersions = localRevisions.map(revision => browserFetcher.remove(revision));
@@ -121,7 +121,7 @@ function buildNode6IfNecessary() {
   if (supportsAsyncAwait())
     return;
   // Re-build node6/ folder.
-  console.log('Building Puppeteer for Node 6');
+  log('Building Puppeteer for Node 6');
   require(path.join(__dirname, 'utils', 'node6-transform'));
 }
 
@@ -145,3 +145,12 @@ function generateProtocolTypesIfNecessary(updated) {
     return;
   return require('./utils/protocol-types-generator');
 }
+
+function log(toBeLogged) {
+  const logLevel = process.env.npm_config_loglevel;
+  const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
+
+  if (!logLevelDisplay)
+    console.log(toBeLogged);
+}
+

--- a/install.js
+++ b/install.js
@@ -21,15 +21,15 @@ if (require('./package.json').name === 'puppeteer-core')
 buildNode6IfNecessary();
 
 if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
-  log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
+  logPolitely('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;
 }
 if (process.env.NPM_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_config_puppeteer_skip_chromium_download) {
-  log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in npm config.');
+  logPolitely('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in npm config.');
   return;
 }
 if (process.env.NPM_PACKAGE_CONFIG_PUPPETEER_SKIP_CHROMIUM_DOWNLOAD || process.env.npm_package_config_puppeteer_skip_chromium_download) {
-  log('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in project config.');
+  logPolitely('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" was set in project config.');
   return;
 }
 
@@ -71,7 +71,7 @@ browserFetcher.download(revisionInfo.revision, onProgress)
  * @return {!Promise}
  */
 function onSuccess(localRevisions) {
-  log('Chromium downloaded to ' + revisionInfo.folderPath);
+  logPolitely('Chromium downloaded to ' + revisionInfo.folderPath);
   localRevisions = localRevisions.filter(revision => revision !== revisionInfo.revision);
   // Remove previous chromium revisions.
   const cleanupOldVersions = localRevisions.map(revision => browserFetcher.remove(revision));
@@ -121,7 +121,7 @@ function buildNode6IfNecessary() {
   if (supportsAsyncAwait())
     return;
   // Re-build node6/ folder.
-  log('Building Puppeteer for Node 6');
+  logPolitely('Building Puppeteer for Node 6');
   require(path.join(__dirname, 'utils', 'node6-transform'));
 }
 
@@ -146,7 +146,7 @@ function generateProtocolTypesIfNecessary(updated) {
   return require('./utils/protocol-types-generator');
 }
 
-function log(toBeLogged) {
+function logPolitely(toBeLogged) {
   const logLevel = process.env.npm_config_loglevel;
   const logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
 


### PR DESCRIPTION
This adds support for disabling console.log when the loglevel asks for it.