### PR TITLE
Clean travis.yml and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,62 +1,46 @@
 language: node_js
-os: linux
-dist: trusty
-addons:
-  apt:
-    packages:
-      # This is required to run new chrome on old trusty
-      - libnss3
-      # Needed for realpath which we use in npm run test-install
-      - realpath
-notifications:
-  email: false
-cache:
-  directories:
-    - node_modules
+services: xvfb
+
 jobs:
   include:
+
     - os: "osx"
       node_js: "10.19.0"
       env:
         - CHROMIUM=true
       before_install:
-        # populate .local-firefox for launcher tests
         - PUPPETEER_PRODUCT=firefox npm install
       script:
         - ls .local-chromium .local-firefox
         - npm run tsc
         - npm run unit
+
     - os: "windows"
       node_js: "10.19.0"
       env:
         - CHROMIUM=true
       before_install:
-        # populate .local-firefox for launcher tests
         - PUPPETEER_PRODUCT=firefox npm install
       script:
         - ls .local-chromium .local-firefox
         - npm run tsc
         - travis_retry npm run unit
+
     - node_js: "10.19.0"
-      dist: trusty
       env:
         - CHROMIUM=true
       before_install:
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        # populate .local-firefox for launcher tests
         - PUPPETEER_PRODUCT=firefox npm install
       script:
         - npm run test-install
         - travis/chromium.sh
     - node_js: "10.19.0"
-      dist: trusty
       env:
         - FIREFOX=true
       before_install:
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        # install step will add .local-chromium for launcher tests
         - PUPPETEER_PRODUCT=firefox npm install
       script:
-        -  "npm run funit"
+        - npm run funit
+
+notifications:
+  email: false

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -187,33 +187,20 @@ export CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox
 > 👋 We run our tests for Puppeteer on Travis CI - see our [`.travis.yml`](https://github.com/puppeteer/puppeteer/blob/master/.travis.yml) for reference.
 
 Tips-n-tricks:
-- The `libnss3` package must be installed in order to run Chromium on Ubuntu Trusty
-- [user namespace cloning](http://man7.org/linux/man-pages/man7/user_namespaces.7.html) should be enabled to support
-  proper sandboxing
-- [xvfb](https://en.wikipedia.org/wiki/Xvfb) should be launched in order to run Chromium in non-headless mode (e.g. to test Chrome Extensions)
+- [xvfb](https://en.wikipedia.org/wiki/Xvfb) service should be launched in order to run Chromium in non-headless mode
+- Runs on Xenial Linux on Travis by default
+- Runs `npm install` by default
+- `node_modules` is cached by default
 
-To sum up, your `.travis.yml` might look like this:
+`.travis.yml` might look like this:
 
 ```yml
 language: node_js
-dist: trusty
-addons:
-  apt:
-    packages:
-      # This is required to run new chrome on old trusty
-      - libnss3
-notifications:
-  email: false
-cache:
-  directories:
-    - node_modules
-# allow headful tests
-before_install:
-  # Enable user namespace cloning
-  - "sysctl kernel.unprivileged_userns_clone=1"
-  # Launch XVFB
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+node_js: node
+services: xvfb
+
+script:
+  - npm run test
 ```
 
 ## Running Puppeteer on CircleCI


### PR DESCRIPTION
There was an outdated Travis initialization style, right now in Travis
* linux os with xenial dist by default
* node_modules cache by default
* xvfb service will greatly improve configs

UPD:
* added a simplified docs