### PR TITLE
docs(firefox): Adding bug reference & prototype clarification to juggler

### DIFF
--- a/experimental/puppeteer-firefox/README.md
+++ b/experimental/puppeteer-firefox/README.md
@@ -1,16 +1,18 @@
 <img src="https://user-images.githubusercontent.com/39191/49555713-a07b3c00-f8b5-11e8-8aba-f2d03cd83da5.png" height="200" align="right">
 
-# Puppeteer for Firefox
+# Prototype: Puppeteer for Firefox
 
 > Use Puppeteer's API with Firefox
 
-> **BEWARE**: This project is experimental. 🐊 live here. [Is Puppeteer-Firefox Ready?](https://aslushnikov.github.io/ispuppeteerfirefoxready/)
+**⚠️ BEWARE**: Experimental. Just for preview. Installation and usage will change.
+
+This project is a feasibility prototype to guide the work of implementing Puppeteer endpoints into Firefox's code base. Mozilla's [bug 1545057](https://bugzilla.mozilla.org/show_bug.cgi?id=1545057) tracks the initial milestone, which will be based on a CDP-based [remote protocol](https://wiki.mozilla.org/Remote).
 
 ## Getting Started
 
 ### Installation
 
-To use Puppeteer with Firefox in your project, run:
+To try out Puppeteer with Firefox in your project, run:
 
 ```bash
 npm i puppeteer-firefox


### PR DESCRIPTION
Given that the readme is the current source of truth for most users that are interested in Juggler, this tries to further clarify the experimental nature of the project and the follow up work happening on the Firefox side.

Does that reflect your assumptions as well, @aslushnikov, or should I tweak it?