### PR TITLE
Remove extract-zip

### DIFF
--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -341,17 +341,28 @@ function extractZip(zipPath, folderPath) {
     const zipfile = await openZip(zipPath, { lazyEntries: true });
     const openReadStream = util.promisify(zipfile.openReadStream.bind(zipfile));
 
-    zipfile.on('end', fulfill);
+    const finishedPromises = [];
+
+    zipfile.on('end', async() => {
+      await Promise.all(finishedPromises);
+      fulfill();
+    });
     zipfile.on('error', reject);
 
     zipfile.readEntry();
     zipfile.on('entry', async entry => {
-      // Skip directories, since we'll just make them anyway
-      if (!entry.fileName.endsWith('/')) {
+      if (entry.fileName.endsWith('/')) {
+        await fs.promises.mkdir(path.resolve(folderPath, entry.fileName), { recursive: true });
+      } else {
         const filepath = path.resolve(folderPath, entry.fileName);
         await fs.promises.mkdir(path.parse(filepath).dir, { recursive: true });
+
         try {
           const stream = await openReadStream(entry);
+
+          const finishPromise = new Promise(res => stream.on('end', res));
+          finishedPromises.push(finishPromise);
+
           stream.on('error', reject);
           stream.pipe(fs.createWriteStream(filepath));
         } catch (error) {

--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -19,8 +19,7 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const childProcess = require('child_process');
-// @ts-ignore
-const yauzl = require('yauzl');
+const yauzl = require('yauzl-promise');
 const debugFetcher = require('debug')(`puppeteer:fetcher`);
 const URL = require('url');
 const {helper, assert} = require('./helper');
@@ -333,45 +332,34 @@ function install(archivePath, folderPath) {
 /**
  * @param {string} zipPath
  * @param {string} folderPath
- * @return {!Promise<?Error>}
+ * @return {Promise}
  */
-function extractZip(zipPath, folderPath) {
-  const openZip = util.promisify(yauzl.open);
-  return new Promise(async(fulfill, reject) => {
-    const zipfile = await openZip(zipPath, { lazyEntries: true });
-    const openReadStream = util.promisify(zipfile.openReadStream.bind(zipfile));
+async function extractZip(zipPath, folderPath) {
+  const zipfile = await yauzl.open(zipPath);
 
-    const finishedPromises = [];
+  const finishedPromises = [];
 
-    zipfile.on('end', async() => {
-      await Promise.all(finishedPromises);
-      fulfill();
-    });
-    zipfile.on('error', reject);
+  await zipfile.walkEntries(async entry => {
+    if (entry.fileName.endsWith('/')) {
+      await fs.promises.mkdir(path.resolve(folderPath, entry.fileName), { recursive: true });
+    } else {
+      const filepath = path.resolve(folderPath, entry.fileName);
+      await fs.promises.mkdir(path.parse(filepath).dir, { recursive: true });
 
-    zipfile.readEntry();
-    zipfile.on('entry', async entry => {
-      if (entry.fileName.endsWith('/')) {
-        await fs.promises.mkdir(path.resolve(folderPath, entry.fileName), { recursive: true });
-      } else {
-        const filepath = path.resolve(folderPath, entry.fileName);
-        await fs.promises.mkdir(path.parse(filepath).dir, { recursive: true });
+      const stream = await zipfile.openReadStream(entry);
 
-        try {
-          const stream = await openReadStream(entry);
+      const finishedPromise = new Promise((resolve, reject) => {
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      finishedPromises.push(finishedPromise);
 
-          const finishPromise = new Promise(res => stream.on('end', res));
-          finishedPromises.push(finishPromise);
-
-          stream.on('error', reject);
-          stream.pipe(fs.createWriteStream(filepath));
-        } catch (error) {
-          reject(error);
-        }
-      }
-      zipfile.readEntry();
-    });
+      stream.pipe(fs.createWriteStream(filepath));
+    }
   });
+
+  await Promise.all(finishedPromises);
+  zipfile.close();
 }
 
 /**

--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -19,7 +19,8 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const childProcess = require('child_process');
-const extract = require('extract-zip');
+// @ts-ignore
+const yauzl = require('yauzl');
 const debugFetcher = require('debug')(`puppeteer:fetcher`);
 const URL = require('url');
 const {helper, assert} = require('./helper');
@@ -335,12 +336,31 @@ function install(archivePath, folderPath) {
  * @return {!Promise<?Error>}
  */
 function extractZip(zipPath, folderPath) {
-  return new Promise((fulfill, reject) => extract(zipPath, {dir: folderPath}, err => {
-    if (err)
-      reject(err);
-    else
-      fulfill();
-  }));
+  const openZip = util.promisify(yauzl.open);
+  return new Promise(async(fulfill, reject) => {
+    const zipfile = await openZip(zipPath, { lazyEntries: true });
+    const openReadStream = util.promisify(zipfile.openReadStream.bind(zipfile));
+
+    zipfile.on('end', fulfill);
+    zipfile.on('error', reject);
+
+    zipfile.readEntry();
+    zipfile.on('entry', async entry => {
+      // Skip directories, since we'll just make them anyway
+      if (!entry.fileName.endsWith('/')) {
+        const filepath = path.resolve(folderPath, entry.fileName);
+        await fs.promises.mkdir(path.parse(filepath).dir, { recursive: true });
+        try {
+          const stream = await openReadStream(entry);
+          stream.on('error', reject);
+          stream.pipe(fs.createWriteStream(filepath));
+        } catch (error) {
+          reject(error);
+        }
+      }
+      zipfile.readEntry();
+    });
+  });
 }
 
 /**

--- a/lib/BrowserFetcher.js
+++ b/lib/BrowserFetcher.js
@@ -344,7 +344,7 @@ async function extractZip(zipPath, folderPath) {
       await fs.promises.mkdir(path.resolve(folderPath, entry.fileName), { recursive: true });
     } else {
       const filepath = path.resolve(folderPath, entry.fileName);
-      await fs.promises.mkdir(path.parse(filepath).dir, { recursive: true });
+      await fs.promises.mkdir(path.dirname(filepath), { recursive: true });
 
       const stream = await zipfile.openReadStream(entry);
 

--- a/package.json
+++ b/package.json
@@ -40,17 +40,16 @@
     "rimraf": "^3.0.2",
     "tar-fs": "^2.0.0",
     "unbzip2-stream": "^1.3.3",
-    "ws": "^6.1.0",
-    "yauzl": "^2.10.0"
+    "ws": "^6.1.0"
   },
   "devDependencies": {
     "@types/debug": "0.0.31",
-    "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.0",
     "@types/node": "^10.17.14",
     "@types/rimraf": "^2.0.2",
     "@types/tar-fs": "^1.16.2",
     "@types/ws": "^6.0.1",
+    "@types/yauzl-promise": "^2.1.0",
     "commonmark": "^0.28.1",
     "cross-env": "^5.0.5",
     "eslint": "^5.15.1",
@@ -61,7 +60,8 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "3.2.2"
+    "typescript": "3.2.2",
+    "yauzl-promise": "^2.1.3"
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@types/mime-types": "^2.1.0",
     "debug": "^4.1.0",
-    "extract-zip": "^1.6.6",
     "https-proxy-agent": "^4.0.0",
     "mime": "^2.0.3",
     "mime-types": "^2.1.25",
@@ -41,7 +40,8 @@
     "rimraf": "^3.0.2",
     "tar-fs": "^2.0.0",
     "unbzip2-stream": "^1.3.3",
-    "ws": "^6.1.0"
+    "ws": "^6.1.0",
+    "yauzl": "^2.10.0"
   },
   "devDependencies": {
     "@types/debug": "0.0.31",


### PR DESCRIPTION
Use `yauzl` directly since `extract-zip` seems to be abandonware and has some security issues through the `mkdirp` package. Since `extract-zip` was already using `yauzl`, so this just overall cuts down on packages.

Fixes: #5522 #5513 (and maybe some other ones)

Note that I'm making some assumptions about the zip file that gets downloaded (like there's no symbolic links or whatever), since I would imagine it's always going to be a very simple download.

Also, no reliance on `mkdirp`, since `fs.mkdir` supports recursive directories since Node.js v10.12.