### PR TITLE
fix: try running without `--disable-gpu` on windows

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -242,8 +242,6 @@ class Launcher {
           '--hide-scrollbars',
           '--mute-audio'
       );
-      if (os.platform() === 'win32')
-        chromeArguments.push('--disable-gpu');
     }
     if (args.every(arg => arg.startsWith('-')))
       chromeArguments.push('about:blank');


### PR DESCRIPTION
It looks like https://crbug.com/737678 and https://crbug.com/729961
are fixed - so we shouldn't need the `--disable-gpu` flag on windows
headless.

Reference #1260