### PR TITLE
chore: forbid importing src/common/Events.ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,11 @@ module.exports = {
         "mocha/no-exclusive-tests": "error",
 
         // enforce the variable in a catch block is named error
-        "unicorn/catch-error-name": "error"
+        "unicorn/catch-error-name": "error",
+
+        "no-restricted-imports": ["error", {
+            patterns: ["*Events"],
+        }]
     },
     "overrides": [
         {

--- a/src/common/LifecycleWatcher.ts
+++ b/src/common/LifecycleWatcher.ts
@@ -16,7 +16,6 @@
 
 import { assert } from './assert';
 import { helper, PuppeteerEventListener } from './helper';
-import { Events } from './Events';
 import { TimeoutError } from './Errors';
 import { FrameManager, Frame, FrameManagerEmittedEvents } from './FrameManager';
 import { HTTPRequest } from './HTTPRequest';

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -18,7 +18,6 @@ import * as fs from 'fs';
 import { promisify } from 'util';
 import { EventEmitter } from './EventEmitter';
 import * as mime from 'mime';
-import { Events } from './Events';
 import { Connection, CDPSession, CDPSessionEmittedEvents } from './Connection';
 import { Dialog } from './Dialog';
 import { EmulationManager } from './EmulationManager';


### PR DESCRIPTION

This file is now deprecated and only used by the coverage tool and
DocLint - these tools will be updated to not rely on it in the future.

We now have events defined per class - e.g. all the events that `Page`
can emit are defined in the `PageEmittedEvents` enum, and similar. We
have to keep `Events.ts` around for the aforementioned tools, but don't
want its usage creeping back into our source code.