### PR TITLE
feat(page): introduce newPage in background

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -718,7 +718,7 @@ Indicates that the browser is connected.
 
 #### browser.newPage([options])
 - `options` <[Object]>
-  - `background` <[boolean]> Defaults to `false`. Whether to run open the new page in background or not.
+  - `background` <[boolean]> Defaults to `false`. Whether to run open the new page in the background or not.
 - returns: <[Promise]<[Page]>>
 
 Promise which resolves to a new [Page] object. The [Page] is created in a default browser context.
@@ -849,7 +849,7 @@ The default browser context is the only non-incognito browser context.
 
 #### browserContext.newPage([options])
 - `options` <[Object]>
-  - `background` <[boolean]> Defaults to `false`. Whether to run open the new page in background or not.
+  - `background` <[boolean]> Defaults to `false`. Whether to run open the new page in the background or not.
 - returns: <[Promise]<[Page]>>
 
 Creates a new page in the browser context.

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,7 @@
   * [browser.defaultBrowserContext()](#browserdefaultbrowsercontext)
   * [browser.disconnect()](#browserdisconnect)
   * [browser.isConnected()](#browserisconnected)
-  * [browser.newPage()](#browsernewpage)
+  * [browser.newPage([options])](#browsernewpageoptions)
   * [browser.pages()](#browserpages)
   * [browser.process()](#browserprocess)
   * [browser.target()](#browsertarget)
@@ -64,7 +64,7 @@
   * [browserContext.clearPermissionOverrides()](#browsercontextclearpermissionoverrides)
   * [browserContext.close()](#browsercontextclose)
   * [browserContext.isIncognito()](#browsercontextisincognito)
-  * [browserContext.newPage()](#browsercontextnewpage)
+  * [browserContext.newPage([options])](#browsercontextnewpageoptions)
   * [browserContext.overridePermissions(origin, permissions)](#browsercontextoverridepermissionsorigin-permissions)
   * [browserContext.pages()](#browsercontextpages)
   * [browserContext.targets()](#browsercontexttargets)
@@ -716,7 +716,9 @@ Disconnects Puppeteer from the browser, but leaves the Chromium process running.
 
 Indicates that the browser is connected.
 
-#### browser.newPage()
+#### browser.newPage([options])
+- `options` <[Object]>
+  - `background` <[boolean]> Defaults to `false`. Whether to run open the new page in background or not.
 - returns: <[Promise]<[Page]>>
 
 Promise which resolves to a new [Page] object. The [Page] is created in a default browser context.
@@ -845,7 +847,9 @@ The default browser context is the only non-incognito browser context.
 
 > **NOTE** the default browser context cannot be closed.
 
-#### browserContext.newPage()
+#### browserContext.newPage([options])
+- `options` <[Object]>
+  - `background` <[boolean]> Defaults to `false`. Whether to run open the new page in background or not.
 - returns: <[Promise]<[Page]>>
 
 Creates a new page in the browser context.

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -160,19 +160,23 @@ class Browser extends EventEmitter {
   }
 
   /**
+   * @param {{background?: boolean}=} options
    * @return {!Promise<!Puppeteer.Page>}
    */
-  async newPage() {
-    return this._defaultContext.newPage();
+  newPage(options = {}) {
+    return this._defaultContext.newPage(options);
   }
 
   /**
    * @param {?string} contextId
    * @return {!Promise<!Puppeteer.Page>}
    */
-  async _createPageInContext(contextId) {
-    const {targetId} = await this._connection.send('Target.createTarget', {url: 'about:blank', browserContextId: contextId || undefined});
-    const target = await this._targets.get(targetId);
+  async _createPageInContext(contextId, options) {
+    const {
+      background = false
+    } = options;
+    const {targetId} = await this._connection.send('Target.createTarget', {url: 'about:blank', browserContextId: contextId || undefined, background});
+    const target = this._targets.get(targetId);
     assert(await target._initializedPromise, 'Failed to create target for page');
     const page = await target.page();
     return page;
@@ -361,10 +365,11 @@ class BrowserContext extends EventEmitter {
   }
 
   /**
+   * @param {{background?: boolean}=} options
    * @return {!Promise<!Puppeteer.Page>}
    */
-  newPage() {
-    return this._browser._createPageInContext(this._id);
+  newPage(options = {}) {
+    return this._browser._createPageInContext(this._id, options);
   }
 
   /**

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -26,7 +26,7 @@ const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
 
 module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowserOptions}) {
-  const {describe, xdescribe, fdescribe} = testRunner;
+  const {describe, xdescribe, fdescribe, it_fails_ffox} = testRunner;
   const {it, fit, xit} = testRunner;
   const {beforeAll, beforeEach, afterAll, afterEach} = testRunner;
 
@@ -144,6 +144,20 @@ module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowse
 
       await page1.close();
       await page2.close();
+      await browser.close();
+    });
+  });
+
+  describe('Page.newPage', function() {
+    it_fails_ffox('newPage in background', async() => {
+      const browser = await puppeteer.launch(headfulOptions);
+
+      const pageInFront = await browser.newPage();
+      expect(await pageInFront.evaluate(() => document.visibilityState)).toBe('visible');
+
+      const pageInBackground = await browser.newPage({background: true});
+      expect(await pageInBackground.evaluate(() => document.visibilityState)).toBe('hidden');
+
       await browser.close();
     });
   });

--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -149,7 +149,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer, defaultBrowse
   });
 
   describe('Page.newPage', function() {
-    it_fails_ffox('newPage in background', async() => {
+    it_fails_ffox('newPage in background', async () => {
       const browser = await puppeteer.launch(headfulOptions);
 
       const pageInFront = await browser.newPage();


### PR DESCRIPTION
closes #5025 

This flag didn´t work for me in headless mode, so I added the test on the headful spec.
I could also have added the [newWindow](https://chromedevtools.github.io/devtools-protocol/tot/Target#method-createTarget) flag, but I don´t know what that could be tested.