### PR TITLE
Fix docs linter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -185,7 +185,6 @@
   * [keyboard.type(text[, options])](#keyboardtypetext-options)
   * [keyboard.up(key)](#keyboardupkey)
 - [class: Mouse](#class-mouse)
-  * [Selecting text and moving the mouse](#selecting-text-and-moving-the-mouse)
   * [mouse.click(x, y[, options])](#mouseclickx-y-options)
   * [mouse.down([options])](#mousedownoptions)
   * [mouse.move(x, y[, options])](#mousemovex-y-options)


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/commit/4205ff79d93c1d27b9cadde6f56c19be04397abd
removed the header in the Mouse class documentation, but the linter
requires the reference to that header to be removed as well.