### PR TITLE
docs(troubleshooting): updated Lambda resources

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -347,9 +347,8 @@ There's also another [simple guide](https://timleland.com/headless-chrome-on-her
 
 AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) deployment package sizes to ~50MB. This presents challenges for running headless Chrome (and therefore Puppeteer) on Lambda. The community has put together a few resources that work around the issues:
 
-- https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (tracks the latest Chromium snapshots)
 - https://github.com/alixaxel/chrome-aws-lambda (kept updated with the latest stable release of puppeteer)
-- https://github.com/Kikobeats/aws-lambda-chrome
+- https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (serverless plugin - outdated)
 
 ## Code Transpilation Issues
 


### PR DESCRIPTION
- removed deprecated [Kikobeats/aws-lambda-chrome](https://github.com/Kikobeats/aws-lambda-chrome)
- added outdated info to [adieuadieu/serverless-chrome](https://github.com/adieuadieu/serverless-chrome) (last updated 6 months ago)