### PR TITLE
test(page): add failing test for complex objects in exposeFunction

### DIFF
--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -656,6 +656,16 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer, CHR
       });
       expect(result).toBe(15);
     });
+
+    xit('should work with complex objects', async({page, server}) => {
+      await page.exposeFunction('complexObject', function(a, b) {
+        return {x: a.x + b.x};
+      });
+      const result = await page.evaluate(async function() {
+        return complexObject({x: 5}, {x: 2});
+      });
+      expect(result.x).toBe(7);
+    });
   });
 
   describe('Page.Events.PageError', function() {


### PR DESCRIPTION
related to #4334

I have this fix locally:

```ts
async _onBindingCalled(event) {
    let {name, seq, args} = JSON.parse(event.payload);
    let expression = null;

   //THIS IF
    if (helper.isString(args))
      args = JSON.parse(args);

    try {
      const result = await this._pageBindings.get(name)(...args);
      expression = helper.evaluationString(deliverResult, name, seq, result);
    } catch (error) {
      if (error instanceof Error)
        expression = helper.evaluationString(deliverError, name, seq, error.message, error.stack);
      else
        expression = helper.evaluationString(deliverErrorValue, name, seq, error);
    }
    this._client.send('Runtime.evaluate', { expression, contextId: event.executionContextId }).catch(debugError);

    /**
     * @param {string} name
     * @param {number} seq
     * @param {*} result
     */
    function deliverResult(name, seq, result) {
      window[name]['callbacks'].get(seq).resolve(result);
      window[name]['callbacks'].delete(seq);
    }

    /**
     * @param {string} name
     * @param {number} seq
     * @param {string} message
     * @param {string} stack
     */
    function deliverError(name, seq, message, stack) {
      const error = new Error(message);
      error.stack = stack;
      window[name]['callbacks'].get(seq).reject(error);
      window[name]['callbacks'].delete(seq);
    }

    /**
     * @param {string} name
     * @param {number} seq
     * @param {*} value
     */
    function deliverErrorValue(name, seq, value) {
      window[name]['callbacks'].get(seq).reject(value);
      window[name]['callbacks'].delete(seq);
    }
  }
```

But it could also be fixed on Chromium.