### PR TITLE
docs: fix broken link to USKeyboardLayout file

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4066,7 +4066,7 @@ This method is identical to `off` and maintained for compatibility with Node's E
 [Touchscreen]: #class-touchscreen "Touchscreen"
 [Tracing]: #class-tracing "Tracing"
 [UIEvent.detail]: https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail "UIEvent.detail"
-[USKeyboardLayout]: ../src/USKeyboardLayout.ts "USKeyboardLayout"
+[USKeyboardLayout]: ../src/common/USKeyboardLayout.ts "USKeyboardLayout"
 [UnixTime]: https://en.wikipedia.org/wiki/Unix_time "Unix Time"
 [WebWorker]: #class-worker "Worker"
 [boolean]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type "Boolean"


### PR DESCRIPTION
Link in api doc to USKeyboardLayout returns a 404 (missing common folder in link)