### PR TITLE
Add page.pdfReadable, a way to stream the pdf without disk I/O

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1519,6 +1519,21 @@ If URLs are specified, only cookies for those URLs are returned.
 
 > **NOTE** This method is identical to [page.pdf](#pagepdfoptions), except it returns the PDF as a readable stream of binary data. If you are generating very large PDFs, it may be useful to use a stream to avoid high memory usage. This version will ignore the `path` option.
 
+```js
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  // Stream a PDF into a file
+  const pdfStream = await page.createPDFStream();
+  const writeStream = fs.createWriteStream('test.pdf');
+  pdfStream.pipe(writeStream);
+  await browser.close();
+})();
+```
+
 #### page.deleteCookie(...cookies)
 
 - `...cookies` <...[Object]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -162,6 +162,7 @@
   * [page.metrics()](#pagemetrics)
   * [page.mouse](#pagemouse)
   * [page.pdf([options])](#pagepdfoptions)
+  * [page.pdfReadable([options])](#pagepdfreadableoptions)
   * [page.queryObjects(prototypeHandle)](#pagequeryobjectsprototypehandle)
   * [page.reload([options])](#pagereloadoptions)
   * [page.screenshot([options])](#pagescreenshotoptions)
@@ -2050,6 +2051,33 @@ The `format` options are:
 >
 > 1. Script tags inside templates are not evaluated.
 > 2. Page styles are not visible inside templates.
+
+#### page.pdfReadable([options])
+- `options` <[Object]> Options object which might have the following properties:
+  - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`. Scale amount must be between 0.1 and 2.
+  - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
+  - `headerTemplate` <[string]> HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
+    - `date` formatted print date
+    - `title` document title
+    - `url` document location
+    - `pageNumber` current page number
+    - `totalPages` total pages in the document
+  - `footerTemplate` <[string]> HTML template for the print footer. Should use the same format as the `headerTemplate`.
+  - `printBackground` <[boolean]> Print background graphics. Defaults to `false`.
+  - `landscape` <[boolean]> Paper orientation. Defaults to `false`.
+  - `pageRanges` <[string]> Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
+  - `format` <[string]> Paper format. If set, takes priority over `width` or `height` options. Defaults to 'Letter'.
+  - `width` <[string]|[number]> Paper width, accepts values labeled with units.
+  - `height` <[string]|[number]> Paper height, accepts values labeled with units.
+  - `margin` <[Object]> Paper margins, defaults to none.
+    - `top` <[string]|[number]> Top margin, accepts values labeled with units.
+    - `right` <[string]|[number]> Right margin, accepts values labeled with units.
+    - `bottom` <[string]|[number]> Bottom margin, accepts values labeled with units.
+    - `left` <[string]|[number]> Left margin, accepts values labeled with units.
+  - `preferCSSPageSize` <[boolean]> Give any CSS `@page` size declared in the page priority over what is declared in `width` and `height` or `format` options. Defaults to `false`, which will scale the content to fit the paper size.
+- returns: <[Promise]<[Readable]>> Promise which resolves with a Readable stream
+
+This method is identical to [page.pdf](#pagepdfoptions), except it returns the PDF as a readable stream of binary data. If you are generating very large PDFs, it may be useful to use a stream to avoid high memory usage.
 
 #### page.queryObjects(prototypeHandle)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,6 +136,7 @@
   * [page.content()](#pagecontent)
   * [page.cookies([...urls])](#pagecookiesurls)
   * [page.coverage](#pagecoverage)
+  * [page.createPDFStream([options])](#pagecreatepdfstreamoptions)
   * [page.deleteCookie(...cookies)](#pagedeletecookiecookies)
   * [page.emulate(options)](#pageemulateoptions)
   * [page.emulateIdleState(overrides)](#pageemulateidlestateoverrides)
@@ -162,7 +163,6 @@
   * [page.metrics()](#pagemetrics)
   * [page.mouse](#pagemouse)
   * [page.pdf([options])](#pagepdfoptions)
-  * [page.pdfReadable([options])](#pagepdfreadableoptions)
   * [page.queryObjects(prototypeHandle)](#pagequeryobjectsprototypehandle)
   * [page.reload([options])](#pagereloadoptions)
   * [page.screenshot([options])](#pagescreenshotoptions)
@@ -1489,6 +1489,35 @@ If URLs are specified, only cookies for those URLs are returned.
 
 - returns: <[Coverage]>
 
+#### page.createPDFStream([options])
+- `options` <[Object]> Options object which might have the following properties:
+  - `path` <[string]> The file path to save the PDF to. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the PDF won't be saved to the disk.
+  - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`. Scale amount must be between 0.1 and 2.
+  - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
+  - `headerTemplate` <[string]> HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
+    - `date` formatted print date
+    - `title` document title
+    - `url` document location
+    - `pageNumber` current page number
+    - `totalPages` total pages in the document
+  - `footerTemplate` <[string]> HTML template for the print footer. Should use the same format as the `headerTemplate`.
+  - `printBackground` <[boolean]> Print background graphics. Defaults to `false`.
+  - `landscape` <[boolean]> Paper orientation. Defaults to `false`.
+  - `pageRanges` <[string]> Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
+  - `format` <[string]> Paper format. If set, takes priority over `width` or `height` options. Defaults to 'Letter'.
+  - `width` <[string]|[number]> Paper width, accepts values labeled with units.
+  - `height` <[string]|[number]> Paper height, accepts values labeled with units.
+  - `margin` <[Object]> Paper margins, defaults to none.
+    - `top` <[string]|[number]> Top margin, accepts values labeled with units.
+    - `right` <[string]|[number]> Right margin, accepts values labeled with units.
+    - `bottom` <[string]|[number]> Bottom margin, accepts values labeled with units.
+    - `left` <[string]|[number]> Left margin, accepts values labeled with units.
+  - `preferCSSPageSize` <[boolean]> Give any CSS `@page` size declared in the page priority over what is declared in `width` and `height` or `format` options. Defaults to `false`, which will scale the content to fit the paper size.
+  - `omitBackground` <[boolean]> Hides default white background and allows capturing screenshots with transparency. Defaults to `false`.
+- returns: <[Promise]<[Readable]>> Promise which resolves with a Node.js stream for the PDF file.
+
+> **NOTE** This method is identical to [page.pdf](#pagepdfoptions), except it returns the PDF as a readable stream of binary data. If you are generating very large PDFs, it may be useful to use a stream to avoid high memory usage. This version will ignore the `path` option.
+
 #### page.deleteCookie(...cookies)
 
 - `...cookies` <...[Object]>
@@ -1979,7 +2008,6 @@ Page is guaranteed to have a main frame which persists during navigations.
 - returns: <[Mouse]>
 
 #### page.pdf([options])
-
 - `options` <[Object]> Options object which might have the following properties:
   - `path` <[string]> The file path to save the PDF to. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the PDF won't be saved to the disk.
   - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`. Scale amount must be between 0.1 and 2.
@@ -2011,6 +2039,8 @@ Page is guaranteed to have a main frame which persists during navigations.
 `page.pdf()` generates a pdf of the page with `print` CSS media. To generate a pdf with `screen` media, call [page.emulateMediaType('screen')](#pageemulatemediatypetype) before calling `page.pdf()`:
 
 > **NOTE** By default, `page.pdf()` generates a pdf with modified colors for printing. Use the [`-webkit-print-color-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust) property to force rendering of exact colors.
+
+> **NOTE** If you are generating very large PDFs, it may be useful to use the streaming version of this function ([page.createPDFStream](#pagecreatepdfstreamoptions)) to avoid high memory usage.
 
 ```js
 // Generates a PDF with 'screen' media type.
@@ -2051,33 +2081,6 @@ The `format` options are:
 >
 > 1. Script tags inside templates are not evaluated.
 > 2. Page styles are not visible inside templates.
-
-#### page.pdfReadable([options])
-- `options` <[Object]> Options object which might have the following properties:
-  - `scale` <[number]> Scale of the webpage rendering. Defaults to `1`. Scale amount must be between 0.1 and 2.
-  - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
-  - `headerTemplate` <[string]> HTML template for the print header. Should be valid HTML markup with following classes used to inject printing values into them:
-    - `date` formatted print date
-    - `title` document title
-    - `url` document location
-    - `pageNumber` current page number
-    - `totalPages` total pages in the document
-  - `footerTemplate` <[string]> HTML template for the print footer. Should use the same format as the `headerTemplate`.
-  - `printBackground` <[boolean]> Print background graphics. Defaults to `false`.
-  - `landscape` <[boolean]> Paper orientation. Defaults to `false`.
-  - `pageRanges` <[string]> Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
-  - `format` <[string]> Paper format. If set, takes priority over `width` or `height` options. Defaults to 'Letter'.
-  - `width` <[string]|[number]> Paper width, accepts values labeled with units.
-  - `height` <[string]|[number]> Paper height, accepts values labeled with units.
-  - `margin` <[Object]> Paper margins, defaults to none.
-    - `top` <[string]|[number]> Top margin, accepts values labeled with units.
-    - `right` <[string]|[number]> Right margin, accepts values labeled with units.
-    - `bottom` <[string]|[number]> Bottom margin, accepts values labeled with units.
-    - `left` <[string]|[number]> Left margin, accepts values labeled with units.
-  - `preferCSSPageSize` <[boolean]> Give any CSS `@page` size declared in the page priority over what is declared in `width` and `height` or `format` options. Defaults to `false`, which will scale the content to fit the paper size.
-- returns: <[Promise]<[Readable]>> Promise which resolves with a Readable stream
-
-This method is identical to [page.pdf](#pagepdfoptions), except it returns the PDF as a readable stream of binary data. If you are generating very large PDFs, it may be useful to use a stream to avoid high memory usage.
 
 #### page.queryObjects(prototypeHandle)
 

--- a/src/common/Tracing.ts
+++ b/src/common/Tracing.ts
@@ -106,10 +106,17 @@ export class Tracing {
       fulfill = x;
       reject = y;
     });
-    this._client.once('Tracing.tracingComplete', (event) => {
-      helper
-        .readProtocolStream(this._client, event.stream, this._path)
-        .then(fulfill, reject);
+    this._client.once('Tracing.tracingComplete', async (event) => {
+      try {
+        const readable = await helper.getReadableFromProtocolStream(
+          this._client,
+          event.stream
+        );
+        const buffer = await helper.getReadableAsBuffer(readable, this._path);
+        fulfill(buffer);
+      } catch (error) {
+        reject(error);
+      }
     });
     await this._client.send('Tracing.end');
     this._recording = false;

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import type { Readable } from 'stream';
+
 import { TimeoutError } from './Errors.js';
 import { debug } from './Debug.js';
 import { CDPSession } from './Connection.js';
@@ -307,9 +310,8 @@ async function waitWithTimeout<T extends any>(
   }
 }
 
-async function readProtocolStream(
-  client: CDPSession,
-  handle: string,
+async function getReadableAsBuffer(
+  readable: Readable,
   path?: string
 ): Promise<Buffer> {
   if (!isNode && path) {
@@ -318,33 +320,54 @@ async function readProtocolStream(
 
   const fs = isNode ? await importFSModule() : null;
 
-  let eof = false;
   let fileHandle: import('fs').promises.FileHandle;
 
   if (path && fs) {
     fileHandle = await fs.promises.open(path, 'w');
   }
-  const bufs = [];
-  while (!eof) {
-    const response = await client.send('IO.read', { handle });
-    eof = response.eof;
-    const buf = Buffer.from(
-      response.data,
-      response.base64Encoded ? 'base64' : undefined
-    );
-    bufs.push(buf);
-    if (path && fs) {
-      await fs.promises.writeFile(fileHandle, buf);
+  const buffers = [];
+  for await (const chunk of readable) {
+    buffers.push(chunk);
+    if (fileHandle) {
+      await fs.promises.writeFile(fileHandle, chunk);
     }
   }
+
   if (path) await fileHandle.close();
-  await client.send('IO.close', { handle });
   let resultBuffer = null;
   try {
-    resultBuffer = Buffer.concat(bufs);
+    resultBuffer = Buffer.concat(buffers);
   } finally {
     return resultBuffer;
   }
+}
+
+async function getReadableFromProtocolStream(
+  client: CDPSession,
+  handle: string
+): Promise<Readable> {
+  if (!isNode) {
+    throw new Error('Cannot create a stream outside of Node.js environment.');
+  }
+
+  const { Readable } = await import('stream');
+
+  let eof = false;
+  return new Readable({
+    async read(size: number) {
+      if (eof) {
+        return null;
+      }
+
+      const response = await client.send('IO.read', { handle, size });
+      this.push(response.data, response.base64Encoded ? 'base64' : undefined);
+      if (response.eof) {
+        this.push(null);
+        eof = true;
+        await client.send('IO.close', { handle });
+      }
+    },
+  });
 }
 
 /**
@@ -378,7 +401,8 @@ export const helper = {
   pageBindingDeliverErrorString,
   pageBindingDeliverErrorValueString,
   makePredicateString,
-  readProtocolStream,
+  getReadableAsBuffer,
+  getReadableFromProtocolStream,
   waitWithTimeout,
   waitForEvent,
   isString,

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -346,6 +346,8 @@ async function getReadableFromProtocolStream(
   client: CDPSession,
   handle: string
 ): Promise<Readable> {
+  // TODO:
+  // This restriction can be lifted once https://github.com/nodejs/node/pull/39062 has landed
   if (!isNode) {
     throw new Error('Cannot create a stream outside of Node.js environment.');
   }

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -1514,6 +1514,20 @@ describe('Page', function () {
       expect(fs.readFileSync(outputFile).byteLength).toBeGreaterThan(0);
       fs.unlinkSync(outputFile);
     });
+
+    it('can print to PDF and stream the result', async () => {
+      // Printing to pdf is currently only supported in headless
+      const { isHeadless, page } = getTestState();
+
+      if (!isHeadless) return;
+
+      const stream = await page.createPDFStream();
+      let size = 0;
+      for await (const chunk of stream) {
+        size += chunk.size;
+      }
+      expect(size).toBeGreaterThan(0);
+    });
   });
 
   describe('Page.title', function () {

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -1524,7 +1524,7 @@ describe('Page', function () {
       const stream = await page.createPDFStream();
       let size = 0;
       for await (const chunk of stream) {
-        size += chunk.size;
+        size += chunk.length;
       }
       expect(size).toBeGreaterThan(0);
     });

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -775,6 +775,13 @@ function compareDocumentations(actual, expected) {
         },
       ],
       [
+        'Method Page.createPDFStream() options',
+        {
+          actualName: 'Object',
+          expectedName: 'PDFOptions',
+        },
+      ],
+      [
         'Method Page.screenshot() options',
         {
           actualName: 'Object',


### PR DESCRIPTION
Hello.

I had to render some big PDFs. Unfortunately, puppeteer's public API exposes only `Page.pdf()`, which always returns a concatenated `Buffer`, even though internally it deals with a stream of data. Buffer.concat seems to be copying each chunk before concatenating them, so processing my sample 60MB PDF required at least 120MB of node's memory for a single PDF. Saving to a temporary file won't help because the method always creates the buffer. This can be avoided by exposing the underlying stream as `Readable`.

I wanted to add a parameter to `Page.pdf()`, but its return type would have to change to `Promise<Buffer | Readable>` or, ideally, its signature changed to `pdf<B extends boolean>(..., returnReadable: B): Promise<B extends true ? Readable : Buffer>`, but both would be a breaking change for TypeScript consumers. Therefore, I settled on adding a new method, `pdfReadable`, which allows us to retain 100% backwards compatibility.

🤗