### PR TITLE
test: use require('puppeteer') instead of utils.requireRoot

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Assuming you have a checkout of the Puppeteer repo and have run npm i (or yarn) to install the dependencies, the examples can be run from the root folder like so:
 
 ```sh
-NODE_PATH=../ node examples/search.js
+node examples/search.js
 ```
 
 ## Larger examples

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "3.2.2"
+    "typescript": "3.2.2",
+    "puppeteer": "."
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -15,13 +15,13 @@
  */
 
 const utils = require('./utils');
-const DeviceDescriptors = utils.requireRoot('DeviceDescriptors');
-const iPhone = DeviceDescriptors['iPhone 6'];
 
-module.exports.addTests = function({testRunner, expect}) {
+module.exports.addTests = function({testRunner, expect, DeviceDescriptors}) {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit, it_fails_ffox} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+  const iPhone = DeviceDescriptors['iPhone 6'];
+
   describe('Page.click', function() {
     it('should click the button', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-const utils = require('./utils');
-
 module.exports.addTests = function({testRunner, expect, product, DeviceDescriptors}) {
   const {describe, xdescribe, fdescribe, describe_fails_ffox} = testRunner;
   const {it, fit, xit, it_fails_ffox} = testRunner;

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -15,14 +15,14 @@
  */
 
 const utils = require('./utils');
-const DeviceDescriptors = utils.requireRoot('DeviceDescriptors');
-const iPhone = DeviceDescriptors['iPhone 6'];
-const iPhoneLandscape = DeviceDescriptors['iPhone 6 landscape'];
 
-module.exports.addTests = function({testRunner, expect, product}) {
+module.exports.addTests = function({testRunner, expect, product, DeviceDescriptors}) {
   const {describe, xdescribe, fdescribe, describe_fails_ffox} = testRunner;
   const {it, fit, xit, it_fails_ffox} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  const iPhone = DeviceDescriptors['iPhone 6'];
+  const iPhoneLandscape = DeviceDescriptors['iPhone 6 landscape'];
 
   describe('Page.viewport', function() {
     it('should get the proper viewport size', async({page, server}) => {

--- a/test/test.js
+++ b/test/test.js
@@ -80,7 +80,7 @@ if (process.env.BROWSER === 'firefox') {
       product: 'Firefox',
       puppeteer: require('../experimental/puppeteer-firefox'),
       Errors: require('../experimental/puppeteer-firefox/Errors'),
-      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
+      DeviceDescriptors: require('puppeteer/DeviceDescriptors'),
       testRunner,
     });
   });
@@ -90,9 +90,9 @@ if (process.env.BROWSER === 'firefox') {
   describe('Chromium', () => {
     require('./puppeteer.spec.js').addTests({
       product: 'Chromium',
-      puppeteer: utils.requireRoot('index'),
-      Errors: utils.requireRoot('Errors'),
-      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
+      puppeteer: require('puppeteer'),
+      Errors: require('puppeteer/Errors'),
+      DeviceDescriptors: require('puppeteer/DeviceDescriptors'),
       testRunner,
     });
     if (process.env.COVERAGE)

--- a/test/utils.js
+++ b/test/utils.js
@@ -71,13 +71,6 @@ const utils = module.exports = {
   },
 
   /**
-   * @return {*}
-   */
-  requireRoot: function(name) {
-    return require(path.join(PROJECT_ROOT, name));
-  },
-
-  /**
    * @param {!Page} page
    * @param {string} frameId
    * @param {string} url


### PR DESCRIPTION
Add a dev-dependency "puppeteer" that points to "self" to use
`require('puppeteer')` instead of a `utils.requireRoot`.

NOTE: This also eliminates the need for `NODE_PATH` when running
Puppeteer examples.