### PR TITLE
fix: Allow PUPPETEER_EXECUTABLE_PATH to be set in npmrc and package.json

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -297,7 +297,7 @@ class Launcher {
     const browserFetcher = new BrowserFetcher(this._projectRoot);
     // puppeteer-core doesn't take into account PUPPETEER_* env variables.
     if (!this._isPuppeteerCore) {
-      const executablePath = process.env['PUPPETEER_EXECUTABLE_PATH'];
+      const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.npm_config_puppeteer_executable_path || process.env.npm_package_config_puppeteer_executable_path;
       if (executablePath) {
         const missingText = !fs.existsSync(executablePath) ? 'Tried to use PUPPETEER_EXECUTABLE_PATH env variable to launch browser but did not find any executable at: ' + executablePath : null;
         return { executablePath, missingText };


### PR DESCRIPTION
Hello,

This PR sets fixes the PUPPETEER_EXECUTABLE_PATH environment variable so that it can be set in the .npmrc or package.json like the documentation says. Other env variables are set up this way, this one just seems to have been missed.