### PR TITLE
chore: migrate src/ExecutionContext

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,9 @@ module.exports = {
                 "semi": 0,
                 "@typescript-eslint/semi": 2,
                 "@typescript-eslint/no-empty-function": 0,
-                "@typescript-eslint/no-use-before-define": 0
+                "@typescript-eslint/no-use-before-define": 0,
+                // We know it's bad and use it very sparingly but it's needed :(
+                "@typescript-eslint/ban-ts-ignore": 0
             }
         }
     ]

--- a/src/DOMWorld.js
+++ b/src/DOMWorld.js
@@ -21,6 +21,9 @@ const {TimeoutError} = require('./Errors');
 // Used as a TypeDef
 // eslint-disable-next-line no-unused-vars
 const {JSHandle, ElementHandle} = require('./JSHandle');
+// Used as a TypeDef
+// eslint-disable-next-line no-unused-vars
+const {ExecutionContext} = require('./ExecutionContext');
 
 // Used as a TypeDef
 // eslint-disable-next-line no-unused-vars
@@ -44,7 +47,7 @@ class DOMWorld {
 
     /** @type {?Promise<!ElementHandle>} */
     this._documentPromise = null;
-    /** @type {!Promise<!Puppeteer.ExecutionContext>} */
+    /** @type {!Promise<!ExecutionContext>} */
     this._contextPromise;
     this._contextResolveCallback = null;
     this._setContext(null);
@@ -62,7 +65,7 @@ class DOMWorld {
   }
 
   /**
-   * @param {?Puppeteer.ExecutionContext} context
+   * @param {?ExecutionContext} context
    */
   _setContext(context) {
     if (context) {
@@ -92,7 +95,7 @@ class DOMWorld {
   }
 
   /**
-   * @return {!Promise<!Puppeteer.ExecutionContext>}
+   * @return {!Promise<!ExecutionContext>}
    */
   executionContext() {
     if (this._detached)

--- a/src/JSHandle.ts
+++ b/src/JSHandle.ts
@@ -1,4 +1,4 @@
-**
+/**
  * Copyright 2019 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,11 +172,12 @@ export class ElementHandle extends JSHandle {
         });
         observer.observe(element);
       });
-      if (visibleRatio !== 1.0)
+      if (visibleRatio !== 1.0) {
         // Chrome still supports behavior: instant but it's not in the spec so TS shouts
         // We don't want to make this breaking change in Puppeteer yet so we'll ignore the line.
         // @ts-ignore
         element.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
+      }
       return false;
     }, this._page._javascriptEnabled);
 

--- a/src/externs.d.ts
+++ b/src/externs.d.ts
@@ -4,7 +4,6 @@ import {Page as RealPage} from './Page.js';
 import {Mouse as RealMouse, Keyboard as RealKeyboard, Touchscreen as RealTouchscreen}  from './Input.js';
 import {Frame as RealFrame, FrameManager as RealFrameManager}  from './FrameManager.js';
 import {DOMWorld as RealDOMWorld}  from './DOMWorld.js';
-import {ExecutionContext as RealExecutionContext}  from './ExecutionContext.js';
 import { NetworkManager as RealNetworkManager, Request as RealRequest, Response as RealResponse } from './NetworkManager.js';
 import * as child_process from 'child_process';
 declare global {
@@ -19,7 +18,6 @@ declare global {
     export class FrameManager extends RealFrameManager {}
     export class NetworkManager extends RealNetworkManager {}
     export class DOMWorld extends RealDOMWorld {}
-    export class ExecutionContext extends RealExecutionContext {}
     export class Page extends RealPage { }
     export class Response extends RealResponse { }
     export class Request extends RealRequest { }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -52,7 +52,7 @@ function getExceptionMessage(exceptionDetails: Protocol.Runtime.ExceptionDetails
   return message;
 }
 
-function valueFromRemoteObject(remoteObject: Protocol.Runtime.RemoteObject): unknown {
+function valueFromRemoteObject(remoteObject: Protocol.Runtime.RemoteObject): any {
   assert(!remoteObject.objectId, 'Cannot extract value when objectId is given');
   if (remoteObject.unserializableValue) {
     if (remoteObject.type === 'bigint' && typeof BigInt !== 'undefined')


### PR DESCRIPTION
I spent a while trying to decide on the best course of action for
typing the `evaluate` function.

Ideally I wanted to use generics so that as a user you could type
something like:

```
handle.evaluate<HTMLElement, number, boolean>((node, x) => true, 5)
```

And have TypeScript know the arguments of `node` and `x` based on those
generics. But I hit two problems with that:

* you have to have n overloads of `evaluate` to cope for as many number
of arguments as you can be bothered too (e.g. we'd need an overload for
1 arg, 2 args, 3 args, etc)
* I decided it's actually confusing because you don't know as a user
what those generics actually map to.

So in the end I went with one generic which is the return type of the
function:

```
handle.evaluate<boolean>((node, x) => true, 5)
```

And `node` and `x` get typed as `any` which means you can tell TS
yourself:

```
handle.evaluate<boolean>((node: HTMLElement, x:  number) => true, 5)
```

I'd like to find a way to force that the arguments after the function do
match the arguments you've given (in the above example, TS would moan if
I swapped that `5` for `"foo"`), but I tried a few things and to be
honest the complexity of the types wasn't worth it, I don't think.

I'm very open to tweaking these but I'd rather ship this and tweak going
forwards rather than spend hours now tweaking. Once we ship these
typedefs and get feedback from the community I'm sure we can improve
them.