### PR TITLE
chore: enable mocha retries

### DIFF
--- a/mocha-config/puppeteer-unit-tests.js
+++ b/mocha-config/puppeteer-unit-tests.js
@@ -20,5 +20,7 @@ module.exports = {
   ...base,
   file: ['./test/mocha-utils.js'],
   spec: 'test/*.spec.js',
+  // retry twice more, so we run each test up to 3 times if needed.
+  retries: 2,
   timeout: 25 * 1000,
 };


### PR DESCRIPTION
We are seeing some CI flakes due to network resets, or issues out of our
control. Let's try to avoid some of those by using Mocha's built-in
retries.
