### PR TITLE
chore: rename Request class to HTTPRequest

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -281,20 +281,20 @@
   * [elementHandle.toString()](#elementhandletostring)
   * [elementHandle.type(text[, options])](#elementhandletypetext-options)
   * [elementHandle.uploadFile(...filePaths)](#elementhandleuploadfilefilepaths)
-- [class: Request](#class-request)
-  * [request.abort([errorCode])](#requestaborterrorcode)
-  * [request.continue([overrides])](#requestcontinueoverrides)
-  * [request.failure()](#requestfailure)
-  * [request.frame()](#requestframe)
-  * [request.headers()](#requestheaders)
-  * [request.isNavigationRequest()](#requestisnavigationrequest)
-  * [request.method()](#requestmethod)
-  * [request.postData()](#requestpostdata)
-  * [request.redirectChain()](#requestredirectchain)
-  * [request.resourceType()](#requestresourcetype)
-  * [request.respond(response)](#requestrespondresponse)
-  * [request.response()](#requestresponse)
-  * [request.url()](#requesturl)
+- [class: HTTPRequest](#class-httprequest)
+  * [httpRequest.abort([errorCode])](#httprequestaborterrorcode)
+  * [httpRequest.continue([overrides])](#httprequestcontinueoverrides)
+  * [httpRequest.failure()](#httprequestfailure)
+  * [httpRequest.frame()](#httprequestframe)
+  * [httpRequest.headers()](#httprequestheaders)
+  * [httpRequest.isNavigationRequest()](#httprequestisnavigationrequest)
+  * [httpRequest.method()](#httprequestmethod)
+  * [httpRequest.postData()](#httprequestpostdata)
+  * [httpRequest.redirectChain()](#httprequestredirectchain)
+  * [httpRequest.resourceType()](#httprequestresourcetype)
+  * [httpRequest.respond(response)](#httprequestrespondresponse)
+  * [httpRequest.response()](#httprequestresponse)
+  * [httpRequest.url()](#httprequesturl)
 - [class: Response](#class-response)
   * [response.buffer()](#responsebuffer)
   * [response.frame()](#responseframe)
@@ -3543,7 +3543,7 @@ await elementHandle.press('Enter');
 
 This method expects `elementHandle` to point to an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
 
-### class: Request
+### class: HTTPRequest
 
 Whenever the page sends a request, such as for a network resource, the following events are emitted by puppeteer's page:
 - [`'request'`](#event-request) emitted when the request is issued by the page.
@@ -3556,7 +3556,7 @@ If request fails at some point, then instead of `'requestfinished'` event (and p
 
 If request gets a 'redirect' response, the request is successfully finished with the 'requestfinished' event, and a new request is  issued to a redirected url.
 
-#### request.abort([errorCode])
+#### httpRequest.abort([errorCode])
 - `errorCode` <[string]> Optional error code. Defaults to `failed`, could be
   one of the following:
   - `aborted` - An operation was aborted (due to user action)
@@ -3579,7 +3579,7 @@ If request gets a 'redirect' response, the request is successfully finished with
 Aborts request. To use this, request interception should be enabled with `page.setRequestInterception`.
 Exception is immediately thrown if the request interception is not enabled.
 
-#### request.continue([overrides])
+#### httpRequest.continue([overrides])
 - `overrides` <[Object]> Optional request overwrites, which can be one of the following:
   - `url` <[string]> If set, the request url will be changed. This is not a redirect. The request will be silently forwarded to the new url. For example, the address bar will show the original url.
   - `method` <[string]> If set changes the request method (e.g. `GET` or `POST`)
@@ -3602,7 +3602,7 @@ page.on('request', request => {
 });
 ```
 
-#### request.failure()
+#### httpRequest.failure()
 - returns: <?[Object]> Object describing request failure, if any
   - `errorText` <[string]> Human-readable error message, e.g. `'net::ERR_FAILED'`.
 
@@ -3617,24 +3617,24 @@ page.on('requestfailed', request => {
 });
 ```
 
-#### request.frame()
+#### httpRequest.frame()
 - returns: <?[Frame]> A [Frame] that initiated this request, or `null` if navigating to error pages.
 
-#### request.headers()
+#### httpRequest.headers()
 - returns: <[Object]> An object with HTTP headers associated with the request. All header names are lower-case.
 
-#### request.isNavigationRequest()
+#### httpRequest.isNavigationRequest()
 - returns: <[boolean]>
 
 Whether this request is driving frame's navigation.
 
-#### request.method()
+#### httpRequest.method()
 - returns: <[string]> Request's method (GET, POST, etc.)
 
-#### request.postData()
+#### httpRequest.postData()
 - returns: <[string]> Request's post body, if any.
 
-#### request.redirectChain()
+#### httpRequest.redirectChain()
 - returns: <[Array]<[Request]>>
 
 A `redirectChain` is a chain of requests initiated to fetch a resource.
@@ -3661,13 +3661,13 @@ const chain = response.request().redirectChain();
 console.log(chain.length); // 0
 ```
 
-#### request.resourceType()
+#### httpRequest.resourceType()
 - returns: <[string]>
 
 Contains the request's resource type as it was perceived by the rendering engine.
 ResourceType will be one of the following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`, `websocket`, `manifest`, `other`.
 
-#### request.respond(response)
+#### httpRequest.respond(response)
 - `response` <[Object]> Response that will fulfill this request
   - `status` <[number]> Response status code, defaults to `200`.
   - `headers` <[Object]> Optional response headers. Header values will be converted to a string.
@@ -3695,10 +3695,10 @@ page.on('request', request => {
 > **NOTE** Mocking responses for dataURL requests is not supported.
 > Calling `request.respond` for a dataURL request is a noop.
 
-#### request.response()
+#### httpRequest.response()
 - returns: <?[Response]> A matching [Response] object, or `null` if the response has not been received yet.
 
-#### request.url()
+#### httpRequest.url()
 - returns: <[string]> URL of the request.
 
 ### class: Response

--- a/src/HTTPRequest.ts
+++ b/src/HTTPRequest.ts
@@ -19,14 +19,14 @@ import { Response } from './Response';
 import { helper, assert, debugError } from './helper';
 import Protocol from './protocol';
 
-export class Request {
+export class HTTPRequest {
   _requestId: string;
   _interceptionId: string;
   _failureText = null;
   _response: Response | null = null;
 
   _fromMemoryCache = false;
-  _redirectChain: Request[];
+  _redirectChain: HTTPRequest[];
 
   private _client: CDPSession;
   private _isNavigationRequest: boolean;
@@ -46,7 +46,7 @@ export class Request {
     interceptionId: string,
     allowInterception: boolean,
     event: Protocol.Network.requestWillBeSentPayload,
-    redirectChain: Request[]
+    redirectChain: HTTPRequest[]
   ) {
     this._client = client;
     this._requestId = event.requestId;
@@ -97,7 +97,7 @@ export class Request {
     return this._isNavigationRequest;
   }
 
-  redirectChain(): Request[] {
+  redirectChain(): HTTPRequest[] {
     return this._redirectChain.slice();
   }
 

--- a/src/LifecycleWatcher.ts
+++ b/src/LifecycleWatcher.ts
@@ -18,7 +18,7 @@ import { helper, assert, PuppeteerEventListener } from './helper';
 import { Events } from './Events';
 import { TimeoutError } from './Errors';
 import { FrameManager, Frame } from './FrameManager';
-import { Request } from './Request';
+import { HTTPRequest } from './HTTPRequest';
 import { Response } from './Response';
 
 export type PuppeteerLifeCycleEvent =
@@ -47,7 +47,7 @@ export class LifecycleWatcher {
   _frameManager: FrameManager;
   _frame: Frame;
   _timeout: number;
-  _navigationRequest?: Request;
+  _navigationRequest?: HTTPRequest;
   _eventListeners: PuppeteerEventListener[];
   _initialLoaderId: string;
 
@@ -139,7 +139,7 @@ export class LifecycleWatcher {
     this._checkLifecycleComplete();
   }
 
-  _onRequest(request: Request): void {
+  _onRequest(request: HTTPRequest): void {
     if (request.frame() !== this._frame || !request.isNavigationRequest())
       return;
     this._navigationRequest = request;

--- a/src/NetworkManager.ts
+++ b/src/NetworkManager.ts
@@ -19,7 +19,7 @@ import Protocol from './protocol';
 import { Events } from './Events';
 import { CDPSession } from './Connection';
 import { FrameManager } from './FrameManager';
-import { Request } from './Request';
+import { HTTPRequest } from './HTTPRequest';
 import { Response } from './Response';
 
 export interface Credentials {
@@ -31,7 +31,7 @@ export class NetworkManager extends EventEmitter {
   _client: CDPSession;
   _ignoreHTTPSErrors: boolean;
   _frameManager: FrameManager;
-  _requestIdToRequest = new Map<string, Request>();
+  _requestIdToRequest = new Map<string, HTTPRequest>();
   _requestIdToRequestWillBeSentEvent = new Map<
     string,
     Protocol.Network.requestWillBeSentPayload
@@ -250,7 +250,7 @@ export class NetworkManager extends EventEmitter {
     const frame = event.frameId
       ? this._frameManager.frame(event.frameId)
       : null;
-    const request = new Request(
+    const request = new HTTPRequest(
       this._client,
       frame,
       interceptionId,
@@ -270,7 +270,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   _handleRequestRedirect(
-    request: Request,
+    request: HTTPRequest,
     responsePayload: Protocol.Network.Response
   ): void {
     const response = new Response(this._client, request, responsePayload);

--- a/src/Page.ts
+++ b/src/Page.ts
@@ -32,7 +32,7 @@ import { Target } from './Target';
 import { createJSHandle, JSHandle, ElementHandle } from './JSHandle';
 import type { Viewport } from './PuppeteerViewport';
 import { Credentials } from './NetworkManager';
-import { Request as PuppeteerRequest } from './Request';
+import { HTTPRequest } from './HTTPRequest';
 import { Response as PuppeteerResponse } from './Response';
 import { Accessibility } from './Accessibility';
 import { TimeoutSettings } from './TimeoutSettings';
@@ -801,7 +801,7 @@ export class Page extends EventEmitter {
   async waitForRequest(
     urlOrPredicate: string | Function,
     options: { timeout?: number } = {}
-  ): Promise<PuppeteerRequest> {
+  ): Promise<HTTPRequest> {
     const { timeout = this._timeoutSettings.timeout() } = options;
     return helper.waitForEvent(
       this._frameManager.networkManager(),

--- a/src/Response.ts
+++ b/src/Response.ts
@@ -15,7 +15,7 @@
  */
 import { CDPSession } from './Connection';
 import { Frame } from './FrameManager';
-import { Request } from './Request';
+import { HTTPRequest } from './HTTPRequest';
 import { SecurityDetails } from './SecurityDetails';
 import Protocol from './protocol';
 
@@ -26,7 +26,7 @@ interface RemoteAddress {
 
 export class Response {
   private _client: CDPSession;
-  private _request: Request;
+  private _request: HTTPRequest;
   private _contentPromise: Promise<Buffer> | null = null;
   private _bodyLoadedPromise: Promise<Error | void>;
   private _bodyLoadedPromiseFulfill: (err: Error | void) => void;
@@ -41,7 +41,7 @@ export class Response {
 
   constructor(
     client: CDPSession,
-    request: Request,
+    request: HTTPRequest,
     responsePayload: Protocol.Network.Response
   ) {
     this._client = client;
@@ -125,7 +125,7 @@ export class Response {
     return JSON.parse(content);
   }
 
-  request(): Request {
+  request(): HTTPRequest {
     return this._request;
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -36,7 +36,7 @@ module.exports = {
   Mouse: require('./Input').Mouse,
   Page: require('./Page').Page,
   Puppeteer: require('./Puppeteer').Puppeteer,
-  Request: require('./Request').Request,
+  HTTPRequest: require('./HTTPRequest').HTTPRequest,
   Response: require('./Response').Response,
   SecurityDetails: require('./SecurityDetails').SecurityDetails,
   Target: require('./Target').Target,

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -377,7 +377,7 @@ function compareDocumentations(actual, expected) {
         },
       ],
       [
-        'Method Request.abort() errorCode',
+        'Method HTTPRequest.abort() errorCode',
         {
           actualName: 'string',
           expectedName: 'ErrorCode',


### PR DESCRIPTION
It conflicts with an inbuilt TypeScript `Request` type so can cause
confusion when in TS land. Note: `Response.ts` and `Worker.ts` also
suffer from this; PRs to rename them are incoming.
