### PR TITLE
feat(chromium): roll Chromium to r662092

### DIFF
--- a/experimental/puppeteer-firefox/lib/DOMWorld.js
+++ b/experimental/puppeteer-firefox/lib/DOMWorld.js
@@ -132,11 +132,11 @@ class DOMWorld {
    * @param {string} html
    */
   async setContent(html) {
-    await this.evaluate(base64html => {
+    await this.evaluate(html => {
       document.open();
-      document.write(decodeURIComponent(atob(base64html).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join('')));
+      document.write(html);
       document.close();
-    }, Buffer.from(html).toString('base64'));
+    }, html);
   }
 
   /**

--- a/lib/DOMWorld.js
+++ b/lib/DOMWorld.js
@@ -203,11 +203,11 @@ class DOMWorld {
     } = options;
     // We rely upon the fact that document.open() will reset frame lifecycle with "init"
     // lifecycle event. @see https://crrev.com/608658
-    await this.evaluate(base64html => {
+    await this.evaluate(html => {
       document.open();
-      document.write(decodeURIComponent(atob(base64html).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join('')));
+      document.write(html);
       document.close();
-    }, Buffer.from(html).toString('base64'));
+    }, html);
     const watcher = new LifecycleWatcher(this._frameManager, this._frame, waitUntil, timeout);
     const error = await Promise.race([
       watcher.timeoutOrTerminationPromise(),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "656675"
+    "chromium_revision": "662092"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -85,7 +85,7 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(await page.evaluate(a.sum, 1, 2)).toBe(3);
       expect(await page.evaluate(a.mult, 2, 4)).toBe(8);
     });
-    xit('should work with unicode chars', async({page, server}) => {
+    it('should work with unicode chars', async({page, server}) => {
       const result = await page.evaluate(a => a['中文字符'], {'中文字符': 42});
       expect(result).toBe(42);
     });


### PR DESCRIPTION
This roll includes:
- [inspector_protocol:8ec18cf](https://chromium.googlesource.com/deps/inspector_protocol/+/8ec18cf0885bef0b5c2a922c5dc3813cbf63e962) Support STRING16 in the template when converting CBOR map keys
to protocol::Value.
- [inspector_protocol:37518ac](https://chromium.googlesource.com/deps/inspector_protocol/+/37518ac4214de146d39e324060a20b2e78673c53) fix parsing of the last ASCII character

This fixes protocol handling of UTF8 in both V8 and Chromium.

Fixes #4443.