### PR TITLE
feat(browser): Add browser.isConnected()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,7 @@
   * [browser.createIncognitoBrowserContext()](#browsercreateincognitobrowsercontext)
   * [browser.defaultBrowserContext()](#browserdefaultbrowsercontext)
   * [browser.disconnect()](#browserdisconnect)
+  * [browser.isConnected()](#browserisconnected)
   * [browser.newPage()](#browsernewpage)
   * [browser.pages()](#browserpages)
   * [browser.process()](#browserprocess)
@@ -699,6 +700,12 @@ Returns the default browser context. The default browser context can not be clos
 #### browser.disconnect()
 
 Disconnects Puppeteer from the browser, but leaves the Chromium process running. After calling `disconnect`, the [Browser] object is considered disposed and cannot be used anymore.
+
+#### browser.isConnected()
+
+- returns: <[boolean]>
+
+Indicates that the browser is connected.
 
 #### browser.newPage()
 - returns: <[Promise]<[Page]>>

--- a/experimental/puppeteer-firefox/lib/Browser.js
+++ b/experimental/puppeteer-firefox/lib/Browser.js
@@ -58,6 +58,13 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @return {boolean}
+   */
+  isConnected() {
+    return !this._connection._closed;
+  }
+
+  /**
    * @return {!BrowserContext}
    */
   async createIncognitoBrowserContext() {

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -261,6 +261,13 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @return {boolean}
+   */
+  isConnected() {
+    return !this._connection._closed;
+  }
+
+  /**
    * @return {!Promise<!Object>}
    */
   _getVersion() {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -60,4 +60,14 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer, CHR
       await remoteBrowser.disconnect();
     });
   });
+
+  describe('Browser.isConnected', () => {
+    it('should set the browser connected state', async({browser}) => {
+      const browserWSEndpoint = browser.wsEndpoint();
+      const newBrowser = await puppeteer.connect({browserWSEndpoint});
+      expect(newBrowser.isConnected()).toBe(true);
+      await newBrowser.disconnect();
+      expect(newBrowser.isConnected()).toBe(false);
+    });
+  });
 };


### PR DESCRIPTION
Add `browser.isConnected()` to the public api to be able to tell when the browser is connected

fixes https://github.com/smooth-code/jest-puppeteer/pull/237#issuecomment-490260041