### PR TITLE
test: move AX tests to Chrome-only

### DIFF
--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -117,7 +117,6 @@ module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescri
 
       // Page-level tests that are given a browser, a context and a page.
       // Each test is launched in a new browser context.
-      require('./accessibility.spec.js').addTests(testOptions);
       require('./browser.spec.js').addTests(testOptions);
       require('./click.spec.js').addTests(testOptions);
       require('./cookies.spec.js').addTests(testOptions);
@@ -140,6 +139,7 @@ module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescri
       require('./waittask.spec.js').addTests(testOptions);
       require('./worker.spec.js').addTests(testOptions);
       if (CHROME) {
+        require('./accessibility.spec.js').addTests(testOptions);
         require('./CDPSession.spec.js').addTests(testOptions);
         require('./coverage.spec.js').addTests(testOptions);
         require('./chromiumonly.spec.js').addTests(testOptions);


### PR DESCRIPTION
Let's not focus on AX for now for Firefox.