### PR TITLE
feat(workers): create workers from service workers and shared workers

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -301,6 +301,7 @@
   * [target.createCDPSession()](#targetcreatecdpsession)
   * [target.opener()](#targetopener)
   * [target.page()](#targetpage)
+  * [target.worker()](#targetworker)
   * [target.type()](#targettype)
   * [target.url()](#targeturl)
 - [class: CDPSession](#class-cdpsession)
@@ -3471,10 +3472,15 @@ Get the target that opened this target. Top-level targets return `null`.
 
 If the target is not of type `"page"` or `"background_page"`, returns `null`.
 
-#### target.type()
-- returns: <"page"|"background_page"|"service_worker"|"other"|"browser">
+#### target.worker()
+- returns <[Promise]<?[Worker]>>
 
-Identifies what kind of target this is. Can be `"page"`, [`"background_page"`](https://developer.chrome.com/extensions/background_pages), `"service_worker"`, `"browser"` or `"other"`.
+If the target is not of type `"service_worker"` or `"shared_worker"`, returns `null`.
+
+#### target.type()
+- returns: <"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser">
+
+Identifies what kind of target this is. Can be `"page"`, [`"background_page"`](https://developer.chrome.com/extensions/background_pages), `"service_worker"`, `"shared_worker"`, `"browser"` or `"other"`.
 
 #### target.url()
 - returns: <[string]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -301,9 +301,9 @@
   * [target.createCDPSession()](#targetcreatecdpsession)
   * [target.opener()](#targetopener)
   * [target.page()](#targetpage)
-  * [target.worker()](#targetworker)
   * [target.type()](#targettype)
   * [target.url()](#targeturl)
+  * [target.worker()](#targetworker)
 - [class: CDPSession](#class-cdpsession)
   * [cdpSession.detach()](#cdpsessiondetach)
   * [cdpSession.send(method[, params])](#cdpsessionsendmethod-params)
@@ -3472,11 +3472,6 @@ Get the target that opened this target. Top-level targets return `null`.
 
 If the target is not of type `"page"` or `"background_page"`, returns `null`.
 
-#### target.worker()
-- returns <[Promise]<?[Worker]>>
-
-If the target is not of type `"service_worker"` or `"shared_worker"`, returns `null`.
-
 #### target.type()
 - returns: <"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser">
 
@@ -3484,6 +3479,11 @@ Identifies what kind of target this is. Can be `"page"`, [`"background_page"`](h
 
 #### target.url()
 - returns: <[string]>
+
+#### target.worker()
+- returns: <[Promise]<?[Worker]>>
+
+If the target is not of type `"service_worker"` or `"shared_worker"`, returns `null`.
 
 ### class: CDPSession
 

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -84,19 +84,16 @@ class Target {
     if (this._targetInfo.type !== 'service_worker' && this._targetInfo.type !== 'shared_worker')
       return null;
     if (!this._workerPromise) {
-      this._workerPromise = (async() => {
-        // top level workers have a fake page wrapping the actual worker
-        const client = await this._sessionFactory();
-        const sessionId = new Promise(resolve => {
-          client.once('Target.attachedToTarget', event => {
-            resolve(event.sessionId);
-          });
-        });
-        await client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false, flatten: true});
-        const session = Connection.fromSession(client).session(await sessionId);
-        // TODO(einbinder): Make workers send thier conosle logs
-        return new Worker(session, this._targetInfo.url, () => void 0, () => void 0);
-      })();
+      this._workerPromise = this._sessionFactory().then(async client => {
+        // Top level workers have a fake page wrapping the actual worker.
+        const [targetAttached] = await Promise.all([
+          new Promise(x => client.once('Target.attachedToTarget', x)),
+          client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false, flatten: true}),
+        ]);
+        const session = Connection.fromSession(client).session(targetAttached.sessionId);
+        // TODO(einbinder): Make workers send their console logs.
+        return new Worker(session, this._targetInfo.url, () => {} /* consoleAPICalled */, () => {} /* exceptionThrown */);
+      });
     }
     return this._workerPromise;
   }

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -16,6 +16,8 @@
 
 const {Events} = require('./Events');
 const {Page} = require('./Page');
+const {Worker} = require('./Worker');
+const {Connection} = require('./Connection');
 
 class Target {
   /**
@@ -36,6 +38,8 @@ class Target {
     this._screenshotTaskQueue = screenshotTaskQueue;
     /** @type {?Promise<!Puppeteer.Page>} */
     this._pagePromise = null;
+    /** @type {?Promise<!Worker>} */
+    this._workerPromise = null;
     this._initializedPromise = new Promise(fulfill => this._initializedCallback = fulfill).then(async success => {
       if (!success)
         return false;
@@ -74,6 +78,30 @@ class Target {
   }
 
   /**
+   * @return {!Promise<?Worker>}
+   */
+  async worker() {
+    if (this._targetInfo.type !== 'service_worker' && this._targetInfo.type !== 'shared_worker')
+      return null;
+    if (!this._workerPromise) {
+      this._workerPromise = (async() => {
+        // top level workers have a fake page wrapping the actual worker
+        const client = await this._sessionFactory();
+        const sessionId = new Promise(resolve => {
+          client.once('Target.attachedToTarget', event => {
+            resolve(event.sessionId);
+          });
+        });
+        await client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false, flatten: true});
+        const session = Connection.fromSession(client).session(await sessionId);
+        // TODO(einbinder): Make workers send thier conosle logs
+        return new Worker(session, this._targetInfo.url, () => void 0, () => void 0);
+      })();
+    }
+    return this._workerPromise;
+  }
+
+  /**
    * @return {string}
    */
   url() {
@@ -81,11 +109,11 @@ class Target {
   }
 
   /**
-   * @return {"page"|"background_page"|"service_worker"|"other"|"browser"}
+   * @return {"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser"}
    */
   type() {
     const type = this._targetInfo.type;
-    if (type === 'page' || type === 'background_page' || type === 'service_worker' || type === 'browser')
+    if (type === 'page' || type === 'background_page' || type === 'service_worker' || type === 'shared_worker' || type === 'browser')
       return type;
     return 'other';
   }

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -83,6 +83,23 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       await page.evaluate(() => window.registrationPromise.then(registration => registration.unregister()));
       expect(await destroyedTarget).toBe(await createdTarget);
     });
+    it_fails_ffox('should create a worker from a service worker', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
+
+      const target = await context.waitForTarget(target => target.type() === 'service_worker');
+      const worker = await target.worker();
+      expect(await worker.evaluate(() => self.toString())).toBe('[object ServiceWorkerGlobalScope]');
+    });
+    it_fails_ffox('should create a worker from a shared worker', async({page, server, context}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        new SharedWorker('data:text/javascript,console.log("hi")');
+      });
+      const target = await context.waitForTarget(target => target.type() === 'shared_worker');
+      const worker = await target.worker();
+      expect(await worker.evaluate(() => self.toString())).toBe('[object SharedWorkerGlobalScope]');
+    });
     it('should report when a target url changes', async({page, server, context}) => {
       await page.goto(server.EMPTY_PAGE);
       let changedTarget = new Promise(fulfill => context.once('targetchanged', target => fulfill(target)));

--- a/test/target.spec.js
+++ b/test/target.spec.js
@@ -84,7 +84,6 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       expect(await destroyedTarget).toBe(await createdTarget);
     });
     it_fails_ffox('should create a worker from a service worker', async({page, server, context}) => {
-      await page.goto(server.EMPTY_PAGE);
       await page.goto(server.PREFIX + '/serviceworkers/empty/sw.html');
 
       const target = await context.waitForTarget(target => target.type() === 'service_worker');


### PR DESCRIPTION
This allows users to easily evaluate javascript inside service workers and shared workers by creating a `Worker` object for them.