### PR TITLE
fix: waitForSelector with visible:true causes timeout

### DIFF
--- a/experimental/puppeteer-firefox/lib/DOMWorld.js
+++ b/experimental/puppeteer-firefox/lib/DOMWorld.js
@@ -409,24 +409,52 @@ class DOMWorld {
      * @return {?Node|boolean}
      */
     function predicate(selectorOrXPath, isXPath, waitForVisible, waitForHidden) {
-      const node = isXPath
-        ? document.evaluate(selectorOrXPath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue
-        : document.querySelector(selectorOrXPath);
-      if (!node)
-        return waitForHidden;
-      if (!waitForVisible && !waitForHidden)
-        return node;
-      const element = /** @type {Element} */ (node.nodeType === Node.TEXT_NODE ? node.parentElement : node);
+      if (!waitForVisible) {
+        const node = isXPath
+          ? document.evaluate(selectorOrXPath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue
+          : document.querySelector(selectorOrXPath);
 
-      const style = window.getComputedStyle(element);
-      const isVisible = style && style.visibility !== 'hidden' && hasVisibleBoundingBox();
-      const success = (waitForVisible === isVisible || waitForHidden === !isVisible);
-      return success ? node : null;
+        if (!node)
+          return waitForHidden;
+        if (!waitForHidden)
+          return node;
+      }
+
+      // We need to loop over all matching nodes, and test each one, returning the first successful one... or null
+      if (isXPath) {
+        const nodeIterator = document.evaluate(selectorOrXPath, document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+        let node = nodeIterator.iterateNext();
+        while (node) {
+          if (testNode(node))
+            return node;
+          node = nodeIterator.iterateNext();
+        }
+      } else {
+        for (const node of Array.from(document.querySelectorAll(selectorOrXPath))) {
+          if (testNode(node))
+            return node;
+        }
+      }
+
+      return null;
 
       /**
+       * tests if node passes visible/hidden test
+       * @param {Node} node
+       */
+      function testNode(node) {
+        const element = /** @type {Element} */ (node.nodeType === Node.TEXT_NODE ? node.parentElement : node);
+        const style = window.getComputedStyle(element);
+        const isVisible = style && style.visibility !== 'hidden' && hasVisibleBoundingBox(element);
+        const success = (waitForVisible === isVisible || waitForHidden === !isVisible);
+        return success ? node : null;
+      }
+
+      /**
+       * @param {Element} element
        * @return {boolean}
        */
-      function hasVisibleBoundingBox() {
+      function hasVisibleBoundingBox(element) {
         const rect = element.getBoundingClientRect();
         return !!(rect.top || rect.bottom || rect.width || rect.height);
       }

--- a/lib/DOMWorld.js
+++ b/lib/DOMWorld.js
@@ -503,24 +503,52 @@ class DOMWorld {
      * @return {?Node|boolean}
      */
     function predicate(selectorOrXPath, isXPath, waitForVisible, waitForHidden) {
-      const node = isXPath
-        ? document.evaluate(selectorOrXPath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue
-        : document.querySelector(selectorOrXPath);
-      if (!node)
-        return waitForHidden;
-      if (!waitForVisible && !waitForHidden)
-        return node;
-      const element = /** @type {Element} */ (node.nodeType === Node.TEXT_NODE ? node.parentElement : node);
+      if (!waitForVisible) {
+        const node = isXPath
+          ? document.evaluate(selectorOrXPath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue
+          : document.querySelector(selectorOrXPath);
 
-      const style = window.getComputedStyle(element);
-      const isVisible = style && style.visibility !== 'hidden' && hasVisibleBoundingBox();
-      const success = (waitForVisible === isVisible || waitForHidden === !isVisible);
-      return success ? node : null;
+        if (!node)
+          return waitForHidden;
+        if (!waitForHidden)
+          return node;
+      }
+
+      // We need to loop over all matching nodes, and test each one, returning the first successful one... or null
+      if (isXPath) {
+        const nodeIterator = document.evaluate(selectorOrXPath, document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+        let node = nodeIterator.iterateNext();
+        while (node) {
+          if (testNode(node))
+            return node;
+          node = nodeIterator.iterateNext();
+        }
+      } else {
+        for (const node of Array.from(document.querySelectorAll(selectorOrXPath))) {
+          if (testNode(node))
+            return node;
+        }
+      }
+
+      return null;
 
       /**
+       * tests if node passes visible/hidden test
+       * @param {Node} node
+       */
+      function testNode(node) {
+        const element = /** @type {Element} */ (node.nodeType === Node.TEXT_NODE ? node.parentElement : node);
+        const style = window.getComputedStyle(element);
+        const isVisible = style && style.visibility !== 'hidden' && hasVisibleBoundingBox(element);
+        const success = (waitForVisible === isVisible || waitForHidden === !isVisible);
+        return success ? node : null;
+      }
+
+      /**
+       * @param {Element} element
        * @return {boolean}
        */
-      function hasVisibleBoundingBox() {
+      function hasVisibleBoundingBox(element) {
         const rect = element.getBoundingClientRect();
         return !!(rect.top || rect.bottom || rect.width || rect.height);
       }


### PR DESCRIPTION
This patch fixes an issue where waitForSelector with visible:true would cause a timeout should there be multiple elements matching the selector, but the ones higher up on the DOM are hidden. It now returns the first visible element it finds.

fixes #4356