### PR TITLE
docs(api.md): Adding new example to page.$$eval

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1113,6 +1113,11 @@ Examples:
 const divsCounts = await page.$$eval('div', divs => divs.length);
 ```
 
+```js
+const options = await page.$$eval('div > span.options', options => options.map(option => option.innerText));
+```
+
+
 #### page.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> A [selector] to query page for
 - `pageFunction` <[function]\([Element]\)> Function to be evaluated in browser context

--- a/docs/api.md
+++ b/docs/api.md
@@ -1110,13 +1110,12 @@ If `pageFunction` returns a [Promise], then `page.$$eval` would wait for the pro
 
 Examples:
 ```js
-const divsCounts = await page.$$eval('div', divs => divs.length);
+const divCount = await page.$$eval('div', divs => divs.length);
 ```
 
 ```js
-const options = await page.$$eval('div > span.options', options => options.map(option => option.innerText));
+const options = await page.$$eval('div > span.options', options => options.map(option => option.textContent));
 ```
-
 
 #### page.$eval(selector, pageFunction[, ...args])
 - `selector` <[string]> A [selector] to query page for


### PR DESCRIPTION
IMHO it's unclear that the second parameter actually receives the array instead of being executed for each item. Adding this example to maybe make that clear.