### PR TITLE
feat(chromium): roll Chromium to r654752

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1205,7 +1205,7 @@ Gets the full HTML contents of the page, including the doctype.
   - `httpOnly` <[boolean]>
   - `secure` <[boolean]>
   - `session` <[boolean]>
-  - `sameSite` <"Strict"|"Lax">
+  - `sameSite` <"Strict"|"Lax"|"Extended"|"None">
 
 If no URLs are specified, this method returns cookies for the current page URL.
 If URLs are specified, only cookies for those URLs are returned.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1193,7 +1193,7 @@ function convertPrintParameterToInches(parameter) {
  * @property {boolean} httpOnly
  * @property {boolean} secure
  * @property {boolean} session
- * @property {("Strict"|"Lax")=} sameSite
+ * @property {("Strict"|"Lax"|"Extended"|"None")=} sameSite
  */
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "650583"
+    "chromium_revision": "654752"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -89,9 +89,7 @@ module.exports.addTests = function({testRunner, expect}) {
       let error = null;
       await page.evaluate(() => {
         location.reload();
-        return new Promise(resolve => {
-          setTimeout(() => resolve(1), 0);
-        });
+        return new Promise(() => {});
       }).catch(e => error = e);
       expect(error.message).toContain('Protocol error');
     });

--- a/test/navigation.spec.js
+++ b/test/navigation.spec.js
@@ -540,18 +540,20 @@ module.exports.addTests = function({testRunner, expect, puppeteer, CHROME}) {
       expect(response.frame()).toBe(frame);
       expect(page.url()).toContain('/frames/one-frame.html');
     });
-    it_fails_ffox('should resolve when frame detaches', async({page, server}) => {
+    it('should fail when frame detaches', async({page, server}) => {
       await page.goto(server.PREFIX + '/frames/one-frame.html');
       const frame = page.frames()[1];
 
       server.setRoute('/empty.html', () => {});
-      const navigationPromise = frame.waitForNavigation();
+      let error = null;
+      const navigationPromise = frame.waitForNavigation().catch(e => error = e);
       await Promise.all([
         server.waitForRequest('/empty.html'),
         frame.evaluate(() => window.location = '/empty.html')
       ]);
       await page.$eval('iframe', frame => frame.remove());
       await navigationPromise;
+      expect(error.message).toBe('Navigating frame was detached');
     });
   });
 


### PR DESCRIPTION
This roll includes:
- https://crrev.com/653809 - FrameLoader: ignore failing provisional loads entirely
- https://crrev.com/654750 - DevTools: make sure Network.requestWillBeSent is emitted on time for sync xhrs

The FrameLoader patch is the reason behind the test change. It's
actually desirable to fail frame navigation if the frame detaches - and
that's consistent with Firefox.

Fixes #4337