### PR TITLE
Add durableStorage to allowed permissions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1094,7 +1094,7 @@ Creates a new page in the browser context.
   - `'clipboard-read'`
   - `'clipboard-write'`
   - `'payment-handler'`
-  - `'durable-storage'`
+  - `'persistent-storage'`
 - returns: <[Promise]>
 
 ```js

--- a/docs/api.md
+++ b/docs/api.md
@@ -1094,6 +1094,7 @@ Creates a new page in the browser context.
   - `'clipboard-read'`
   - `'clipboard-write'`
   - `'payment-handler'`
+  - `'durable-storage'`
 - returns: <[Promise]>
 
 ```js

--- a/src/common/Browser.ts
+++ b/src/common/Browser.ts
@@ -56,7 +56,7 @@ const WEB_PERMISSION_TO_PROTOCOL_PERMISSION = new Map<
   ['clipboard-read', 'clipboardReadWrite'],
   ['clipboard-write', 'clipboardReadWrite'],
   ['payment-handler', 'paymentHandler'],
-  ['durable-storage', 'durableStorage'],
+  ['persistent-storage', 'durableStorage'],
   ['idle-detection', 'idleDetection'],
   // chrome-specific permissions we have.
   ['midi-sysex', 'midiSysex'],
@@ -80,7 +80,7 @@ export type Permission =
   | 'clipboard-read'
   | 'clipboard-write'
   | 'payment-handler'
-  | 'durable-storage'
+  | 'persistent-storage'
   | 'idle-detection'
   | 'midi-sysex';
 

--- a/src/common/Browser.ts
+++ b/src/common/Browser.ts
@@ -56,6 +56,7 @@ const WEB_PERMISSION_TO_PROTOCOL_PERMISSION = new Map<
   ['clipboard-read', 'clipboardReadWrite'],
   ['clipboard-write', 'clipboardReadWrite'],
   ['payment-handler', 'paymentHandler'],
+  ['durable-storage', 'durableStorage'],
   ['idle-detection', 'idleDetection'],
   // chrome-specific permissions we have.
   ['midi-sysex', 'midiSysex'],
@@ -79,6 +80,7 @@ export type Permission =
   | 'clipboard-read'
   | 'clipboard-write'
   | 'payment-handler'
+  | 'durable-storage'
   | 'idle-detection'
   | 'midi-sysex';
 

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -339,12 +339,13 @@ describe('Page', function () {
         await otherContext.close();
       }
     );
-    itFailsFirefox('should grant durable-storage', async () => {
+    itFailsFirefox('should grant persistent-storage', async () => {
       const { page, server, context } = getTestState();
 
       await page.goto(server.EMPTY_PAGE);
-      await context.overridePermissions(server.EMPTY_PAGE, ['durable-storage']);
-      expect(await getPermission(page, 'durable-storage')).toBe('granted');
+      expect(await getPermission(page, 'persistent-storage')).not.toBe('granted');
+      await context.overridePermissions(server.EMPTY_PAGE, ['persistent-storage']);
+      expect(await getPermission(page, 'persistent-storage')).toBe('granted');
     });
   });
 

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -343,8 +343,12 @@ describe('Page', function () {
       const { page, server, context } = getTestState();
 
       await page.goto(server.EMPTY_PAGE);
-      expect(await getPermission(page, 'persistent-storage')).not.toBe('granted');
-      await context.overridePermissions(server.EMPTY_PAGE, ['persistent-storage']);
+      expect(await getPermission(page, 'persistent-storage')).not.toBe(
+        'granted'
+      );
+      await context.overridePermissions(server.EMPTY_PAGE, [
+        'persistent-storage',
+      ]);
       expect(await getPermission(page, 'persistent-storage')).toBe('granted');
     });
   });

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -339,6 +339,13 @@ describe('Page', function () {
         await otherContext.close();
       }
     );
+    itFailsFirefox('should grant durable-storage', async () => {
+      const { page, server, context } = getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      await context.overridePermissions(server.EMPTY_PAGE, ['durable-storage']);
+      expect(await getPermission(page, 'durable-storage')).toBe('granted');
+    });
   });
 
   describe('Page.setGeolocation', function () {


### PR DESCRIPTION
Please tell me if I've got the wrong end of the stick, I'm totally operating under guess work. I'd like to be able to use indexeddb. I've found "durableStorage" [here](https://chromium-review.googlesource.com/c/chromium/src/+/1185877/4/content/browser/devtools/protocol/browser_handler.cc#120).

I can also see it in the [dart puppeteer docs](https://pub.dev/documentation/puppeteer/latest/protocol_browser/PermissionType-class.html) (along with a bunch of others).

So I was hoping it was as simple as just adding to this list 🤞 