### PR TITLE
Fix for incorrect catch syntax

### DIFF
--- a/install.js
+++ b/install.js
@@ -172,7 +172,7 @@ async function download() {
             try {
               const versions = JSON.parse(data);
               return resolve(versions.FIREFOX_NIGHTLY);
-            } catch {
+            } catch (error) {
               return reject(new Error('Firefox version not found'));
             }
           });


### PR DESCRIPTION
This was causing npm install to fail.