### PR TITLE
chore: force Mocha to exit on CI

### DIFF
--- a/mocha-config/base.js
+++ b/mocha-config/base.js
@@ -1,3 +1,4 @@
 module.exports = {
   reporter: 'dot',
+  exit: !!process.env.CI,
 };


### PR DESCRIPTION
We have some bug where some test runs will pass but then stall as Mocha
doesn't exit cleanly. This is proving very hard to track down (I've yet
to replicate it or find the test that causes it) and it doesn't happen
consistently.

The `exit` flag forces Mocha to hard exit. This will help with CI
stability. The flag only gets set on CI runs.
