### PR TITLE
chore: rename `createJSHandle` to `createHandle`

### DIFF
--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -16,7 +16,7 @@
 
 import { assert } from './assert';
 import { helper } from './helper';
-import { createJSHandle, JSHandle, ElementHandle } from './JSHandle';
+import { createHandle, JSHandle, ElementHandle } from './JSHandle';
 import { CDPSession } from './Connection';
 import { DOMWorld } from './DOMWorld';
 import { Frame } from './FrameManager';
@@ -214,7 +214,7 @@ export class ExecutionContext {
 
       return returnByValue
         ? helper.valueFromRemoteObject(remoteObject)
-        : createJSHandle(this, remoteObject);
+        : createHandle(this, remoteObject);
     }
 
     if (typeof pageFunction !== 'function')
@@ -267,7 +267,7 @@ export class ExecutionContext {
       );
     return returnByValue
       ? helper.valueFromRemoteObject(remoteObject)
-      : createJSHandle(this, remoteObject);
+      : createHandle(this, remoteObject);
 
     /**
      * @param {*} arg
@@ -349,7 +349,7 @@ export class ExecutionContext {
     const response = await this._client.send('Runtime.queryObjects', {
       prototypeObjectId: prototypeHandle._remoteObject.objectId,
     });
-    return createJSHandle(this, response.objects);
+    return createHandle(this, response.objects);
   }
 
   /**
@@ -362,7 +362,7 @@ export class ExecutionContext {
       backendNodeId: backendNodeId,
       executionContextId: this._contextId,
     });
-    return createJSHandle(this, object) as ElementHandle;
+    return createHandle(this, object) as ElementHandle;
   }
 
   /**

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -64,8 +64,16 @@ export interface BoundingBox {
 
 /**
  * @internal
+ *
+ * Note that this function will return either a JSHandle or an ElementHandle. It
+ * will create an ElementHandle if the object it's got back is a node (e.g. a
+ * <div> element). This is used if the user returns a DOM node from
+ * `page.evaluate(...)`.
+ *
+ * If the user returns some value from `page.evaluate()`, it is wrapped in a
+ * JSHandle.
  */
-export function createJSHandle(
+export function createHandle(
   context: ExecutionContext,
   remoteObject: Protocol.Runtime.RemoteObject
 ): JSHandle {
@@ -229,7 +237,7 @@ export class JSHandle {
     const result = new Map<string, JSHandle>();
     for (const property of response.result) {
       if (!property.enumerable) continue;
-      result.set(property.name, createJSHandle(this._context, property.value));
+      result.set(property.name, createHandle(this._context, property.value));
     }
     return result;
   }

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -31,7 +31,7 @@ import { Coverage } from './Coverage';
 import { WebWorker } from './WebWorker';
 import { Browser, BrowserContext } from './Browser';
 import { Target } from './Target';
-import { createJSHandle, JSHandle, ElementHandle } from './JSHandle';
+import { createHandle, JSHandle, ElementHandle } from './JSHandle';
 import { Viewport } from './PuppeteerViewport';
 import { Credentials } from './NetworkManager';
 import { HTTPRequest } from './HTTPRequest';
@@ -1170,7 +1170,7 @@ export class Page extends EventEmitter {
     const context = this._frameManager.executionContextById(
       event.executionContextId
     );
-    const values = event.args.map((arg) => createJSHandle(context, arg));
+    const values = event.args.map((arg) => createHandle(context, arg));
     this._addConsoleMessage(event.type, values, event.stackTrace);
   }
 


### PR DESCRIPTION

The name was misleading as the function will create an `ElementHandle`
should the remote object its given be a DOM Node.

For clarity, this is a function that's only used internally, and this is
therefore not a breaking change. It's not part of the public API.