### PR TITLE
chore: ensure new-docs are up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
         - npm run test-install
         - npm run lint
         - npm run test-doclint
+        - npm run ensure-new-docs-up-to-date
 
     # Runs unit tests on Linux + Firefox
     - node_js: "10.19.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "compare-protocol-d-ts": "node utils/protocol-types-generator compare",
     "test-install": "scripts/test-install.sh",
     "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
-    "ensure-new-docs-up-to-date": "npm run generate-docs && exit (git status --porcelain | head -255 | wc -l)"
+    "ensure-new-docs-up-to-date": "npm run generate-docs && exit `git status --porcelain | head -255 | wc -l`"
   },
   "files": [
     "lib/",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "update-protocol-d-ts": "node utils/protocol-types-generator update",
     "compare-protocol-d-ts": "node utils/protocol-types-generator compare",
     "test-install": "scripts/test-install.sh",
-    "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs"
+    "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
+    "ensure-new-docs-up-to-date": "npm run generate-docs && exit (git status --porcelain | head -255 | wc -l)"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
This adds a Travis check that if we re-generate the docs we get the
exact output (by checking if the Git tree is dirty).

We do the dirty check by using `git status --porcelain`, seeing how many
lines that outputs, and using that as the exit code (taking only the
first 255 lines to avoid invalid exit codes). `--porcelain` makes the
output be empty if the repo is not dirty in anyway which translates into
an exit code of 0.
