### PR TITLE
chore: upgrade https-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/mime-types": "^2.1.0",
     "debug": "^4.1.0",
     "extract-zip": "^1.6.6",
-    "https-proxy-agent": "^3.0.0",
+    "https-proxy-agent": "^4.0.0",
     "mime": "^2.0.3",
     "mime-types": "^2.1.25",
     "progress": "^2.0.1",


### PR DESCRIPTION
`https-proxy-agent` requires `agent-base`, which currently monkey patches the core [https Node module](https://nodejs.org/api/https.html), causing problems in unrelated code. The latest version of `https-proxy-agent` uses the latest version of `agent-base`, which no longer does this monkey patching.

Fixes #5230.

#5224 is an alternative fix.