### PR TITLE
feat(chromium): roll Chromium to r686378

### DIFF
--- a/lib/Target.js
+++ b/lib/Target.js
@@ -17,7 +17,6 @@
 const {Events} = require('./Events');
 const {Page} = require('./Page');
 const {Worker} = require('./Worker');
-const {Connection} = require('./Connection');
 
 class Target {
   /**
@@ -84,16 +83,9 @@ class Target {
     if (this._targetInfo.type !== 'service_worker' && this._targetInfo.type !== 'shared_worker')
       return null;
     if (!this._workerPromise) {
-      this._workerPromise = this._sessionFactory().then(async client => {
-        // Top level workers have a fake page wrapping the actual worker.
-        const [targetAttached] = await Promise.all([
-          new Promise(x => client.once('Target.attachedToTarget', x)),
-          client.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: false, flatten: true}),
-        ]);
-        const session = Connection.fromSession(client).session(targetAttached.sessionId);
-        // TODO(einbinder): Make workers send their console logs.
-        return new Worker(session, this._targetInfo.url, () => {} /* consoleAPICalled */, () => {} /* exceptionThrown */);
-      });
+      // TODO(einbinder): Make workers send their console logs.
+      this._workerPromise = this._sessionFactory()
+          .then(client => new Worker(client, this._targetInfo.url, () => {} /* consoleAPICalled */, () => {} /* exceptionThrown */));
     }
     return this._workerPromise;
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "682225"
+    "chromium_revision": "686378"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/page.spec.js
+++ b/test/page.spec.js
@@ -903,7 +903,8 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer, CHR
       expect(await page.evaluate(() => __injected)).toBe(35);
     });
 
-    it_fails_ffox('should throw when added with content to the CSP page', async({page, server}) => {
+    // @see https://github.com/GoogleChrome/puppeteer/issues/4840
+    xit('should throw when added with content to the CSP page', async({page, server}) => {
       await page.goto(server.PREFIX + '/csp.html');
       let error = null;
       await page.addScriptTag({ content: 'window.__injected = 35;' }).catch(e => error = e);


### PR DESCRIPTION
This roll includes:
- https://crrev.com/685152 - [DevTools] Do not debug worker shadow pages
- https://crrev.com/683391 - [CSP] Check inline script CSP in prepare-a-script
- https://chromium-review.googlesource.com/c/v8/v8/+/1707331 - Ignore returnByValue when serializing caught value in promise rejections.