### PR TITLE
chore(git): Fix line endings in text  files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have LF line endings on checkout.
+*.txt eol=lf


### PR DESCRIPTION
Although we said on #4315 to add just a comment in the CONTRIBUTING.md file. I think this solution will be better for the repository's health.

We could also apply this for `*.js` but it's up to you.

This is what I needed to run after I added this file:
```
git rm --cached -r .
git reset --hard
```

closes #4315