### PR TITLE
feat(frame): introduce frame.ownerElement

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -206,6 +206,7 @@
   * [frame.$x(expression)](#framexexpression)
   * [frame.addScriptTag(options)](#frameaddscripttagoptions)
   * [frame.addStyleTag(options)](#frameaddstyletagoptions)
+  * [frame.asElement()](#frameaselement)
   * [frame.childFrames()](#framechildframes)
   * [frame.click(selector[, options])](#frameclickselector-options)
   * [frame.content()](#framecontent)
@@ -229,7 +230,6 @@
   * [frame.waitForNavigation([options])](#framewaitfornavigationoptions)
   * [frame.waitForSelector(selector[, options])](#framewaitforselectorselector-options)
   * [frame.waitForXPath(xpath[, options])](#framewaitforxpathxpath-options)
-  * [frame.asElement()](#frameaselement)
 - [class: ExecutionContext](#class-executioncontext)
   * [executionContext.evaluate(pageFunction[, ...args])](#executioncontextevaluatepagefunction-args)
   * [executionContext.evaluateHandle(pageFunction[, ...args])](#executioncontextevaluatehandlepagefunction-args)
@@ -2572,6 +2572,9 @@ Adds a `<script>` tag into the page with the desired url or content.
 
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content.
 
+#### frame.asElement()
+- returns: <[Promise]<?[ElementHandle]>> Resolves to the element handle representing frame node. The method will return null for the main frame.
+
 #### frame.childFrames()
 - returns: <[Array]<[Frame]>>
 
@@ -2912,9 +2915,6 @@ puppeteer.launch().then(async browser => {
   await browser.close();
 });
 ```
-
-#### frame.asElement()
-- returns: <[Promise]<?[ElementHandle]>> Resolves to the element handle representing frame node. The method will return null for the main frame.
 
 ### class: ExecutionContext
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -229,6 +229,7 @@
   * [frame.waitForNavigation([options])](#framewaitfornavigationoptions)
   * [frame.waitForSelector(selector[, options])](#framewaitforselectorselector-options)
   * [frame.waitForXPath(xpath[, options])](#framewaitforxpathxpath-options)
+  * [frame.asElement()](#frameaselement)
 - [class: ExecutionContext](#class-executioncontext)
   * [executionContext.evaluate(pageFunction[, ...args])](#executioncontextevaluatepagefunction-args)
   * [executionContext.evaluateHandle(pageFunction[, ...args])](#executioncontextevaluatehandlepagefunction-args)
@@ -2911,6 +2912,9 @@ puppeteer.launch().then(async browser => {
   await browser.close();
 });
 ```
+
+#### frame.asElement()
+- returns: <[Promise]<?[ElementHandle]>> Resolves to the element handle representing frame node. The method will return null for the main frame.
 
 ### class: ExecutionContext
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -206,7 +206,6 @@
   * [frame.$x(expression)](#framexexpression)
   * [frame.addScriptTag(options)](#frameaddscripttagoptions)
   * [frame.addStyleTag(options)](#frameaddstyletagoptions)
-  * [frame.asElement()](#frameaselement)
   * [frame.childFrames()](#framechildframes)
   * [frame.click(selector[, options])](#frameclickselector-options)
   * [frame.content()](#framecontent)
@@ -218,6 +217,7 @@
   * [frame.hover(selector)](#framehoverselector)
   * [frame.isDetached()](#frameisdetached)
   * [frame.name()](#framename)
+  * [frame.ownerElement()](#frameownerelement)
   * [frame.parentFrame()](#frameparentframe)
   * [frame.select(selector, ...values)](#frameselectselector-values)
   * [frame.setContent(html[, options])](#framesetcontenthtml-options)
@@ -2572,9 +2572,6 @@ Adds a `<script>` tag into the page with the desired url or content.
 
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content.
 
-#### frame.asElement()
-- returns: <[Promise]<?[ElementHandle]>> Resolves to the element handle representing frame node. The method will return null for the main frame.
-
 #### frame.childFrames()
 - returns: <[Array]<[Frame]>>
 
@@ -2719,6 +2716,9 @@ Returns frame's name attribute as specified in the tag.
 If the name is empty, returns the id attribute instead.
 
 > **NOTE** This value is calculated once when the frame is created, and will not update if the attribute is changed later.
+
+#### frame.ownerElement()
+- returns: <[Promise]<?[ElementHandle]>> Resolves to the element handle representing frame node. The method will return null for the main frame.
 
 #### frame.parentFrame()
 - returns: <?[Frame]> Parent frame, if any. Detached frames and main frames return `null`.

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -673,16 +673,16 @@ class Frame {
     if (!this.parentFrame())
       return null;
 
-    const mainExecutionContext = await this._mainWorld.executionContext();
+    const executionContext = await this.parentFrame().executionContext();
     const nodeInfo = await this._client.send('DOM.getFrameOwner', {
       frameId: this._id,
     });
 
     const {object} = await this._client.send('DOM.resolveNode', {
       backendNodeId: nodeInfo.backendNodeId,
-      executionContextId: mainExecutionContext._contextId,
+      executionContextId: executionContext._contextId,
     });
-    return /** @type {Puppeteer.ElementHandle}*/(createJSHandle(mainExecutionContext, object));
+    return /** @type {Puppeteer.ElementHandle}*/(createJSHandle(executionContext, object));
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -21,6 +21,7 @@ const {ExecutionContext, EVALUATION_SCRIPT_URL} = require('./ExecutionContext');
 const {LifecycleWatcher} = require('./LifecycleWatcher');
 const {DOMWorld} = require('./DOMWorld');
 const {NetworkManager} = require('./NetworkManager');
+const {createJSHandle} = require('./JSHandle');
 
 const UTILITY_WORLD_NAME = '__puppeteer_utility_world__';
 
@@ -663,6 +664,25 @@ class Frame {
    */
   async title() {
     return this._secondaryWorld.title();
+  }
+
+  /**
+   * @return {!Promise<?Puppeteer.ElementHandle>}
+   */
+  async asElement() {
+    if (!this.parentFrame())
+      return null;
+
+    const mainExecutionContext = await this._mainWorld.executionContext();
+    const nodeInfo = await this._client.send('DOM.getFrameOwner', {
+      frameId: this._id,
+    });
+
+    const {object} = await this._client.send('DOM.resolveNode', {
+      backendNodeId: nodeInfo.backendNodeId,
+      executionContextId: mainExecutionContext._contextId,
+    });
+    return /** @type {Puppeteer.ElementHandle}*/(createJSHandle(mainExecutionContext, object));
   }
 
   /**

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -669,7 +669,7 @@ class Frame {
   /**
    * @return {!Promise<?Puppeteer.ElementHandle>}
    */
-  async asElement() {
+  async ownerElement() {
     if (!this.parentFrame())
       return null;
 

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -208,4 +208,25 @@ module.exports.addTests = function({testRunner, expect}) {
       expect(frame1).not.toBe(frame2);
     });
   });
+
+  describe_fails_ffox('Frame.asElementHandle', function() {
+    it('should work', async({page,server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      const elementHandle = await page.$('#frame1');
+      const frame = await elementHandle.contentFrame();
+      const elementFromFrame = await frame.asElement();
+
+      expect(elementFromFrame._protocolValue).toBe(elementHandle._protocolValue);
+
+      const frameFromNewHandle = await elementFromFrame.contentFrame();
+      expect(frameFromNewHandle).toBe(frame);
+    });
+
+    it('should return null for mainFrame().asElemenHandle()', async({page,server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      expect(await page.mainFrame().asElement()).toBe(null);
+    });
+  });
 };

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -17,7 +17,7 @@
 const utils = require('./utils');
 
 module.exports.addTests = function({testRunner, expect}) {
-  const {describe, xdescribe, fdescribe} = testRunner;
+  const {describe, xdescribe, fdescribe, describe_fails_ffox} = testRunner;
   const {it, fit, xit, it_fails_ffox} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -209,21 +209,17 @@ module.exports.addTests = function({testRunner, expect}) {
     });
   });
 
-  describe_fails_ffox('Frame.asElementHandle', function() {
+  describe_fails_ffox('Frame.asElement', function() {
     it('should work', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
-      const elementHandle = await page.$('#frame1');
-      const frame = await elementHandle.contentFrame();
-      const elementFromFrame = await frame.asElement();
+      const handle = await page.$('#frame1');
+      const frame = await handle.contentFrame();
 
-      expect(elementFromFrame._protocolValue).toBe(elementHandle._protocolValue);
-
-      const frameFromNewHandle = await elementFromFrame.contentFrame();
-      expect(frameFromNewHandle).toBe(frame);
+      expect(await page.evaluate((f1, f2) => f1 === f2, handle, await frame.asElement())).toBe(true);
     });
 
-    it('should return null for mainFrame().asElemenHandle()', async({page,server}) => {
+    it('should return null for mainFrame().asElement()', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
       expect(await page.mainFrame().asElement()).toBe(null);

--- a/test/frame.spec.js
+++ b/test/frame.spec.js
@@ -209,20 +209,20 @@ module.exports.addTests = function({testRunner, expect}) {
     });
   });
 
-  describe_fails_ffox('Frame.asElement', function() {
+  describe_fails_ffox('Frame.ownerElement', function() {
     it('should work', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
       const handle = await page.$('#frame1');
       const frame = await handle.contentFrame();
 
-      expect(await page.evaluate((f1, f2) => f1 === f2, handle, await frame.asElement())).toBe(true);
+      expect(await page.evaluate((f1, f2) => f1 === f2, handle, await frame.ownerElement())).toBe(true);
     });
 
-    it('should return null for mainFrame().asElement()', async({page,server}) => {
+    it('should return null for mainFrame().ownerElement()', async({page,server}) => {
       await page.goto(server.EMPTY_PAGE);
       await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
-      expect(await page.mainFrame().asElement()).toBe(null);
+      expect(await page.mainFrame().ownerElement()).toBe(null);
     });
   });
 };


### PR DESCRIPTION
closes #4709 (I found this issue with a few ❤️)

The `asElement` name is used so it's consistent with [JSHandle.asElement](https://github.com/GoogleChrome/puppeteer/blob/v1.19.0/docs/api.md#jshandleaselement). 
[DOM.getFrameOwner](https://chromedevtools.github.io/devtools-protocol/tot/DOM#method-getFrameOwner) is marked as experimental. I don't know whether we should use it or not.