### PR TITLE
feat(firefox): support Response.text()/Response.json()/Response.buffer()

### DIFF
--- a/experimental/puppeteer-firefox/misc/puppeteer.cfg
+++ b/experimental/puppeteer-firefox/misc/puppeteer.cfg
@@ -17,6 +17,12 @@ pref("browser.newtabpage.enabled", false);
 // Disable topstories
 pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
 
+// DevTools JSONViewer sometimes fails to load dependencies with its require.js.
+// This doesn't affect Puppeteer operations, but spams console with a lot of
+// unpleasant errors.
+// (bug 1424372)
+pref("devtools.jsonview.enabled", false);
+
 // Increase the APZ content response timeout in tests to 1 minute.
 // This is to accommodate the fact that test environments tends to be
 // slower than production environments (with the b2g emulator being

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "f7b25713dd00f0deda7032dc25a72d4c7b42446e"
+    "firefox_revision": "3ba79216e3c5ae4e85006047cdd93eac4197427d"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -499,7 +499,7 @@ module.exports.addTests = function({testRunner, expect, Errors, CHROME}) {
       const error = await navigationPromise;
       expect(error.message).toBe('Navigating frame was detached');
     });
-    it_fails_ffox('should return matching responses', async({page, server}) => {
+    it('should return matching responses', async({page, server}) => {
       // Disable cache: otherwise, chromium will cache similar requests.
       await page.setCacheEnabled(false);
       await page.goto(server.EMPTY_PAGE);

--- a/utils/testserver/index.js
+++ b/utils/testserver/index.js
@@ -80,6 +80,8 @@ class TestServer {
     this._auths = new Map();
     /** @type {!Map<string, string>} */
     this._csp = new Map();
+    /** @type {!Set<string>} */
+    this._gzipRoutes = new Set();
     /** @type {!Map<string, !Promise>} */
     this._requestSubscribers = new Map();
   }
@@ -109,6 +111,10 @@ class TestServer {
    */
   setAuth(path, username, password) {
     this._auths.set(path, {username, password});
+  }
+
+  enableGzip(path) {
+    this._gzipRoutes.add(path);
   }
 
   /**
@@ -169,6 +175,7 @@ class TestServer {
     this._routes.clear();
     this._auths.clear();
     this._csp.clear();
+    this._gzipRoutes.clear();
     const error = new Error('Static Server has been reset');
     for (const subscriber of this._requestSubscribers.values())
       subscriber[rejectSymbol].call(null, error);
@@ -230,14 +237,22 @@ class TestServer {
     if (this._csp.has(pathName))
       response.setHeader('Content-Security-Policy', this._csp.get(pathName));
 
-    fs.readFile(filePath, function(err, data) {
+    fs.readFile(filePath, (err, data) => {
       if (err) {
         response.statusCode = 404;
         response.end(`File not found: ${filePath}`);
         return;
       }
       response.setHeader('Content-Type', mime.getType(filePath));
-      response.end(data);
+      if (this._gzipRoutes.has(pathName)) {
+        response.setHeader('Content-Encoding', 'gzip');
+        const zlib = require('zlib');
+        zlib.gzip(data, (_, result) => {
+          response.end(result);
+        });
+      } else {
+        response.end(data);
+      }
     });
   }
 


### PR DESCRIPTION
This patch:
- implements Response.buffer() and other methods
- splits out relevant tests into a separate test suites
- implements `testServer.enableGzip()` method to optionally gzip
  certain routes in tests
- adds tests to make sure `Response.text()` returns expected results
  for binary and compressed responses.