### PR TITLE
fix(connection): separate send/receive debug logging

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -16,7 +16,8 @@
 import { assert } from './helper';
 import { Events } from './Events';
 import * as debug from 'debug';
-const debugProtocol = debug('puppeteer:protocol');
+const debugProtocolSend = debug('puppeteer:protocol:SEND ►');
+const debugProtocolReceive = debug('puppeteer:protocol:RECV ◀');
 
 import Protocol from './protocol';
 import { ConnectionTransport } from './ConnectionTransport';
@@ -78,14 +79,14 @@ export class Connection extends EventEmitter {
   _rawSend(message: {}): number {
     const id = ++this._lastId;
     message = JSON.stringify(Object.assign({}, message, { id }));
-    debugProtocol('SEND ► ' + message);
+    debugProtocolSend(message);
     this._transport.send(message);
     return id;
   }
 
   async _onMessage(message: string): Promise<void> {
     if (this._delay) await new Promise((f) => setTimeout(f, this._delay));
-    debugProtocol('◀ RECV ' + message);
+    debugProtocolReceive(message);
     const object = JSON.parse(message);
     if (object.method === 'Target.attachedToTarget') {
       const sessionId = object.params.sessionId;


### PR DESCRIPTION
This PR splits the logging for send and receive messages in to separate debug channels.

This way it is easier to filter and takes advantage of `debug`'s automatic coloring to make
it easier to visually parse on the command line.

Before PR:
![Screen Shot 2020-06-13 at 10 42 23 PM](https://user-images.githubusercontent.com/842798/84583520-2a6b6580-adc7-11ea-9ce3-5f218ec67760.png)

After PR:
![Screen Shot 2020-06-13 at 10 41 39 PM](https://user-images.githubusercontent.com/842798/84583509-10ca1e00-adc7-11ea-8496-7663d76cb288.png)
