### PR TITLE
chore: Error for bad Node versions

### DIFF
--- a/install.js
+++ b/install.js
@@ -26,6 +26,19 @@
 
 const compileTypeScriptIfRequired = require('./typescript-if-required');
 
+const checkNodeVersionSupported = () => {
+  const minRequiredVersion = require('./package.json').engines.node;
+  const semver = require('semver');
+
+  if (!semver.satisfies(process.version, minRequiredVersion)) {
+    console.error(`Error: Node version ${process.version} is not supported.`);
+    console.error(
+      `You must be running at least ${minRequiredVersion} to use Puppeteer.`
+    );
+    process.exit(1);
+  }
+};
+
 const firefoxVersions =
   'https://product-details.mozilla.org/1.0/firefox_versions.json';
 const supportedProducts = {
@@ -172,7 +185,7 @@ async function download() {
             try {
               const versions = JSON.parse(data);
               return resolve(versions.FIREFOX_NIGHTLY);
-            } catch {
+            } catch (_error) {
               return reject(new Error('Firefox version not found'));
             }
           });
@@ -239,4 +252,5 @@ if (
   return;
 }
 
+checkNodeVersionSupported();
 download();

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "progress": "^2.0.1",
     "proxy-from-env": "^1.0.0",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.2",
     "tar-fs": "^2.0.0",
     "unbzip2-stream": "^1.3.3",
     "ws": "^7.2.3"


### PR DESCRIPTION
We define the Node version in the `engines` field in `package.json`
however this is only used and mentioned to the user when installing the
package as a dependency [1]. Node/npm is quite noisy when installing
these so it's very easily missed.

We now use the semver package to check our version in the install script
and bail if it's not at least what's in our `engines` field. This fix
isn't perfect because if we use syntax that isn't supported in old
versions the user will get a syntax error rather than our nice error,
but it should help moving forwards as we push Node versions up. e.g.
when we were to drop Node 10 (for the avoidance of doubt, not happening
anytime soon at all) this would help users be aware and know to upgrade.

[1]: https://docs.npmjs.com/files/package.json#engines
