### PR TITLE
chore: migrate NetworkManager events

### DIFF
--- a/src/common/Events.ts
+++ b/src/common/Events.ts
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+/**
+ * IMPORTANT: we are mid-way through migrating away from this Events.ts file
+ * in favour of defining events next to the class that emits them.
+ *
+ * However we need to maintain this file for now because the legacy DocLint
+ * system relies on them. Be aware in the mean time if you make a change here
+ * you probably need to replicate it in the relevant class. For example if you
+ * add a new Page event, you should update the PageEmittedEvents enum in
+ * src/common/Page.ts.
+ *
+ * Chat to @jackfranklin if you're unsure.
+ */
+
 export const Events = {
   Page: {
     Close: 'close',

--- a/src/common/LifecycleWatcher.ts
+++ b/src/common/LifecycleWatcher.ts
@@ -21,6 +21,7 @@ import { TimeoutError } from './Errors';
 import { FrameManager, Frame } from './FrameManager';
 import { HTTPRequest } from './HTTPRequest';
 import { HTTPResponse } from './HTTPResponse';
+import { NetworkManagerEmittedEvents } from './NetworkManager';
 
 export type PuppeteerLifeCycleEvent =
   | 'load'
@@ -117,7 +118,7 @@ export class LifecycleWatcher {
       ),
       helper.addEventListener(
         this._frameManager.networkManager(),
-        Events.NetworkManager.Request,
+        NetworkManagerEmittedEvents.Request,
         this._onRequest.bind(this)
       ),
     ];

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -33,7 +33,7 @@ import { Browser, BrowserContext } from './Browser';
 import { Target } from './Target';
 import { createJSHandle, JSHandle, ElementHandle } from './JSHandle';
 import { Viewport } from './PuppeteerViewport';
-import { Credentials } from './NetworkManager';
+import { Credentials, NetworkManagerEmittedEvents } from './NetworkManager';
 import { HTTPRequest } from './HTTPRequest';
 import { HTTPResponse } from './HTTPResponse';
 import { Accessibility } from './Accessibility';
@@ -486,16 +486,16 @@ export class Page extends EventEmitter {
     );
 
     const networkManager = this._frameManager.networkManager();
-    networkManager.on(Events.NetworkManager.Request, (event) =>
+    networkManager.on(NetworkManagerEmittedEvents.Request, (event) =>
       this.emit(PageEmittedEvents.Request, event)
     );
-    networkManager.on(Events.NetworkManager.Response, (event) =>
+    networkManager.on(NetworkManagerEmittedEvents.Response, (event) =>
       this.emit(PageEmittedEvents.Response, event)
     );
-    networkManager.on(Events.NetworkManager.RequestFailed, (event) =>
+    networkManager.on(NetworkManagerEmittedEvents.RequestFailed, (event) =>
       this.emit(PageEmittedEvents.RequestFailed, event)
     );
-    networkManager.on(Events.NetworkManager.RequestFinished, (event) =>
+    networkManager.on(NetworkManagerEmittedEvents.RequestFinished, (event) =>
       this.emit(PageEmittedEvents.RequestFinished, event)
     );
     this._fileChooserInterceptors = new Set();
@@ -1339,7 +1339,7 @@ export class Page extends EventEmitter {
     const { timeout = this._timeoutSettings.timeout() } = options;
     return helper.waitForEvent(
       this._frameManager.networkManager(),
-      Events.NetworkManager.Request,
+      NetworkManagerEmittedEvents.Request,
       (request) => {
         if (helper.isString(urlOrPredicate))
           return urlOrPredicate === request.url();
@@ -1359,7 +1359,7 @@ export class Page extends EventEmitter {
     const { timeout = this._timeoutSettings.timeout() } = options;
     return helper.waitForEvent(
       this._frameManager.networkManager(),
-      Events.NetworkManager.Response,
+      NetworkManagerEmittedEvents.Response,
       (response) => {
         if (helper.isString(urlOrPredicate))
           return urlOrPredicate === response.url();


### PR DESCRIPTION

This is part of the effort to remove `Events.ts` in favour of defining
events next to the class that emits them. In this case these events are
internal, so there's no docs changes, but it's still worth doing such
that we can remove the Events.ts file in the long term once all the
different events are migrated.