### PR TITLE
chore: Upgrade TypeScript to 3.6

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -26,7 +26,7 @@ const {Keyboard, Mouse, Touchscreen} = require('./Input');
 const Tracing = require('./Tracing');
 const {helper, debugError, assert} = require('./helper');
 const {Coverage} = require('./Coverage');
-const {Worker} = require('./Worker');
+const {Worker: PuppeteerWorker} = require('./Worker');
 const {createJSHandle} = require('./JSHandle');
 const {Accessibility} = require('./Accessibility');
 const {TimeoutSettings} = require('./TimeoutSettings');
@@ -79,7 +79,7 @@ class Page extends EventEmitter {
 
     this._screenshotTaskQueue = screenshotTaskQueue;
 
-    /** @type {!Map<string, Worker>} */
+    /** @type {!Map<string, PuppeteerWorker>} */
     this._workers = new Map();
     client.on('Target.attachedToTarget', event => {
       if (event.targetInfo.type !== 'worker') {
@@ -90,7 +90,7 @@ class Page extends EventEmitter {
         return;
       }
       const session = Connection.fromSession(client).session(event.sessionId);
-      const worker = new Worker(session, event.targetInfo.url, this._addConsoleMessage.bind(this), this._handleException.bind(this));
+      const worker = new PuppeteerWorker(session, event.targetInfo.url, this._addConsoleMessage.bind(this), this._handleException.bind(this));
       this._workers.set(event.sessionId, worker);
       this.emit(Events.Page.WorkerCreated, worker);
     });
@@ -274,7 +274,7 @@ class Page extends EventEmitter {
   }
 
   /**
-   * @return {!Array<!Worker>}
+   * @return {!Array<!PuppeteerWorker>}
    */
   workers() {
     return Array.from(this._workers.values());

--- a/lib/Target.js
+++ b/lib/Target.js
@@ -16,7 +16,7 @@
 
 const {Events} = require('./Events');
 const {Page} = require('./Page');
-const {Worker} = require('./Worker');
+const {Worker: PuppeteerWorker} = require('./Worker');
 
 class Target {
   /**
@@ -37,7 +37,7 @@ class Target {
     this._screenshotTaskQueue = screenshotTaskQueue;
     /** @type {?Promise<!Puppeteer.Page>} */
     this._pagePromise = null;
-    /** @type {?Promise<!Worker>} */
+    /** @type {?Promise<!PuppeteerWorker>} */
     this._workerPromise = null;
     this._initializedPromise = new Promise(fulfill => this._initializedCallback = fulfill).then(async success => {
       if (!success)
@@ -77,7 +77,7 @@ class Target {
   }
 
   /**
-   * @return {!Promise<?Worker>}
+   * @return {!Promise<?PuppeteerWorker>}
    */
   async worker() {
     if (this._targetInfo.type !== 'service_worker' && this._targetInfo.type !== 'shared_worker')
@@ -85,7 +85,7 @@ class Target {
     if (!this._workerPromise) {
       // TODO(einbinder): Make workers send their console logs.
       this._workerPromise = this._sessionFactory()
-          .then(client => new Worker(client, this._targetInfo.url, () => {} /* consoleAPICalled */, () => {} /* exceptionThrown */));
+          .then(client => new PuppeteerWorker(client, this._targetInfo.url, () => {} /* consoleAPICalled */, () => {} /* exceptionThrown */));
     }
     return this._workerPromise;
   }

--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const WebSocket = require('ws');
+const NodeWebSocket = require('ws');
 
 /**
  * @implements {!Puppeteer.ConnectionTransport}
@@ -25,17 +25,22 @@ class WebSocketTransport {
    */
   static create(url) {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url, [], {
+      const ws = new NodeWebSocket(url, [], {
         perMessageDeflate: false,
         maxPayload: 256 * 1024 * 1024, // 256Mb
       });
+
+      /* error that WebSocket is not assignable to type WebSocket
+      * due to a misisng dispatchEvent() method which the ws library
+      * does not implement and we do not need
+      */
       ws.addEventListener('open', () => resolve(new WebSocketTransport(ws)));
       ws.addEventListener('error', reject);
     });
   }
 
   /**
-   * @param {!WebSocket} ws
+   * @param {!NodeWebSocket} ws
    */
   constructor(ws) {
     this._ws = ws;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "3.5.3"
+    "typescript": "3.6.5"
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,


### PR DESCRIPTION
Continues the work to get up to TS 3.8 (latest release at time of
writing).

This version of TS introduced built in definitions for web workers that
include an `interface Worker` so TS gets confused when it sees us
reference a `Worker`. I have renamed the imports to `PuppeteerWorker` as
I couldn't figure out a way to tell TS to not load in the worker types;
longer term we might consider renaming `Worker` to `PuppeteerWorker` (or
an alternative) but that would be a breaking change that we don't need
right now.

The other fix is to solve an issue where the `ws` library doesn't
implement a `dispatchEvent` method - which is not a problem - but TS
expects it to. I've used `@ts-ignore` on that error because it's
absolutely fine and not something we rely on.