### PR TITLE
Update troubleshooting docs' Alpine to Chromium 73 and Puppeteer 1.12.2

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -284,7 +284,7 @@ how to run this Dockerfile from a webserver running on App Engine Flex (Node).
 
 ### Running on Alpine
 
-The [newest Chromium package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium) supported on Alpine is 72, which was corresponding to [Puppeteer v1.11.0](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.11.0).
+The [newest Chromium package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium) supported on Alpine is 73, which was corresponding to [Puppeteer v1.12.2](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.12.2).
 
 Example Dockerfile:
 
@@ -296,7 +296,7 @@ RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
     apk add --no-cache \
-      chromium@edge=72.0.3626.121-r0 \
+      chromium@edge=~73.0.3683.103 \
       nss@edge \
       freetype@edge \
       harfbuzz@edge \
@@ -307,8 +307,8 @@ RUN apk update && apk upgrade && \
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
-# Puppeteer v1.11.0 works with Chromium 72.
-RUN yarn add puppeteer@1.11.0
+# Puppeteer v1.12.2 works with Chromium 73.
+RUN yarn add puppeteer@1.12.2
 
 # Add user so we don't need --no-sandbox.
 RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \


### PR DESCRIPTION
According to the compatibility pages these versions are the most recent supported ones