### PR TITLE
Warn when given unsupported product name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^5.0.0",
     "prettier": "^2.0.5",
+    "sinon": "^9.0.2",
     "text-diff": "^1.0.1",
     "typescript": "3.8.3"
   },

--- a/src/Launcher.ts
+++ b/src/Launcher.ts
@@ -1027,6 +1027,15 @@ function Launcher(
       );
     case 'chrome':
     default:
+      if (typeof product !== 'undefined' && product !== 'chrome') {
+        /* The user gave us an incorrect product name
+         * we'll default to launching Chrome, but log to the console
+         * to let the user know (they've probably typoed).
+         */
+        console.warn(
+          `Warning: unknown product name ${product}. Falling back to chrome.`
+        );
+      }
       return new ChromeLauncher(
         projectRoot,
         preferredRevision,

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const sinon = require('sinon');
 const { helper } = require('../lib/helper');
 const rmAsync = helper.promisify(require('rimraf'));
 const mkdtempAsync = helper.promisify(fs.mkdtemp);
@@ -442,6 +443,20 @@ describe('Launcher specs', function () {
         const userAgent = await browser.userAgent();
         await browser.close();
         expect(userAgent).toContain('Chrome');
+      });
+
+      it('falls back to launching chrome if there is an unknown product but logs a warning', async () => {
+        const { puppeteer } = getTestState();
+        const consoleStub = sinon.stub(console, 'warn');
+        const browser = await puppeteer.launch({ product: 'SO_NOT_A_PRODUCT' });
+        const userAgent = await browser.userAgent();
+        await browser.close();
+        consoleStub.resetBehavior();
+        expect(userAgent).toContain('Chrome');
+        expect(consoleStub.callCount).toEqual(1);
+        expect(consoleStub.firstCall.args).toEqual([
+          'Warning: unknown product name SO_NOT_A_PRODUCT. Falling back to chrome.',
+        ]);
       });
 
       /* We think there's a bug in the FF Windows launcher, or some

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -451,7 +451,6 @@ describe('Launcher specs', function () {
         const browser = await puppeteer.launch({ product: 'SO_NOT_A_PRODUCT' });
         const userAgent = await browser.userAgent();
         await browser.close();
-        consoleStub.resetBehavior();
         expect(userAgent).toContain('Chrome');
         expect(consoleStub.callCount).toEqual(1);
         expect(consoleStub.firstCall.args).toEqual([

--- a/test/mocha-utils.js
+++ b/test/mocha-utils.js
@@ -18,6 +18,7 @@ const { TestServer } = require('../utils/testserver/index');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const sinon = require('sinon');
 const puppeteer = require('../');
 const utils = require('./utils');
 const { trackCoverage } = require('./coverage-utils');
@@ -168,4 +169,8 @@ after(async () => {
   state.server = null;
   await state.httpsServer.stop();
   state.httpsServer = null;
+});
+
+afterEach(() => {
+  sinon.restore();
 });


### PR DESCRIPTION
Fixes #5844.

This change means when a user launches Puppeteer with a product name
that is not supported (which at the time of this commit means it's not
`firefox` or `chrome) we will warn them about it.

Decided on just a warning vs an error because the current behaviour is
that we fallback to launching Chrome and I don't think this warrants a
breaking change.
