### PR TITLE
fix(firefox): fix cookies in default browser context

### DIFF
--- a/experimental/puppeteer-firefox/lib/Page.js
+++ b/experimental/puppeteer-firefox/lib/Page.js
@@ -88,7 +88,7 @@ class Page extends EventEmitter {
   async cookies(...urls) {
     const connection = Connection.fromSession(this._session);
     return (await connection.send('Browser.getCookies', {
-      browserContextId: this._target._context._browserContextId,
+      browserContextId: this._target._context._browserContextId || undefined,
       urls: urls.length ? urls : [this.url()]
     })).cookies;
   }
@@ -113,7 +113,7 @@ class Page extends EventEmitter {
 
     const connection = Connection.fromSession(this._session);
     await connection.send('Browser.deleteCookies', {
-      browserContextId: this._target._context._browserContextId,
+      browserContextId: this._target._context._browserContextId || undefined,
       cookies: items,
     });
   }
@@ -136,7 +136,7 @@ class Page extends EventEmitter {
     if (items.length) {
       const connection = Connection.fromSession(this._session);
       await connection.send('Browser.setCookies', {
-        browserContextId: this._target._context._browserContextId,
+        browserContextId: this._target._context._browserContextId || undefined,
         cookies: items
       });
     }

--- a/test/defaultbrowsercontext.spec.js
+++ b/test/defaultbrowsercontext.spec.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, puppeteer}) {
+  const {describe, xdescribe, fdescribe, describe_fails_ffox} = testRunner;
+  const {it, fit, xit, it_fails_ffox} = testRunner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
+
+  describe_fails_ffox('DefaultBrowserContext', function() {
+    beforeEach(async state => {
+      state.browser = await puppeteer.launch(defaultBrowserOptions);
+      state.page = await state.browser.newPage();
+    });
+    afterEach(async state => {
+      await state.browser.close();
+      delete state.browser;
+      delete state.page;
+    });
+    it('page.cookies() should work', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        document.cookie = 'username=John Doe';
+      });
+      expect(await page.cookies()).toEqual([{
+        name: 'username',
+        value: 'John Doe',
+        domain: 'localhost',
+        path: '/',
+        expires: -1,
+        size: 16,
+        httpOnly: false,
+        secure: false,
+        session: true
+      }]);
+    });
+    it('page.setCookie() should work', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setCookie({
+        name: 'username',
+        value: 'John Doe'
+      });
+      expect(await page.evaluate(() => document.cookie)).toBe('username=John Doe');
+      expect(await page.cookies()).toEqual([{
+        name: 'username',
+        value: 'John Doe',
+        domain: 'localhost',
+        path: '/',
+        expires: -1,
+        size: 16,
+        httpOnly: false,
+        secure: false,
+        session: true
+      }]);
+    });
+    it('page.deleteCookie() should work', async({page, server}) => {
+      await page.goto(server.EMPTY_PAGE);
+      await page.setCookie({
+        name: 'cookie1',
+        value: '1'
+      }, {
+        name: 'cookie2',
+        value: '2'
+      });
+      expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
+      await page.deleteCookie({name: 'cookie2'});
+      expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
+      expect(await page.cookies()).toEqual([{
+        name: 'cookie1',
+        value: '1',
+        domain: 'localhost',
+        path: '/',
+        expires: -1,
+        size: 8,
+        httpOnly: false,
+        secure: false,
+        session: true
+      }]);
+    });
+  });
+};

--- a/test/puppeteer.spec.js
+++ b/test/puppeteer.spec.js
@@ -155,6 +155,7 @@ module.exports.addTests = ({testRunner, product, puppeteerPath}) => {
 
   // Top-level tests that launch Browser themselves.
   require('./ignorehttpserrors.spec.js').addTests(testOptions);
+  require('./defaultbrowsercontext.spec.js').addTests(testOptions);
   require('./launcher.spec.js').addTests(testOptions);
   require('./fixtures.spec.js').addTests(testOptions);
   if (CHROME) {


### PR DESCRIPTION
This patch adds tests and fixes the nodejs part of the problem.
The issue will be fixed once we roll a new version of Firefox.

References #4470