### PR TITLE
docs(troubleshooting): list libgbm-dev dependency

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,22 +45,27 @@ machine to check which dependencies are missing. The common ones are provided be
 <summary>Debian (e.g. Ubuntu) Dependencies</summary>
 
 ```
+ca-certificates
+fonts-liberation
 gconf-service
+libappindicator1
 libasound2
-libatk1.0-0
 libatk-bridge2.0-0
+libatk1.0-0
 libc6
 libcairo2
 libcups2
 libdbus-1-3
 libexpat1
 libfontconfig1
+libgbm-dev
 libgcc1
 libgconf-2-4
 libgdk-pixbuf2.0-0
 libglib2.0-0
 libgtk-3-0
 libnspr4
+libnss3
 libpango-1.0-0
 libpangocairo-1.0-0
 libstdc++6
@@ -77,13 +82,9 @@ libxrandr2
 libxrender1
 libxss1
 libxtst6
-ca-certificates
-fonts-liberation
-libappindicator1
-libnss3
 lsb-release
-xdg-utils
 wget
+xdg-utils
 ```
 </details>
 
@@ -91,27 +92,27 @@ wget
 <summary>CentOS Dependencies</summary>
 
 ```
-pango.x86_64
+alsa-lib.x86_64
+atk.x86_64
+cups-libs.x86_64
+GConf2.x86_64
+gtk3.x86_64
+ipa-gothic-fonts
 libXcomposite.x86_64
 libXcursor.x86_64
 libXdamage.x86_64
 libXext.x86_64
 libXi.x86_64
-libXtst.x86_64
-cups-libs.x86_64
-libXScrnSaver.x86_64
 libXrandr.x86_64
-GConf2.x86_64
-alsa-lib.x86_64
-atk.x86_64
-gtk3.x86_64
-ipa-gothic-fonts
+libXScrnSaver.x86_64
+libXtst.x86_64
+pango.x86_64
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-75dpi
-xorg-x11-utils
 xorg-x11-fonts-cyrillic
-xorg-x11-fonts-Type1
 xorg-x11-fonts-misc
+xorg-x11-fonts-Type1
+xorg-x11-utils
 ```
 
 After installing dependencies you need to update nss library using this command


### PR DESCRIPTION
This also alphasorts the dependency lists.

Fixes #5661.