### PR TITLE
chore(docker): Add missing chromium dependency

### DIFF
--- a/.ci/node10/Dockerfile.linux
+++ b/.ci/node10/Dockerfile.linux
@@ -2,7 +2,7 @@ FROM node:10
 
 RUN apt-get update && \
     apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
-      libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+      libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
       libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
       libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
       libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \

--- a/.ci/node12/Dockerfile.linux
+++ b/.ci/node12/Dockerfile.linux
@@ -2,7 +2,7 @@ FROM node:12
 
 RUN apt-get update && \
     apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
-      libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+      libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
       libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
       libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
       libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,7 +58,7 @@ libcups2
 libdbus-1-3
 libexpat1
 libfontconfig1
-libgbm-dev
+libgbm1
 libgcc1
 libgconf-2-4
 libgdk-pixbuf2.0-0


### PR DESCRIPTION
* Add missing chromium dependency `libgbm1` to the CI Dockerfiles, fixes #5674 
* Use [correct libgbm package](https://chromium.googlesource.com/chromium/src.git/+/refs/tags/84.0.4120.1/build/install-build-deps.sh#248)  name in the troubleshooting doc (`libgbm-dev` -> `libgbm1`) - the dev package is not necessary, it's used only for development.