### PR TITLE
Fix connection issue to VSCode instance

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -55,8 +55,11 @@ class Browser extends EventEmitter {
     this._defaultContext = new BrowserContext(this._connection, this, null);
     /** @type {Map<string, BrowserContext>} */
     this._contexts = new Map();
-    for (const contextId of contextIds)
+    if (contextIds!=null) {
+      for (const contextId of contextIds)
       this._contexts.set(contextId, new BrowserContext(this._connection, this, contextId));
+    }
+    
 
     /** @type {Map<string, Target>} */
     this._targets = new Map();

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -285,7 +285,13 @@ class Launcher {
       connection = new Connection(connectionURL, connectionTransport, slowMo);
     }
 
-    const {browserContextIds} = await connection.send('Target.getBrowserContexts');
+    let browserContextIds = null;
+    try {
+      const {browserContextIds} = await connection.send('Target.getBrowserContexts');
+    } catch(error){
+      console.log("Got error for cmd Target.getBrowserContexts");
+      console.log(error);
+    }
     return Browser.create(connection, browserContextIds, ignoreHTTPSErrors, defaultViewport, null, () => connection.send('Browser.close').catch(debugError));
   }
 


### PR DESCRIPTION
fix(Launcher): fix Launcher.connect method

This patch fixes Launcher.connect  so that it works with existing Visual Studio code instance.


The is an issue when connecting to the existing Visual Studio Code instance.

Visual Studio Code seems not supporting the protocol command _Target.getBrowserContexts_

So when trying to connect to the Visual Studio Code instance by these steps, it will failed

1. Open a Visual Studio Code instance, code . --remote-debugging-port=9222
2. Get the WSEndPoint in http://localhost:9222/json/version
3. Connect to this WSEndPoint by puppeteer.connect({browserWSEndpoint:'...'})

The issue raises from 
const {browserContextIds} = await connection.send('Target.getBrowserContexts');
in Launcher.js

I take a look the value when VSCode is lanuched with puppeteer.Lanuch, and it is null. So null is set for this parameter, and the Browser.js need to updated to check if contextIds is not null when trying to loop the contextIds.

With this fix, I could connect to an existing Visual Studio Code instance.

