### PR TITLE
Error Handling When Checking Version of Firefox

### DIFF
--- a/install.js
+++ b/install.js
@@ -172,7 +172,7 @@ async function download() {
             try {
               const versions = JSON.parse(data);
               return resolve(versions.FIREFOX_NIGHTLY);
-            } catch {
+            } catch (e) {
               return reject(new Error('Firefox version not found'));
             }
           });


### PR DESCRIPTION
On line `175` of `install.js` there's a missing error within the `try... catch` statement, resulting in a syntax error when installing. 