### PR TITLE
docs: Change the Alpine Docker example to use env instead of launch option

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -340,7 +340,8 @@ RUN apk add --no-cache \
 ...
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Puppeteer v1.19.0 works with Chromium 77.
 RUN yarn add puppeteer@1.19.0
@@ -355,14 +356,6 @@ RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
 USER pptruser
 
 ...
-```
-
-And when launching Chrome, be sure to use the `chromium-browser` executable:
-
-```js
-const browser = await puppeteer.launch({
-  executablePath: '/usr/bin/chromium-browser'
-});
 ```
 
 #### Tips


### PR DESCRIPTION
This PR changes the documentation for the way to specify `executablePath` on Alpine Docker.

Formerly, the doc used options of `puppeteer.launch`, but since Puppeteer has an environment variable for it, I think it would be better to use it instead of specifying it every time.

I've already verified this can be built through the latest version of Docker. The Docker image can be found at [DockerHub](https://hub.docker.com/repository/docker/neetshin/pptr-alpine) and the source code it at [neetbox/pptr-alpine-docker](https://github.com/neetbox/pptr-alpine-docker).