### PR TITLE
fix(network): handle newline delimited headers in request interception

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3494,7 +3494,7 @@ ResourceType will be one of the following: `document`, `stylesheet`, `image`, `m
 #### request.respond(response)
 - `response` <[Object]> Response that will fulfill this request
   - `status` <[number]> Response status code, defaults to `200`.
-  - `headers` <[Object]> Optional response headers. Header values will be converted to a string.
+  - `headers` <[Object]> Optional response headers. Header values will be converted to a string. To set multiple values for the same header, separate them with a line break. For example, for setting multiple cookies: `'Set-Cookie': 'a=1\nb=2'`.
   - `contentType` <[string]> If set, equals to setting `Content-Type` response header
   - `body` <[string]|[Buffer]> Optional response body
 - returns: <[Promise]>

--- a/lib/NetworkManager.js
+++ b/lib/NetworkManager.js
@@ -718,8 +718,10 @@ class SecurityDetails {
 function headersArray(headers) {
   const result = [];
   for (const name in headers) {
-    if (!Object.is(headers[name], undefined))
-      result.push({name, value: headers[name] + ''});
+    if (!Object.is(headers[name], undefined)) {
+      for (const value of (headers[name] + '').split('\n'))
+        result.push({name, value});
+    }
   }
   return result;
 }


### PR DESCRIPTION
The current behavior of `\n` in headers seems to, somewhere down the line, screw up chrome's idea of whether a request is complete. Page navigation will hang until it times out.

Since the existing behavior for returned header models on request and response objects is to join same named headers with a line break (`\n`) as a `Record<string, string>`. Seems like at the very least `request.respond` and `request.continue` should accept `\n`s without crashing. `\n` is an illegal character in http headers, so it's safe to assume they mean the header value is a list. 

This change allow multiple headers to be passed through in `request.respond` and partially fixes `request.continue`

Partial fix for #1893 (related to  #4379)