### PR TITLE
chore: Defer Windows FF test for longer

### DIFF
--- a/test/headful.spec.js
+++ b/test/headful.spec.js
@@ -93,7 +93,7 @@ describeChromeOnly('headful tests', function () {
        * date in to force us to come back and debug properly in the
        * future.
        */
-      new Date('2020-06-01'),
+      new Date('2020-07-01'),
       'headless should be able to read cookies written by headful',
       async () => {
         const { server, puppeteer } = getTestState();

--- a/test/launcher.spec.js
+++ b/test/launcher.spec.js
@@ -464,7 +464,7 @@ describe('Launcher specs', function () {
        * properly with help from the Mozilla folks.
        */
       itFailsWindowsUntilDate(
-        new Date('2020-06-01'),
+        new Date('2020-07-01'),
         'should be able to launch Firefox',
         async () => {
           const { puppeteer } = getTestState();


### PR DESCRIPTION
We deferred this initially because our Windows CI built wasn't stable
and so debugging this was hard. It's now much more stable so let's push
this back a month but at the same time I'll reach out to the Moz folks
as it should be easier to debug reliably now CI is stable on Windows.
