### PR TITLE
Fix `USKeyboardLayout` relative url

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3926,7 +3926,7 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [Touchscreen]: #class-touchscreen "Touchscreen"
 [Tracing]: #class-tracing "Tracing"
 [UIEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail "UIEvent.detail"
-[USKeyboardLayout]: ../src/USKeyboardLayout.js "USKeyboardLayout"
+[USKeyboardLayout]: ../src/USKeyboardLayout.ts "USKeyboardLayout"
 [UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
 [Worker]: #class-worker "Worker"
 [boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type "Boolean"


### PR DESCRIPTION
Seems like the `USKeyboardLayout.js` is turned into a `.ts` file and the docs hyperlink is broken.