### PR TITLE
feat(firefox): Implement header overrides in request interception

### DIFF
--- a/experimental/puppeteer-firefox/lib/NetworkManager.js
+++ b/experimental/puppeteer-firefox/lib/NetworkManager.js
@@ -146,12 +146,19 @@ class Request {
     return this._errorText ? {errorText: this._errorText} : null;
   }
 
-  async continue() {
+  async continue(overrides = {}) {
+    assert(!overrides.url, 'Puppeteer-Firefox does not support overriding URL');
+    assert(!overrides.method, 'Puppeteer-Firefox does not support overriding method');
+    assert(!overrides.postData, 'Puppeteer-Firefox does not support overriding postData');
     assert(this._suspended, 'Request Interception is not enabled!');
     assert(!this._interceptionHandled, 'Request is already handled!');
     this._interceptionHandled = true;
+    const {
+      headers,
+    } = overrides;
     await this._session.send('Network.resumeSuspendedRequest', {
       requestId: this._id,
+      headers: headers ? Object.entries(headers).map(([name, value]) => ({name, value})) : undefined,
     }).catch(error => {
       debugError(error);
     });

--- a/experimental/puppeteer-firefox/package.json
+++ b/experimental/puppeteer-firefox/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.4"
   },
   "puppeteer": {
-    "firefox_revision": "2f959d575a3d61f5dda12e4e2dca1f46a92ab569"
+    "firefox_revision": "d152aecb47c733342b7a8691e899f7b2981ef797"
   },
   "scripts": {
     "install": "node install.js",

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -717,7 +717,7 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
     });
   });
 
-  describe_fails_ffox('Request.continue', function() {
+  describe('Request.continue', function() {
     it('should work', async({page, server}) => {
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
@@ -737,7 +737,7 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
       ]);
       expect(request.headers['foo']).toBe('bar');
     });
-    it('should redirect in a way non-observable to page', async({page, server}) => {
+    it_fails_ffox('should redirect in a way non-observable to page', async({page, server}) => {
       await page.setRequestInterception(true);
       page.on('request', request => {
         const redirectURL = request.url().includes('/empty.html') ? server.PREFIX + '/consolelog.html' : undefined;
@@ -749,7 +749,7 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
       expect(page.url()).toBe(server.EMPTY_PAGE);
       expect(consoleMessage.text()).toBe('yellow');
     });
-    it('should amend method', async({page, server}) => {
+    it_fails_ffox('should amend method', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
 
       await page.setRequestInterception(true);
@@ -762,7 +762,7 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
       ]);
       expect(request.method).toBe('POST');
     });
-    it('should amend post data', async({page, server}) => {
+    it_fails_ffox('should amend post data', async({page, server}) => {
       await page.goto(server.EMPTY_PAGE);
 
       await page.setRequestInterception(true);

--- a/utils/testserver/index.js
+++ b/utils/testserver/index.js
@@ -248,7 +248,10 @@ class TestServer {
         response.end(`File not found: ${filePath}`);
         return;
       }
-      response.setHeader('Content-Type', mime.getType(filePath));
+      const mimeType = mime.getType(filePath);
+      const isTextEncoding = /^text\/|^application\/(javascript|json)/.test(mimeType);
+      let contentType = isTextEncoding ? `${mimeType}; charset=utf-8` : mimeType;
+      response.setHeader('Content-Type', contentType);
       if (this._gzipRoutes.has(pathName)) {
         response.setHeader('Content-Encoding', 'gzip');
         const zlib = require('zlib');

--- a/utils/testserver/index.js
+++ b/utils/testserver/index.js
@@ -250,7 +250,7 @@ class TestServer {
       }
       const mimeType = mime.getType(filePath);
       const isTextEncoding = /^text\/|^application\/(javascript|json)/.test(mimeType);
-      let contentType = isTextEncoding ? `${mimeType}; charset=utf-8` : mimeType;
+      const contentType = isTextEncoding ? `${mimeType}; charset=utf-8` : mimeType;
       response.setHeader('Content-Type', contentType);
       if (this._gzipRoutes.has(pathName)) {
         response.setHeader('Content-Encoding', 'gzip');


### PR DESCRIPTION
This patch makes sure header overrides in request interception are
functioning as expected.

Drive-by: teach test server to use utf-8 charset header for text files.