### PR TITLE
test: Make intervention test Edge friendly

### DIFF
--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -118,6 +118,8 @@ module.exports.addPageTests = function({testRunner, expect}) {
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
       await page.goto(server.PREFIX + '/intervention');
+      // Check for feature URL substring rather than https://www.chromestatus.com to
+      // make it work with Edgium.
       expect(serverRequest.headers.intervention).toContain('feature/5718547946799104');
     });
   });

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -118,7 +118,7 @@ module.exports.addPageTests = function({testRunner, expect}) {
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
       await page.goto(server.PREFIX + '/intervention');
-      expect(serverRequest.headers.intervention).toContain('www.chromestatus.com');
+      expect(serverRequest.headers.intervention).toContain('feature/5718547946799104');
     });
   });
 };


### PR DESCRIPTION
All tests are green when running against [Microsoft Edge Insider](https://www.microsoftedgeinsider.com/en-us/), except this test.

Edge returns `https://to-be-replaced.invalid/feature/5718547946799104` instead of `https://www.chromestatus.com/feature/5718547946799104`

I think that checking for `feature/5718547946799104` is a small test and will do the job for both browsers.

```
$env:CHROME = "C:\Program Files (x86)\Microsoft\Edge Dev\Application\msedge.exe"; node
.\test.js
```
