### PR TITLE
fix(page): Resolve file chooser using a single promise

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -112,7 +112,8 @@ class Page extends EventEmitter {
     networkManager.on(Events.NetworkManager.RequestFailed, event => this.emit(Events.Page.RequestFailed, event));
     networkManager.on(Events.NetworkManager.RequestFinished, event => this.emit(Events.Page.RequestFinished, event));
     this._fileChooserInterceptionIsDisabled = false;
-    this._fileChooserInterceptors = new Set();
+    /** @type {?Promise<FileChooser>} */
+    this._fileChooserPromise = null;
 
     client.on('Page.domContentEventFired', event => this.emit(Events.Page.DOMContentLoaded));
     client.on('Page.loadEventFired', event => this.emit(Events.Page.Load));
@@ -146,15 +147,13 @@ class Page extends EventEmitter {
    * @param {!Protocol.Page.fileChooserOpenedPayload} event
    */
   _onFileChooser(event) {
-    if (!this._fileChooserInterceptors.size) {
+    if (!this._fileChooserPromise) {
       this._client.send('Page.handleFileChooser', { action: 'fallback' }).catch(debugError);
       return;
     }
-    const interceptors = Array.from(this._fileChooserInterceptors);
-    this._fileChooserInterceptors.clear();
     const fileChooser = new FileChooser(this._client, event);
-    for (const interceptor of interceptors)
-      interceptor.call(null, fileChooser);
+    this._fileChooserCallback(fileChooser);
+    this._fileChooserPromise = null;
   }
 
   /**
@@ -167,13 +166,11 @@ class Page extends EventEmitter {
     const {
       timeout = this._timeoutSettings.timeout(),
     } = options;
-    let callback;
-    const promise = new Promise(x => callback = x);
-    this._fileChooserInterceptors.add(callback);
-    return helper.waitWithTimeout(promise, 'waiting for file chooser', timeout).catch(e => {
-      this._fileChooserInterceptors.delete(callback);
-      throw e;
-    });
+
+    if (!this._fileChooserPromise)
+      this._fileChooserPromise = new Promise(fulfill => this._fileChooserCallback = fulfill);
+
+    return helper.waitWithTimeout(this._fileChooserPromise, 'waiting for file chooser', timeout);
   }
 
   /**


### PR DESCRIPTION
Can't we resolve all the `waitForFileChooser` calls using a single promise instead of creating a `Set` of promises that will be resolved at the same time with the same output? 