### PR TITLE
fix(page): Simplify _clickablePoint function

### DIFF
--- a/lib/JSHandle.js
+++ b/lib/JSHandle.js
@@ -199,7 +199,7 @@ class ElementHandle extends JSHandle {
       throw new Error('Node is either not visible or not an HTMLElement');
     // Filter out quads that have too small area to click into.
     const {clientWidth, clientHeight} = layoutMetrics.layoutViewport;
-    const quads = result.quads.map(quad => this._fromProtocolQuad(quad)).map(quad => this._intersectQuadWithViewport(quad, clientWidth, clientHeight)).filter(quad => computeQuadArea(quad) > 1);
+    const quads = result.quads.map(quad => this._intersectQuadWithViewport(quad, clientWidth, clientHeight)).filter(quad => computeQuadArea(quad) > 1);
     if (!quads.length)
       throw new Error('Node is either not visible or not an HTMLElement');
     // Return the middle point of the first quad.
@@ -239,13 +239,13 @@ class ElementHandle extends JSHandle {
   }
 
   /**
-   * @param {!Array<{x: number, y: number}>} quad
+   * @param {!Array<number>} quad
    * @param {number} width
    * @param {number} height
    * @return {!Array<{x: number, y: number}>}
    */
   _intersectQuadWithViewport(quad, width, height) {
-    return quad.map(point => ({
+    return this._fromProtocolQuad(quad).map(point => ({
       x: Math.min(Math.max(point.x, 0), width),
       y: Math.min(Math.max(point.y, 0), height),
     }));


### PR DESCRIPTION
Based on #4277

We have two loops in `_clickablePoint`. One to convert an `Array<number>` to `Array<{x: number, y: number}>` and another run to call `_intersectQuadWithViewport`.
I think that having all that in on run will make the code a little easier to read and also little faster. 