### PR TITLE
fix: don’t disable BlinkGenPropertyTrees anymore

### DIFF
--- a/lib/Launcher.js
+++ b/lib/Launcher.js
@@ -268,8 +268,7 @@ class ChromeLauncher {
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',
-      // BlinkGenPropertyTrees disabled due to crbug.com/937609
-      '--disable-features=TranslateUI,BlinkGenPropertyTrees',
+      '--disable-features=TranslateUI',
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',


### PR DESCRIPTION
Ref. #5080.