### PR TITLE
chore(deps): update extract-zip to version 2

### DIFF
--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -291,7 +291,7 @@ function downloadFile(url, destinationPath, progressCallback) {
  */
 async function extractZip(zipPath, folderPath) {
   try {
-    extract(zipPath, {dir: folderPath});
+    await extract(zipPath, {dir: folderPath});
   } catch (e) {
     return e;
   }

--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -289,8 +289,12 @@ function downloadFile(url, destinationPath, progressCallback) {
  * @param {string} folderPath
  * @return {!Promise<?Error>}
  */
-function extractZip(zipPath, folderPath) {
-  return extract(zipPath, {dir: folderPath});
+async function extractZip(zipPath, folderPath) {
+  try {
+    extract(zipPath, {dir: folderPath});
+  } catch (e) {
+    return e;
+  }
 }
 
 function httpRequest(url, method, response) {

--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -292,8 +292,8 @@ function downloadFile(url, destinationPath, progressCallback) {
 async function extractZip(zipPath, folderPath) {
   try {
     await extract(zipPath, {dir: folderPath});
-  } catch (e) {
-    return e;
+  } catch (error) {
+    return error;
   }
 }
 

--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -290,12 +290,7 @@ function downloadFile(url, destinationPath, progressCallback) {
  * @return {!Promise<?Error>}
  */
 function extractZip(zipPath, folderPath) {
-  return new Promise((fulfill, reject) => extract(zipPath, {dir: folderPath}, err => {
-    if (err)
-      reject(err);
-    else
-      fulfill();
-  }));
+  return extract(zipPath, {dir: folderPath});
 }
 
 function httpRequest(url, method, response) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@types/mime-types": "^2.1.0",
     "debug": "^4.1.0",
-    "extract-zip": "^1.6.6",
+    "extract-zip": "^2.0.0",
     "https-proxy-agent": "^4.0.0",
     "mime": "^2.0.3",
     "mime-types": "^2.1.25",
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@types/debug": "0.0.31",
-    "@types/extract-zip": "^1.6.2",
     "@types/mime": "^2.0.0",
     "@types/node": "^10.17.14",
     "@types/rimraf": "^2.0.2",

--- a/src/BrowserFetcher.js
+++ b/src/BrowserFetcher.js
@@ -334,8 +334,12 @@ function install(archivePath, folderPath) {
  * @param {string} folderPath
  * @return {!Promise<?Error>}
  */
-function extractZip(zipPath, folderPath) {
-  return extract(zipPath, {dir: folderPath});
+async function extractZip(zipPath, folderPath) {
+  try {
+    extract(zipPath, {dir: folderPath});
+  } catch (e) {
+    return e;
+  }
 }
 
 /**

--- a/src/BrowserFetcher.js
+++ b/src/BrowserFetcher.js
@@ -337,8 +337,8 @@ function install(archivePath, folderPath) {
 async function extractZip(zipPath, folderPath) {
   try {
     await extract(zipPath, {dir: folderPath});
-  } catch (e) {
-    return e;
+  } catch (error) {
+    return error;
   }
 }
 

--- a/src/BrowserFetcher.js
+++ b/src/BrowserFetcher.js
@@ -336,7 +336,7 @@ function install(archivePath, folderPath) {
  */
 async function extractZip(zipPath, folderPath) {
   try {
-    extract(zipPath, {dir: folderPath});
+    await extract(zipPath, {dir: folderPath});
   } catch (e) {
     return e;
   }

--- a/src/BrowserFetcher.js
+++ b/src/BrowserFetcher.js
@@ -335,12 +335,7 @@ function install(archivePath, folderPath) {
  * @return {!Promise<?Error>}
  */
 function extractZip(zipPath, folderPath) {
-  return new Promise((fulfill, reject) => extract(zipPath, {dir: folderPath}, err => {
-    if (err)
-      reject(err);
-    else
-      fulfill();
-  }));
+  return extract(zipPath, {dir: folderPath});
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "allowJs": true,
     "checkJs": true,
     "outDir": "./lib",
-    "target": "ESNext"
+    "target": "ESNext",
+    "moduleResolution": "node"
   },
   "include": [
     "src"


### PR DESCRIPTION
extract-zip removed support for callbacks and instead uses promises.
Moreover, it has TypeScript support which allows us to remove the
@types/extract-zip package.

This update allows downstream users to remove their installation
of mkdirp, which uses a vulnerable version of minimist.

For more info, see https://github.com/maxogden/extract-zip/releases/tag/v2.0.0