### PR TITLE
fix: fix isNode variable not properly detecting Node.js environment

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-export const isNode = typeof document === 'undefined';
+export const isNode = !!(
+  typeof process !== 'undefined' &&
+  process.versions &&
+  process.versions.node
+);


### PR DESCRIPTION
This patch fixes Node.js being detected by the lack of `global.document` which isn't necessairly always true in Node.js (example: using JSDOM library). Instead, we're now detecting `process.versions.node` being present, which I copied over from [here](https://github.com/MatthewSH/is-node/commit/426943ae936536f9c2fd10fd58a9a46b59470097#diff-168726dbe96b3ce427e7fedce31bb0bc).

Fixes #6147