### PR TITLE
chore: Log reminder about tsc if DocLint fails locally

### DIFF
--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -87,6 +87,10 @@ async function run() {
     clearExit = false;
   }
   console.log(`${errors.length} failures, ${warnings.length} warnings.`);
+
+  if (!clearExit && !process.env.TRAVIS)
+    console.log('\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n');
+
   const runningTime = Date.now() - startTime;
   console.log(`DocLint Finished in ${runningTime / 1000} seconds`);
   process.exit(clearExit ? 0 : 1);


### PR DESCRIPTION
I lost some time debugging before realising that I needed to run tsc. I
don't really want to put `npm run tsc` before this command else we'll
run tsc multiple times on each CI build, so I think this message is
suitable.

Travis defines `process.env.TRAVIS` and if that exists we don't want to
log this as on CI we're guaranteed to have an up to date `lib/`
directory.
