### PR TITLE
fix(test): make sure selection is not empty before running copy command

### DIFF
--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -226,9 +226,11 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(error.message).toContain('JSHandles can be evaluated only in the context they were created');
     });
     it('should simulate a user gesture', async({page, server}) => {
-      await page.evaluate(() => document.body.appendChild(document.createTextNode('test')));
-      await page.evaluate(() => document.execCommand('selectAll'));
-      const result = await page.evaluate(() => document.execCommand('copy'));
+      const result = await page.evaluate(() => {
+        document.body.appendChild(document.createTextNode('test'));
+        document.execCommand('selectAll');
+        return document.execCommand('copy');
+      });
       expect(result).toBe(true);
     });
     it('should throw a nice error after a navigation', async({page, server}) => {

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -227,10 +227,9 @@ module.exports.addTests = function({testRunner, expect}) {
     });
     it('should simulate a user gesture', async({page, server}) => {
       await page.evaluate(() => document.body.appendChild(document.createTextNode('test')));
-      const selectResult = await page.evaluate(() => document.execCommand('selectAll'));
-      expect(selectResult).toBe(true);
-      const copyResult = await page.evaluate(() => document.execCommand('copy'));
-      expect(copyResult).toBe(true);
+      await page.evaluate(() => document.execCommand('selectAll'));
+      const result = await page.evaluate(() => document.execCommand('copy'));
+      expect(result).toBe(true);
     });
     it('should throw a nice error after a navigation', async({page, server}) => {
       const executionContext = await page.mainFrame().executionContext();

--- a/test/evaluation.spec.js
+++ b/test/evaluation.spec.js
@@ -226,8 +226,11 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(error.message).toContain('JSHandles can be evaluated only in the context they were created');
     });
     it('should simulate a user gesture', async({page, server}) => {
-      const result = await page.evaluate(() => document.execCommand('copy'));
-      expect(result).toBe(true);
+      await page.evaluate(() => document.body.appendChild(document.createTextNode('test')));
+      const selectResult = await page.evaluate(() => document.execCommand('selectAll'));
+      expect(selectResult).toBe(true);
+      const copyResult = await page.evaluate(() => document.execCommand('copy'));
+      expect(copyResult).toBe(true);
     });
     it('should throw a nice error after a navigation', async({page, server}) => {
       const executionContext = await page.mainFrame().executionContext();


### PR DESCRIPTION
If current selection is empty document.execCommand('copy') may return false in some browsers (e.g. WebKit based ones).