### PR TITLE
docs(puppeteer-chromium): docker alpine freetype-dev dependency

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -299,6 +299,7 @@ RUN apk update && apk upgrade && \
       chromium@edge=~73.0.3683.103 \
       nss@edge \
       freetype@edge \
+      freetype-dev@edge \
       harfbuzz@edge \
       ttf-freefont@edge
 


### PR DESCRIPTION
A freetype update broke bitmap fonts. Adding freetype-dev to the Alpine dependencies resolves related issues.

This resolves these errors when launching chromium:
```/usr/bin/chromium-browser

Error relocating /usr/lib/chromium/chrome: FT_Get_Color_Glyph_Layer: symbol not found
Error relocating /usr/lib/chromium/chrome: FT_Palette_Select: symbol not found```


Background:
https://bugs.alpinelinux.org/issues/10309
https://github.com/stark/siji/issues/28
https://github.com/lucy/tewi-font/issues/35