### PR TITLE
chore: upgrade TypeScript to 3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prettier": "^2.0.5",
     "sinon": "^9.0.2",
     "text-diff": "^1.0.1",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "browser": {
     "./lib/BrowserFetcher.js": false,


### PR DESCRIPTION
Sticking to a specific version of TS rather than a ^ version so we know
everyone is on the exact same version. Think that's preferable for such
an important dependency.
