### PR TITLE
feat(firefox): support Browser.target()

### DIFF
--- a/experimental/puppeteer-firefox/lib/Browser.js
+++ b/experimental/puppeteer-firefox/lib/Browser.js
@@ -160,7 +160,7 @@ class Browser extends EventEmitter {
   }
 
   async pages() {
-    const pageTargets = Array.from(this._targets.values());
+    const pageTargets = Array.from(this._targets.values()).filter(target => target.type() === 'page');
     return await Promise.all(pageTargets.map(target => target.page()));
   }
 

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "10282bfac697c69a6fdfeec4cddae7caf98e1969"
+    "firefox_revision": "2ede4ae19f39ec7a1b73162a6004235908260dfe"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -20,7 +20,7 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer}) {
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Browser.target', function() {
-    it_fails_ffox('should return browser target', async({browser}) => {
+    it('should return browser target', async({browser}) => {
       const target = browser.target();
       expect(target.type()).toBe('browser');
     });

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -24,7 +24,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, Errors}) {
   const {TimeoutError} = Errors;
 
   describe('Target', function() {
-    it_fails_ffox('Browser.targets should return all of the targets', async({page, server, browser}) => {
+    it('Browser.targets should return all of the targets', async({page, server, browser}) => {
       // The pages will be the testing page and the original newtab page
       const targets = browser.targets();
       expect(targets.some(target => target.type() === 'page' &&
@@ -38,7 +38,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, Errors}) {
       expect(allPages).toContain(page);
       expect(allPages[0]).not.toBe(allPages[1]);
     });
-    it_fails_ffox('should contain browser target', async({browser}) => {
+    it('should contain browser target', async({browser}) => {
       const targets = browser.targets();
       const browserTarget = targets.find(target => target.type() === 'browser');
       expect(browserTarget).toBeTruthy();


### PR DESCRIPTION
Support browser target.

Drive-by: switch over to a more devtools'ish protocol:

- use `targetId` instead of `pageId` everywhere
- use target events instead of tab events