### PR TITLE
fix(launcher): make dumpio and pipe options work together

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -123,7 +123,14 @@ class Launcher {
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');
     /** @type {!Array<"ignore"|"pipe">} */
-    const stdio = usePipe ? ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'];
+    let stdio = ['pipe', 'pipe', 'pipe'];
+    if (usePipe) {
+      if (dumpio) {
+        stdio = ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'];
+      } else {
+        stdio = ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'];
+      }
+    }
     const chromeProcess = childProcess.spawn(
         chromeExecutable,
         chromeArguments,

--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -125,11 +125,10 @@ class Launcher {
     /** @type {!Array<"ignore"|"pipe">} */
     let stdio = ['pipe', 'pipe', 'pipe'];
     if (usePipe) {
-      if (dumpio) {
+      if (dumpio)
         stdio = ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'];
-      } else {
+      else
         stdio = ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'];
-      }
     }
     const chromeProcess = childProcess.spawn(
         chromeExecutable,

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -22,6 +22,19 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Fixtures', function() {
+    it('dumpio option should work with pipe option ', async({server}) => {
+      let dumpioData = '';
+      const {spawn} = require('child_process');
+      const options = Object.assign({}, defaultBrowserOptions, {pipe:true, dumpio: true});
+      const res = spawn('node',
+          [path.join(__dirname, 'fixtures', 'dumpio.js'), puppeteerPath, JSON.stringify(options)]);
+      if (CHROME)
+        res.stderr.on('data', data => dumpioData += data.toString('utf8'));
+      else
+        res.stdout.on('data', data => dumpioData += data.toString('utf8'));
+      await new Promise(resolve => res.on('close', resolve));
+      expect(dumpioData).toContain('message from dumpio');
+    });
     it('should dump browser process stderr', async({server}) => {
       let dumpioData = '';
       const {spawn} = require('child_process');

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -22,16 +22,13 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
   describe('Fixtures', function() {
-    it('dumpio option should work with pipe option ', async({server}) => {
+    it_fails_ffox('dumpio option should work with pipe option ', async({server}) => {
       let dumpioData = '';
       const {spawn} = require('child_process');
       const options = Object.assign({}, defaultBrowserOptions, {pipe: true, dumpio: true});
       const res = spawn('node',
           [path.join(__dirname, 'fixtures', 'dumpio.js'), puppeteerPath, JSON.stringify(options)]);
-      if (CHROME)
-        res.stderr.on('data', data => dumpioData += data.toString('utf8'));
-      else
-        res.stdout.on('data', data => dumpioData += data.toString('utf8'));
+      res.stderr.on('data', data => dumpioData += data.toString('utf8'));
       await new Promise(resolve => res.on('close', resolve));
       expect(dumpioData).toContain('message from dumpio');
     });

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -25,7 +25,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
     it('dumpio option should work with pipe option ', async({server}) => {
       let dumpioData = '';
       const {spawn} = require('child_process');
-      const options = Object.assign({}, defaultBrowserOptions, {pipe:true, dumpio: true});
+      const options = Object.assign({}, defaultBrowserOptions, {pipe: true, dumpio: true});
       const res = spawn('node',
           [path.join(__dirname, 'fixtures', 'dumpio.js'), puppeteerPath, JSON.stringify(options)]);
       if (CHROME)

--- a/test/fixtures/dumpio.js
+++ b/test/fixtures/dumpio.js
@@ -2,7 +2,7 @@
   const [, , puppeteerRoot, options] = process.argv;
   const browser = await require(puppeteerRoot).launch(JSON.parse(options));
   const page = await browser.newPage();
-  await page.evaluate(() => console.error("message from dumpio"));
+  await page.evaluate(() => console.error('message from dumpio'));
   await page.close();
   await browser.close();
 })();

--- a/test/fixtures/dumpio.js
+++ b/test/fixtures/dumpio.js
@@ -2,6 +2,7 @@
   const [, , puppeteerRoot, options] = process.argv;
   const browser = await require(puppeteerRoot).launch(JSON.parse(options));
   const page = await browser.newPage();
+  await page.evaluate(() => console.error("message from dumpio"));
   await page.close();
   await browser.close();
 })();


### PR DESCRIPTION
Don't ignore stdout and stderr when using pipe for remote debugging and dumpio is true. In that case puppeteer process connects to the stdout/stderr streams of the child process and it will not hang.