### PR TITLE
Remove prefers-color-scheme "no-preference".

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1342,8 +1342,6 @@ await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches);
 // → true
 await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches);
 // → false
-await page.evaluate(() => matchMedia('(prefers-color-scheme: no-preference)').matches);
-// → false
 
 await page.emulateMediaFeatures([{ name: 'prefers-reduced-motion', value: 'reduce' }]);
 await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches);
@@ -1358,8 +1356,6 @@ await page.emulateMediaFeatures([
 await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches);
 // → true
 await page.evaluate(() => matchMedia('(prefers-color-scheme: light)').matches);
-// → false
-await page.evaluate(() => matchMedia('(prefers-color-scheme: no-preference)').matches);
 // → false
 await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches);
 // → true

--- a/test/emulation.spec.js
+++ b/test/emulation.spec.js
@@ -249,11 +249,6 @@ describe('Emulation', () => {
           () => matchMedia('(prefers-color-scheme: dark)').matches
         )
       ).toBe(false);
-      expect(
-        await page.evaluate(
-          () => matchMedia('(prefers-color-scheme: no-preference)').matches
-        )
-      ).toBe(false);
       await page.emulateMediaFeatures([
         { name: 'prefers-color-scheme', value: 'dark' },
       ]);
@@ -265,11 +260,6 @@ describe('Emulation', () => {
       expect(
         await page.evaluate(
           () => matchMedia('(prefers-color-scheme: light)').matches
-        )
-      ).toBe(false);
-      expect(
-        await page.evaluate(
-          () => matchMedia('(prefers-color-scheme: no-preference)').matches
         )
       ).toBe(false);
       await page.emulateMediaFeatures([
@@ -294,11 +284,6 @@ describe('Emulation', () => {
       expect(
         await page.evaluate(
           () => matchMedia('(prefers-color-scheme: dark)').matches
-        )
-      ).toBe(false);
-      expect(
-        await page.evaluate(
-          () => matchMedia('(prefers-color-scheme: no-preference)').matches
         )
       ).toBe(false);
     });


### PR DESCRIPTION
The 'no-preference' value has been removed from the spec per resolution
in [1]. The appropriate web-platform-tests [2] have already been updated.

@mathiasbynens can you please review? Thanks.

[1] https://github.com/w3c/csswg-drafts/issues/3857#issuecomment-634779976
[2] https://github.com/web-platform-tests/wpt/pull/24024