### PR TITLE
chore: fetch Firefox from json source instead of run a RegExp

### DIFF
--- a/src/BrowserFetcher.ts
+++ b/src/BrowserFetcher.ts
@@ -40,10 +40,10 @@ const downloadURLs = {
     win64: '%s/chromium-browser-snapshots/Win_x64/%d/%s.zip',
   },
   firefox: {
-    linux: '%s/firefox-%s.0a1.en-US.%s-x86_64.tar.bz2',
-    mac: '%s/firefox-%s.0a1.en-US.%s.dmg',
-    win32: '%s/firefox-%s.0a1.en-US.%s.zip',
-    win64: '%s/firefox-%s.0a1.en-US.%s.zip',
+    linux: '%s/firefox-%s.en-US.%s-x86_64.tar.bz2',
+    mac: '%s/firefox-%s.en-US.%s.dmg',
+    win32: '%s/firefox-%s.en-US.%s.zip',
+    win64: '%s/firefox-%s.en-US.%s.zip',
   },
 } as const;
 

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -81,7 +81,7 @@ describe('Launcher specs', function () {
           host: server.PREFIX,
           product: 'firefox',
         });
-        const expectedVersion = '75';
+        const expectedVersion = '75.0a1';
         let revisionInfo = browserFetcher.revisionInfo(expectedVersion);
         server.setRoute(
           revisionInfo.url.substring(server.PREFIX.length),

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -89,7 +89,7 @@ describe('Launcher specs', function () {
             server.serveFile(
               req,
               res,
-              `/firefox-${expectedVersion}.0a1.en-US.linux-x86_64.tar.bz2`
+              `/firefox-${expectedVersion}.en-US.linux-x86_64.tar.bz2`
             );
           }
         );


### PR DESCRIPTION
Instead of parsing the https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/ directory this patch fetches the Firefox revision from an official endpoint.

fixes #5742