### PR TITLE
feat(firefox): basic request interception support

### DIFF
--- a/experimental/puppeteer-firefox/lib/Page.js
+++ b/experimental/puppeteer-firefox/lib/Page.js
@@ -73,6 +73,10 @@ class Page extends EventEmitter {
     });
   }
 
+  async setRequestInterception(enabled) {
+    await this._networkManager.setRequestInterception(enabled);
+  }
+
   /**
    * @param {(string|Function)} urlOrPredicate
    * @param {!{timeout?: number}=} options

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "387ac6bbbe5357d174e9fb3aa9b6f935113c315d"
+    "firefox_revision": "98116977b3f0c936c92e917bdd571c340167a536"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -69,7 +69,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       expect(error).toBe(null);
       expect(response.ok()).toBe(true);
     });
-    it_fails_ffox('should work with request interception', async({page, server, httpsServer}) => {
+    it('should work with request interception', async({page, server, httpsServer}) => {
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
       const response = await page.goto(httpsServer.EMPTY_PAGE);


### PR DESCRIPTION
This patch implements `page.setRequestInterception`, `page.continue` (without overrides)
and `page.abort` (without custom error codes) methods.