### PR TITLE
fix(page): properly create isolated worlds

### DIFF
--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -15,7 +15,7 @@
  */
 
 const EventEmitter = require('events');
-const {helper, assert} = require('./helper');
+const {helper, assert, debugError} = require('./helper');
 const {Events} = require('./Events');
 const {ExecutionContext, EVALUATION_SCRIPT_URL} = require('./ExecutionContext');
 const {LifecycleWatcher} = require('./LifecycleWatcher');
@@ -276,7 +276,7 @@ class FrameManager extends EventEmitter {
       frameId: frame._id,
       grantUniveralAccess: true,
       worldName: name,
-    })));
+    }).catch(debugError)));
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -276,7 +276,7 @@ class FrameManager extends EventEmitter {
       frameId: frame._id,
       grantUniveralAccess: true,
       worldName: name,
-    }).catch(debugError)));
+    }).catch(debugError))); // frames might be removed before we send this
   }
 
   /**


### PR DESCRIPTION
The following error:
```
Error: Protocol error (Page.createIsolatedWorld): No frame for given id found
```

was mentioned here:
https://github.com/FlowCrypt/flowcrypt-browser/pull/1799#issuecomment-508729602

This indeed seems to be a bug with our creation of isolated worlds.