### PR TITLE
feat(launcher): add 'detached' option to launch

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -532,7 +532,8 @@ try {
   - `env` <[Object]> Specify environment variables that will be visible to the browser. Defaults to `process.env`.
   - `devtools` <[boolean]> Whether to auto-open a DevTools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
   - `pipe` <[boolean]> Connects to the browser over a pipe instead of a WebSocket. Defaults to `false`.
-- returns: <[Promise]<[Browser]>> Promise which resolves to browser instance.
+  - `detached` <[boolean]> Detaches from browser after launch and returns null. The browser will remain open after the process that launched it exits. To connect to it you need to know the websocket endpoint so this is best used with the --remote-debugging-port option so the endpoint is predictable. Defaults to `false`.
+- returns: <[Promise]<[Browser]>|null> Promise which resolves to browser instance.
 
 
 You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default arguments:

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -76,7 +76,7 @@ class Launcher {
 
   /**
    * @param {!(Launcher.LaunchOptions & Launcher.ChromeArgOptions & Launcher.BrowserOptions)=} options
-   * @return {!Promise<!Browser>}
+   * @return {!Promise<!Browser>|null}
    */
   async launch(options = {}) {
     const {
@@ -92,7 +92,8 @@ class Launcher {
       ignoreHTTPSErrors = false,
       defaultViewport = {width: 800, height: 600},
       slowMo = 0,
-      timeout = 30000
+      timeout = 30000,
+      detached = false
     } = options;
 
     const chromeArguments = [];
@@ -122,19 +123,24 @@ class Launcher {
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');
     /** @type {!Array<"ignore"|"pipe">} */
-    const stdio = usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'];
+    const stdio = detached ? ['ignore', 'ignore', 'ignore'] : usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'];
     const chromeProcess = childProcess.spawn(
         chromeExecutable,
         chromeArguments,
         {
-          // On non-windows platforms, `detached: false` makes child process a leader of a new
+          // On non-windows platforms, `detached: true` makes child process a leader of a new
           // process group, making it possible to kill child process tree with `.kill(-pid)` command.
           // @see https://nodejs.org/api/child_process.html#child_process_options_detached
-          detached: process.platform !== 'win32',
+          detached: process.platform !== 'win32' || detached,
           env,
           stdio
         }
     );
+
+    if (detached) {
+      chromeProcess.unref();
+      return null;
+    }
 
     if (dumpio) {
       chromeProcess.stderr.pipe(process.stderr);
@@ -425,6 +431,7 @@ function getWSEndpoint(browserURL) {
  * @property {boolean=} dumpio
  * @property {!Object<string, string | undefined>=} env
  * @property {boolean=} pipe
+ * @property {boolean=} detached
  */
 
 /**

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -99,7 +99,7 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
     describe('Puppeteer.launch |detached| option', function() {
       it('should support the detached option', async() => {
         const options = Object.assign({}, defaultBrowserOptions, {
-          args: ['--remote-debugging-port=9222'],
+          args: ['--remote-debugging-port=21223'],
           detached: true
         });
         let browser = await puppeteer.launch(options);
@@ -108,8 +108,7 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
         // unfortunately, after this point if the test fails before reaching the end of this test
         // there will be a chromium process left running
 
-        const responseBody = await utils.fetch('http://127.0.0.1:9222/json/version');
-        console.log(responseBody);
+        const responseBody = await utils.fetch('http://127.0.0.1:21223/json/version');
         const endpoint = JSON.parse(responseBody).webSocketDebuggerUrl;
 
         browser = await puppeteer.connect({

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -109,6 +109,7 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
         // there will be a chromium process left running
 
         const responseBody = await utils.fetch('http://127.0.0.1:9222/json/version');
+        console.log(responseBody);
         const endpoint = JSON.parse(responseBody).webSocketDebuggerUrl;
 
         browser = await puppeteer.connect({

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -117,6 +117,7 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
             endpoint = JSON.parse(responseBody).webSocketDebuggerUrl;
             break;
           }
+          await utils.sleep(100);
         }
 
         browser = await puppeteer.connect({

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -108,7 +108,7 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
         // unfortunately, after this point if the test fails before reaching the end of this test
         // there will be a chromium process left running
 
-        const responseBody = await utils.fetch('http://localhost:9222/json/version');
+        const responseBody = await utils.fetch('http://127.0.0.1:9222/json/version');
         const endpoint = JSON.parse(responseBody).webSocketDebuggerUrl;
 
         browser = await puppeteer.connect({

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -108,8 +108,16 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
         // unfortunately, after this point if the test fails before reaching the end of this test
         // there will be a chromium process left running
 
-        const responseBody = await utils.fetch('http://127.0.0.1:21223/json/version');
-        const endpoint = JSON.parse(responseBody).webSocketDebuggerUrl;
+        // it can take a little time for the chrome process to startup so we might have
+        // to retry this a few times
+        let endpoint = null;
+        for (let i = 0; i < 10; i++) {
+          const responseBody = await utils.fetch('http://127.0.0.1:21223/json/version');
+          if (responseBody !== null) {
+            endpoint = JSON.parse(responseBody).webSocketDebuggerUrl;
+            break;
+          }
+        }
 
         browser = await puppeteer.connect({
           browserWSEndpoint: endpoint

--- a/test/utils.js
+++ b/test/utils.js
@@ -153,4 +153,31 @@ const utils = module.exports = {
       });
     });
   },
+
+  /**
+   * @param {string} url
+   * @return {!Promise<?string>}
+   */
+  fetch(url) {
+    let resolve;
+    const promise = new Promise(x => resolve = x);
+    const http = require('http');
+    http.get(url, response => {
+      if (response.statusCode !== 200) {
+        resolve(null);
+        return;
+      }
+      let body = '';
+      response.on('data', function(chunk){
+        body += chunk;
+      });
+      response.on('end', function(){
+        resolve(body);
+      });
+    }).on('error', function(e){
+      console.error('Error fetching json: ' + e);
+      resolve(null);
+    });
+    return promise;
+  }
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -175,9 +175,17 @@ const utils = module.exports = {
         resolve(body);
       });
     }).on('error', function(e){
-      console.error('Error fetching json: ' + e);
       resolve(null);
     });
+    return promise;
+  },
+
+  sleep(ms) {
+    let resolve;
+    const promise = new Promise(x => resolve = x);
+    setTimeout(() => {
+      resolve();
+    }, ms);
     return promise;
   }
 };


### PR DESCRIPTION
This option causes launch to run the browser in a detached state and return null. You can use 'connect' to use the launched instance.

To connect to it you need to know the websocket endpoint so this is best used with the --remote-debugging-port option so that you can query the browser to get the endpoint.