### PR TITLE
fix(connection): bump websocket max received message size to 256Mb

### DIFF
--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -25,7 +25,10 @@ class WebSocketTransport {
    */
   static create(url) {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url, [], { perMessageDeflate: false });
+      const ws = new WebSocket(url, [], {
+        perMessageDeflate: false,
+        maxPayload: 256 * 1024 * 1024, // 256Mb
+      });
       ws.addEventListener('open', () => resolve(new WebSocketTransport(ws)));
       ws.addEventListener('error', reject);
     });

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -247,6 +247,10 @@ module.exports.addTests = function({testRunner, expect}) {
       });
       expect(result).toEqual([42]);
     });
+    it_fails_ffox('should transfer 100Mb of data from page to node.js', async({page, server}) => {
+      const a = await page.evaluate(() => Array(100 * 1024 * 1024 + 1).join('a'));
+      expect(a.length).toBe(100 * 1024 * 1024);
+    });
   });
 
   describe('Page.evaluateOnNewDocument', function() {


### PR DESCRIPTION
This is the max message size that DevTools can emit over the DevTools
protocol: https://cs.chromium.org/chromium/src/content/browser/devtools/devtools_http_handler.cc?type=cs&q=kSendBufferSizeForDevTools&sq=package:chromium&g=0&l=83

Test is failing on firefox since Firefox crashes when allocating 100Mb string.

Fix #4543