### PR TITLE
test: improve accessibility tests with autofocus

### DIFF
--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -42,6 +42,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
         </select>
       </body>`);
 
+      await page.focus('[placeholder="Empty input"]');
       const golden = FFOX ? {
         role: 'document',
         name: 'Accessibility Test',
@@ -81,6 +82,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
     });
     it('should report uninteresting nodes', async function({page}) {
       await page.setContent(`<textarea autofocus>hi</textarea>`);
+      await page.focus('textarea');
       const golden = FFOX ? {
         role: 'entry',
         name: '',


### PR DESCRIPTION
When trying to roll [puppeteer-sharp](https://github.com/kblok/puppeteer-sharp) to chromium r705776, I started getting many fails on these two tests.
I found that I'm getting the same running these tests on puppeteer locally. It seems that the inputs are not being autofocused sometimes, so the `focused` is false.
I saw that puppeteer's PRs are being merged in green, but I also saw these errors on intermediate builds [1](https://cirrus-ci.com/task/5965400315002880), [2](https://cirrus-ci.com/task/5702468658266112), [3](https://cirrus-ci.com/task/4976328738078720).

We could merge this PR, because accessibility tests are not about autofocusing with setContent, but we would also be hiding this issue on  r705776.