### PR TITLE
feat(request): add request.initiator() method.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -341,6 +341,7 @@
   * [httpRequest.finalizeInterceptions()](#httprequestfinalizeinterceptions)
   * [httpRequest.frame()](#httprequestframe)
   * [httpRequest.headers()](#httprequestheaders)
+  * [httpRequest.initiator()](#httprequestinitiator)
   * [httpRequest.isNavigationRequest()](#httprequestisnavigationrequest)
   * [httpRequest.method()](#httprequestmethod)
   * [httpRequest.postData()](#httprequestpostdata)
@@ -4777,8 +4778,17 @@ When in Cooperative Mode, awaits pending interception handlers and then decides 
 
 - returns: <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.
 
-#### httpRequest.isNavigationRequest()
+#### httpRequest.initiator()
+- returns: <[Object]> An object describing the initiator of the request
+  - `type` <[string]> Type of this initiator. Values : `'parser'`, `'script'`, `'preload'`, `'SignedExchange'`, `'other'`
+  - `stack` <?[Object]> Initiator JavaScript stack trace, set for Script only. Visit [ChromeDevTools Doc](https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-StackTrace "Runtime.StackTrace") for more information.
+  - `url` <?[string]> Initiator URL, set for Parser type or for Script type (when script is importing module) or for SignedExchange type.
+  - `lineNumber` <?[number]> Initiator line number, set for Parser type or for Script type (when script is importing module) (0-based).
 
+For more information about the returned object:
+https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Initiator
+
+#### httpRequest.isNavigationRequest()
 - returns: <[boolean]>
 
 Whether this request is driving frame's navigation.

--- a/src/common/HTTPRequest.ts
+++ b/src/common/HTTPRequest.ts
@@ -130,6 +130,7 @@ export class HTTPRequest {
   private _currentStrategy: InterceptResolutionStrategy;
   private _currentPriority: number | undefined;
   private _interceptActions: Array<() => void | PromiseLike<any>>;
+  private _initiator: Protocol.Network.Initiator;
 
   /**
    * @internal
@@ -158,6 +159,7 @@ export class HTTPRequest {
     this._currentStrategy = 'none';
     this._currentPriority = undefined;
     this._interceptActions = [];
+    this._initiator = event.initiator;
 
     for (const key of Object.keys(event.request.headers))
       this._headers[key.toLowerCase()] = event.request.headers[key];
@@ -273,6 +275,13 @@ export class HTTPRequest {
    */
   headers(): Record<string, string> {
     return this._headers;
+  }
+
+  /**
+   * @returns the initiator for the request.
+   */
+  initiator(): Protocol.Network.Initiator {
+    return this._initiator;
   }
 
   /**

--- a/test/assets/initiator.html
+++ b/test/assets/initiator.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+	<head>For request.initiator test</head>
+	<body>
+		<iframe src="./frames/frame.html"></iframe>
+		<script src="./initiator.js"></script>
+	</body>
+</html>

--- a/test/assets/initiator.js
+++ b/test/assets/initiator.js
@@ -1,0 +1,8 @@
+const script = document.createElement('script');
+script.src = './injectedfile.js';
+document.body.appendChild(script);
+
+const style = document.createElement('link');
+style.rel = 'stylesheet';
+style.href = './injectedstyle.css';
+document.head.appendChild(style);

--- a/test/network.spec.ts
+++ b/test/network.spec.ts
@@ -469,6 +469,30 @@ describe('network', function () {
     });
   });
 
+  describe('Request.initiator', () => {
+    it('should work', async({page, server}) => {
+      const initiators = new Map();
+      page.on('request', request => initiators.set(request.url().split('/').pop(), request.initiator()));
+      await page.goto(server.PREFIX + '/initiator.html');
+
+      expect(initiators.get('initiator.html').type).toBe('other');
+      expect(initiators.get('initiator.js').type).toBe('parser');
+      expect(initiators.get('initiator.js').url).toBe(server.PREFIX + '/initiator.html');
+      expect(initiators.get('frame.html').type).toBe('parser');
+      expect(initiators.get('frame.html').url).toBe(server.PREFIX + '/initiator.html');
+      expect(initiators.get('script.js').type).toBe('parser');
+      expect(initiators.get('script.js').url).toBe(server.PREFIX + '/frames/frame.html');
+      expect(initiators.get('style.css').type).toBe('parser');
+      expect(initiators.get('style.css').url).toBe(server.PREFIX + '/frames/frame.html');
+      expect(initiators.get('initiator.js').type).toBe('parser');
+      expect(initiators.get('injectedfile.js').type).toBe('script');
+      expect(initiators.get('injectedfile.js').stack.callFrames[0].url).toBe(server.PREFIX + '/initiator.js');
+      expect(initiators.get('injectedstyle.css').type).toBe('script');
+      expect(initiators.get('injectedstyle.css').stack.callFrames[0].url).toBe(server.PREFIX + '/initiator.js');
+      expect(initiators.get('initiator.js').url).toBe(server.PREFIX + '/initiator.html');
+    });
+  });
+
   describe('Request.isNavigationRequest', () => {
     itFailsFirefox('should work', async () => {
       const { page, server } = getTestState();


### PR DESCRIPTION
add request.initiator() method, with tests and api doc

Requested by #1395

I was looking for this feature, and after reading the code, I realised it was really easy to implement.
All it took was 8 lines (+doc and tests). I wonder why it was not added earlier ?