### PR TITLE
Require https-proxy-agent only when actually needed

### DIFF
--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -23,8 +23,6 @@ const URL = require('url');
 const {helper, assert} = require('./helper');
 const removeRecursive = require('rimraf');
 // @ts-ignore
-const ProxyAgent = require('https-proxy-agent');
-// @ts-ignore
 const getProxyForUrl = require('proxy-from-env').getProxyForUrl;
 
 const DEFAULT_DOWNLOAD_HOST = 'https://storage.googleapis.com';
@@ -285,6 +283,8 @@ function httpRequest(url, method, response) {
       const parsedProxyURL = URL.parse(proxyURL);
       parsedProxyURL.secureProxy = parsedProxyURL.protocol === 'https:';
 
+      // @ts-ignore
+      const ProxyAgent = require('https-proxy-agent');
       options.agent = new ProxyAgent(parsedProxyURL);
       options.rejectUnauthorized = false;
     }


### PR DESCRIPTION
`https-proxy-agent` patches core Node methods in `https` for whatever reason, and that breaks unrelated code. In our app we don't use proxy, and the mere fact that `puppeteeer` requires the proxy package, it breaks other code.

See TooTallNate/node-agent-base#35 and sindresorhus/got#951