### PR TITLE
docs(api): fix overview diagram for pptr.dev

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -356,7 +356,7 @@ The Puppeteer API is hierarchical and mirrors the browser structure.
 
 > **NOTE** On the following diagram, faded entities are not currently represented in Puppeteer.
 
-![puppeteer overview](../docs/assets/overview.png)
+![puppeteer overview](https://user-images.githubusercontent.com/81942/86137523-ab2ba080-baed-11ea-9d4b-30eda784585a.png)
 
 - [`Puppeteer`](#class-puppeteer) communicates with the browser using [DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
 - [`Browser`](#class-browser) instance can own multiple browser contexts.


### PR DESCRIPTION
We need to serve the image from user-images.githubusercontent.com for it to work properly on pptr.dev. This broke when merging #5947.

Fixes #6127.