### PR TITLE
chore: fix Firefox install checker

### DIFF
--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -22,7 +22,7 @@ cd $TMPDIR
 PUPPETEER_PRODUCT=firefox npm install --loglevel silent "${tarball}"
 node --eval="require('puppeteer')"
 rm "${tarball}"
-ls $TMPDIR/node_modules/puppeteer/.local-firefox/linux-79.0a1/firefox/firefox
+ls $TMPDIR/node_modules/puppeteer/.local-firefox/
 
 # Again for puppeteer-core
 cd $ROOTDIR


### PR DESCRIPTION

I think when the FF version changes this check breaks - let's just make
it check that a version installed rather than the specific version else
this will happen on a continuing basis.