### PR TITLE
chore: fix dependency chart generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test-install": "scripts/test-install.sh",
     "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
     "ensure-new-docs-up-to-date": "npm run generate-docs && exit `git status --porcelain | head -255 | wc -l`",
-    "generate-dependency-graph": "echo 'Requires graphviz installed locally!' && depcruise --max-depth 3 --output-type dot src/index.ts | dot -T png > dependency-chart.png"
+    "generate-dependency-graph": "echo 'Requires graphviz installed locally!' && depcruise --do-not-follow '^node_modules' --output-type dot src/index.ts | dot -T png > dependency-chart.png"
   },
   "files": [
     "lib/",


### PR DESCRIPTION

`--max-depth` stopped the chart including our own modules. What we want
instead is the `do-not-follow` option to make it go to infinite depth in
our code but stop at the top level of a node module.