### PR TITLE
[WIP] fix: browser.close() yield once close is complete

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -40,6 +40,7 @@
   * [browserFetcher.revisionInfo(revision)](#browserfetcherrevisioninforevision)
 - [class: Browser](#class-browser)
   * [event: 'disconnected'](#event-disconnected)
+  * [event: 'disconnecting'](#event-disconnecting)
   * [event: 'targetchanged'](#event-targetchanged)
   * [event: 'targetcreated'](#event-targetcreated)
   * [event: 'targetdestroyed'](#event-targetdestroyed)
@@ -658,7 +659,10 @@ const puppeteer = require('puppeteer');
 })();
 ```
 #### event: 'disconnected'
-Emitted when Puppeteer gets disconnected from the Chromium instance. This might happen because of one of the following:
+Emitted when Puppeteer gets disconnected from the Chromium instance.  This happens once [`browser.disconnect`](#browserdisconnect) method completes
+
+#### event: 'disconnecting'
+Emitted when Puppeteer starts disconnecting from the Chromium instance. This might happen because of one of the following:
 - Chromium is closed or crashed
 - The [`browser.disconnect`](#browserdisconnect) method was called
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -718,6 +718,7 @@ Creates a new incognito browser context. This won't share cookies/cache with oth
 Returns the default browser context. The default browser context can not be closed.
 
 #### browser.disconnect()
+- returns: <[Promise]<[void]>>
 
 Disconnects Puppeteer from the browser, but leaves the Chromium process running. After calling `disconnect`, the [Browser] object is considered disposed and cannot be used anymore.
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -250,12 +250,18 @@ class Browser extends EventEmitter {
     const version = await this._getVersion();
     return version.userAgent;
   }
-
+  
+  /**
+   * @return {!Promise<void>}
+   */
   async close() {
     await this._closeCallback.call(null);
     await this.disconnect();
   }
 
+  /**
+   * @return {!Promise<void>}
+   */
   async disconnect() {
     await this._connection.dispose();
   }

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -251,17 +251,11 @@ class Browser extends EventEmitter {
     return version.userAgent;
   }
 
-  /**
-   * @return {!Promise<void>} Resolves once browser has disconnected
-   */
   async close() {
     await this._closeCallback.call(null);
     await this.disconnect();
   }
 
-  /**
-   * @return {!Promise<void>} Resolves after connection is disposed
-   */
   async disconnect() {
     await this._connection.dispose();
   }

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -257,6 +257,7 @@ class Browser extends EventEmitter {
   }
 
   async disconnect() {
+    this.emit(Events.Browser.Disconnecting)
     await this._connection.dispose();
   }
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -253,11 +253,11 @@ class Browser extends EventEmitter {
 
   async close() {
     await this._closeCallback.call(null);
-    this.disconnect();
+    await this.disconnect();
   }
 
-  disconnect() {
-    this._connection.dispose();
+  async disconnect() {
+    await this._connection.dispose();
   }
 
   /**

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -257,7 +257,7 @@ class Browser extends EventEmitter {
   }
 
   async disconnect() {
-    this.emit(Events.Browser.Disconnecting)
+    this.emit(Events.Browser.Disconnecting);
     await this._connection.dispose();
   }
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -252,7 +252,7 @@ class Browser extends EventEmitter {
   }
 
   /**
-   * @return {!Promise<void>}
+   * @return {!Promise<void>} Resolves once browser has disconnected
    */
   async close() {
     await this._closeCallback.call(null);
@@ -260,7 +260,7 @@ class Browser extends EventEmitter {
   }
 
   /**
-   * @return {!Promise<void>}
+   * @return {!Promise<void>} Resolves after connection is disposed
    */
   async disconnect() {
     await this._connection.dispose();

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -250,7 +250,7 @@ class Browser extends EventEmitter {
     const version = await this._getVersion();
     return version.userAgent;
   }
-  
+
   /**
    * @return {!Promise<void>}
    */

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -140,9 +140,9 @@ class Connection extends EventEmitter {
     this.emit(Events.Connection.Disconnected);
   }
 
-  dispose() {
+  async dispose() {
     this._onClose();
-    this._transport.close();
+    await this._transport.close();
   }
 
   /**

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -136,13 +136,13 @@ class Connection extends EventEmitter {
     for (const session of this._sessions.values())
       session._onClosed();
     this._sessions.clear();
-    this.emit(Events.Connection.Disconnected);
   }
 
   async dispose() {
     this._onClose();
     await this._transport.close();
     this._closed = true;
+    this.emit(Events.Connection.Disconnected);
   }
 
   /**

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -128,7 +128,6 @@ class Connection extends EventEmitter {
   _onClose() {
     if (this._closed)
       return;
-    this._closed = true;
     this._transport.onmessage = null;
     this._transport.onclose = null;
     for (const callback of this._callbacks.values())
@@ -143,6 +142,7 @@ class Connection extends EventEmitter {
   async dispose() {
     this._onClose();
     await this._transport.close();
+    this._closed = true;
   }
 
   /**

--- a/lib/Events.js
+++ b/lib/Events.js
@@ -42,7 +42,8 @@ const Events = {
     TargetCreated: 'targetcreated',
     TargetDestroyed: 'targetdestroyed',
     TargetChanged: 'targetchanged',
-    Disconnected: 'disconnected'
+    Disconnected: 'disconnected',
+    Disconnecting: 'disconnecting',
   },
 
   BrowserContext: {

--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -43,10 +43,13 @@ class WebSocketTransport {
       if (this.onmessage)
         this.onmessage.call(null, event.data);
     });
-    this._ws.addEventListener('close', event => {
-      if (this.onclose)
-        this.onclose.call(null);
-    });
+    this._closed = new Promise(resolve => {
+      this._ws.addEventListener('close', event => {
+        if (this.onclose)
+          this.onclose.call(null);
+        resolve();
+      });
+    })
     // Silently ignore all errors - we don't know what to do with them.
     this._ws.addEventListener('error', () => {});
     this.onmessage = null;
@@ -60,8 +63,9 @@ class WebSocketTransport {
     this._ws.send(message);
   }
 
-  close() {
+  async close() {
     this._ws.close();
+    await this._closed;
   }
 }
 

--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -49,7 +49,7 @@ class WebSocketTransport {
           this.onclose.call(null);
         resolve();
       });
-    })
+    });
     // Silently ignore all errors - we don't know what to do with them.
     this._ws.addEventListener('error', () => {});
     this.onmessage = null;

--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -43,7 +43,7 @@ class WebSocketTransport {
       if (this.onmessage)
         this.onmessage.call(null, event.data);
     });
-    this._closed = new Promise(resolve => {
+    this._closePromise = new Promise(resolve => {
       this._ws.addEventListener('close', event => {
         if (this.onclose)
           this.onclose.call(null);
@@ -65,7 +65,7 @@ class WebSocketTransport {
 
   async close() {
     this._ws.close();
-    await this._closed;
+    await this._closePromise;
   }
 }
 

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -57,7 +57,7 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer, CHR
       const browserWSEndpoint = browser.wsEndpoint();
       const remoteBrowser = await puppeteer.connect({browserWSEndpoint});
       expect(remoteBrowser.process()).toBe(null);
-      remoteBrowser.disconnect();
+      await remoteBrowser.disconnect();
     });
   });
 
@@ -66,7 +66,7 @@ module.exports.addTests = function({testRunner, expect, headless, puppeteer, CHR
       const browserWSEndpoint = browser.wsEndpoint();
       const newBrowser = await puppeteer.connect({browserWSEndpoint});
       expect(newBrowser.isConnected()).toBe(true);
-      newBrowser.disconnect();
+      await newBrowser.disconnect();
       expect(newBrowser.isConnected()).toBe(false);
     });
   });

--- a/test/browsercontext.spec.js
+++ b/test/browsercontext.spec.js
@@ -149,7 +149,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       });
       const contexts = remoteBrowser.browserContexts();
       expect(contexts.length).toBe(2);
-      remoteBrowser.disconnect();
+      await remoteBrowser.disconnect();
       await context.close();
     });
   });

--- a/test/chromiumonly.spec.js
+++ b/test/chromiumonly.spec.js
@@ -84,13 +84,13 @@ module.exports.addLauncherTests = function({testRunner, expect, defaultBrowserOp
         await page.close();
         await browser.close();
       });
-      it('should fire "disconnected" when closing with pipe', async() => {
+      it('should fire "disconnecting" when closing with pipe', async() => {
         const options = Object.assign({pipe: true}, defaultBrowserOptions);
         const browser = await puppeteer.launch(options);
-        const disconnectedEventPromise = new Promise(resolve => browser.once('disconnected', resolve));
+        const disconnectingEventPromise = new Promise(resolve => browser.once('disconnecting', resolve));
         // Emulate user exiting browser.
         browser.process().kill();
-        await disconnectedEventPromise;
+        await disconnectingEventPromise;
       });
     });
 

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -66,7 +66,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
       });
       const browser = await puppeteer.connect({ browserWSEndpoint: await wsEndPointPromise });
       const promises = [
-        new Promise(resolve => browser.once('disconnected', resolve)),
+        new Promise(resolve => browser.once('disconnecting', resolve)),
         new Promise(resolve => res.on('close', resolve))
       ];
       if (process.platform === 'win32')

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -67,7 +67,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         const page = await remote.newPage();
         const navigationPromise = page.goto(server.PREFIX + '/one-style.html', {timeout: 60000}).catch(e => e);
         await server.waitForRequest('/one-style.css');
-        remote.disconnect();
+        await remote.disconnect();
         const error = await navigationPromise;
         expect(error.message).toBe('Navigation failed because browser has disconnected!');
         await browser.close();
@@ -78,7 +78,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         const remote = await puppeteer.connect({browserWSEndpoint: browser.wsEndpoint()});
         const page = await remote.newPage();
         const watchdog = page.waitForSelector('div', {timeout: 60000}).catch(e => e);
-        remote.disconnect();
+        await remote.disconnect();
         const error = await watchdog;
         expect(error.message).toContain('Protocol error');
         await browser.close();
@@ -283,7 +283,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         });
         const page = await browser.newPage();
         expect(await page.evaluate(() => 7 * 8)).toBe(56);
-        browser.disconnect();
+        await browser.disconnect();
 
         const secondPage = await originalBrowser.newPage();
         expect(await secondPage.evaluate(() => 7 * 6)).toBe(42, 'original browser should still work');
@@ -323,7 +323,7 @@ module.exports.addTests = function({testRunner, expect, defaultBrowserOptions, p
         const browserWSEndpoint = originalBrowser.wsEndpoint();
         const page = await originalBrowser.newPage();
         await page.goto(server.PREFIX + '/frames/nested-frames.html');
-        originalBrowser.disconnect();
+        await originalBrowser.disconnect();
 
         const browser = await puppeteer.connect({browserWSEndpoint});
         const pages = await browser.pages();


### PR DESCRIPTION
Status: sort of trying to fix this....

----

- `WebSocketTransport.close()` resolves after `closed` event
- **`Connection._closed` is true and `Events.Connection.Closed` is only emitted once transport has finished closing**
- `Browser.isConnected()` / `Browser.close()` use awaited underlying closes
- new `Events.Browser.Disconnecting` and **`Events.Browser.Disconnected` does not fire when process is killed** (because atexit stuff cannot await)