### PR TITLE
fix(page): fix missing awaits in mouse.click #4536

### DIFF
--- a/lib/Input.js
+++ b/lib/Input.js
@@ -224,11 +224,20 @@ class Mouse {
    */
   async click(x, y, options = {}) {
     const {delay = null} = options;
-    await this.move(x, y);
-    await this.down(options);
-    if (delay !== null)
+    if (delay !== null) {
+      await Promise.all([
+        this.move(x, y),
+        this.down(options),
+      ]);
       await new Promise(f => setTimeout(f, delay));
-    await this.up(options);
+      await this.up(options);
+    } else {
+      await Promise.all([
+        this.move(x, y),
+        this.down(options),
+        this.up(options),
+      ]);
+    }
   }
 
   /**

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -224,8 +224,8 @@ class Mouse {
    */
   async click(x, y, options = {}) {
     const {delay = null} = options;
-    this.move(x, y);
-    this.down(options);
+    await this.move(x, y);
+    await this.down(options);
     if (delay !== null)
       await new Promise(f => setTimeout(f, delay));
     await this.up(options);


### PR DESCRIPTION
Lack of await causes dangling promises, which lead to unhandled rejections that cannot be caught if these calls fail (e.g. if the page is closed). See issue #4536 for details.