### PR TITLE
fix(helper): fix Helper.installAsyncStackHooks method

### DIFF
--- a/experimental/puppeteer-firefox/lib/helper.js
+++ b/experimental/puppeteer-firefox/lib/helper.js
@@ -28,7 +28,8 @@ class Helper {
       if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function' || method.constructor.name !== 'AsyncFunction')
         continue;
       Reflect.set(classType.prototype, methodName, function(...args) {
-        const syncStack = new Error();
+        const syncStack = {};
+        Error.captureStackTrace(syncStack);
         return method.call(this, ...args).catch(e => {
           const stack = syncStack.stack.substring(syncStack.stack.indexOf('\n') + 1);
           const clientStack = stack.substring(stack.indexOf('\n'));

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -107,7 +107,8 @@ class Helper {
       if (methodName === 'constructor' || typeof methodName !== 'string' || methodName.startsWith('_') || typeof method !== 'function' || method.constructor.name !== 'AsyncFunction')
         continue;
       Reflect.set(classType.prototype, methodName, function(...args) {
-        const syncStack = new Error();
+        const syncStack = {};
+        Error.captureStackTrace(syncStack);
         return method.call(this, ...args).catch(e => {
           const stack = syncStack.stack.substring(syncStack.stack.indexOf('\n') + 1);
           const clientStack = stack.substring(stack.indexOf('\n'));


### PR DESCRIPTION
Using Error.captureStackTrace instead of new Error () to avoid UnhandledPromiseRejectionWarning