### PR TITLE
docs(troubleshooting.md): Update travis examples

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -191,7 +191,27 @@ Tips-n-tricks:
   proper sandboxing
 - [xvfb](https://en.wikipedia.org/wiki/Xvfb) should be launched in order to run Chromium in non-headless mode (e.g. to test Chrome Extensions)
 
-To sum up, your `.travis.yml` might look like this:
+To sum up, your `.travis.yml` might look like this with Bionic:
+
+```yml
+language: node_js
+dist: bionic
+services:
+  - xvfb
+notifications:
+  email: false
+cache:
+  directories:
+    - node_modules
+# allow headful tests
+before_install:
+  # Enable user namespace cloning
+  - "sysctl kernel.unprivileged_userns_clone=1"
+  # Launch XVFB
+  - "export DISPLAY=:99.0"
+```
+
+and this with Trusty:
 
 ```yml
 language: node_js


### PR DESCRIPTION
For the last two days, travis builds using trusty have been failing to install google chrome when configured to do so with:

```yaml
addons:
  chrome: stable
```
https://stackoverflow.com/questions/57903415/travis-ci-chrome-62-instead-of-77
https://github.com/travis-ci/travis-ci/issues/9361

This will probably be fixed in time, but it prompted me to update to the latest LTS distribution (bionic) in my project.

The troubleshooting guide still only gives an example using trusty, so I've updated it with instructions that reflect how a configuration with bionic works.

It's the same except xvfb is started as a service, and libnss3 isn't installed