### PR TITLE
refactor(firefox): migrate onto Juggler flatten protocol

### DIFF
--- a/experimental/puppeteer-firefox/lib/Events.js
+++ b/experimental/puppeteer-firefox/lib/Events.js
@@ -31,6 +31,10 @@ const Events = {
     Disconnected: Symbol('Events.Connection.Disconnected'),
   },
 
+  JugglerSession: {
+    Disconnected: Symbol('Events.JugglerSession.Disconnected'),
+  },
+
   FrameManager: {
     Load: Symbol('Events.FrameManager.Load'),
     DOMContentLoaded: Symbol('Events.FrameManager.DOMContentLoaded'),

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "2ede4ae19f39ec7a1b73162a6004235908260dfe"
+    "firefox_revision": "387ac6bbbe5357d174e9fb3aa9b6f935113c315d"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -265,7 +265,7 @@ module.exports.addTests = function({testRunner, expect, Errors, CHROME}) {
       process.removeListener('warning', warningHandler);
       expect(warning).toBe(null);
     });
-    it_fails_ffox('should not leak listeners during navigation of 11 pages', async({page, context, server}) => {
+    it('should not leak listeners during navigation of 11 pages', async({page, context, server}) => {
       let warning = null;
       const warningHandler = w => warning = w;
       process.on('warning', warningHandler);

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -36,10 +36,11 @@ module.exports.addTests = function({testRunner, expect, headless, Errors, Device
   describe('Page.close', function() {
     it('should reject all promises when page is closed', async({context}) => {
       const newPage = await context.newPage();
-      const neverResolves = newPage.evaluate(() => new Promise(r => {}));
-      newPage.close();
       let error = null;
-      await neverResolves.catch(e => error = e);
+      await Promise.all([
+        newPage.evaluate(() => new Promise(r => {})).catch(e => error = e),
+        newPage.close(),
+      ]);
       expect(error.message).toContain('Protocol error');
     });
     it('should not be visible in browser.pages', async({browser}) => {


### PR DESCRIPTION
Juggler now implements the same "flatten" protocol as CDP.
This patch:
-  copies `Connection.js` from original Puppeteer (with a few renames, e.g. `CDPSesssion` -> `JugglerSession`).
- migrates code to support protocol-level sessions