### PR TITLE
fix(footnote): fix typo in Launcher.js

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -133,7 +133,7 @@ class Launcher {
         chromeExecutable,
         chromeArguments,
         {
-          // On non-windows platforms, `detached: false` makes child process a leader of a new
+          // On non-windows platforms, `detached: true` makes child process a leader of a new
           // process group, making it possible to kill child process tree with `.kill(-pid)` command.
           // @see https://nodejs.org/api/child_process.html#child_process_options_detached
           detached: process.platform !== 'win32',


### PR DESCRIPTION
The original comment says
>  "On non-windows platforms, `detached: false` makes child process a leader of a new process group". 

However, the [Node.js documents](https://nodejs.org/api/child_process.html#child_process_options_detached) say 
> "On non-Windows platforms, if options.detached is set to true, the child process will be made the leader of a new process group and session.". 

so `detached: false` should be `detached: true`.