### PR TITLE
chore: tidy up TODO from TS tests migration

### DIFF
--- a/test/jshandle.spec.ts
+++ b/test/jshandle.spec.ts
@@ -195,18 +195,6 @@ describe('JSHandle', function () {
         await page.evaluate((e) => e.nodeType === Node.TEXT_NODE, element)
       );
     });
-    it('should work with nullified Node', async () => {
-      const { page } = getTestState();
-
-      await page.setContent('<section>test</section>');
-      // TODO (@jackfranklin): this line doesn't do anything. What was intended here?
-      // await page.evaluate(() => delete Node);
-      const handle = await page.evaluateHandle(() =>
-        document.querySelector('section')
-      );
-      const element = handle.asElement();
-      expect(element).not.toBe(null);
-    });
   });
 
   describe('JSHandle.toString', function () {


### PR DESCRIPTION

This line is needed to purposefully test that `asElement` works even
when the main `Node` class has been deleted by the user.