### PR TITLE
feat: element option in page.accessibility.snapshot()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2090,6 +2090,7 @@ Most of the accessibility tree gets filtered out when converting from Blink AX T
 #### accessibility.snapshot([options])
 - `options` <[Object]>
   - `interestingOnly` <[boolean]> Prune uninteresting nodes from the tree. Defaults to `true`.
+  - `element` <[ElementHandle]> The root DOM element for the snapshot. Defaults to the whole page.
 - returns: <[Promise]<[Object]>> An [AXNode] object with the following properties:
   - `role` <[string]> The [role](https://www.w3.org/TR/wai-aria/#usage_intro).
   - `name` <[string]> A human readable name for the node.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2090,7 +2090,7 @@ Most of the accessibility tree gets filtered out when converting from Blink AX T
 #### accessibility.snapshot([options])
 - `options` <[Object]>
   - `interestingOnly` <[boolean]> Prune uninteresting nodes from the tree. Defaults to `true`.
-  - `element` <[ElementHandle]> The root DOM element for the snapshot. Defaults to the whole page.
+  - `root` <[ElementHandle]> The root DOM element for the snapshot. Defaults to the whole page.
 - returns: <[Promise]<[Object]>> An [AXNode] object with the following properties:
   - `role` <[string]> The [role](https://www.w3.org/TR/wai-aria/#usage_intro).
   - `name` <[string]> A human readable name for the node.

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -60,20 +60,36 @@ class Accessibility {
   }
 
   /**
-   * @param {{interestingOnly?: boolean}=} options
+   * @param {{interestingOnly?: boolean, element?: ?Puppeteer.ElementHandle}=} options
    * @return {!Promise<!SerializedAXNode>}
    */
   async snapshot(options = {}) {
-    const {interestingOnly = true} = options;
+    const {
+      interestingOnly = true,
+      element = null,
+    } = options;
     const {nodes} = await this._client.send('Accessibility.getFullAXTree');
+    let backendNodeId = null;
+    if (element) {
+      const {node} = await this._client.send('DOM.describeNode', {objectId: element._remoteObject.objectId});
+      backendNodeId = node.backendNodeId;
+    }
     const root = AXNode.createTree(nodes);
+    let needle = root;
+    if (backendNodeId) {
+      needle = root.find(node => node._payload.backendDOMNodeId === backendNodeId);
+      if (!needle)
+        return null;
+    }
     if (!interestingOnly)
-      return serializeTree(root)[0];
+      return serializeTree(needle)[0];
 
     /** @type {!Set<!AXNode>} */
     const interestingNodes = new Set();
     collectInterestingNodes(interestingNodes, root, false);
-    return serializeTree(root, interestingNodes)[0];
+    if (!interestingNodes.has(needle))
+      return null;
+    return serializeTree(needle, interestingNodes)[0];
   }
 }
 
@@ -177,6 +193,21 @@ class AXNode {
       }
     }
     return this._cachedHasFocusableChild;
+  }
+
+  /**
+   * @param {function(AXNode):boolean} predicate
+   * @return {?AXNode}
+   */
+  find(predicate) {
+    if (predicate(this))
+      return this;
+    for (const child of this._children) {
+      const result = child.find(predicate);
+      if (result)
+        return result;
+    }
+    return null;
   }
 
   /**

--- a/lib/Accessibility.js
+++ b/lib/Accessibility.js
@@ -60,24 +60,24 @@ class Accessibility {
   }
 
   /**
-   * @param {{interestingOnly?: boolean, element?: ?Puppeteer.ElementHandle}=} options
+   * @param {{interestingOnly?: boolean, root?: ?Puppeteer.ElementHandle}=} options
    * @return {!Promise<!SerializedAXNode>}
    */
   async snapshot(options = {}) {
     const {
       interestingOnly = true,
-      element = null,
+      root = null,
     } = options;
     const {nodes} = await this._client.send('Accessibility.getFullAXTree');
     let backendNodeId = null;
-    if (element) {
-      const {node} = await this._client.send('DOM.describeNode', {objectId: element._remoteObject.objectId});
+    if (root) {
+      const {node} = await this._client.send('DOM.describeNode', {objectId: root._remoteObject.objectId});
       backendNodeId = node.backendNodeId;
     }
-    const root = AXNode.createTree(nodes);
-    let needle = root;
+    const defaultRoot = AXNode.createTree(nodes);
+    let needle = defaultRoot;
     if (backendNodeId) {
-      needle = root.find(node => node._payload.backendDOMNodeId === backendNodeId);
+      needle = defaultRoot.find(node => node._payload.backendDOMNodeId === backendNodeId);
       if (!needle)
         return null;
     }
@@ -86,7 +86,7 @@ class Accessibility {
 
     /** @type {!Set<!AXNode>} */
     const interestingNodes = new Set();
-    collectInterestingNodes(interestingNodes, root, false);
+    collectInterestingNodes(interestingNodes, defaultRoot, false);
     if (!interestingNodes.has(needle))
       return null;
     return serializeTree(needle, interestingNodes)[0];

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -309,31 +309,39 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
       });
 
       describe_fails_ffox('element option', function() {
-        it('should work', async({page}) => {
+        it('should work a button', async({page}) => {
           await page.setContent(`
           <button>My Button</button>
+          `);
+
+          const button = await page.$('button');
+          expect(await page.accessibility.snapshot({element: button})).toEqual({
+            role: 'button',
+            name: 'My Button'
+          });
+        });
+        it('should work an input', async({page}) => {
+          await page.setContent(`
           <input title="My Input" value="My Value">
+          `);
+
+          const input = await page.$('input');
+          expect(await page.accessibility.snapshot({element: input})).toEqual({
+            role: 'textbox',
+            name: 'My Input',
+            value: 'My Value'
+          });
+        });
+        it('should work a menu', async({page}) => {
+          await page.setContent(`
           <div role="menu" title="My Menu">
             <div role="menuitem">First Item</div>
             <div role="menuitem">Second Item</div>
             <div role="menuitem">Third Item</div>
           </div>`);
 
-          const button = await page.$('button');
-          expect(await await page.accessibility.snapshot({element: button})).toEqual({
-            role: 'button',
-            name: 'My Button'
-          });
-
-          const input = await page.$('input');
-          expect(await await page.accessibility.snapshot({element: input})).toEqual({
-            role: 'textbox',
-            name: 'My Input',
-            value: 'My Value'
-          });
-
           const menu = await page.$('div[role="menu"]');
-          expect(await await page.accessibility.snapshot({element: menu})).toEqual({
+          expect(await page.accessibility.snapshot({element: menu})).toEqual({
             role: 'menu',
             name: 'My Menu',
             children:
@@ -346,13 +354,13 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
           await page.setContent(`<button>My Button</button>`);
           const button = await page.$('button');
           await page.$eval('button', button => button.remove());
-          expect(await await page.accessibility.snapshot({element: button})).toEqual(null);
+          expect(await page.accessibility.snapshot({element: button})).toEqual(null);
         });
         it('should support the interestingOnly option', async({page}) => {
           await page.setContent(`<div><button>My Button</button></div>`);
           const div = await page.$('div');
-          expect(await await page.accessibility.snapshot({element: div})).toEqual(null);
-          expect(await await page.accessibility.snapshot({element: div, interestingOnly: false})).toEqual({
+          expect(await page.accessibility.snapshot({element: div})).toEqual(null);
+          expect(await page.accessibility.snapshot({element: div, interestingOnly: false})).toEqual({
             role: 'GenericContainer',
             name: '',
             children: [ { role: 'button', name: 'My Button' } ] }

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -308,12 +308,12 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
         expect(snapshot.children[0]).toEqual(golden);
       });
 
-      describe_fails_ffox('element option', function() {
+      describe_fails_ffox('root option', function() {
         it('should work a button', async({page}) => {
           await page.setContent(`<button>My Button</button>`);
 
           const button = await page.$('button');
-          expect(await page.accessibility.snapshot({element: button})).toEqual({
+          expect(await page.accessibility.snapshot({root: button})).toEqual({
             role: 'button',
             name: 'My Button'
           });
@@ -322,7 +322,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
           await page.setContent(`<input title="My Input" value="My Value">`);
 
           const input = await page.$('input');
-          expect(await page.accessibility.snapshot({element: input})).toEqual({
+          expect(await page.accessibility.snapshot({root: input})).toEqual({
             role: 'textbox',
             name: 'My Input',
             value: 'My Value'
@@ -338,7 +338,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
           `);
 
           const menu = await page.$('div[role="menu"]');
-          expect(await page.accessibility.snapshot({element: menu})).toEqual({
+          expect(await page.accessibility.snapshot({root: menu})).toEqual({
             role: 'menu',
             name: 'My Menu',
             children:
@@ -351,13 +351,13 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
           await page.setContent(`<button>My Button</button>`);
           const button = await page.$('button');
           await page.$eval('button', button => button.remove());
-          expect(await page.accessibility.snapshot({element: button})).toEqual(null);
+          expect(await page.accessibility.snapshot({root: button})).toEqual(null);
         });
         it('should support the interestingOnly option', async({page}) => {
           await page.setContent(`<div><button>My Button</button></div>`);
           const div = await page.$('div');
-          expect(await page.accessibility.snapshot({element: div})).toEqual(null);
-          expect(await page.accessibility.snapshot({element: div, interestingOnly: false})).toEqual({
+          expect(await page.accessibility.snapshot({root: div})).toEqual(null);
+          expect(await page.accessibility.snapshot({root: div, interestingOnly: false})).toEqual({
             role: 'GenericContainer',
             name: '',
             children: [ { role: 'button', name: 'My Button' } ] }

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -310,9 +310,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
 
       describe_fails_ffox('element option', function() {
         it('should work a button', async({page}) => {
-          await page.setContent(`
-          <button>My Button</button>
-          `);
+          await page.setContent(`<button>My Button</button>`);
 
           const button = await page.$('button');
           expect(await page.accessibility.snapshot({element: button})).toEqual({
@@ -321,9 +319,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
           });
         });
         it('should work an input', async({page}) => {
-          await page.setContent(`
-          <input title="My Input" value="My Value">
-          `);
+          await page.setContent(`<input title="My Input" value="My Value">`);
 
           const input = await page.$('input');
           expect(await page.accessibility.snapshot({element: input})).toEqual({
@@ -334,11 +330,12 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
         });
         it('should work a menu', async({page}) => {
           await page.setContent(`
-          <div role="menu" title="My Menu">
-            <div role="menuitem">First Item</div>
-            <div role="menuitem">Second Item</div>
-            <div role="menuitem">Third Item</div>
-          </div>`);
+            <div role="menu" title="My Menu">
+              <div role="menuitem">First Item</div>
+              <div role="menuitem">Second Item</div>
+              <div role="menuitem">Third Item</div>
+            </div>
+          `);
 
           const menu = await page.$('div[role="menu"]');
           expect(await page.accessibility.snapshot({element: menu})).toEqual({


### PR DESCRIPTION
Going from  AXNode -> ElementHandle is turning out to be controversial. This patch instead adds a way to go from ElementHandle -> AXNode. If the API looks good, I'll add it into Firefox as well.
#3641