### PR TITLE
test: split out fixture tests and make them work with FF

### DIFF
--- a/experimental/puppeteer-firefox/DeviceDescriptors.js
+++ b/experimental/puppeteer-firefox/DeviceDescriptors.js
@@ -1,0 +1,824 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = [
+  {
+    'name': 'Blackberry PlayBook',
+    'userAgent': 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
+    'viewport': {
+      'width': 600,
+      'height': 1024,
+      'deviceScaleFactor': 1,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Blackberry PlayBook landscape',
+    'userAgent': 'Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+',
+    'viewport': {
+      'width': 1024,
+      'height': 600,
+      'deviceScaleFactor': 1,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'BlackBerry Z30',
+    'userAgent': 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'BlackBerry Z30 landscape',
+    'userAgent': 'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Galaxy Note 3',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Galaxy Note 3 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Galaxy Note II',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Galaxy Note II landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.1; en-us; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Galaxy S III',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Galaxy S III landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Galaxy S5',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Galaxy S5 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPad',
+    'userAgent': 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    'viewport': {
+      'width': 768,
+      'height': 1024,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPad landscape',
+    'userAgent': 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    'viewport': {
+      'width': 1024,
+      'height': 768,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPad Mini',
+    'userAgent': 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    'viewport': {
+      'width': 768,
+      'height': 1024,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPad Mini landscape',
+    'userAgent': 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    'viewport': {
+      'width': 1024,
+      'height': 768,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPad Pro',
+    'userAgent': 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    'viewport': {
+      'width': 1024,
+      'height': 1366,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPad Pro landscape',
+    'userAgent': 'Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1',
+    'viewport': {
+      'width': 1366,
+      'height': 1024,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 4',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53',
+    'viewport': {
+      'width': 320,
+      'height': 480,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 4 landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53',
+    'viewport': {
+      'width': 480,
+      'height': 320,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 5',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+    'viewport': {
+      'width': 320,
+      'height': 568,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 5 landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+    'viewport': {
+      'width': 568,
+      'height': 320,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 6',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 375,
+      'height': 667,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 6 landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 667,
+      'height': 375,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 6 Plus',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 414,
+      'height': 736,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 6 Plus landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 736,
+      'height': 414,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 7',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 375,
+      'height': 667,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 7 landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 667,
+      'height': 375,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 7 Plus',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 414,
+      'height': 736,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 7 Plus landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 736,
+      'height': 414,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 8',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 375,
+      'height': 667,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 8 landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 667,
+      'height': 375,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone 8 Plus',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 414,
+      'height': 736,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone 8 Plus landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 736,
+      'height': 414,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone SE',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+    'viewport': {
+      'width': 320,
+      'height': 568,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone SE landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
+    'viewport': {
+      'width': 568,
+      'height': 320,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'iPhone X',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 375,
+      'height': 812,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'iPhone X landscape',
+    'userAgent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+    'viewport': {
+      'width': 812,
+      'height': 375,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Kindle Fire HDX',
+    'userAgent': 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
+    'viewport': {
+      'width': 800,
+      'height': 1280,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Kindle Fire HDX landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true',
+    'viewport': {
+      'width': 1280,
+      'height': 800,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'LG Optimus L70',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 384,
+      'height': 640,
+      'deviceScaleFactor': 1.25,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'LG Optimus L70 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 640,
+      'height': 384,
+      'deviceScaleFactor': 1.25,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Microsoft Lumia 550',
+    'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Microsoft Lumia 950',
+    'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 4,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Microsoft Lumia 950 landscape',
+    'userAgent': 'Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 4,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 10',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Safari/537.36',
+    'viewport': {
+      'width': 800,
+      'height': 1280,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 10 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Safari/537.36',
+    'viewport': {
+      'width': 1280,
+      'height': 800,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 4',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 384,
+      'height': 640,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 4 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 640,
+      'height': 384,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 5',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 360,
+      'height': 640,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 5 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 640,
+      'height': 360,
+      'deviceScaleFactor': 3,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 5X',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 412,
+      'height': 732,
+      'deviceScaleFactor': 2.625,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 5X landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 732,
+      'height': 412,
+      'deviceScaleFactor': 2.625,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 6',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 412,
+      'height': 732,
+      'deviceScaleFactor': 3.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 6 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 732,
+      'height': 412,
+      'deviceScaleFactor': 3.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 6P',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 412,
+      'height': 732,
+      'deviceScaleFactor': 3.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 6P landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 732,
+      'height': 412,
+      'deviceScaleFactor': 3.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nexus 7',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Safari/537.36',
+    'viewport': {
+      'width': 600,
+      'height': 960,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nexus 7 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Safari/537.36',
+    'viewport': {
+      'width': 960,
+      'height': 600,
+      'deviceScaleFactor': 2,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nokia Lumia 520',
+    'userAgent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
+    'viewport': {
+      'width': 320,
+      'height': 533,
+      'deviceScaleFactor': 1.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nokia Lumia 520 landscape',
+    'userAgent': 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)',
+    'viewport': {
+      'width': 533,
+      'height': 320,
+      'deviceScaleFactor': 1.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Nokia N9',
+    'userAgent': 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
+    'viewport': {
+      'width': 480,
+      'height': 854,
+      'deviceScaleFactor': 1,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Nokia N9 landscape',
+    'userAgent': 'Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13',
+    'viewport': {
+      'width': 854,
+      'height': 480,
+      'deviceScaleFactor': 1,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Pixel 2',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 411,
+      'height': 731,
+      'deviceScaleFactor': 2.625,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Pixel 2 landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 731,
+      'height': 411,
+      'deviceScaleFactor': 2.625,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  },
+  {
+    'name': 'Pixel 2 XL',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 411,
+      'height': 823,
+      'deviceScaleFactor': 3.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': false
+    }
+  },
+  {
+    'name': 'Pixel 2 XL landscape',
+    'userAgent': 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3679.0 Mobile Safari/537.36',
+    'viewport': {
+      'width': 823,
+      'height': 411,
+      'deviceScaleFactor': 3.5,
+      'isMobile': true,
+      'hasTouch': true,
+      'isLandscape': true
+    }
+  }
+];
+for (const device of module.exports)
+  module.exports[device.name] = device;

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {helper} = require('../lib/helper');
+const rmAsync = helper.promisify(require('rimraf'));
+const mkdtempAsync = helper.promisify(fs.mkdtemp);
+const readFileAsync = helper.promisify(fs.readFile);
+const statAsync = helper.promisify(fs.stat);
+const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
+const utils = require('./utils');
+
+module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, puppeteer, puppeteerPath, CHROME}) {
+  const {describe, xdescribe, fdescribe, describe_fails_ffox} = testRunner;
+  const {it, fit, xit, it_fails_ffox} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe('Fixtures', function() {
+    it('should dump browser process stderr', async({server}) => {
+      let dumpioData = '';
+      const {spawn} = require('child_process');
+      const options = Object.assign({}, defaultBrowserOptions, {dumpio: true});
+      const res = spawn('node',
+          [path.join(__dirname, 'fixtures', 'dumpio.js'), puppeteerPath, JSON.stringify(options)]);
+      if (CHROME)
+        res.stderr.on('data', data => dumpioData += data.toString('utf8'));
+      else
+        res.stdout.on('data', data => dumpioData += data.toString('utf8'));
+      await new Promise(resolve => res.on('close', resolve));
+
+      if (CHROME)
+        expect(dumpioData).toContain('DevTools listening on ws://');
+      else
+        expect(dumpioData).toContain('Juggler listening on ws://');
+    });
+    it('should close the browser when the node process closes', async({ server }) => {
+      const {spawn, execSync} = require('child_process');
+      const res = spawn('node', [path.join(__dirname, 'fixtures', 'closeme.js'), puppeteerPath, JSON.stringify(defaultBrowserOptions)]);
+      let wsEndPointCallback;
+      const wsEndPointPromise = new Promise(x => wsEndPointCallback = x);
+      let output = '';
+      res.stdout.on('data', data => {
+        output += data;
+        if (output.indexOf('\n'))
+          wsEndPointCallback(output.substring(0, output.indexOf('\n')));
+      });
+      const browser = await puppeteer.connect({ browserWSEndpoint: await wsEndPointPromise });
+      const promises = [
+        new Promise(resolve => browser.once('disconnected', resolve)),
+        new Promise(resolve => res.on('close', resolve))
+      ];
+      if (process.platform === 'win32')
+        execSync(`taskkill /pid ${res.pid} /T /F`);
+      else
+        process.kill(res.pid);
+      await Promise.all(promises);
+    });
+  });
+};

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -1,13 +1,20 @@
-const fs = require('fs');
-const os = require('os');
+/**
+ * Copyright 2019 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const path = require('path');
-const {helper} = require('../lib/helper');
-const rmAsync = helper.promisify(require('rimraf'));
-const mkdtempAsync = helper.promisify(fs.mkdtemp);
-const readFileAsync = helper.promisify(fs.readFile);
-const statAsync = helper.promisify(fs.stat);
-const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
-const utils = require('./utils');
 
 module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, puppeteer, puppeteerPath, CHROME}) {
   const {describe, xdescribe, fdescribe, describe_fails_ffox} = testRunner;

--- a/test/fixtures/dumpio.js
+++ b/test/fixtures/dumpio.js
@@ -1,9 +1,7 @@
 (async() => {
-  const [, , puppeteerRoot, options, emptyPage, dumpioTextToLog] = process.argv;
+  const [, , puppeteerRoot, options] = process.argv;
   const browser = await require(puppeteerRoot).launch(JSON.parse(options));
   const page = await browser.newPage();
-  await page.goto(emptyPage);
-  await page.evaluate(_dumpioTextToLog => console.log(_dumpioTextToLog), dumpioTextToLog);
   await page.close();
   await browser.close();
 })();

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -22,13 +22,17 @@ const {Matchers} = require('../utils/testrunner/');
 const YELLOW_COLOR = '\x1b[33m';
 const RESET_COLOR = '\x1b[0m';
 
-module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescriptors}) => {
+module.exports.addTests = ({testRunner, product, puppeteerPath}) => {
   const {describe, xdescribe, fdescribe} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   const CHROME = product === 'Chromium';
   const FFOX = product === 'Firefox';
+
+  const puppeteer = require(puppeteerPath);
+  const Errors = require(path.join(puppeteerPath, 'Errors'));
+  const DeviceDescriptors = require(path.join(puppeteerPath, 'DeviceDescriptors'));
 
   const headless = (process.env.HEADLESS || 'true').trim().toLowerCase() === 'true';
   const slowMo = parseInt((process.env.SLOW_MO || '0').trim(), 10);
@@ -67,6 +71,7 @@ module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescri
     DeviceDescriptors,
     expect,
     defaultBrowserOptions,
+    puppeteerPath,
     headless: !!defaultBrowserOptions.headless,
   };
 
@@ -155,6 +160,7 @@ module.exports.addTests = ({testRunner, product, puppeteer, Errors, DeviceDescri
   // Top-level tests that launch Browser themselves.
   require('./ignorehttpserrors.spec.js').addTests(testOptions);
   require('./launcher.spec.js').addTests(testOptions);
+  require('./fixtures.spec.js').addTests(testOptions);
   if (CHROME) {
     require('./headful.spec.js').addTests(testOptions);
     require('./tracing.spec.js').addTests(testOptions);

--- a/test/test.js
+++ b/test/test.js
@@ -78,9 +78,7 @@ if (process.env.BROWSER === 'firefox') {
   describe('Firefox', () => {
     require('./puppeteer.spec.js').addTests({
       product: 'Firefox',
-      puppeteer: require('../experimental/puppeteer-firefox'),
-      Errors: require('../experimental/puppeteer-firefox/Errors'),
-      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
+      puppeteerPath: path.resolve(__dirname, '../experimental/puppeteer-firefox/'),
       testRunner,
     });
   });
@@ -90,9 +88,7 @@ if (process.env.BROWSER === 'firefox') {
   describe('Chromium', () => {
     require('./puppeteer.spec.js').addTests({
       product: 'Chromium',
-      puppeteer: utils.requireRoot('index'),
-      Errors: utils.requireRoot('Errors'),
-      DeviceDescriptors: utils.requireRoot('DeviceDescriptors'),
+      puppeteerPath: utils.projectRoot(),
       testRunner,
     });
     if (process.env.COVERAGE)


### PR DESCRIPTION
Drive-By: give Puppeteer-Firefox its own copy of DeviceDescriptors.