### PR TITLE
chore: small CI tidy ups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ jobs:
       before_install:
         - PUPPETEER_PRODUCT=firefox npm install
       script:
-        - npm run test-install
         - npm run coverage
 
     # This bot runs all the extra checks that aren't the main Puppeteer unit tests

--- a/mocha-config/puppeteer-unit-tests.js
+++ b/mocha-config/puppeteer-unit-tests.js
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-const os = require('os');
 const base = require('./base');
-
-const longerTimeoutRequired = process.env.PUPPETEER_PRODUCT === 'firefox' || os.platform() === 'win32';
-
-const timeout = longerTimeoutRequired ? 25 * 1000 : 10 * 1000;
-
-console.log('Mocha config: Timeout set to', timeout / 1000, 'seconds');
 
 module.exports = {
   ...base,
   file: ['./test/mocha-utils.js'],
   spec: 'test/*.spec.js',
-  timeout,
+  timeout: 25 * 1000,
 };


### PR DESCRIPTION
* Increased the timeout to a flat 25 second for every build because we
still see the odd, non-reproducible timeout on a variety of machines.
* Removed an extraneous `npm run test-install` which meant we did that
check twice on each CI run.
