### PR TITLE
chore: bump https-proxy-agent to mitigate a security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "debug": "^4.1.0",
     "extract-zip": "^1.6.6",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^3.0.0",
     "mime": "^2.0.3",
     "progress": "^2.0.1",
     "proxy-from-env": "^1.0.0",


### PR DESCRIPTION
Context: 
* https://github.com/TooTallNate/node-https-proxy-agent/issues/78
* https://app.snyk.io/test/npm/https-proxy-agent/2.2.2
* https://hackerone.com/reports/541502

According to [release notes](https://github.com/TooTallNate/node-https-proxy-agent/releases/tag/3.0.0), the bump should not bring any breaking changes for Puppeteer. I believe it can get shipped with the next patch release.