### PR TITLE
fix(pipe): handle 'error' events on pipes to avoid crashing

### DIFF
--- a/lib/PipeTransport.js
+++ b/lib/PipeTransport.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const {helper} = require('./helper');
+const {helper, debugError} = require('./helper');
 
 /**
  * @implements {!Puppeteer.ConnectionTransport}
@@ -31,7 +31,9 @@ class PipeTransport {
       helper.addEventListener(pipeRead, 'close', () => {
         if (this.onclose)
           this.onclose.call(null);
-      })
+      }),
+      helper.addEventListener(pipeRead, 'error', debugError),
+      helper.addEventListener(pipeWrite, 'error', debugError),
     ];
     this.onmessage = null;
     this.onclose = null;


### PR DESCRIPTION
Fix #4374