### PR TITLE
Better describe how to install Firefox Nightly with Puppeteer

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -593,7 +593,7 @@ const browser = await puppeteer.launch({
 #### puppeteer.product
 - returns: <[string]> returns the name of the browser that is under automation (`"chrome"` or `"firefox"`)
 
-The product is set by the `PUPPETEER_PRODUCT` environment variable or the `product` option in [puppeteer.launch([options])](#puppeteerlaunchoptions) and defaults to `chrome`. Firefox support is experimental.
+The product is set by the `PUPPETEER_PRODUCT` environment variable or the `product` option in [puppeteer.launch([options])](#puppeteerlaunchoptions) and defaults to `chrome`. Firefox support is experimental and requires to install Puppeteer via `PUPPETEER_PRODUCT=firefox npm i puppeteer`.
 
 
 ### class: BrowserFetcher

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -771,7 +771,7 @@ function resolveExecutablePath(
   }
   const revisionInfo = browserFetcher.revisionInfo(launcher._preferredRevision);
   const missingText = !revisionInfo.local
-    ? `Could not find browser revision ${launcher._preferredRevision}. Run "PUPPETEER_PRODUCT=firefox npm install" or "PUPPETEER_PRODUCT=firefox yarn install" to download a support version of the Firefox browser binary.`
+    ? `Could not find browser revision ${launcher._preferredRevision}. Run "PUPPETEER_PRODUCT=firefox npm install" or "PUPPETEER_PRODUCT=firefox yarn install" to download a supported Firefox browser binary.`
     : null;
   return { executablePath: revisionInfo.executablePath, missingText };
 }

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -771,7 +771,7 @@ function resolveExecutablePath(
   }
   const revisionInfo = browserFetcher.revisionInfo(launcher._preferredRevision);
   const missingText = !revisionInfo.local
-    ? `Could not find browser revision ${launcher._preferredRevision}. Run "npm install" or "yarn install" to download a browser binary.`
+    ? `Could not find browser revision ${launcher._preferredRevision}. Run "PUPPETEER_PRODUCT=firefox npm install" or "PUPPETEER_PRODUCT=firefox yarn install" to download a support version of the Firefox browser binary.`
     : null;
   return { executablePath: revisionInfo.executablePath, missingText };
 }


### PR DESCRIPTION
It can be very confusing when someone installs Puppeteer and wants to run Firefox. This small patch enhances the docs to make this a bit more obvious.

refs #6224