### PR TITLE
feat: report iframe target types

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3481,7 +3481,7 @@ Get the target that opened this target. Top-level targets return `null`.
 If the target is not of type `"page"` or `"background_page"`, returns `null`.
 
 #### target.type()
-- returns: <"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser">
+- returns: <"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser"|"iframe">
 
 Identifies what kind of target this is. Can be `"page"`, [`"background_page"`](https://developer.chrome.com/extensions/background_pages), `"service_worker"`, `"shared_worker"`, `"browser"` or `"other"`.
 

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -110,7 +110,7 @@ class Target {
    */
   type() {
     const type = this._targetInfo.type;
-    if (type === 'page' || type === 'background_page' || type === 'service_worker' || type === 'shared_worker' || type === 'browser')
+    if (type === 'page' || type === 'background_page' || type === 'service_worker' || type === 'shared_worker' || type === 'browser' || type === 'iframe')
       return type;
     return 'other';
   }

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -106,7 +106,7 @@ class Target {
   }
 
   /**
-   * @return {"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser"}
+   * @return {"page"|"background_page"|"service_worker"|"shared_worker"|"other"|"browser"|"iframe"}
    */
   type() {
     const type = this._targetInfo.type;

--- a/test/oopif.spec.js
+++ b/test/oopif.spec.js
@@ -55,6 +55,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       page.on('request', request => request.continue());
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'oopif', server.CROSS_PROCESS_PREFIX + '/grid.html');
+      expect(page.frames().length).toBe(2);
     });
   });
 };

--- a/test/oopif.spec.js
+++ b/test/oopif.spec.js
@@ -21,7 +21,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
-  xdescribe('OOPIF', function() {
+  describe('OOPIF', function() {
     beforeAll(async function(state) {
       state.browser = await puppeteer.launch(Object.assign({}, defaultBrowserOptions, {
         args: (defaultBrowserOptions.args || []).concat(['--site-per-process']),
@@ -40,17 +40,21 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       await state.browser.close();
       state.browser = null;
     });
-    it('should report oopif frames', async function({page, server}) {
+    it('make sure --site-per-process does work', async function({page, server}) {
+      await page.goto(server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'oopif', server.CROSS_PROCESS_PREFIX + '/empty.html');
+      expect(page.browser().targets().find(target => target.type() === 'iframe')).toBeTruthy();
+    });
+    xit('should report oopif frames', async function({page, server}) {
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'oopif', server.CROSS_PROCESS_PREFIX + '/empty.html');
       expect(page.frames().length).toBe(2);
     });
-    it('should load oopif iframes with subresources and request interception', async function({page, server}) {
+    xit('should load oopif iframes with subresources and request interception', async function({page, server}) {
       await page.setRequestInterception(true);
       page.on('request', request => request.continue());
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'oopif', server.CROSS_PROCESS_PREFIX + '/grid.html');
-      expect(page.frames().length).toBe(2);
     });
   });
 };


### PR DESCRIPTION
This is necessary so that we (and our users) can diagnose OOPIFs
and OOPIF-related issues.

Add a test to make sure that `--site-per-process` chromium flag actually forces iframes to be out-of-process. 