### PR TITLE
test: Fix should fire for fetches test

### DIFF
--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -41,7 +41,7 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
       const requests = [];
       page.on('request', request => !utils.isFavicon(request) && requests.push(request));
       await page.goto(server.EMPTY_PAGE);
-      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      await page.evaluate(() => fetch('/empty.html'));
       expect(requests.length).toBe(2);
     });
   });


### PR DESCRIPTION
The code in "should fire for fetches" was copy of "should fire for iframes"
I bet the test was supposed to use a fetch there.