### PR TITLE
Module not found error can't resolve 'ws' in puppeteer-core/lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "browser": {
     "./lib/BrowserFetcher.js": false,
     "./node6/lib/Puppeteer": false,
-    "ws": "./utils/browser/WebSocket",
+    "ws": "./node_modules/ws",
     "fs": false,
     "child_process": false,
     "rimraf": false,


### PR DESCRIPTION
npm run bundle has a problem about loss module ws,so i corret the ws module path,then it now ok.