### PR TITLE
refactor(firefox): migrate onto ExecutionContext events

### DIFF
--- a/experimental/puppeteer-firefox/lib/JSHandle.js
+++ b/experimental/puppeteer-firefox/lib/JSHandle.js
@@ -59,7 +59,7 @@ class JSHandle {
    * @return {!Promise<Map<string, !JSHandle>>}
    */
   async getProperties() {
-    const response = await this._session.send('Page.getObjectProperties', {
+    const response = await this._session.send('Runtime.getObjectProperties', {
       executionContextId: this._executionContextId,
       objectId: this._objectId,
     });
@@ -85,10 +85,10 @@ class JSHandle {
   async jsonValue() {
     if (!this._objectId)
       return this._deserializeValue(this._protocolValue);
-    const simpleValue = await this._session.send('Page.evaluate', {
+    const simpleValue = await this._session.send('Runtime.callFunction', {
       executionContextId: this._executionContextId,
       returnByValue: true,
-      functionText: (e => e).toString(),
+      functionDeclaration: (e => e).toString(),
       args: [this._protocolValue],
     });
     return this._deserializeValue(simpleValue.result);
@@ -105,7 +105,7 @@ class JSHandle {
     if (!this._objectId)
       return;
     this._disposed = true;
-    await this._session.send('Page.disposeObject', {
+    await this._session.send('Runtime.disposeObject', {
       executionContextId: this._executionContextId,
       objectId: this._objectId,
     });

--- a/experimental/puppeteer-firefox/lib/JSHandle.js
+++ b/experimental/puppeteer-firefox/lib/JSHandle.js
@@ -108,6 +108,10 @@ class JSHandle {
     await this._session.send('Runtime.disposeObject', {
       executionContextId: this._executionContextId,
       objectId: this._objectId,
+    }).catch(error => {
+      // Exceptions might happen in case of a page been navigated or closed.
+      // Swallow these since they are harmless and we don't leak anything in this case.
+      debugError(error);
     });
   }
 }

--- a/experimental/puppeteer-firefox/lib/Page.js
+++ b/experimental/puppeteer-firefox/lib/Page.js
@@ -27,6 +27,7 @@ class Page extends EventEmitter {
     await Promise.all([
       session.send('Page.enable'),
       session.send('Network.enable'),
+      session.send('Runtime.enable'),
     ]);
 
     if (defaultViewport)
@@ -139,7 +140,7 @@ class Page extends EventEmitter {
       else
         expression = helper.evaluationString(deliverErrorValue, name, seq, error);
     }
-    this._session.send('Page.evaluate', { script: expression, executionContextId: event.frameId }).catch(debugError);
+    this._session.send('Runtime.evaluate', { expression, executionContextId: event.executionContextId }).catch(debugError);
 
     /**
      * @param {string} name
@@ -651,9 +652,9 @@ class Page extends EventEmitter {
   _onClosed() {
   }
 
-  _onConsole({type, args, frameId, location}) {
-    const frame = this._frameManager.frame(frameId);
-    this.emit(Events.Page.Console, new ConsoleMessage(type, args.map(arg => createHandle(frame._executionContext, arg)), location));
+  _onConsole({type, args, executionContextId, location}) {
+    const context = this._frameManager.executionContextById(executionContextId);
+    this.emit(Events.Page.Console, new ConsoleMessage(type, args.map(arg => createHandle(context, arg)), location));
   }
 
   /**

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "3ba79216e3c5ae4e85006047cdd93eac4197427d"
+    "firefox_revision": "764023af0aa07d232984dec6bc81d9e904f25ddb"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -209,7 +209,7 @@ module.exports.addTests = function({testRunner, expect}) {
       const result = await page.evaluate(() => document.execCommand('copy'));
       expect(result).toBe(true);
     });
-    it_fails_ffox('should throw a nice error after a navigation', async({page, server}) => {
+    it('should throw a nice error after a navigation', async({page, server}) => {
       const executionContext = await page.mainFrame().executionContext();
 
       await Promise.all([


### PR DESCRIPTION
Juggler now has Runtime domain that emits Execution Context events
"ExecutionContextCreated" and "ExecutionContextDestroyed".