### PR TITLE
chore: Enforce array type styles in TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,10 @@ module.exports = {
                 "@typescript-eslint/no-empty-function": 0,
                 "@typescript-eslint/no-use-before-define": 0,
                 // We know it's bad and use it very sparingly but it's needed :(
-                "@typescript-eslint/ban-ts-ignore": 0
+                "@typescript-eslint/ban-ts-ignore": 0,
+                "@typescript-eslint/array-type": [2, {
+                    "default": "array-simple"
+                }]
             }
         }
     ]

--- a/src/Accessibility.ts
+++ b/src/Accessibility.ts
@@ -48,7 +48,7 @@ interface SerializedAXNode {
   haspopup?: string;
   invalid?: string;
   orientation?: string;
-  children?: Array<SerializedAXNode>;
+  children?: SerializedAXNode[];
 }
 
 export class Accessibility {


### PR DESCRIPTION
This change enforces how we type arrays, e.g. choosing between:

* `string[]`
* `Array<string>`

I've gone for the `array-simple` option [1] which enforces that:

* primitive types and type references use `X[]`
* complex types use `Array<X>`

For example, we'd type an array of strings as `string[]`, but an array
of a union type as `Array<SomeUnionType>`.

[1]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md
