### PR TITLE
chore: add test runner for testing pptr in a browser

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@ lib/
 # in the Puppeteer src, so it trips up the ESLint-TypeScript parser.
 utils/doclint/generate_types/test/test.ts
 vendor/
+web-test-runner.config.mjs

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,6 +125,17 @@ module.exports = {
                     "default": "array-simple"
                 }]
             }
+        },
+        {
+            "files": ["test-browser/**/*.js"],
+            "parserOptions": {
+                "sourceType": "module"
+            },
+            "env": {
+                "es6": true,
+                "browser": true,
+                "es2020": true
+            },        
         }
     ]
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,13 @@ jobs:
       script:
         - travis_retry npm run unit
 
+    - node_js: "12.16.3"
+      name: 'Browser tests: Linux/Chromium'
+      env:
+        - CHROMIUM=true
+      script:
+        - travis_retry npm run test-browser
+
     # This bot runs all the extra checks that aren't the main Puppeteer unit tests
     - node_js: "10.19.0"
       name: 'Extra tests: Linux/Chromium'

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "node": ">=10.18.1"
   },
   "scripts": {
+    "test-browser": "wtr",
+    "test-browser-watch": "wtr --watch",
     "unit": "npm run tsc-cjs && mocha --config mocha-config/puppeteer-unit-tests.js",
     "unit-with-coverage": "cross-env COVERAGE=1 npm run unit",
     "assert-unit-coverage": "cross-env COVERAGE=1 mocha --config mocha-config/coverage-tests.js",
     "funit": "PUPPETEER_PRODUCT=firefox npm run unit",
     "debug-unit": "node --inspect-brk test/test.js",
-    "test": "npm run tsc && npm run lint --silent && npm run unit-with-coverage && npm run test-types",
+    "test": "npm run tsc && npm run lint --silent && npm run unit-with-coverage && npm run test-browser && npm run test-types",
     "prepare": "node typescript-if-required.js",
     "prepublishOnly": "npm run tsc",
     "dev-install": "npm run tsc && node install.js",
@@ -69,6 +71,7 @@
     "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
+    "@web/test-runner": "^0.6.40",
     "commonmark": "^0.28.1",
     "cross-env": "^5.0.5",
     "dependency-cruiser": "^9.7.0",

--- a/test-browser/debug.spec.js
+++ b/test-browser/debug.spec.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { debug } from '../lib/esm/puppeteer/common/Debug.js';
+import expect from '../node_modules/expect/build-es5/index.js';
+
+describe('debug', () => {
+  let originalLog;
+  let logs;
+  beforeEach(() => {
+    originalLog = console.log;
+    logs = [];
+    console.log = (...args) => {
+      logs.push(args);
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  it('should return a function', async () => {
+    expect(debug('foo')).toBeInstanceOf(Function);
+  });
+
+  it('does not log to the console if __PUPPETEER_DEBUG global is not set', async () => {
+    const debugFn = debug('foo');
+    debugFn('lorem', 'ipsum');
+
+    expect(logs.length).toEqual(0);
+  });
+
+  it('logs to the console if __PUPPETEER_DEBUG global is set to *', async () => {
+    globalThis.__PUPPETEER_DEBUG = '*';
+    const debugFn = debug('foo');
+    debugFn('lorem', 'ipsum');
+
+    expect(logs.length).toEqual(1);
+    expect(logs).toEqual([['foo:', 'lorem', 'ipsum']]);
+  });
+
+  it('logs only messages matching the __PUPPETEER_DEBUG prefix', async () => {
+    globalThis.__PUPPETEER_DEBUG = 'foo';
+    const debugFoo = debug('foo');
+    const debugBar = debug('bar');
+    debugFoo('a');
+    debugBar('b');
+
+    expect(logs.length).toEqual(1);
+    expect(logs).toEqual([['foo:', 'a']]);
+  });
+});

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  files: ['test-browser/**/*.spec.js'],
+  plugins: [
+    {
+      // turn expect UMD into an es module
+      name: 'esmify-expect',
+      transform(context) {
+        if (context.path === '/node_modules/expect/build-es5/index.js') {
+          return `const module = {}; const exports = {};\n${context.body};\n export default module.exports;`;
+        }
+      },
+    },
+  ],
+};


### PR DESCRIPTION
@jackfranklin @TimvdLippe 
As discussed, this is a basic example setup for web test runner. I added an example test using mocha and expect, similar to the node tests.

Reference: https://github.com/puppeteer/puppeteer/issues/6125

The config is an es module (requires latest node 12 or 14) but it can be commonjs as well. 

### Things to be done:

**Make the tests actually work**
~~Ideally we can reuse the existing unit tests, or at least a subset of them~~

**TS or JS tests**
~~The node tests are written in TS and run in mocha with ts-node. I followed a similar approach of using esbuild to compile TS to JS on the fly. We could also run the compiled JS in the browser.~~

**Handle `expect` errors**
~~I created a small UMD wrapper to make `expect` work in the browser. However the error stack traces are handled properly by web test runner (I've only been testing with chai until now). Something to look into on WTR side.~~

**Remove caniuse dependency**
~~caniuse has a license which isn't whitelisted, and it's actually problematic in general. I thought I had gotten rid of it, but it turns out for test coverage we still need to use babel. I want to get rid of this dependency and use v8 test coverage information. I got it working with playwright, but for puppeteer we need something like https://github.com/puppeteer/puppeteer/issues/2136.~~

**puppeteer dependency**
web test runner uses puppeteer-core to control the browser when running tests. so we have puppeteer-ception. I'm not sure that would be a problem here?

The test runner is brand new, so I'm sure we'll find some rough edges. 