### PR TITLE
chore(examples): Add wait for custom event

### DIFF
--- a/examples/await-custom-event.js
+++ b/examples/await-custom-event.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const puppeteer = require('puppeteer');
+
+(async() => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  /**
+   * Attach an event listener to page to capture a custom event on page load/navigation.
+   * @param {string} type Event name.
+   * @return {!Promise}
+   */
+  function addEventListener(type) {
+    return page.evaluateOnNewDocument(type => {
+      // this will run in the browser context
+      document.addEventListener(type, e => {
+        window.onCustomEvent({type, detail: e.detail});
+      });
+    }, type);
+  }
+
+  const e = await new Promise(async resolve => {
+    // Define a window.onCustomEvent function on the page.
+    await page.exposeFunction('onCustomEvent', evt => {
+      // this will run in the node context
+      resolve(evt);
+    });
+
+    await addEventListener('app-ready'); // Setup event listener for "app-ready" custom event on page load.
+    console.log('added event listener');
+
+    await page.goto('https://www.chromestatus.com/features'); // N.B! Do not use {waitUntil: 'networkidle0'} as that may cause a race condition
+    console.log('page visited');
+  });
+
+  console.log(`${e.type} fired`, e.detail || '');
+
+  await browser.close();
+})();


### PR DESCRIPTION
This patch adds an example that waits for a custom event to trigger