### PR TITLE
Updated troubleshooting.md with recommendation of using args for heroku

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -408,7 +408,7 @@ Running Puppeteer on Heroku requires some additional dependencies that aren't in
 
 The url for the buildpack is https://github.com/jontewks/puppeteer-heroku-buildpack
 
-Ensure that you're using `'--no-sandbox'` mode when launching pupeteer. You can achieve it by passing it as an argument to your `.launch()` call, like this `puppeteer.launch({args: ['--no-sandbox']});`
+Ensure that you're using `'--no-sandbox'` mode when launching Puppeteer. This can be done by passing it as an argument to your `.launch()` call: `puppeteer.launch({ args: ['--no-sandbox'] });`.
 
 When you click add buildpack, simply paste that url into the input, and click save. On the next deploy, your app will also install the dependencies that Puppeteer needs to run.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -408,6 +408,8 @@ Running Puppeteer on Heroku requires some additional dependencies that aren't in
 
 The url for the buildpack is https://github.com/jontewks/puppeteer-heroku-buildpack
 
+Ensure that you're using `'--no-sandbox'` mode when launching pupeteer. You can achieve it by passing it as an argument to your `.launch()` call, like this `puppeteer.launch({args: ['--no-sandbox']});`
+
 When you click add buildpack, simply paste that url into the input, and click save. On the next deploy, your app will also install the dependencies that Puppeteer needs to run.
 
 If you need to render Chinese, Japanese, or Korean characters you may need to use a buildpack with additional font files like https://github.com/CoffeeAndCode/puppeteer-heroku-buildpack


### PR DESCRIPTION
I decided to bring @ebidel [advice](https://github.com/puppeteer/puppeteer/issues/758#issuecomment-328906039) in #758 issue to the troubleshooting.md file, since it isn't specified explicitly, only in mentioned issue and that "simple guide" below.

This argument stuff really helped me with getting puppeteer up and running on Heroku and I was frustrated when I realized that this solution is mentioned everywhere but in troubleshooting.md

P.S.
Really thankful for such an awesome tool. I ❤️it!