### PR TITLE
fix(tests): jshandle test fix

### DIFF
--- a/experimental/puppeteer-firefox/lib/ExecutionContext.js
+++ b/experimental/puppeteer-firefox/lib/ExecutionContext.js
@@ -67,7 +67,7 @@ class ExecutionContext {
         executionContextId: this._executionContextId
       });
     } catch (err) {
-      if (err instanceof TypeError && err.message === 'Converting circular structure to JSON')
+      if (err instanceof TypeError && err.message.startsWith('Converting circular structure to JSON'))
         err.message += ' Are you passing a nested JSHandle?';
       throw err;
     }

--- a/lib/ExecutionContext.js
+++ b/lib/ExecutionContext.js
@@ -113,7 +113,7 @@ class ExecutionContext {
         userGesture: true
       });
     } catch (err) {
-      if (err instanceof TypeError && err.message === 'Converting circular structure to JSON')
+      if (err instanceof TypeError && err.message.startsWith('Converting circular structure to JSON'))
         err.message += ' Are you passing a nested JSHandle?';
       throw err;
     }


### PR DESCRIPTION
Check message prefix rather than strict equality when detecting circular JSON error. The message format has changed recently which broke the condition.