### PR TITLE
fix: add default port to options if port not specified to fix #4264

### DIFF
--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -270,7 +270,7 @@ function httpRequest(url, method, response) {
   /** @type {Object} */
   const options = URL.parse(url);
   options.method = method;
-
+  options.port = options.port || (options.protocol === 'https:' ? 443 : 80);
   const proxyURL = getProxyForUrl(url);
   if (proxyURL) {
     /** @type {Object} */


### PR DESCRIPTION
add default port to options if port not specified