### PR TITLE
feat: Improve error reporting on AArch64

### DIFF
--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -158,32 +158,14 @@ class BrowserFetcher {
     if (!(await existsAsync(this._downloadsFolder)))
       await mkdirAsync(this._downloadsFolder);
     try {
-      if (os.arch() === 'arm64'){
-        fs.stat('/usr/bin/chromium-browser', function(err, stats) {
-          if (stats === undefined){
-            console.error('Chromium Binary is not available for aarch64, Download it manually.');
-            const result = require('child_process').execSync('cat /etc/lsb-release | grep -in "DISTRIB_ID" | cut -f 2 -s -d =').toString().trim();
-            if (result === 'Ubuntu'){
-              console.error(' You can install with: ');
-              console.error('\n apt-get install chromium-browser\n');
-            } else {
-              console.error('\n');
-            }
-            throw new Error();
-          }
-        });
-      } else {
-        await downloadFile(url, zipPath, progressCallback);
-        await extractZip(zipPath, folderPath);
-      }
+      await downloadFile(url, zipPath, progressCallback);
+      await extractZip(zipPath, folderPath);
     } finally {
-      if (os.arch() !== 'arm64'){
-        if (await existsAsync(zipPath))
-          await unlinkAsync(zipPath);
-      }
+      if (await existsAsync(zipPath))
+        await unlinkAsync(zipPath);
     }
     const revisionInfo = this.revisionInfo(revision);
-    if (revisionInfo && os.arch() !== 'arm64')
+    if (revisionInfo)
       await chmodAsync(revisionInfo.executablePath, 0o755);
     return revisionInfo;
   }

--- a/install.js
+++ b/install.js
@@ -25,6 +25,7 @@
  */
 
 const compileTypeScriptIfRequired = require('./typescript-if-required');
+const os = require('os');
 
 const firefoxVersions =
   'https://product-details.mozilla.org/1.0/firefox_versions.json';
@@ -99,9 +100,11 @@ async function download() {
      * @return {!Promise}
      */
     function onSuccess(localRevisions) {
-      logPolitely(
-        `${supportedProducts[product]} (${revisionInfo.revision}) downloaded to ${revisionInfo.folderPath}`
-      );
+      if (os.arch() !== 'arm64') {
+        logPolitely(
+          `${supportedProducts[product]} (${revisionInfo.revision}) downloaded to ${revisionInfo.folderPath}`
+        );
+      }
       localRevisions = localRevisions.filter(
         (revision) => revision !== revisionInfo.revision
       );

--- a/src/BrowserFetcher.ts
+++ b/src/BrowserFetcher.ts
@@ -232,16 +232,16 @@ export class BrowserFetcher {
     if (os.arch() === 'arm64') {
       await handleArm64();
       return;
-    } else {
-      try {
-        await downloadFile(url, archivePath, progressCallback);
-        await install(archivePath, outputPath);
-      } finally {
-        if (await existsAsync(archivePath)) await unlinkAsync(archivePath);
-      }
-      const revisionInfo = this.revisionInfo(revision);
-      if (revisionInfo) await chmodAsync(revisionInfo.executablePath, 0o755);
-      return revisionInfo;
+    }
+    try {
+      await downloadFile(url, archivePath, progressCallback);
+      await install(archivePath, outputPath);
+    } finally {
+      if (await existsAsync(archivePath)) await unlinkAsync(archivePath);
+    }
+    const revisionInfo = this.revisionInfo(revision);
+    if (revisionInfo) await chmodAsync(revisionInfo.executablePath, 0o755);
+    return revisionInfo;
     }
   }
 

--- a/src/BrowserFetcher.ts
+++ b/src/BrowserFetcher.ts
@@ -230,7 +230,7 @@ export class BrowserFetcher {
     if (!(await existsAsync(this._downloadsFolder)))
       await mkdirAsync(this._downloadsFolder);
     if (os.arch() === 'arm64') {
-      await handleArm64();
+      handleArm64();
       return;
     }
     try {

--- a/src/BrowserFetcher.ts
+++ b/src/BrowserFetcher.ts
@@ -242,7 +242,6 @@ export class BrowserFetcher {
     const revisionInfo = this.revisionInfo(revision);
     if (revisionInfo) await chmodAsync(revisionInfo.executablePath, 0o755);
     return revisionInfo;
-    }
   }
 
   async localRevisions(): Promise<string[]> {

--- a/src/Launcher.ts
+++ b/src/Launcher.ts
@@ -106,7 +106,9 @@ class ChromeLauncher implements ProductLauncher {
     }
 
     let chromeExecutable = executablePath;
-    if (!executablePath) {
+    if (os.arch() === 'arm64') {
+      chromeExecutable = '/usr/bin/chromium-browser';
+    } else if (!executablePath) {
       const { missingText, executablePath } = resolveExecutablePath(this);
       if (missingText) throw new Error(missingText);
       chromeExecutable = executablePath;


### PR DESCRIPTION
This patch provides architecture check for aarch64 to use local chromium binary and works as usual with other architectures.

Fixes #5147 

