### PR TITLE
fix(launcher): disable component extensions

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -42,6 +42,7 @@ const DEFAULT_ARGS = [
   '--disable-backgrounding-occluded-windows',
   '--disable-breakpad',
   '--disable-client-side-phishing-detection',
+  '--disable-component-extensions-with-background-pages',
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',

--- a/test/assets/simple-extension/index.js
+++ b/test/assets/simple-extension/index.js
@@ -1,1 +1,2 @@
 // Mock script for background extension
+window.MAGIC = 42;

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -73,6 +73,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowse
       const backgroundPageTarget = await waitForBackgroundPageTarget(browserWithExtension);
       const page = await backgroundPageTarget.page();
       expect(await page.evaluate(() => 2 * 3)).toBe(6);
+      expect(await page.evaluate(() => window.MAGIC)).toBe(42);
       await browserWithExtension.close();
     });
     it('should have default url when launching browser', async function() {


### PR DESCRIPTION
Chrome has a set of component extensions - e.g. CryptoTokenExtension
that helps with 2FA.

These extensions are loaded regardless of the `--disable-extensions`
flag we already pass. To disable these extensions, we need to pass additional
`--disable-component-extensions-with-background-pages` flag.

Fix #4300