### PR TITLE
docs: Add puppeteer-loadtest to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ More complex and use case driven examples can be found at [github.com/GoogleChro
 - [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) - (almost) Zero configuration tool for setting up and running Jest and Puppeteer easily. Also includes an assertion library for Puppeteer.
 - [puppeteer-har](https://github.com/Everettss/puppeteer-har) - Generate HAR file with puppeteer.
 - [puppetry](https://puppetry.app/) - A desktop app to build Puppeteer/Jest driven tests without coding.
+- [puppeteer-loadtest](https://github.com/svenkatreddy/puppeteer-loadtest) - commandline interface for performing load test on puppeteer scripts.
 
 ## Services
 - [Checkly](https://checklyhq.com) - Monitoring SaaS that uses Puppeteer to check availability and correctness of web pages and apps.


### PR DESCRIPTION
Adding `puppeteer-loadtest` which is used to do load test on puppeteer scripts.