### PR TITLE
chore: rename `Response` to `HTTPResponse`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -295,21 +295,21 @@
   * [httpRequest.respond(response)](#httprequestrespondresponse)
   * [httpRequest.response()](#httprequestresponse)
   * [httpRequest.url()](#httprequesturl)
-- [class: Response](#class-response)
-  * [response.buffer()](#responsebuffer)
-  * [response.frame()](#responseframe)
-  * [response.fromCache()](#responsefromcache)
-  * [response.fromServiceWorker()](#responsefromserviceworker)
-  * [response.headers()](#responseheaders)
-  * [response.json()](#responsejson)
-  * [response.ok()](#responseok)
-  * [response.remoteAddress()](#responseremoteaddress)
-  * [response.request()](#responserequest)
-  * [response.securityDetails()](#responsesecuritydetails)
-  * [response.status()](#responsestatus)
-  * [response.statusText()](#responsestatustext)
-  * [response.text()](#responsetext)
-  * [response.url()](#responseurl)
+- [class: HTTPResponse](#class-httpresponse)
+  * [httpResponse.buffer()](#httpresponsebuffer)
+  * [httpResponse.frame()](#httpresponseframe)
+  * [httpResponse.fromCache()](#httpresponsefromcache)
+  * [httpResponse.fromServiceWorker()](#httpresponsefromserviceworker)
+  * [httpResponse.headers()](#httpresponseheaders)
+  * [httpResponse.json()](#httpresponsejson)
+  * [httpResponse.ok()](#httpresponseok)
+  * [httpResponse.remoteAddress()](#httpresponseremoteaddress)
+  * [httpResponse.request()](#httpresponserequest)
+  * [httpResponse.securityDetails()](#httpresponsesecuritydetails)
+  * [httpResponse.status()](#httpresponsestatus)
+  * [httpResponse.statusText()](#httpresponsestatustext)
+  * [httpResponse.text()](#httpresponsetext)
+  * [httpResponse.url()](#httpresponseurl)
 - [class: SecurityDetails](#class-securitydetails)
   * [securityDetails.issuer()](#securitydetailsissuer)
   * [securityDetails.protocol()](#securitydetailsprotocol)
@@ -3708,64 +3708,64 @@ page.on('request', request => {
 #### httpRequest.url()
 - returns: <[string]> URL of the request.
 
-### class: Response
+### class: HTTPResponse
 
 [Response] class represents responses which are received by page.
 
-#### response.buffer()
+#### httpResponse.buffer()
 - returns: <Promise<[Buffer]>> Promise which resolves to a buffer with response body.
 
-#### response.frame()
+#### httpResponse.frame()
 - returns: <?[Frame]> A [Frame] that initiated this response, or `null` if navigating to error pages.
 
-#### response.fromCache()
+#### httpResponse.fromCache()
 - returns: <[boolean]>
 
 True if the response was served from either the browser's disk cache or memory cache.
 
-#### response.fromServiceWorker()
+#### httpResponse.fromServiceWorker()
 - returns: <[boolean]>
 
 True if the response was served by a service worker.
 
-#### response.headers()
+#### httpResponse.headers()
 - returns: <[Object]> An object with HTTP headers associated with the response. All header names are lower-case.
 
-#### response.json()
+#### httpResponse.json()
 - returns: <Promise<[Object]>> Promise which resolves to a JSON representation of response body.
 
 This method will throw if the response body is not parsable via `JSON.parse`.
 
-#### response.ok()
+#### httpResponse.ok()
 - returns: <[boolean]>
 
 Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
 
-#### response.remoteAddress()
+#### httpResponse.remoteAddress()
 - returns: <[Object]>
   - `ip` <[string]> the IP address of the remote server
   - `port` <[number]> the port used to connect to the remote server
 
-#### response.request()
+#### httpResponse.request()
 - returns: <[Request]> A matching [Request] object.
 
-#### response.securityDetails()
+#### httpResponse.securityDetails()
 - returns: <?[SecurityDetails]> Security details if the response was received over the secure connection, or `null` otherwise.
 
-#### response.status()
+#### httpResponse.status()
 - returns: <[number]>
 
 Contains the status code of the response (e.g., 200 for a success).
 
-#### response.statusText()
+#### httpResponse.statusText()
 - returns: <[string]>
 
 Contains the status text of the response (e.g. usually an "OK" for a success).
 
-#### response.text()
+#### httpResponse.text()
 - returns: <[Promise]<[string]>> Promise which resolves to a text representation of response body.
 
-#### response.url()
+#### httpResponse.url()
 - returns: <[string]>
 
 Contains the URL of the response.

--- a/src/FrameManager.ts
+++ b/src/FrameManager.ts
@@ -26,7 +26,7 @@ import { CDPSession } from './Connection';
 import { JSHandle, ElementHandle } from './JSHandle';
 import { MouseButtonInput } from './Input';
 import { Page } from './Page';
-import { Response } from './Response';
+import { HTTPResponse } from './HTTPResponse';
 import Protocol from './protocol';
 
 const UTILITY_WORLD_NAME = '__puppeteer_utility_world__';
@@ -113,7 +113,7 @@ export class FrameManager extends EventEmitter {
       timeout?: number;
       waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
     } = {}
-  ): Promise<Response | null> {
+  ): Promise<HTTPResponse | null> {
     assertNoLegacyNavigationOptions(options);
     const {
       referer = this._networkManager.extraHTTPHeaders()['referer'],
@@ -167,7 +167,7 @@ export class FrameManager extends EventEmitter {
       timeout?: number;
       waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
     } = {}
-  ): Promise<Response | null> {
+  ): Promise<HTTPResponse | null> {
     assertNoLegacyNavigationOptions(options);
     const {
       waitUntil = ['load'],
@@ -412,14 +412,14 @@ export class Frame {
       timeout?: number;
       waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
     }
-  ): Promise<Response | null> {
+  ): Promise<HTTPResponse | null> {
     return await this._frameManager.navigateFrame(this, url, options);
   }
 
   async waitForNavigation(options: {
     timeout?: number;
     waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-  }): Promise<Response | null> {
+  }): Promise<HTTPResponse | null> {
     return await this._frameManager.waitForFrameNavigation(this, options);
   }
 

--- a/src/HTTPRequest.ts
+++ b/src/HTTPRequest.ts
@@ -15,7 +15,7 @@
  */
 import { CDPSession } from './Connection';
 import { Frame } from './FrameManager';
-import { Response } from './Response';
+import { HTTPResponse } from './HTTPResponse';
 import { helper, assert, debugError } from './helper';
 import Protocol from './protocol';
 
@@ -23,7 +23,7 @@ export class HTTPRequest {
   _requestId: string;
   _interceptionId: string;
   _failureText = null;
-  _response: Response | null = null;
+  _response: HTTPResponse | null = null;
 
   _fromMemoryCache = false;
   _redirectChain: HTTPRequest[];
@@ -85,7 +85,7 @@ export class HTTPRequest {
     return this._headers;
   }
 
-  response(): Response | null {
+  response(): HTTPResponse | null {
     return this._response;
   }
 

--- a/src/HTTPResponse.ts
+++ b/src/HTTPResponse.ts
@@ -24,7 +24,7 @@ interface RemoteAddress {
   port: number;
 }
 
-export class Response {
+export class HTTPResponse {
   private _client: CDPSession;
   private _request: HTTPRequest;
   private _contentPromise: Promise<Buffer> | null = null;

--- a/src/LifecycleWatcher.ts
+++ b/src/LifecycleWatcher.ts
@@ -19,7 +19,7 @@ import { Events } from './Events';
 import { TimeoutError } from './Errors';
 import { FrameManager, Frame } from './FrameManager';
 import { HTTPRequest } from './HTTPRequest';
-import { Response } from './Response';
+import { HTTPResponse } from './HTTPResponse';
 
 export type PuppeteerLifeCycleEvent =
   | 'load'
@@ -156,7 +156,7 @@ export class LifecycleWatcher {
     this._checkLifecycleComplete();
   }
 
-  navigationResponse(): Response | null {
+  navigationResponse(): HTTPResponse | null {
     return this._navigationRequest ? this._navigationRequest.response() : null;
   }
 

--- a/src/NetworkManager.ts
+++ b/src/NetworkManager.ts
@@ -20,7 +20,7 @@ import { Events } from './Events';
 import { CDPSession } from './Connection';
 import { FrameManager } from './FrameManager';
 import { HTTPRequest } from './HTTPRequest';
-import { Response } from './Response';
+import { HTTPResponse } from './HTTPResponse';
 
 export interface Credentials {
   username: string;
@@ -273,7 +273,7 @@ export class NetworkManager extends EventEmitter {
     request: HTTPRequest,
     responsePayload: Protocol.Network.Response
   ): void {
-    const response = new Response(this._client, request, responsePayload);
+    const response = new HTTPResponse(this._client, request, responsePayload);
     request._response = response;
     request._redirectChain.push(request);
     response._resolveBody(
@@ -289,7 +289,7 @@ export class NetworkManager extends EventEmitter {
     const request = this._requestIdToRequest.get(event.requestId);
     // FileUpload sends a response without a matching request.
     if (!request) return;
-    const response = new Response(this._client, request, event.response);
+    const response = new HTTPResponse(this._client, request, event.response);
     request._response = response;
     this.emit(Events.NetworkManager.Response, response);
   }

--- a/src/Page.ts
+++ b/src/Page.ts
@@ -33,7 +33,7 @@ import { createJSHandle, JSHandle, ElementHandle } from './JSHandle';
 import type { Viewport } from './PuppeteerViewport';
 import { Credentials } from './NetworkManager';
 import { HTTPRequest } from './HTTPRequest';
-import { Response as PuppeteerResponse } from './Response';
+import { HTTPResponse } from './HTTPResponse';
 import { Accessibility } from './Accessibility';
 import { TimeoutSettings } from './TimeoutSettings';
 import { FileChooser } from './FileChooser';
@@ -769,13 +769,13 @@ export class Page extends EventEmitter {
   async goto(
     url: string,
     options: WaitForOptions & { referer?: string }
-  ): Promise<PuppeteerResponse> {
+  ): Promise<HTTPResponse> {
     return await this._frameManager.mainFrame().goto(url, options);
   }
 
-  async reload(options?: WaitForOptions): Promise<PuppeteerResponse | null> {
+  async reload(options?: WaitForOptions): Promise<HTTPResponse | null> {
     const result = await Promise.all<
-      PuppeteerResponse,
+      HTTPResponse,
       Protocol.Page.reloadReturnValue
     >([this.waitForNavigation(options), this._client.send('Page.reload')]);
 
@@ -784,7 +784,7 @@ export class Page extends EventEmitter {
 
   async waitForNavigation(
     options: WaitForOptions = {}
-  ): Promise<PuppeteerResponse | null> {
+  ): Promise<HTTPResponse | null> {
     return await this._frameManager.mainFrame().waitForNavigation(options);
   }
 
@@ -821,7 +821,7 @@ export class Page extends EventEmitter {
   async waitForResponse(
     urlOrPredicate: string | Function,
     options: { timeout?: number } = {}
-  ): Promise<PuppeteerResponse> {
+  ): Promise<HTTPResponse> {
     const { timeout = this._timeoutSettings.timeout() } = options;
     return helper.waitForEvent(
       this._frameManager.networkManager(),
@@ -838,23 +838,23 @@ export class Page extends EventEmitter {
     );
   }
 
-  async goBack(options: WaitForOptions): Promise<PuppeteerResponse | null> {
+  async goBack(options: WaitForOptions): Promise<HTTPResponse | null> {
     return this._go(-1, options);
   }
 
-  async goForward(options: WaitForOptions): Promise<PuppeteerResponse | null> {
+  async goForward(options: WaitForOptions): Promise<HTTPResponse | null> {
     return this._go(+1, options);
   }
 
   async _go(
     delta: number,
     options: WaitForOptions
-  ): Promise<PuppeteerResponse | null> {
+  ): Promise<HTTPResponse | null> {
     const history = await this._client.send('Page.getNavigationHistory');
     const entry = history.entries[history.currentIndex + delta];
     if (!entry) return null;
     const result = await Promise.all<
-      PuppeteerResponse,
+      HTTPResponse,
       Protocol.Page.navigateToHistoryEntryReturnValue
     >([
       this.waitForNavigation(options),

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,7 +38,7 @@ module.exports = {
   Page: require('./Page').Page,
   Puppeteer: require('./Puppeteer').Puppeteer,
   HTTPRequest: require('./HTTPRequest').HTTPRequest,
-  Response: require('./Response').Response,
+  HTTPResponse: require('./HTTPResponse').HTTPResponse,
   SecurityDetails: require('./SecurityDetails').SecurityDetails,
   Target: require('./Target').Target,
   TimeoutError: require('./Errors').TimeoutError,


### PR DESCRIPTION
To avoid any conflicts with the TS `Response` type.
