### PR TITLE
Emit change event on uploadFile calls

### DIFF
--- a/lib/JSHandle.js
+++ b/lib/JSHandle.js
@@ -341,6 +341,7 @@ class ElementHandle extends JSHandle {
       }
       element.files = dt.files;
       element.dispatchEvent(new Event('input', { bubbles: true }));
+      element.dispatchEvent(new Event('change', { bubbles: true }));
     }, files);
   }
 

--- a/test/input.spec.js
+++ b/test/input.spec.js
@@ -27,8 +27,14 @@ module.exports.addTests = function({testRunner, expect, puppeteer}) {
       await page.goto(server.PREFIX + '/input/fileupload.html');
       const filePath = path.relative(process.cwd(), FILE_TO_UPLOAD);
       const input = await page.$('input');
+      await page.evaluate(e => {
+        window._inputEvents = [];
+        e.addEventListener('change', ev => window._inputEvents.push(ev.type));
+        e.addEventListener('input', ev => window._inputEvents.push(ev.type));
+      }, input);
       await input.uploadFile(filePath);
       expect(await page.evaluate(e => e.files[0].name, input)).toBe('file-to-upload.txt');
+      expect(await page.evaluate(() => window._inputEvents)).toEqual(['input', 'change']);
       expect(await page.evaluate(e => {
         const reader = new FileReader();
         const promise = new Promise(fulfill => reader.onload = fulfill);


### PR DESCRIPTION
In puppeteer 1.20.0, the following code emitted an alert:
```
const puppeteer = require('puppeteer');

(async () => {
	const browser = await puppeteer.launch({args: ['--no-sandbox'], headless: false});
	const page = (await browser.pages())[0];

	await page.setContent(`
		<input type=file>
		<script>
		document.querySelector('input').addEventListener('change', () => {
			alert('Uploaded a file');
		});
		</script>
		`);
	const input = await page.waitForSelector('input[type="file"]');
	await input.uploadFile(__filename);
})();
```

This is broken in puppeteer 2.0.0 and 2.1.0.
A bisection yielded 6091a34a360b0b8aec4d67f6190f131d7e8e3300 as the commit that broke this.

Emitting the change event as well seems to fix the problem.