### PR TITLE
feat: make it possible to run `install.js` script with `puppeteer-core`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -370,6 +370,7 @@ In most cases, you'll be fine using the `puppeteer` package.
 However, you should use `puppeteer-core` if:
 - you're building another end-user product or library atop of DevTools protocol. For example, one might build a PDF generator using `puppeteer-core` and write a custom `install.js` script that downloads [`headless_shell`](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) instead of Chromium to save disk space.
 - you're bundling Puppeteer to use in Chrome Extension / browser with the DevTools protocol where downloading an additional Chromium binary is unnecessary.
+- you're building a set of tools where `puppeteer-core` is one of the ingridients and you want to postponed `install.js` script execution until Chromium is about to be used.
 
 When using `puppeteer-core`, remember to change the *include* line:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -370,7 +370,7 @@ In most cases, you'll be fine using the `puppeteer` package.
 However, you should use `puppeteer-core` if:
 - you're building another end-user product or library atop of DevTools protocol. For example, one might build a PDF generator using `puppeteer-core` and write a custom `install.js` script that downloads [`headless_shell`](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) instead of Chromium to save disk space.
 - you're bundling Puppeteer to use in Chrome Extension / browser with the DevTools protocol where downloading an additional Chromium binary is unnecessary.
-- you're building a set of tools where `puppeteer-core` is one of the ingridients and you want to postponed `install.js` script execution until Chromium is about to be used.
+- you're building a set of tools where `puppeteer-core` is one of the ingredients and you want to postpone `install.js` script execution until Chromium is about to be used.
 
 When using `puppeteer-core`, remember to change the *include* line:
 

--- a/install.js
+++ b/install.js
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+/**
+ * This file is part of public API.
+ *
+ * By default, the `puppeteer` package runs this script during the installation
+ * process unless one of the env flags is provided.
+ * `puppeteer-core` package doesn't include this step at all. However, it's
+ * still possible to install Chromium using this script when necessary.
+ */
 if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
   logPolitely('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;

--- a/install.js
+++ b/install.js
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-// puppeteer-core should not install anything.
-if (require('./package.json').name === 'puppeteer-core')
-  return;
-
 if (process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) {
   logPolitely('**INFO** Skipping Chromium download. "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD" environment variable was found.');
   return;

--- a/utils/prepare_puppeteer_core.js
+++ b/utils/prepare_puppeteer_core.js
@@ -22,4 +22,5 @@ const packagePath = path.join(__dirname, '..', 'package.json');
 const json = require(packagePath);
 
 json.name = 'puppeteer-core';
+delete json.scripts['install'];
 fs.writeFileSync(packagePath, JSON.stringify(json, null, '  '));

--- a/utils/prepare_puppeteer_core.js
+++ b/utils/prepare_puppeteer_core.js
@@ -22,5 +22,5 @@ const packagePath = path.join(__dirname, '..', 'package.json');
 const json = require(packagePath);
 
 json.name = 'puppeteer-core';
-delete json.scripts['install'];
+delete json.scripts.install;
 fs.writeFileSync(packagePath, JSON.stringify(json, null, '  '));


### PR DESCRIPTION
## Problem

At the moment, when you set `puppeteer-core` as a dependency of your project, you won't have Chromium installed as part of `npm install` run. This is great. However, the existing setup prevents 3rd party tools to run `install.js` script, which might be desired in some scenarios.

We see the growing number of complaints about Chromium download in `@wordpress/scripts` (A set of reusable scripts tailored for WordPress development) package which for many use cases is not necessary when you don’t want to use e2e tests. Some projects decide to not use this package because of the time and size factors introduced by the installation process of Chromium. We are seeking for a way to make it a non-issue. The idea is to use `puppeteer-core` and use `install.js` script only when someone opts-in for the e2e script and actually runs it.

### Related Issues

Sharing some issues from the WordPress project, which triggered this proposal:

- [Scripts: Download Puppeteer's Chromium binary on-demand](https://github.com/WordPress/gutenberg/issues/15667)
- [Scripts: Defer installation of dependencies until they are used for the first time](https://github.com/WordPress/gutenberg/issues/17987)
- [Build: Remove chromium install from common flows](https://github.com/Automattic/wp-calypso/pull/38900)

## Solution

Update `utils/prepare_puppeteer_core.js` to remove `install` from `script` section `package.json` for `puppeteer-core`. This is nearly identical to the current configuration but opens `install.js` for usage from `puppeteer-core`. At the same time, it would become a public API, so the project would have to maintain it.

It will allow starting using `puppeteer-core` as a dependency in the `@wordpress/scripts` package intended to offer zero-config reusable scripts for WordPress development. This way, folks who don't use Puppeteer in their workflows won't complain about the install process of Chromium. Instead, it should be possible to install Chromium on demand, when the script which needs it would run for the first time. The update could run whenever the version changes as part of the regular run as well.

The only inconvenience would be that other dependency which set `puppeteer` as a peer dependency would warn. Still, it's something that can be ignored and listed in the docs in the troubleshooting section.

## Open Question

Should the same change get applied to `puppeteer-firefox`? I see this guard clause:
https://github.com/puppeteer/puppeteer/blob/14b236965000c2821aece8deae72fb927ab33930/experimental/puppeteer-firefox/install.js#L19-L20

However, it's not clear for me how it would work with `puppeteer-core`.