### PR TITLE
fix(launcher): support https for browserURL endpoint

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -16,6 +16,7 @@
 const os = require('os');
 const path = require('path');
 const http = require('http');
+const https = require('https');
 const URL = require('url');
 const removeFolder = require('rimraf');
 const childProcess = require('child_process');
@@ -382,8 +383,9 @@ function getWSEndpoint(browserURL) {
   const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
 
   const endpointURL = URL.resolve(browserURL, '/json/version');
+  const protocol = endpointURL.startsWith('https') ? https : http;
   const requestOptions = Object.assign(URL.parse(endpointURL), { method: 'GET' });
-  const request = http.request(requestOptions, res => {
+  const request = protocol.request(requestOptions, res => {
     let data = '';
     if (res.statusCode !== 200) {
       // Consume response data to free up memory.


### PR DESCRIPTION
Hey there 👋

We'd like to deploy Puppeteer to internal Kubernetes (which serves everything via https, at least in our setup), but apperently `browserURL` is limited to http requests at the moment. I wonder if there's any particular reason behind it?

I'm not sure how to setup https case for testing, but happy to work on it with some guidance.

Thanks!