### PR TITLE
docs(puppeteer-firefox/readme.md): Add add-ons installation

### DIFF
--- a/experimental/puppeteer-firefox/README.md
+++ b/experimental/puppeteer-firefox/README.md
@@ -50,6 +50,49 @@ node example.js
 
 Current tip-of-tree status of Puppeteer-Firefox is availabe at [isPuppeteerFirefoxReady?](https://aslushnikov.github.io/ispuppeteerfirefoxready/)
 
+### Add-ons
+
+Firefox Add-ons differs from Chrome extensions, hence precess of its install is different.
+Firefox Add-on can be installed using [web-ext](https://github.com/mozilla/web-ext) library which runs Firefox binary and can be connected using Puppeteer `connect` API.
+
+```js
+const webExt = require('web-ext').default;
+const pptrFirefox = require('puppeteer-firefox');
+const getPort = require('get-port');
+
+(async () => {
+  const CDPPort = await getPort();
+  await webExt.cmd.run(
+      {
+        sourceDir: 'path-to-add-on',
+        firefox: pptrFirefox.executablePath(),
+        args: [`-juggler=${CDPPort}`]
+      },
+      {
+        // These are non CLI related options for each function.
+        // You need to specify this one so that your NodeJS application
+        // can continue running after web-ext is finished.
+        shouldExitProgram: false
+      }
+    );
+    const browser = await pptrFirefox.connect({
+      browserWSEndpoint: `ws://127.0.0.1:${CDPPort}`
+    });
+})();
+```
+
+`package.json` example
+```js
+{
+  "dependencies": {
+    ...
+    "get-port": "^4.2.0",
+    "web-ext": "^3.1.0",
+    "puppeteer-firefox": "^0.5.0"
+    ...
+  },
+}
+```
 
 ### Credits
 


### PR DESCRIPTION
Adds documentation for add-ons installation for Firefox. Since [web-ext](https://github.com/mozilla/web-ext) 3.1.0 was released, now it's possible to install them without any hacks. 

Related to:
#3660 #4162