### PR TITLE
docs(examples): adding prescript example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ More complex and use case driven examples can be found at [github.com/GoogleChro
 ## Rendering and web scraping
 
 - [Puppetron](https://github.com/cheeaun/puppetron) - Demo site that shows how to use Puppeteer and Headless Chrome to render pages. Inspired by [GoogleChrome/rendertron](https://github.com/GoogleChrome/rendertron).
-- [Thal](https://medium.com/@e_mad_ehsan/getting-started-with-puppeteer-and-chrome-headless-for-web-scrapping-6bf5979dee3e "An article on medium") - Getting started with Puppeteer and Chrome Headless for Web Scraping.
+- [Thal](https://medium.com/@e_mad_ehsan/getting-started-with-puppeteer-and-chrome-headless-for-web-scrapping-6bf5979dee3e 'An article on medium') - Getting started with Puppeteer and Chrome Headless for Web Scraping.
 - [pupperender](https://github.com/LasaleFamine/pupperender) - Express middleware that checks the User-Agent header of incoming requests, and if it matches one of a configurable set of bots, render the page using Puppeteer. Useful for PWA rendering.
 - [headless-chrome-crawler](https://github.com/yujiosaka/headless-chrome-crawler) - Crawler that provides simple APIs to manipulate Headless Chrome and allows you to crawl dynamic websites.
 - [puppeteer-examples](https://github.com/checkly/puppeteer-examples) - Puppeteer Headless Chrome examples for real life use cases such as getting useful info from the web pages or common login scenarios.
@@ -32,6 +32,8 @@ More complex and use case driven examples can be found at [github.com/GoogleChro
 - [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) - (almost) Zero configuration tool for setting up and running Jest and Puppeteer easily. Also includes an assertion library for Puppeteer.
 - [puppeteer-har](https://github.com/Everettss/puppeteer-har) - Generate HAR file with puppeteer.
 - [puppetry](https://puppetry.app/) - A desktop app to build Puppeteer/Jest driven tests without coding.
+- [puppeteer-prescript](https://github.com/cerberus/pup) - An example of puppeteer project with prescript
 
 ## Services
+
 - [Checkly](https://checklyhq.com) - Monitoring SaaS that uses Puppeteer to check availability and correctness of web pages and apps.


### PR DESCRIPTION
- Added an example of puppeteer project with prescript
  - [prescript](https://prescript.netlify.com/): an end-to-end test runner that sparks joy
  - know more why I used prescript [read my article](https://medium.com/@SunCerberus/puppeteer-with-prescript-js-proxy-example-b53526d356fe) : )
- [minor] Applied prettier style to README.md file.