### PR TITLE
Bugfix: Docker build failure

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -264,7 +264,9 @@ FROM node:10-slim
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
     && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \


### PR DESCRIPTION
The recommended Dockerfile uses `node:10-slim` image as a base,
but the base image does not contain `wget` command anymore.
(About the reason, see https://github.com/nodejs/docker-node/issues/1185)
So fixed the problem.