### PR TITLE
fix: `page.goto` options type should be optional

### DIFF
--- a/new-docs/puppeteer.frame.goto.md
+++ b/new-docs/puppeteer.frame.goto.md
@@ -7,7 +7,7 @@
 <b>Signature:</b>
 
 ```typescript
-goto(url: string, options: {
+goto(url: string, options?: {
         referer?: string;
         timeout?: number;
         waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];

--- a/new-docs/puppeteer.page.goto.md
+++ b/new-docs/puppeteer.page.goto.md
@@ -7,7 +7,7 @@
 <b>Signature:</b>
 
 ```typescript
-goto(url: string, options: WaitForOptions & {
+goto(url: string, options?: WaitForOptions & {
         referer?: string;
     }): Promise<HTTPResponse>;
 ```

--- a/src/FrameManager.ts
+++ b/src/FrameManager.ts
@@ -412,7 +412,7 @@ export class Frame {
       referer?: string;
       timeout?: number;
       waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-    }
+    } = {}
   ): Promise<HTTPResponse | null> {
     return await this._frameManager.navigateFrame(this, url, options);
   }

--- a/src/Page.ts
+++ b/src/Page.ts
@@ -838,7 +838,7 @@ export class Page extends EventEmitter {
 
   async goto(
     url: string,
-    options: WaitForOptions & { referer?: string }
+    options: WaitForOptions & { referer?: string } = {}
   ): Promise<HTTPResponse> {
     return await this._frameManager.mainFrame().goto(url, options);
   }


### PR DESCRIPTION

The TypeScript definition erroneously made `options` required. We can
fix it by providing a default value, which means users calling the
function will be able to leave it blank without TS complaining.

Issues like this are a +1 to porting our tests to TypeScript in order to
catch these on our own test suite, so that's something we should look into.