### PR TITLE
feat(network): allow fulfilling requests with custom status text

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3343,6 +3343,7 @@ ResourceType will be one of the following: `document`, `stylesheet`, `image`, `m
 #### request.respond(response)
 - `response` <[Object]> Response that will fulfill this request
   - `status` <[number]> Response status code, defaults to `200`.
+  - `statusText` <[string]> Custom response status text. Must be present for non-standard HTTP status codes.
   - `headers` <[Object]> Optional response headers. Header values will be converted to a string.
   - `contentType` <[string]> If set, equals to setting `Content-Type` response header
   - `body` <[string]|[Buffer]> Optional response body

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -452,7 +452,7 @@ class Request {
   }
 
   /**
-   * @param {!{status: number, headers: Object, contentType: string, body: (string|Buffer)}} response
+   * @param {!{status: number, statusText: string, headers: Object, contentType: string, body: (string|Buffer)}} response
    */
   async respond(response) {
     // Mocking responses for dataURL requests is not currently supported.
@@ -479,6 +479,7 @@ class Request {
       requestId: this._interceptionId,
       responseCode: response.status || 200,
       responseHeaders: headersArray(responseHeaders),
+      responsePhrase: response.statusText || undefined,
       body: responseBody ? responseBody.toString('base64') : undefined,
     }).catch(error => {
       // In certain cases, protocol will return error if the request was already canceled

--- a/test/requestinterception.spec.js
+++ b/test/requestinterception.spec.js
@@ -483,6 +483,34 @@ module.exports.addTests = function({testRunner, expect, CHROME}) {
       expect(response.headers().foo).toBe('bar');
       expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
     });
+    it('should allow specifying custom status text', async({page, server}) => {
+      await page.setRequestInterception(true);
+      page.on('request', request => {
+        request.respond({
+          status: 200,
+          statusText: 'of course!',
+          body: 'Yo, page!'
+        });
+      });
+      const response = await page.goto(server.EMPTY_PAGE);
+      expect(response.status()).toBe(200);
+      expect(response.statusText()).toBe('of course!');
+      expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
+    });
+    it('should work with non-standard status codes', async({page, server}) => {
+      await page.setRequestInterception(true);
+      page.on('request', request => {
+        request.respond({
+          status: 422,
+          statusText: 'YEP',
+          body: 'Yo, page!'
+        });
+      });
+      const response = await page.goto(server.EMPTY_PAGE);
+      expect(response.status()).toBe(422);
+      expect(response.statusText()).toBe('YEP');
+      expect(await page.evaluate(() => document.body.textContent)).toBe('Yo, page!');
+    });
     it('should redirect', async({page, server}) => {
       await page.setRequestInterception(true);
       page.on('request', request => {


### PR DESCRIPTION
Teach `request.respond()` to accept custom status text. It is necessary
when responding with non-standard HTTP status codes.

Fix #4454