### PR TITLE
test(network): be able to remove headers using request.continue

### DIFF
--- a/experimental/puppeteer-firefox/lib/NetworkManager.js
+++ b/experimental/puppeteer-firefox/lib/NetworkManager.js
@@ -158,7 +158,7 @@ class Request {
     } = overrides;
     await this._session.send('Network.resumeSuspendedRequest', {
       requestId: this._id,
-      headers: headers ? Object.entries(headers).map(([name, value]) => ({name, value})) : undefined,
+      headers: headers ? Object.entries(headers).filter(([, value]) => !Object.is(value, undefined)).map(([name, value]) => ({name, value})) : undefined,
     }).catch(error => {
       debugError(error);
     });

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -724,7 +724,8 @@ class SecurityDetails {
 function headersArray(headers) {
   const result = [];
   for (const name in headers)
-    result.push({name, value: headers[name] + ''});
+    if(!Object.is(headers[name], undefined))
+      result.push({name, value: headers[name] + ''});
   return result;
 }
 

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -723,9 +723,10 @@ class SecurityDetails {
  */
 function headersArray(headers) {
   const result = [];
-  for (const name in headers)
-    if(!Object.is(headers[name], undefined))
+  for (const name in headers) {
+    if (!Object.is(headers[name], undefined))
       result.push({name, value: headers[name] + ''});
+  }
   return result;
 }
 


### PR DESCRIPTION
closes #4743 

I think this was a regression caused here https://github.com/GoogleChrome/puppeteer/pull/4265/files#diff-d2ac7cb061b0c51644d0a5d6140e3a32R446