### PR TITLE
chore: pin TSDoc related dependencies

### DIFF
--- a/new-docs/puppeteer.browser.md
+++ b/new-docs/puppeteer.browser.md
@@ -9,6 +9,7 @@
 ```typescript
 export declare class Browser extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Constructors
 

--- a/new-docs/puppeteer.browsercontext.md
+++ b/new-docs/puppeteer.browsercontext.md
@@ -9,6 +9,7 @@
 ```typescript
 export declare class BrowserContext extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Constructors
 

--- a/new-docs/puppeteer.cdpsession.md
+++ b/new-docs/puppeteer.cdpsession.md
@@ -9,6 +9,7 @@
 ```typescript
 export declare class CDPSession extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Constructors
 

--- a/new-docs/puppeteer.connection.md
+++ b/new-docs/puppeteer.connection.md
@@ -9,6 +9,7 @@
 ```typescript
 export declare class Connection extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Constructors
 

--- a/new-docs/puppeteer.elementhandle.md
+++ b/new-docs/puppeteer.elementhandle.md
@@ -9,6 +9,7 @@
 ```typescript
 export declare class ElementHandle extends JSHandle 
 ```
+<b>Extends:</b> [JSHandle](./puppeteer.jshandle.md)
 
 ## Constructors
 

--- a/new-docs/puppeteer.eventemitter.md
+++ b/new-docs/puppeteer.eventemitter.md
@@ -11,6 +11,7 @@ The EventEmitter class that many Puppeteer classes extend.
 ```typescript
 export declare class EventEmitter implements CommonEventEmitter 
 ```
+<b>Implements:</b> CommonEventEmitter
 
 ## Remarks
 

--- a/new-docs/puppeteer.framemanager.md
+++ b/new-docs/puppeteer.framemanager.md
@@ -9,6 +9,7 @@
 ```typescript
 export declare class FrameManager extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Constructors
 

--- a/new-docs/puppeteer.page.md
+++ b/new-docs/puppeteer.page.md
@@ -11,6 +11,7 @@ Page provides methods to interact with a single tab or \[extension background pa
 ```typescript
 export declare class Page extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Remarks
 

--- a/new-docs/puppeteer.timeouterror.md
+++ b/new-docs/puppeteer.timeouterror.md
@@ -9,3 +9,5 @@
 ```typescript
 export declare class TimeoutError extends CustomError 
 ```
+<b>Extends:</b> CustomError
+

--- a/new-docs/puppeteer.webworker.md
+++ b/new-docs/puppeteer.webworker.md
@@ -11,6 +11,7 @@ The WebWorker class represents a [WebWorker](https://developer.mozilla.org/en-US
 ```typescript
 export declare class WebWorker extends EventEmitter 
 ```
+<b>Extends:</b> [EventEmitter](./puppeteer.eventemitter.md)
 
 ## Remarks
 

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "ws": "^7.2.3"
   },
   "devDependencies": {
-    "@microsoft/api-documenter": "^7.8.8",
-    "@microsoft/api-extractor": "^7.8.8",
+    "@microsoft/api-documenter": "7.8.14",
+    "@microsoft/api-extractor": "7.8.12",
     "@types/debug": "0.0.31",
     "@types/mime": "^2.0.0",
     "@types/node": "^10.17.14",


### PR DESCRIPTION

Without the API-* dependencies pinned different versions may be
installed on local machines vs CI. One of the checks we do is to check
that the checked in docs matches what is generated on CI. Therefore we
need to ensure devs locally run the exact version that CI runs such that
they generate the same output. So in this case we pin to a particular
version of the dependencies.