### PR TITLE
fix: check if async error has a stack

### DIFF
--- a/experimental/puppeteer-firefox/lib/helper.js
+++ b/experimental/puppeteer-firefox/lib/helper.js
@@ -32,7 +32,7 @@ class Helper {
         return method.call(this, ...args).catch(e => {
           const stack = syncStack.stack.substring(syncStack.stack.indexOf('\n') + 1);
           const clientStack = stack.substring(stack.indexOf('\n'));
-          if (!e.stack.includes(clientStack))
+          if (e instanceof Error && e.stack && !e.stack.includes(clientStack))
             e.stack += '\n  -- ASYNC --\n' + stack;
           throw e;
         });

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -109,7 +109,7 @@ class Helper {
         return method.call(this, ...args).catch(e => {
           const stack = syncStack.stack.substring(syncStack.stack.indexOf('\n') + 1);
           const clientStack = stack.substring(stack.indexOf('\n'));
-          if (!e.stack.includes(clientStack))
+          if (e instanceof Error && e.stack && !e.stack.includes(clientStack))
             e.stack += '\n  -- ASYNC --\n' + stack;
           throw e;
         });


### PR DESCRIPTION
If a non-error object or an error without a stack was thrown, the async stack trace could would fail.