### PR TITLE
fix(launcher): ensure PUPPETEER_EXECUTABLE_PATH is used if set

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -292,7 +292,6 @@ class Launcher {
    * @return {{executablePath: string, missingText: ?string}}
    */
   _resolveExecutablePath() {
-    const browserFetcher = new BrowserFetcher(this._projectRoot);
     // puppeteer-core doesn't take into account PUPPETEER_* env variables.
     if (!this._isPuppeteerCore) {
       const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.npm_config_puppeteer_executable_path || process.env.npm_package_config_puppeteer_executable_path;
@@ -300,6 +299,9 @@ class Launcher {
         const missingText = !fs.existsSync(executablePath) ? 'Tried to use PUPPETEER_EXECUTABLE_PATH env variable to launch browser but did not find any executable at: ' + executablePath : null;
         return { executablePath, missingText };
       }
+    }
+    const browserFetcher = new BrowserFetcher(this._projectRoot);
+    if (!this._isPuppeteerCore) {
       const revision = process.env['PUPPETEER_CHROMIUM_REVISION'];
       if (revision) {
         const revisionInfo = browserFetcher.revisionInfo(revision);


### PR DESCRIPTION
Without this patch, Puppeteer exits with `Error: Unsupported platform: freebsd` on FreeBSD despite `PUPPETEER_EXECUTABLE_PATH` being set.