### PR TITLE
chore: migrate `src/pipetransport` to typescript

### DIFF
--- a/src/Launcher.js
+++ b/src/Launcher.js
@@ -29,7 +29,7 @@ const {helper, assert, debugError} = require('./helper');
 const debugLauncher = require('debug')(`puppeteer:launcher`);
 const {TimeoutError} = require('./Errors');
 const WebSocketTransport = require('./WebSocketTransport');
-const PipeTransport = require('./PipeTransport');
+const {PipeTransport} = require('./PipeTransport');
 
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -103,7 +103,7 @@ function installAsyncStackHooks(classType: AnyClass): void {
 }
 
 
-function addEventListener(emitter: NodeJS.EventEmitter, eventName: string|symbol, handler: (...args: any[]) => void): { emitter: NodeJS.EventEmitter; eventName: string|symbol; handler: (...args: any[]) => void} {
+function addEventListener(emitter: NodeJS.EventEmitter, eventName: string|symbol, handler: (...args: any[]) => void): PuppeteerEventListener {
   emitter.on(eventName, handler);
   return { emitter, eventName, handler };
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,8 +15,8 @@
  */
 
 /* These types exist here until we migrate over to ESM where we can
- *import / export them properly from modules - TS doesn't support
- *exposing interfaces in CommonJS land.
+ * import / export them properly from modules - TS doesn't support
+ * exposing interfaces in CommonJS land.
  */
 interface PuppeteerEventListener {
   emitter: NodeJS.EventEmitter;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* These types exist here until we migrate over to ESM where we can
+ *import / export them properly from modules - TS doesn't support
+ *exposing interfaces in CommonJS land.
+ */
+interface PuppeteerEventListener {
+  emitter: NodeJS.EventEmitter;
+  eventName: string | symbol;
+  handler: (...args: any[]) => void;
+}


### PR DESCRIPTION
Hit one bump in the fact that I want to share an interface across files.
TypeScript only lets you import/export these if you're using ESM, not
CommonJS. So the two options are:

- Migrate to ESM on a per file basis as we do this migration. This won't
affect the output as we output as CommonJS.
- Create a global `types.d.ts` file that we'll use and then migrate to
ESM after.

Right now I've gone for the second option in order to not introduce more
changes in one go. But if we end up finding we have lots of
interfaces/types/etc that we want modules to expose, we might decide
slowly introducing ESM might be a better way forwards.
