### PR TITLE
fix(tests): Get TLS version from Node instead of hardcoding it

### DIFF
--- a/test/ignorehttpserrors.spec.js
+++ b/test/ignorehttpserrors.spec.js
@@ -39,10 +39,12 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
 
     describe('Response.securityDetails', function() {
       it('should work', async({page, httpsServer}) => {
+        const requestEvent = httpsServer.waitForRequest('/empty.html');
         const response = await page.goto(httpsServer.EMPTY_PAGE);
         const securityDetails = response.securityDetails();
         expect(securityDetails.issuer()).toBe('puppeteer-tests');
-        expect(securityDetails.protocol()).toBe('TLS 1.2');
+        const protocol = (await requestEvent).socket.getProtocol().replace('v', ' ');
+        expect(securityDetails.protocol()).toBe(protocol);
         expect(securityDetails.subjectName()).toBe('puppeteer-tests');
         expect(securityDetails.validFrom()).toBe(1550084863);
         expect(securityDetails.validTo()).toBe(33086084863);
@@ -55,11 +57,13 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         httpsServer.setRedirect('/plzredirect', '/empty.html');
         const responses =  [];
         page.on('response', response => responses.push(response));
+        const requestEvent = httpsServer.waitForRequest('/plzredirect');
         await page.goto(httpsServer.PREFIX + '/plzredirect');
         expect(responses.length).toBe(2);
         expect(responses[0].status()).toBe(302);
         const securityDetails = responses[0].securityDetails();
-        expect(securityDetails.protocol()).toBe('TLS 1.2');
+        const protocol = (await requestEvent).socket.getProtocol().replace('v', ' ');
+        expect(securityDetails.protocol()).toBe(protocol);
       });
     });
 

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -287,12 +287,14 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
 
         const browser = await puppeteer.connect({browserWSEndpoint, ignoreHTTPSErrors: true});
         const page = await browser.newPage();
+        const requestEvent = httpsServer.waitForRequest('/empty.html');
         let error = null;
         const response = await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
         expect(error).toBe(null);
         expect(response.ok()).toBe(true);
         expect(response.securityDetails()).toBeTruthy();
-        expect(response.securityDetails().protocol()).toBe('TLS 1.2');
+        const protocol = (await requestEvent).socket.getProtocol().replace('v', ' ');
+        expect(response.securityDetails().protocol()).toBe(protocol);
         await page.close();
         await browser.close();
       });

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -287,13 +287,15 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
 
         const browser = await puppeteer.connect({browserWSEndpoint, ignoreHTTPSErrors: true});
         const page = await browser.newPage();
-        const requestEvent = httpsServer.waitForRequest('/empty.html');
         let error = null;
-        const response = await page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e);
+        const [serverRequest, response] = await Promise.all([
+          httpsServer.waitForRequest('/empty.html'),
+          page.goto(httpsServer.EMPTY_PAGE).catch(e => error = e)
+        ]);
         expect(error).toBe(null);
         expect(response.ok()).toBe(true);
         expect(response.securityDetails()).toBeTruthy();
-        const protocol = (await requestEvent).socket.getProtocol().replace('v', ' ');
+        const protocol = serverRequest.socket.getProtocol().replace('v', ' ');
         expect(response.securityDetails().protocol()).toBe(protocol);
         await page.close();
         await browser.close();

--- a/utils/testserver/index.js
+++ b/utils/testserver/index.js
@@ -46,7 +46,6 @@ class TestServer {
     const server = new TestServer(dirPath, port, {
       key: fs.readFileSync(path.join(__dirname, 'key.pem')),
       cert: fs.readFileSync(path.join(__dirname, 'cert.pem')),
-      secureProtocol: 'TLSv1_2_method',
       passphrase: 'aaaa',
     });
     await new Promise(x => server._server.once('listening', x));


### PR DESCRIPTION
This will make the tests resilient to open ssl updates in node.