### PR TITLE
chore: extract `SecurityDetails` into its own module

### DIFF
--- a/src/NetworkManager.ts
+++ b/src/NetworkManager.ts
@@ -18,6 +18,7 @@ import { helper, assert, debugError } from './helper';
 import { Events } from './Events';
 import { CDPSession } from './Connection';
 import { FrameManager, Frame } from './FrameManager';
+import { SecurityDetails } from './SecurityDetails';
 
 export interface Credentials {
   username: string;
@@ -655,42 +656,6 @@ export class Response {
 
   frame(): Frame | null {
     return this._request.frame();
-  }
-}
-
-export class SecurityDetails {
-  _subjectName: string;
-  _issuer: string;
-  _validFrom: number;
-  _validTo: number;
-  _protocol: string;
-
-  constructor(securityPayload: Protocol.Network.SecurityDetails) {
-    this._subjectName = securityPayload.subjectName;
-    this._issuer = securityPayload.issuer;
-    this._validFrom = securityPayload.validFrom;
-    this._validTo = securityPayload.validTo;
-    this._protocol = securityPayload.protocol;
-  }
-
-  subjectName(): string {
-    return this._subjectName;
-  }
-
-  issuer(): string {
-    return this._issuer;
-  }
-
-  validFrom(): number {
-    return this._validFrom;
-  }
-
-  validTo(): number {
-    return this._validTo;
-  }
-
-  protocol(): string {
-    return this._protocol;
   }
 }
 

--- a/src/SecurityDetails.ts
+++ b/src/SecurityDetails.ts
@@ -15,11 +15,11 @@
  */
 
 export class SecurityDetails {
-  _subjectName: string;
-  _issuer: string;
-  _validFrom: number;
-  _validTo: number;
-  _protocol: string;
+  private _subjectName: string;
+  private _issuer: string;
+  private _validFrom: number;
+  private _validTo: number;
+  private _protocol: string;
 
   constructor(securityPayload: Protocol.Network.SecurityDetails) {
     this._subjectName = securityPayload.subjectName;

--- a/src/SecurityDetails.ts
+++ b/src/SecurityDetails.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2019 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class SecurityDetails {
+  _subjectName: string;
+  _issuer: string;
+  _validFrom: number;
+  _validTo: number;
+  _protocol: string;
+
+  constructor(securityPayload: Protocol.Network.SecurityDetails) {
+    this._subjectName = securityPayload.subjectName;
+    this._issuer = securityPayload.issuer;
+    this._validFrom = securityPayload.validFrom;
+    this._validTo = securityPayload.validTo;
+    this._protocol = securityPayload.protocol;
+  }
+
+  subjectName(): string {
+    return this._subjectName;
+  }
+
+  issuer(): string {
+    return this._issuer;
+  }
+
+  validFrom(): number {
+    return this._validFrom;
+  }
+
+  validTo(): number {
+    return this._validTo;
+  }
+
+  protocol(): string {
+    return this._protocol;
+  }
+}

--- a/src/SecurityDetails.ts
+++ b/src/SecurityDetails.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google Inc. All rights reserved.
+ * Copyright 2020 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,7 +38,7 @@ module.exports = {
   Puppeteer: require('./Puppeteer').Puppeteer,
   Request: require('./NetworkManager').Request,
   Response: require('./NetworkManager').Response,
-  SecurityDetails: require('./NetworkManager').SecurityDetails,
+  SecurityDetails: require('./SecurityDetails').SecurityDetails,
   Target: require('./Target').Target,
   TimeoutError: require('./Errors').TimeoutError,
   Touchscreen: require('./Input').Touchscreen,


### PR DESCRIPTION
Continuing with the effort of #5856 splitting classes into their own modules.