### PR TITLE
Update node image in Dockerfile doc 

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,7 +259,7 @@ To fix, you'll need to install the missing dependencies and the
 latest Chromium package in your Dockerfile:
 
 ```Dockerfile
-FROM node:10-slim
+FROM node:10-stretch
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer


### PR DESCRIPTION
Problem with node:10-slim since today

![image](https://user-images.githubusercontent.com/48441421/72058817-1334c300-32d1-11ea-9b2b-6defb84dfa77.png)

