### PR TITLE
style(page): Refactored code to remove redundancy

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -892,10 +892,8 @@ class Page extends EventEmitter {
       screenshotType = options.type;
     } else if (options.path) {
       const mimeType = mime.getType(options.path);
-      if (mimeType === 'image/png')
-        screenshotType = 'png';
-      else if (mimeType === 'image/jpeg')
-        screenshotType = 'jpeg';
+      const mimeMatch = mimeType.match(/^image\/(png|jpeg)$/);
+      screenshotType = Array.isArray(mimeMatch) ? mimeMatch[1] || null : null;
       assert(screenshotType, 'Unsupported screenshot mime type: ' + mimeType);
     }
 

--- a/test/accessibility.spec.js
+++ b/test/accessibility.spec.js
@@ -42,6 +42,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
         </select>
       </body>`);
 
+      await page.focus('[placeholder="Empty input"]');
       const golden = FFOX ? {
         role: 'document',
         name: 'Accessibility Test',
@@ -81,6 +82,7 @@ module.exports.addTests = function({testRunner, expect, FFOX}) {
     });
     it('should report uninteresting nodes', async function({page}) {
       await page.setContent(`<textarea autofocus>hi</textarea>`);
+      await page.focus('textarea');
       const golden = FFOX ? {
         role: 'entry',
         name: '',


### PR DESCRIPTION
There were multiple if block in the logic that can be ironed
out into a single statement, which is much more robust and readable.