### PR TITLE
chore: update ws library

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2",
     "tar-fs": "^2.0.0",
     "unbzip2-stream": "^1.3.3",
-    "ws": "^6.1.0"
+    "ws": "^7.2.3"
   },
   "devDependencies": {
     "@types/debug": "0.0.31",
@@ -52,7 +52,7 @@
     "@types/node": "^10.17.14",
     "@types/rimraf": "^2.0.2",
     "@types/tar-fs": "^1.16.2",
-    "@types/ws": "^6.0.1",
+    "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "commonmark": "^0.28.1",


### PR DESCRIPTION
Updates `ws` and `@types/ws` to version 7.

The breaking changes in version 7 are not ones that impact this project
[1].

[1]: https://github.com/websockets/ws/releases/tag/7.0.0
