### PR TITLE
Launcher.js: don't exit process on SIGINT

### DIFF
--- a/src/Launcher.js
+++ b/src/Launcher.js
@@ -30,7 +30,6 @@ const debugLauncher = require('debug')(`puppeteer:launcher`);
 const {TimeoutError} = require('./Errors');
 const {WebSocketTransport} = require('./WebSocketTransport');
 const {PipeTransport} = require('./PipeTransport');
-
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
 const removeFolderAsync = helper.promisify(removeFolder);
 const writeFileAsync = helper.promisify(fs.writeFile);
@@ -106,7 +105,7 @@ class BrowserRunner {
     });
     this._listeners = [ helper.addEventListener(process, 'exit', this.kill.bind(this)) ];
     if (handleSIGINT)
-      this._listeners.push(helper.addEventListener(process, 'SIGINT', () => { this.kill(); process.exit(130); }));
+      this._listeners.push(helper.addEventListener(process, 'SIGINT', this.kill.bind(this)));
     if (handleSIGTERM)
       this._listeners.push(helper.addEventListener(process, 'SIGTERM', this.close.bind(this)));
     if (handleSIGHUP)


### PR DESCRIPTION
This caused a bug where other signal handlers for a node process don't receive 
their listener callbacks on a SIGINT. With this change, other signal listeners 
that were added before puppeteer's will also fire

not sure if this breaks something else inside puppeteer, but this fixed the issue I was running into in my tree

cc @JoelEinbinder 