### PR TITLE
fix: handle promise for reading protocol stream of trace

### DIFF
--- a/src/common/Tracing.ts
+++ b/src/common/Tracing.ts
@@ -101,11 +101,15 @@ export class Tracing {
    */
   async stop(): Promise<Buffer> {
     let fulfill: (value: Buffer) => void;
-    const contentPromise = new Promise<Buffer>((x) => (fulfill = x));
+    let reject: (err: Error) => void;
+    const contentPromise = new Promise<Buffer>((x, y) => {
+      fulfill = x;
+      reject = y;
+    });
     this._client.once('Tracing.tracingComplete', (event) => {
       helper
         .readProtocolStream(this._client, event.stream, this._path)
-        .then(fulfill);
+        .then(fulfill, reject);
     });
     await this._client.send('Tracing.end');
     this._recording = false;

--- a/test/tracing.spec.ts
+++ b/test/tracing.spec.ts
@@ -118,4 +118,16 @@ describeChromeOnly('Tracing', function () {
     const trace = await page.tracing.stop();
     expect(trace.toString()).toContain('screenshot');
   });
+
+  it('should properly fail if readProtocolStream errors out', async () => {
+    await page.tracing.start({ path: __dirname });
+
+    let error: Error = null;
+    try {
+      await page.tracing.stop();
+    } catch (error_) {
+      error = error_;
+    }
+    expect(error).toBeDefined();
+  });
 });


### PR DESCRIPTION
If you provide a malformed `path` property to `Tracing.start`, e.g.

```js
page.tracing.start({ path: __dirname })
```

it will cause a `UnhandledPromiseRejectionWarning` with `tracing.stop()` never being resolved, e.g. due to:

```
(node:37510) UnhandledPromiseRejectionWarning: Error: EISDIR: illegal operation on a directory, open '/path/to/dirname'
```

This is due to the fact that a `readProtocolStream` rejection is not caught. This patch fixes that.