### PR TITLE
feat(chromium): roll Chromium to r682225

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -46,9 +46,8 @@ const DEFAULT_ARGS = [
   '--disable-default-apps',
   '--disable-dev-shm-usage',
   '--disable-extensions',
-  // TODO: Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
   // BlinkGenPropertyTrees disabled due to crbug.com/937609
-  '--disable-features=site-per-process,TranslateUI,BlinkGenPropertyTrees',
+  '--disable-features=TranslateUI,BlinkGenPropertyTrees',
   '--disable-hang-monitor',
   '--disable-ipc-flooding-protection',
   '--disable-popup-blocking',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=6.4.0"
   },
   "puppeteer": {
-    "chromium_revision": "681777"
+    "chromium_revision": "682225"
   },
   "scripts": {
     "unit": "node test/test.js",

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -86,7 +86,8 @@ module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowse
       await rmAsync(userDataDir).catch(e => {});
       expect(cookie).toBe('foo=true');
     });
-    it('OOPIF: should report google.com frame', async({server}) => {
+    // TODO: Support OOOPIF. @see https://github.com/GoogleChrome/puppeteer/issues/2548
+    xit('OOPIF: should report google.com frame', async({server}) => {
       // https://google.com is isolated by default in Chromium embedder.
       const browser = await puppeteer.launch(headfulOptions);
       const page = await browser.newPage();
@@ -114,6 +115,15 @@ module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowse
       // We have to interact with a page so that 'beforeunload' handlers
       // fire.
       await page.click('body');
+      await browser.close();
+    });
+    it('should open devtools when "devtools: true" option is given', async({server}) => {
+      const browser = await puppeteer.launch({...headfulOptions, devtools: true});
+      const context = await browser.createIncognitoBrowserContext();
+      await Promise.all([
+        context.newPage(),
+        context.waitForTarget(target => target.url().startsWith('devtools://')),
+      ]);
       await browser.close();
     });
   });


### PR DESCRIPTION
This roll includes:
- https://crrev.com/681997 - Turn on default SiteInstance by default.

The SiteInstance by default was breaking "devtools: true" option, so
there's a new feature we disable now by default.

This keeps pressuring us towards OOPIF support since that's an
inevitable future.