### PR TITLE
test: fix tests to work on node6

### DIFF
--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -118,11 +118,11 @@ module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowse
       await browser.close();
     });
     it('should open devtools when "devtools: true" option is given', async({server}) => {
-      const browser = await puppeteer.launch({...headfulOptions, devtools: true});
+      const browser = await puppeteer.launch(Object.assign({devtools: true}, headfulOptions));
       const context = await browser.createIncognitoBrowserContext();
       await Promise.all([
         context.newPage(),
-        context.waitForTarget(target => target.url().startsWith('devtools://')),
+        context.waitForTarget(target => target.url().includes('devtools://')),
       ]);
       await browser.close();
     });


### PR DESCRIPTION
Our magical node6 transpiler can't handle object spreads :(

Drive-by: use "includes" instead of "startsWith" for devtools URL
since I remember that it used to be "chrome-devtools://", and somehow
I saw it as "devtools://" somewhere.