### PR TITLE
Fix: support async functions as an argument for waitForFunction

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2070,7 +2070,7 @@ await fileChooser.accept(['/tmp/myfile.pdf']);
 
 
 #### page.waitForFunction(pageFunction[, options[, ...args]])
-- `pageFunction` <[function]|[string]> Function to be evaluated in browser context
+- `pageFunction` <[function]|[AsyncFunction]|[string]> Function to be evaluated in browser context
 - `options` <[Object]> Optional waiting parameters
   - `polling` <[string]|[number]> An interval at which the `pageFunction` is executed, defaults to `raf`. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. If `polling` is a string, then it can be one of the following values:
     - `raf` - to constantly execute `pageFunction` in `requestAnimationFrame` callback. This is the tightest polling mode which is suitable to observe styling changes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2070,7 +2070,7 @@ await fileChooser.accept(['/tmp/myfile.pdf']);
 
 
 #### page.waitForFunction(pageFunction[, options[, ...args]])
-- `pageFunction` <[function]|[AsyncFunction]|[string]> Function to be evaluated in browser context
+- `pageFunction` <[function]|[string]> Function to be evaluated in browser context
 - `options` <[Object]> Optional waiting parameters
   - `polling` <[string]|[number]> An interval at which the `pageFunction` is executed, defaults to `raf`. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. If `polling` is a string, then it can be one of the following values:
     - `raf` - to constantly execute `pageFunction` in `requestAnimationFrame` callback. This is the tightest polling mode which is suitable to observe styling changes.
@@ -2097,7 +2097,7 @@ To pass arguments from node.js to the predicate of `page.waitForFunction` functi
 
 ```js
 const selector = '.foo';
-await page.waitForFunction(selector => !!document.querySelector(selector), {}, selector);
+await page.waitForFunction(async selector => !!document.querySelector(selector), {}, selector);
 ```
 
 Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]])](#framewaitforfunctionpagefunction-options-args).

--- a/docs/api.md
+++ b/docs/api.md
@@ -2097,7 +2097,23 @@ To pass arguments from node.js to the predicate of `page.waitForFunction` functi
 
 ```js
 const selector = '.foo';
-await page.waitForFunction(async selector => !!document.querySelector(selector), {}, selector);
+await page.waitForFunction(selector => !!document.querySelector(selector), {}, selector);
+```
+
+The predicate of `page.waitForFunction` can be asynchronous too:
+
+```js
+const username = 'github-username';
+await page.waitForFunction(async username => {
+  let githubResponse = await fetch(`https://api.github.com/users/${username}`);
+  let githubUser = await githubResponse.json();
+  // show the avatar
+  let img = document.createElement('img');
+  img.src = githubUser.avatar_url;
+  // wait 3 seconds
+  await new Promise((resolve, reject) => setTimeout(resolve, 3000));
+  img.remove();
+}, {}, username);
 ```
 
 Shortcut for [page.mainFrame().waitForFunction(pageFunction[, options[, ...args]])](#framewaitforfunctionpagefunction-options-args).

--- a/docs/api.md
+++ b/docs/api.md
@@ -2105,10 +2105,10 @@ The predicate of `page.waitForFunction` can be asynchronous too:
 ```js
 const username = 'github-username';
 await page.waitForFunction(async username => {
-  let githubResponse = await fetch(`https://api.github.com/users/${username}`);
-  let githubUser = await githubResponse.json();
+  const githubResponse = await fetch(`https://api.github.com/users/${username}`);
+  const githubUser = await githubResponse.json();
   // show the avatar
-  let img = document.createElement('img');
+  const img = document.createElement('img');
   img.src = githubUser.avatar_url;
   // wait 3 seconds
   await new Promise((resolve, reject) => setTimeout(resolve, 3000));

--- a/src/DOMWorld.ts
+++ b/src/DOMWorld.ts
@@ -692,18 +692,18 @@ async function waitForPredicatePageFunction(
   /**
    * @return {!Promise<*>}
    */
-  function pollMutation(): Promise<unknown> {
-    const success = predicate(...args);
+  async function pollMutation(): Promise<unknown> {
+    const success = await predicate(...args);
     if (success) return Promise.resolve(success);
 
     let fulfill;
     const result = new Promise((x) => (fulfill = x));
-    const observer = new MutationObserver(() => {
+    const observer = new MutationObserver(async () => {
       if (timedOut) {
         observer.disconnect();
         fulfill();
       }
-      const success = predicate(...args);
+      const success = await predicate(...args);
       if (success) {
         observer.disconnect();
         fulfill(success);
@@ -717,35 +717,35 @@ async function waitForPredicatePageFunction(
     return result;
   }
 
-  function pollRaf(): Promise<unknown> {
+  async function pollRaf(): Promise<unknown> {
     let fulfill;
     const result = new Promise((x) => (fulfill = x));
-    onRaf();
+    await onRaf();
     return result;
 
-    function onRaf(): void {
+    async function onRaf(): Promise<unknown> {
       if (timedOut) {
         fulfill();
         return;
       }
-      const success = predicate(...args);
+      const success = await predicate(...args);
       if (success) fulfill(success);
       else requestAnimationFrame(onRaf);
     }
   }
 
-  function pollInterval(pollInterval: number): Promise<unknown> {
+  async function pollInterval(pollInterval: number): Promise<unknown> {
     let fulfill;
     const result = new Promise((x) => (fulfill = x));
-    onTimeout();
+    await onTimeout();
     return result;
 
-    function onTimeout(): void {
+    async function onTimeout(): Promise<unknown> {
       if (timedOut) {
         fulfill();
         return;
       }
-      const success = predicate(...args);
+      const success = await predicate(...args);
       if (success) fulfill(success);
       else setTimeout(onTimeout, pollInterval);
     }

--- a/test/waittask.spec.js
+++ b/test/waittask.spec.js
@@ -138,6 +138,22 @@ describe('waittask specs', function () {
       await watchdog;
       expect(Date.now() - startTime).not.toBeLessThan(polling / 2);
     });
+    it('should poll on interval async', async () => {
+      const { page } = getTestState();
+      let success = false;
+      const startTime = Date.now();
+      const polling = 100;
+      const watchdog = page
+        .waitForFunction(async () => window.__FOO === 'hit', { polling })
+        .then(() => (success = true));
+      await page.evaluate(async () => (window.__FOO = 'hit'));
+      expect(success).toBe(false);
+      await page.evaluate(async () =>
+        document.body.appendChild(document.createElement('div'))
+      );
+      await watchdog;
+      expect(Date.now() - startTime).not.toBeLessThan(polling / 2);
+    });
     it('should poll on mutation', async () => {
       const { page } = getTestState();
 
@@ -152,6 +168,22 @@ describe('waittask specs', function () {
       );
       await watchdog;
     });
+    it('should poll on mutation async', async () => {
+      const { page } = getTestState();
+
+      let success = false;
+      const watchdog = page
+        .waitForFunction(async () => window.__FOO === 'hit', {
+          polling: 'mutation',
+        })
+        .then(() => (success = true));
+      await page.evaluate(async () => (window.__FOO = 'hit'));
+      expect(success).toBe(false);
+      await page.evaluate(async () =>
+        document.body.appendChild(document.createElement('div'))
+      );
+      await watchdog;
+    });
     it('should poll on raf', async () => {
       const { page } = getTestState();
 
@@ -159,6 +191,18 @@ describe('waittask specs', function () {
         polling: 'raf',
       });
       await page.evaluate(() => (window.__FOO = 'hit'));
+      await watchdog;
+    });
+    it('should poll on raf async', async () => {
+      const { page } = getTestState();
+
+      const watchdog = page.waitForFunction(
+        async () => window.__FOO === 'hit',
+        {
+          polling: 'raf',
+        }
+      );
+      await page.evaluate(async () => (window.__FOO = 'hit'));
       await watchdog;
     });
     itFailsFirefox('should work with strict CSP policy', async () => {


### PR DESCRIPTION
This PR is made to fix : https://github.com/puppeteer/puppeteer/issues/4045

After investigating I found out that `predicate.apply(null, args)` returns an unresolved promise in case predicate is `AsyncFunction` which causes puppeteer to hang.
