### PR TITLE
fix(testreporter): Test Reporter should not terminate node.js process

### DIFF
--- a/utils/testrunner/Reporter.js
+++ b/utils/testrunner/Reporter.js
@@ -80,13 +80,13 @@ class Reporter {
         description = `${RED_COLOR}<UNKNOWN>${RESET_COLOR}`;
       console.log(`  ${workerId}: [${description}] ${test.fullName} (${formatTestLocation(test)})`);
     }
-    process.exit(2);
+    process.exitCode = 2;
   }
 
   _onFinished() {
     this._printTestResults();
     const failedTests = this._runner.failedTests();
-    process.exit(failedTests.length > 0 ? 1 : 0);
+    process.exitCode = failedTests.length > 0 ? 1 : 0;
   }
 
   _printTestResults() {


### PR DESCRIPTION
This patch starts assigning process exit codes rather than terminating
parent process. Library should never own/terminate parent node.js
process.