### PR TITLE
chore: Upgrade to TypeScript 3.7

### DIFF
--- a/lib/Coverage.js
+++ b/lib/Coverage.js
@@ -137,7 +137,7 @@ class JSCoverage {
   async stop() {
     assert(this._enabled, 'JSCoverage is not enabled');
     this._enabled = false;
-    const [profileResponse] = await Promise.all([
+    const result = await Promise.all([
       this._client.send('Profiler.takePreciseCoverage'),
       this._client.send('Profiler.stopPreciseCoverage'),
       this._client.send('Profiler.disable'),
@@ -146,6 +146,7 @@ class JSCoverage {
     helper.removeEventListeners(this._eventListeners);
 
     const coverage = [];
+    const profileResponse = /** @type Protocol.Profiler.takePreciseCoverageReturnValue */ (result[0]);
     for (const entry of profileResponse.result) {
       let url = this._scriptURLs.get(entry.scriptId);
       if (!url && this._reportAnonymousScripts)

--- a/lib/FrameManager.js
+++ b/lib/FrameManager.js
@@ -56,10 +56,12 @@ class FrameManager extends EventEmitter {
   }
 
   async initialize() {
-    const [,{frameTree}] = await Promise.all([
+    const result = await Promise.all([
       this._client.send('Page.enable'),
       this._client.send('Page.getFrameTree'),
     ]);
+
+    const {frameTree} = /** @type Protocol.Page.getFrameTreeReturnValue*/ (result[1]);
     this._handleFrameTree(frameTree);
     await Promise.all([
       this._client.send('Page.setLifecycleEventsEnabled', { enabled: true }),

--- a/lib/WebSocketTransport.js
+++ b/lib/WebSocketTransport.js
@@ -30,10 +30,6 @@ class WebSocketTransport {
         maxPayload: 256 * 1024 * 1024, // 256Mb
       });
 
-      /* error that WebSocket is not assignable to type WebSocket
-      * due to a misisng dispatchEvent() method which the ws library
-      * does not implement and we do not need
-      */
       ws.addEventListener('open', () => resolve(new WebSocketTransport(ws)));
       ws.addEventListener('error', reject);
     });

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "text-diff": "^1.0.1",
-    "typescript": "3.6.5"
+    "typescript": "3.7.5"
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,

--- a/utils/doclint/check_public_api/JSBuilder.js
+++ b/utils/doclint/check_public_api/JSBuilder.js
@@ -160,7 +160,7 @@ function checkSources(sources) {
           properties.push(...innerType.properties);
         innerTypeNames.push(innerType.name);
       }
-      if (innerTypeNames.length === 1 && innerTypeNames[0] === 'void')
+      if (innerTypeNames.length === 0 || innerTypeNames.length === 1 && innerTypeNames[0] === 'void')
         return new Documentation.Type(type.symbol.name);
       return new Documentation.Type(`${type.symbol.name}<${innerTypeNames.join(', ')}>`, properties);
     }


### PR DESCRIPTION
TypeScript seems to struggle to understand `Promise.all` when the items
in the array return different types. If we were authoring in TS we could
fix this with TS generics (`Promise.all<OurTypeHere>(...)`) but for now
we can typecast the result. We'll fix this properly when we author in
TS.