### PR TITLE
test: assert location value of ConsoleMessage

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -461,6 +461,13 @@ describe('Page', function () {
       ]);
       expect(message.text()).toEqual('hello 5 JSHandle@object');
       expect(message.type()).toEqual('log');
+      expect(message.args()).toHaveLength(3);
+      expect(message.location()).toEqual({
+        url: expect.any(String),
+        lineNumber: expect.any(Number),
+        columnNumber: expect.any(Number),
+      });
+
       expect(await message.args()[0].jsonValue()).toEqual('hello');
       expect(await message.args()[1].jsonValue()).toEqual(5);
       expect(await message.args()[2].jsonValue()).toEqual({ foo: 'bar' });


### PR DESCRIPTION
Issue #6255 shows differences in the `ConsoleMessage` object between Chromium and FF. These differences are already covered in the unit (I guess they are actually e2e tests 😉) tests. This small patch enhances the coverage to include the `location` method as it seems they differ between the browsers too.