### PR TITLE
Bugfix Fix missing error parameter on try catch

### DIFF
--- a/install.js
+++ b/install.js
@@ -172,7 +172,7 @@ async function download() {
             try {
               const versions = JSON.parse(data);
               return resolve(versions.FIREFOX_NIGHTLY);
-            } catch {
+            } catch (error) {
               return reject(new Error('Firefox version not found'));
             }
           });


### PR DESCRIPTION
Missing try-catch error parameter causes an exception when installing puppeteer via npm