### PR TITLE
docs(troubleshooting.md): Pin Alpine Chromium version

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -290,7 +290,7 @@ RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
     apk add --no-cache \
-      chromium@edge \
+      chromium@edge=72.0.3626.121-r0 \
       nss@edge \
       freetype@edge \
       harfbuzz@edge \


### PR DESCRIPTION
* Pins Alpine Chromium version to prevent updates from causing issues

When using these instructions today, I found that the Chromium version in the latest Alpine edge was 73, which caused errors with Puppeteer. Pinning to the latest 72 version in Alpine registry resolved the issue, and should prevent others from running into it in the future.