### PR TITLE
chore: migrate src/Input to typescript

### DIFF
--- a/src/JSHandle.ts
+++ b/src/JSHandle.ts
@@ -17,6 +17,7 @@
 import {helper, assert, debugError} from './helper';
 import {ExecutionContext} from './ExecutionContext';
 import {CDPSession} from './Connection';
+import {KeyInput} from './USKeyboardLayout';
 
 interface BoxModel {
   content: Array<{x: number; y: number}>;
@@ -326,7 +327,7 @@ export class ElementHandle extends JSHandle {
     await this._page.keyboard.type(text, options);
   }
 
-  async press(key: string, options?: {delay?: number; text?: string}): Promise<void> {
+  async press(key: KeyInput, options?: {delay?: number; text?: string}): Promise<void> {
     await this.focus();
     await this._page.keyboard.press(key, options);
   }

--- a/src/USKeyboardLayout.ts
+++ b/src/USKeyboardLayout.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
- interface KeyDefinition {
+
+export interface KeyDefinition {
    keyCode?: number;
    shiftKeyCode?: number;
    key?: string;
@@ -23,9 +24,11 @@
    text?: string;
    shiftText?: string;
    location?: number;
- }
+}
 
-export const keyDefinitions: Readonly<Record<string, KeyDefinition>> = {
+export type KeyInput = '0'|'1'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'|'Power'|'Eject'|'Abort'|'Help'|'Backspace'|'Tab'|'Numpad5'|'NumpadEnter'|'Enter'|'\r'|'\n'|'ShiftLeft'|'ShiftRight'|'ControlLeft'|'ControlRight'|'AltLeft'|'AltRight'|'Pause'|'CapsLock'|'Escape'|'Convert'|'NonConvert'|'Space'|'Numpad9'|'PageUp'|'Numpad3'|'PageDown'|'End'|'Numpad1'|'Home'|'Numpad7'|'ArrowLeft'|'Numpad4'|'Numpad8'|'ArrowUp'|'ArrowRight'|'Numpad6'|'Numpad2'|'ArrowDown'|'Select'|'Open'|'PrintScreen'|'Insert'|'Numpad0'|'Delete'|'NumpadDecimal'|'Digit0'|'Digit1'|'Digit2'|'Digit3'|'Digit4'|'Digit5'|'Digit6'|'Digit7'|'Digit8'|'Digit9'|'KeyA'|'KeyB'|'KeyC'|'KeyD'|'KeyE'|'KeyF'|'KeyG'|'KeyH'|'KeyI'|'KeyJ'|'KeyK'|'KeyL'|'KeyM'|'KeyN'|'KeyO'|'KeyP'|'KeyQ'|'KeyR'|'KeyS'|'KeyT'|'KeyU'|'KeyV'|'KeyW'|'KeyX'|'KeyY'|'KeyZ'|'MetaLeft'|'MetaRight'|'ContextMenu'|'NumpadMultiply'|'NumpadAdd'|'NumpadSubtract'|'NumpadDivide'|'F1'|'F2'|'F3'|'F4'|'F5'|'F6'|'F7'|'F8'|'F9'|'F10'|'F11'|'F12'|'F13'|'F14'|'F15'|'F16'|'F17'|'F18'|'F19'|'F20'|'F21'|'F22'|'F23'|'F24'|'NumLock'|'ScrollLock'|'AudioVolumeMute'|'AudioVolumeDown'|'AudioVolumeUp'|'MediaTrackNext'|'MediaTrackPrevious'|'MediaStop'|'MediaPlayPause'|'Semicolon'|'Equal'|'NumpadEqual'|'Comma'|'Minus'|'Period'|'Slash'|'Backquote'|'BracketLeft'|'Backslash'|'BracketRight'|'Quote'|'AltGraph'|'Props'|'Cancel'|'Clear'|'Shift'|'Control'|'Alt'|'Accept'|'ModeChange'|' '|'Print'|'Execute'|'\u0000'|'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'|'i'|'j'|'k'|'l'|'m'|'n'|'o'|'p'|'q'|'r'|'s'|'t'|'u'|'v'|'w'|'x'|'y'|'z'|'Meta'|'*'|'+'|'-'|'/'|';'|'='|','|'.'|'`'|'['|'\\'|']'|'\''|'Attn'|'CrSel'|'ExSel'|'EraseEof'|'Play'|'ZoomOut'|')'|'!'|'@'|'#'|'$'|'%'|'^'|'&'|'('|'A'|'B'|'C'|'D'|'E'|'F'|'G'|'H'|'I'|'J'|'K'|'L'|'M'|'N'|'O'|'P'|'Q'|'R'|'S'|'T'|'U'|'V'|'W'|'X'|'Y'|'Z'|':'|'<'|'_'|'>'|'?'|'~'|'{'|'|'|'}'|'"'|'SoftLeft'|'SoftRight'|'Camera'|'Call'|'EndCall'|'VolumeDown'|'VolumeUp';
+
+export const keyDefinitions: Readonly<Record<KeyInput, KeyDefinition>> = {
   '0': {'keyCode': 48, 'key': '0', 'code': 'Digit0'},
   '1': {'keyCode': 49, 'key': '1', 'code': 'Digit1'},
   '2': {'keyCode': 50, 'key': '2', 'code': 'Digit2'},

--- a/src/externs.d.ts
+++ b/src/externs.d.ts
@@ -1,16 +1,12 @@
 import { Browser as RealBrowser, BrowserContext as RealBrowserContext} from './Browser.js';
 import {Target as RealTarget} from './Target.js';
 import {Page as RealPage} from './Page.js';
-import {Mouse as RealMouse, Keyboard as RealKeyboard, Touchscreen as RealTouchscreen}  from './Input.js';
 import {Frame as RealFrame, FrameManager as RealFrameManager}  from './FrameManager.js';
 import {DOMWorld as RealDOMWorld}  from './DOMWorld.js';
 import { NetworkManager as RealNetworkManager, Request as RealRequest, Response as RealResponse } from './NetworkManager.js';
 import * as child_process from 'child_process';
 declare global {
   module Puppeteer {
-    export class Mouse extends RealMouse {}
-    export class Keyboard extends RealKeyboard {}
-    export class Touchscreen extends RealTouchscreen {}
     export class Browser extends RealBrowser {}
     export class BrowserContext extends RealBrowserContext {}
     export class Target extends RealTarget {}

--- a/utils/doclint/check_public_api/JSBuilder.js
+++ b/utils/doclint/check_public_api/JSBuilder.js
@@ -185,6 +185,15 @@ function checkSources(sources) {
   }
 
   /**
+   * @param {!ts.Symbol} symbol
+   * @return {boolean}
+   */
+  function symbolHasPrivateModifier(symbol) {
+    const modifiers = symbol.valueDeclaration.modifiers || [];
+    return modifiers.some(modifier => modifier.kind === ts.SyntaxKind.PrivateKeyword);
+  }
+
+  /**
    * @param {string} className
    * @param {!ts.Symbol} symbol
    * @return {}
@@ -194,8 +203,14 @@ function checkSources(sources) {
     const members = classEvents.get(className) || [];
 
     for (const [name, member] of symbol.members || []) {
-      if (name.startsWith('_'))
+
+      /* Before TypeScript we denoted private methods with an underscore
+       * but in TypeScript we use the private keyword
+       * hence we check for either here.
+       */
+      if (name.startsWith('_') || symbolHasPrivateModifier(member))
         continue;
+
       const memberType = checker.getTypeOfSymbolAtLocation(member, member.valueDeclaration);
       const signature = memberType.getCallSignatures()[0];
       if (signature)

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -325,7 +325,7 @@ function compareDocumentations(actual, expected) {
 
 
     /* If we got a naming mismatch and it was expected, don't check the properties
-     * as they will likely be considered "wrong" by DocLint too
+     * as they will likely be considered "wrong" by DocLint too.
      */
     if (namingMismatchIsExpected) return;
     const actualPropertiesMap = new Map(actual.properties.map(property => [property.name, property.type]));

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -271,6 +271,30 @@ function compareDocumentations(actual, expected) {
         actualName: 'Object',
         expectedName: 'CommandParameters[T]'
       }],
+      ['Method ElementHandle.press() key', {
+        actualName: 'string',
+        expectedName: 'KeyInput'
+      }],
+      ['Method Keyboard.down() key', {
+        actualName: 'string',
+        expectedName: 'KeyInput'
+      }],
+      ['Method Keyboard.press() key', {
+        actualName: 'string',
+        expectedName: 'KeyInput'
+      }],
+      ['Method Keyboard.up() key', {
+        actualName: 'string',
+        expectedName: 'KeyInput'
+      }],
+      ['Method Mouse.down() options', {
+        actualName: 'Object',
+        expectedName: 'MouseOptions'
+      }],
+      ['Method Mouse.up() options', {
+        actualName: 'Object',
+        expectedName: 'MouseOptions'
+      }],
     ]);
 
     const expectedForSource = expectedNamingMismatches.get(source);
@@ -295,12 +319,15 @@ function compareDocumentations(actual, expected) {
     const actualName = actual.name.replace(/[\? ]/g, '');
     // TypeScript likes to add some spaces
     const expectedName = expected.name.replace(/\ /g, '');
-    if (expectedName !== actualName) {
-      const namingMismatchIsExpected = namingMisMatchInTypeIsExpected(source, actualName, expectedName);
+    const namingMismatchIsExpected = namingMisMatchInTypeIsExpected(source, actualName, expectedName);
+    if (expectedName !== actualName && !namingMismatchIsExpected)
+      errors.push(`${source} ${actualName} != ${expectedName}`);
 
-      if (!namingMismatchIsExpected)
-        errors.push(`${source} ${actualName} != ${expectedName}`);
-    }
+
+    /* If we got a naming mismatch and it was expected, don't check the properties
+     * as they will likely be considered "wrong" by DocLint too
+     */
+    if (namingMismatchIsExpected) return;
     const actualPropertiesMap = new Map(actual.properties.map(property => [property.name, property.type]));
     const expectedPropertiesMap = new Map(expected.properties.map(property => [property.name, property.type]));
     const propertiesDiff = diff(Array.from(actualPropertiesMap.keys()).sort(), Array.from(expectedPropertiesMap.keys()).sort());


### PR DESCRIPTION
This moves `Keyboard`, `Mouse` and `Touchscreen` to TypeScript. We gain
some nice TS benefits here; by creating a type for all the keycodes we
support we can type the input args as that rather than `string` which
will hopefully save some users some debugging once we ship our TS types
in a future version.
