### PR TITLE
fix a wrong description in function page.screenshot

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -879,7 +879,7 @@ class Page extends EventEmitter {
       assert(typeof options.clip.width === 'number', 'Expected options.clip.width to be a number but found ' + (typeof options.clip.width));
       assert(typeof options.clip.height === 'number', 'Expected options.clip.height to be a number but found ' + (typeof options.clip.height));
       assert(options.clip.width !== 0, 'Expected options.clip.width not to be 0.');
-      assert(options.clip.height !== 0, 'Expected options.clip.width not to be 0.');
+      assert(options.clip.height !== 0, 'Expected options.clip.height not to be 0.');
     }
     return this._screenshotTaskQueue.postTask(this._screenshotTask.bind(this, screenshotType, options));
   }


### PR DESCRIPTION
When options.clip.height===0,  ('options' is Page.screenshot's params).  The error description thrown by Function assert is 'Expected options.clip.width not to be 0.' It's misleading.