### PR TITLE
chore(docs): fix incorrect `@returns` on getter

### DIFF
--- a/new-docs/puppeteer.puppeteer.devices.md
+++ b/new-docs/puppeteer.puppeteer.devices.md
@@ -12,6 +12,7 @@ get devices(): DevicesMap;
 
 ## Remarks
 
+A list of devices to be used with `page.emulate(options)`<!-- -->. Actual list of devices can be found in [src/common/DeviceDescriptors.ts](https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts)<!-- -->.
 
 ## Example
 

--- a/new-docs/puppeteer.puppeteer.errors.md
+++ b/new-docs/puppeteer.puppeteer.errors.md
@@ -14,7 +14,7 @@ get errors(): PuppeteerErrors;
 
 Puppeteer methods might throw errors if they are unable to fulfill a request. For example, `page.waitForSelector(selector[, options])` might fail if the selector doesn't match any nodes during the given timeframe.
 
-For certain types of errors Puppeteer uses specific error classes. These classes are available via `puppeteer.errors`
+For certain types of errors Puppeteer uses specific error classes. These classes are available via `puppeteer.errors`<!-- -->.
 
 ## Example
 

--- a/src/common/Puppeteer.ts
+++ b/src/common/Puppeteer.ts
@@ -202,6 +202,8 @@ export class Puppeteer {
 
   /**
    * @remarks
+   * A list of devices to be used with `page.emulate(options)`. Actual list of devices can be found in {@link https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts | src/common/DeviceDescriptors.ts}.
+   *
    * @example
    *
    * ```js
@@ -218,7 +220,6 @@ export class Puppeteer {
    * })();
    * ```
    *
-   * @returns a list of devices to be used with `page.emulate(options)`. Actual list of devices can be found in {@link https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts | src/common/DeviceDescriptors.ts}.
    */
   get devices(): DevicesMap {
     return devicesMap;
@@ -232,7 +233,8 @@ export class Puppeteer {
    * the selector doesn't match any nodes during the given timeframe.
    *
    * For certain types of errors Puppeteer uses specific error classes.
-   * These classes are available via `puppeteer.errors`
+   * These classes are available via `puppeteer.errors`.
+   *
    * @example
    * An example of handling a timeout error:
    * ```js


### PR DESCRIPTION

On a getter function you don't use `@returns` (as that's just for
methods). Instead we can just add to the general remarks to explain what
the property is providing.