### PR TITLE
Fix: Add mimeType to the File instance uploadFile()

### DIFF
--- a/lib/JSHandle.js
+++ b/lib/JSHandle.js
@@ -336,7 +336,7 @@ class ElementHandle extends JSHandle {
       const dt = new DataTransfer();
       for (const item of files) {
         const response = await fetch(`data:${item.mimeType};base64,${item.content}`);
-        const file = new File([await response.blob()], item.name);
+        const file = new File([await response.blob()], item.name, {type: item.mimeType});
         dt.items.add(file);
       }
       element.files = dt.files;

--- a/test/input.spec.js
+++ b/test/input.spec.js
@@ -29,6 +29,7 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       const input = await page.$('input');
       await input.uploadFile(filePath);
       expect(await page.evaluate(e => e.files[0].name, input)).toBe('file-to-upload.txt');
+      expect(await page.evaluate(e => e.files[0].type, input)).toBe('text/plain');
       expect(await page.evaluate(e => {
         const reader = new FileReader();
         const promise = new Promise(fulfill => reader.onload = fulfill);


### PR DESCRIPTION
Not having the File.type property present breaks fileUpload functionality for implementations that rely on the file mime type being set by the browser.

Was broken in release 2.1.0 by commit https://github.com/puppeteer/puppeteer/commit/6091a34a360b0b8aec4d67f6190f131d7e8e3300