### PR TITLE
fix(types): add jsdoc for the DOMWorld on frames

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -369,6 +369,7 @@ class Frame {
     this._lifecycleEvents = new Set();
     /** @type {!DOMWorld} */
     this._mainWorld = new DOMWorld(frameManager, this, frameManager._timeoutSettings);
+    /** @type {!DOMWorld} */
     this._secondaryWorld = new DOMWorld(frameManager, this, frameManager._timeoutSettings);
 
     /** @type {!Set<!Frame>} */

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -367,6 +367,7 @@ class Frame {
     this._loaderId = '';
     /** @type {!Set<string>} */
     this._lifecycleEvents = new Set();
+    /** @type {!DOMWorld} */
     this._mainWorld = new DOMWorld(frameManager, this, frameManager._timeoutSettings);
     this._secondaryWorld = new DOMWorld(frameManager, this, frameManager._timeoutSettings);
 


### PR DESCRIPTION
TypeScript gets confused when we use `this` as an argument in a constructor. Adding an `@type` JSDoc helps it figure itself out.