### PR TITLE
Use arrow function for default this._closeCallback #3829

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -50,7 +50,7 @@ class Browser extends EventEmitter {
     this._process = process;
     this._screenshotTaskQueue = new TaskQueue();
     this._connection = connection;
-    this._closeCallback = closeCallback || new Function();
+    this._closeCallback = closeCallback || (() => {});
 
     this._defaultContext = new BrowserContext(this._connection, this, null);
     /** @type {Map<string, BrowserContext>} */


### PR DESCRIPTION
`browser.close()` is blocked when used with `readline` in a specific way. 
this issue can be fixed if default value of `this._closeCallback` is assigned with an anonymous function by the arrow function, rather than function constructor.   