### PR TITLE
fix: Stringify response headers for intercepted requests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3253,7 +3253,7 @@ Exception is immediately thrown if the request interception is not enabled.
   - `url` <[string]> If set, the request url will be changed. This is not a redirect. The request will be silently forwarded to the new url. For example, the address bar will show the original url.
   - `method` <[string]> If set changes the request method (e.g. `GET` or `POST`)
   - `postData` <[string]> If set changes the post data of request
-  - `headers` <[Object]> If set changes the request HTTP headers
+  - `headers` <[Object]> If set changes the request HTTP headers. Header values will be converted to a string.
 - returns: <[Promise]>
 
 Continues request with optional request overrides. To use this, request interception should be enabled with `page.setRequestInterception`.
@@ -3339,7 +3339,7 @@ ResourceType will be one of the following: `document`, `stylesheet`, `image`, `m
 #### request.respond(response)
 - `response` <[Object]> Response that will fulfill this request
   - `status` <[number]> Response status code, defaults to `200`.
-  - `headers` <[Object]> Optional response headers
+  - `headers` <[Object]> Optional response headers. Header values will be converted to a string.
   - `contentType` <[string]> If set, equals to setting `Content-Type` response header
   - `body` <[string]|[Buffer]> Optional response body
 - returns: <[Promise]>

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -723,7 +723,7 @@ class SecurityDetails {
 function headersArray(headers) {
   const result = [];
   for (const name in headers)
-    result.push({name, value: headers[name]});
+    result.push({name, value: headers[name] + ''});
   return result;
 }
 

--- a/test/requestinterception.spec.js
+++ b/test/requestinterception.spec.js
@@ -506,6 +506,23 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
       const img = await page.$('img');
       expect(await img.screenshot()).toBeGolden('mock-binary-response.png');
     });
+    it('should stringify intercepted request response headers', async({page, server}) => {
+      await page.setRequestInterception(true);
+      page.on('request', request => {
+        request.respond({
+          status: 200,
+          headers: {
+            'foo': true
+          },
+          body: 'Yo, page!'
+        });
+      });
+      const response = await page.goto(server.EMPTY_PAGE);
+      expect(response.status()).toBe(200);
+      const headers = response.headers();
+      expect(headers.foo).toBe('true');
+      expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
+    });
   });
 
 };


### PR DESCRIPTION
Stringifying the headers was the behaviour before v1.15

Relates to the discussion in #4379