### PR TITLE
Fix missing package in Docker instructions

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -267,7 +267,7 @@ FROM node:10-slim
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`ttf-freefont` is gone -- looks like it's [replaced](https://packages.debian.org/search?keywords=ttf-freefont) by `fonts-freefont-ttf`, which is [available since oldoldstable](https://packages.debian.org/search?keywords=fonts-freefont-ttf).