### PR TITLE
docs(readme.md): explain significance of chromium revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ npm install puppeteer-core@chrome-71
 
 #### Q: Which Chromium version does Puppeteer use?
 
-Look for `chromium_revision` in [package.json](https://github.com/GoogleChrome/puppeteer/blob/master/package.json).
+Look for `chromium_revision` in [package.json](https://github.com/GoogleChrome/puppeteer/blob/master/package.json). To find the specific Chromium commit, search for the revision prefixed by an "r" in the "Find Releases" section of [https://omahaproxy.appspot.com/](https://omahaproxy.appspot.com/).
 
 #### Q: What’s considered a “Navigation”?
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ npm install puppeteer-core@chrome-71
 
 #### Q: Which Chromium version does Puppeteer use?
 
-Look for `chromium_revision` in [package.json](https://github.com/GoogleChrome/puppeteer/blob/master/package.json). To find the corresponding Chromium commit, search for the revision prefixed by an `r` in [OmahaProxy](https://omahaproxy.appspot.com/)'s "Find Releases" section.
+Look for `chromium_revision` in [package.json](https://github.com/GoogleChrome/puppeteer/blob/master/package.json). To find the corresponding Chromium commit and version number, search for the revision prefixed by an `r` in [OmahaProxy](https://omahaproxy.appspot.com/)'s "Find Releases" section.
 
 #### Q: What’s considered a “Navigation”?
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ npm install puppeteer-core@chrome-71
 
 #### Q: Which Chromium version does Puppeteer use?
 
-Look for `chromium_revision` in [package.json](https://github.com/GoogleChrome/puppeteer/blob/master/package.json). To find the specific Chromium commit, search for the revision prefixed by an "r" in the "Find Releases" section of [https://omahaproxy.appspot.com/](https://omahaproxy.appspot.com/).
+Look for `chromium_revision` in [package.json](https://github.com/GoogleChrome/puppeteer/blob/master/package.json). To find the corresponding Chromium commit, search for the revision prefixed by an `r` in [OmahaProxy](https://omahaproxy.appspot.com/)'s "Find Releases" section.
 
 #### Q: What’s considered a “Navigation”?
 


### PR DESCRIPTION
My coworker and I weren't sure what the "chromium revision" actually meant, and googling for "chromium revision" mostly brings up Github issues about puppeteer itself. I searched the repo and found this:

> BrowserFetcher operates on revision strings that specify a precise version of Chromium, e.g. `"533271"`. Revision strings can be obtained from [omahaproxy.appspot.com](http://omahaproxy.appspot.com/).

Which was helpful, so incorporated that info into the README. If there's more info to share about the significance of the chromium revision it'd be great to share that too!