### PR TITLE
chore: remove `helper.promisify`

### DIFF
--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -266,7 +266,9 @@ export class DOMWorld {
       }
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const fs = require('fs');
-      const readFileAsync = helper.promisify(fs.readFile);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { promisify } = require('util');
+      const readFileAsync = promisify(fs.readFile);
       let contents = await readFileAsync(path, 'utf8');
       contents += '//# sourceURL=' + path.replace(/\n/g, '');
       const context = await this.executionContext();
@@ -351,7 +353,9 @@ export class DOMWorld {
       }
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const fs = require('fs');
-      const readFileAsync = helper.promisify(fs.readFile);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { promisify } = require('util');
+      const readFileAsync = promisify(fs.readFile);
       let contents = await readFileAsync(path, 'utf8');
       contents += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';
       const context = await this.executionContext();

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from 'fs';
+import { promisify } from 'util';
 import { EventEmitter } from './EventEmitter';
 import * as mime from 'mime';
 import { Events } from './Events';
@@ -42,7 +43,7 @@ import { ConsoleMessage, ConsoleMessageType } from './ConsoleMessage';
 import { PuppeteerLifeCycleEvent } from './LifecycleWatcher';
 import Protocol from '../protocol';
 
-const writeFileAsync = helper.promisify(fs.writeFile);
+const writeFileAsync = promisify(fs.writeFile);
 
 export interface Metrics {
   Timestamp?: number;

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -268,7 +268,6 @@ async function readProtocolStream(
 }
 
 export const helper = {
-  promisify,
   evaluationString,
   readProtocolStream,
   waitWithTimeout,

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -24,12 +24,13 @@ import * as http from 'http';
 
 import extractZip from 'extract-zip';
 import { debug } from '../common/Debug';
+import { promisify } from 'util';
 import removeRecursive from 'rimraf';
 import * as URL from 'url';
 import ProxyAgent from 'https-proxy-agent';
 import { getProxyForUrl } from 'proxy-from-env';
 import { assert } from '../common/assert';
-import { helper } from '../common/helper';
+
 const debugFetcher = debug(`puppeteer:fetcher`);
 
 const downloadURLs = {
@@ -116,10 +117,10 @@ function handleArm64(): void {
     }
   });
 }
-const readdirAsync = helper.promisify(fs.readdir.bind(fs));
-const mkdirAsync = helper.promisify(fs.mkdir.bind(fs));
-const unlinkAsync = helper.promisify(fs.unlink.bind(fs));
-const chmodAsync = helper.promisify(fs.chmod.bind(fs));
+const readdirAsync = promisify(fs.readdir.bind(fs));
+const mkdirAsync = promisify(fs.mkdir.bind(fs));
+const unlinkAsync = promisify(fs.unlink.bind(fs));
+const chmodAsync = promisify(fs.chmod.bind(fs));
 
 function existsAsync(filePath: string): Promise<boolean> {
   return new Promise((resolve) => {

--- a/src/node/BrowserRunner.ts
+++ b/src/node/BrowserRunner.ts
@@ -26,8 +26,9 @@ import { WebSocketTransport } from '../common/WebSocketTransport';
 import { PipeTransport } from './PipeTransport';
 import * as readline from 'readline';
 import { TimeoutError } from '../common/Errors';
+import { promisify } from 'util';
 
-const removeFolderAsync = helper.promisify(removeFolder);
+const removeFolderAsync = promisify(removeFolder);
 const debugLauncher = debug('puppeteer:launcher');
 const PROCESS_ERROR_EXPLANATION = `Puppeteer was unable to kill the process which ran the browser binary.
 This means that, on future Puppeteer launches, Puppeteer might not be able to launch the browser.

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -24,13 +24,14 @@ import { BrowserFetcher } from './BrowserFetcher';
 import { Connection } from '../common/Connection';
 import { Browser } from '../common/Browser';
 import { assert } from '../common/assert';
-import { helper, debugError } from '../common/helper';
+import { debugError } from '../common/helper';
 import { ConnectionTransport } from '../common/ConnectionTransport';
 import { WebSocketTransport } from '../common/WebSocketTransport';
 import { BrowserRunner } from './BrowserRunner';
+import { promisify } from 'util';
 
-const mkdtempAsync = helper.promisify(fs.mkdtemp);
-const writeFileAsync = helper.promisify(fs.writeFile);
+const mkdtempAsync = promisify(fs.mkdtemp);
+const writeFileAsync = promisify(fs.writeFile);
 
 import {
   ChromeArgOptions,

--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -17,7 +17,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import sinon from 'sinon';
-import { helper } from '../src/common/helper';
+import { promisify } from 'util';
 import {
   getTestState,
   itFailsFirefox,
@@ -29,10 +29,10 @@ import expect from 'expect';
 import rimraf from 'rimraf';
 import { Page } from '../src/common/Page';
 
-const rmAsync = helper.promisify(rimraf);
-const mkdtempAsync = helper.promisify(fs.mkdtemp);
-const readFileAsync = helper.promisify(fs.readFile);
-const statAsync = helper.promisify(fs.stat);
+const rmAsync = promisify(rimraf);
+const mkdtempAsync = promisify(fs.mkdtemp);
+const readFileAsync = promisify(fs.readFile);
+const statAsync = promisify(fs.stat);
 const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
 
 describe('Launcher specs', function () {


### PR DESCRIPTION

It was just re-exporting the built-in Node module so let's just import
from that directly.