### PR TITLE
fix(chromium): bypass service workers when request interception is on

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1758,6 +1758,7 @@ puppeteer.launch().then(async browser => {
 ```
 
 > **NOTE** Enabling request interception disables page caching.
+> **NOTE** Enabling request interception starts bypassing ServiceWorkers for network.
 
 #### page.setUserAgent(userAgent)
 - `userAgent` <[string]> Specific user agent to use in this page

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -128,6 +128,7 @@ class NetworkManager extends EventEmitter {
     const patterns = enabled ? [{urlPattern: '*'}] : [];
     await Promise.all([
       this._client.send('Network.setCacheDisabled', {cacheDisabled: enabled}),
+      this._client.send('Network.setBypassServiceWorker', {bypass: enabled}),
       this._client.send('Network.setRequestInterception', {patterns})
     ]);
   }


### PR DESCRIPTION
Puppeteer currently relies on invariant that once request interception
is enabled in DevTools protocol, every `Network.requestWillBeSent` event
is accompanied with a corresponding `Network.requestIntercepted`.

However, if a request is fulfilled by ServiceWorker, protocol will not
emit the `Network.requestIntercepted` event, and the invariant breaks.
As a result, Puppeteer never dispatches a `request` event.

The proper solution would be connecting to all the service workers and
adding an instrumentation to designate that request was fulfilled from
worker.

The compromised solution is to bypass service workers for all network
requests - and that's what we do here.

Fix #4041