### PR TITLE
chore(coverage): fix coverage for events

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -96,7 +96,7 @@ if (process.env.BROWSER === 'firefox') {
       testRunner,
     });
     if (process.env.COVERAGE)
-      utils.recordAPICoverage(testRunner, require('../lib/api'), CHROMIUM_NO_COVERAGE);
+      utils.recordAPICoverage(testRunner, require('../lib/api'), require('../lib/Events').Events, CHROMIUM_NO_COVERAGE);
   });
 }
 


### PR DESCRIPTION
We used to track API Coverage for public events, but this was regressed in the refactoring that
introduced `//lib/Events.js`.

This patch:
- Brings back API Coverage for events
- Combines all coverage-generated tests into a single one. This way
we can generate less data for flakiness dashboard.