### PR TITLE
fix(browserfetcher): fix httpRequest when using proxy against http HOST

### DIFF
--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -268,17 +268,26 @@ function extractZip(zipPath, folderPath) {
 
 function httpRequest(url, method, response) {
   /** @type {Object} */
-  const options = URL.parse(url);
+  let options = URL.parse(url);
   options.method = method;
 
   const proxyURL = getProxyForUrl(url);
   if (proxyURL) {
-    /** @type {Object} */
-    const parsedProxyURL = URL.parse(proxyURL);
-    parsedProxyURL.secureProxy = parsedProxyURL.protocol === 'https:';
+    if (url.startsWith('http:')) {
+      const proxy = URL.parse(proxyURL);
+      options = {
+        path: options.href,
+        host: proxy.hostname,
+        port: proxy.port,
+      };
+    } else {
+      /** @type {Object} */
+      const parsedProxyURL = URL.parse(proxyURL);
+      parsedProxyURL.secureProxy = parsedProxyURL.protocol === 'https:';
 
-    options.agent = new ProxyAgent(parsedProxyURL);
-    options.rejectUnauthorized = false;
+      options.agent = new ProxyAgent(parsedProxyURL);
+      options.rejectUnauthorized = false;
+    }
   }
 
   const requestCallback = res => {


### PR DESCRIPTION
This patch avoids https-proxy-agent usage when target host protocol is http and proxy is specified.
This is a valid scenario for installer but was failing.

Fixes #4556

PS: second try. fixed code lint issues