### PR TITLE
fix(firefox): fix missing awaits in mouse.click

### DIFF
--- a/experimental/puppeteer-firefox/lib/Input.js
+++ b/experimental/puppeteer-firefox/lib/Input.js
@@ -218,11 +218,20 @@ class Mouse {
    */
   async click(x, y, options = {}) {
     const {delay = null} = options;
-    this.move(x, y);
-    this.down(options);
-    if (delay !== null)
+    if (delay !== null) {
+      await Promise.all([
+        this.move(x, y),
+        this.down(options),
+      ]);
       await new Promise(f => setTimeout(f, delay));
-    await this.up(options);
+      await this.up(options);
+    } else {
+      await Promise.all([
+        this.move(x, y),
+        this.down(options),
+        this.up(options),
+      ]);
+    }
   }
 
   /**

--- a/test/click.spec.js
+++ b/test/click.spec.js
@@ -55,6 +55,13 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       await page.click('span');
       expect(await page.evaluate(() => window.CLICKED)).toBe(42);
     });
+    it('should not throw UnhandledPromiseRejection when page closes', async({page, server}) => {
+      const newPage = await page.browser().newPage();
+      await Promise.all([
+        newPage.close(),
+        newPage.mouse.click(1, 2),
+      ]).catch(e => {});
+    });
     it('should click the button after navigation ', async({page, server}) => {
       await page.goto(server.PREFIX + '/input/button.html');
       await page.click('button');


### PR DESCRIPTION
This applies the same fix we used on the Chrome-side and adds a test.

Fix #4536