### PR TITLE
Remove hard coded `?hl=en` from docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,7 @@
 
 ## Chrome headless doesn't launch on Windows
 
-Some [chrome policies](https://support.google.com/chrome/a/answer/7532015?hl=en) might enforce running Chrome/Chromium
+Some [chrome policies](https://support.google.com/chrome/a/answer/7532015) might enforce running Chrome/Chromium
 with certain extensions.
 
 Puppeteer passes `--disable-extensions` flag by default and will fail to launch when such policies are active.


### PR DESCRIPTION
The hard coded `?hl=en` is breaking deployments on WebFu