### PR TITLE
chore: Error if coverage couldn't find the given class

### DIFF
--- a/test/coverage-utils.js
+++ b/test/coverage-utils.js
@@ -37,6 +37,12 @@ const fs = require('fs');
  */
 function traceAPICoverage(apiCoverage, events, className, classType) {
   className = className.substring(0, 1).toLowerCase() + className.substring(1);
+  if (!classType || !classType.prototype) {
+    console.error(
+      `Coverage error: could not find class for ${className}. Is src/api.ts up to date?`
+    );
+    process.exit(1);
+  }
   for (const methodName of Reflect.ownKeys(classType.prototype)) {
     const method = Reflect.get(classType.prototype, methodName);
     if (


### PR DESCRIPTION
The coverage utils depend on `src/api.ts` being up to date and pointing
to the right modules. If they aren't, you would get a cryptic error on
CI:

```
1) "before all" hook in "{root}":
   TypeError: Cannot read property 'prototype' of undefined
    at traceAPICoverage (test/coverage-utils.js:40:54)
    at Context.before (test/coverage-utils.js:103:7)
2) "after all" hook in "{root}":
   TypeError: Cannot read property 'stop' of undefined
    at Context.after (test/mocha-utils.js:168:22)
```

This change logs a clearer error that highlights the missing class and
exits, so it's much easier to realise what's gone wrong.

Ideally the  coverage wouldn't need a hardcoded list of sources, but
until then this will help spot this error in the future.
