### PR TITLE
chore: log product + binary on unit test runs

### DIFF
--- a/test/mocha-utils.js
+++ b/test/mocha-utils.js
@@ -117,6 +117,11 @@ global.describeChromeOnly = (...args) => {
 if (process.env.COVERAGE)
   assertCoverage();
 
+console.log(
+    `Running unit tests with:
+  -> product: ${product}
+  -> binary: ${path.relative(process.cwd(), puppeteer.executablePath())}`);
+
 exports.setupTestBrowserHooks = () => {
   before(async() => {
     const browser = await puppeteer.launch(defaultBrowserOptions);


### PR DESCRIPTION
So it's super clear which product and binary you're testing against.
