### PR TITLE
Ship Puppeteer TypeScript definitions

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -12,7 +12,8 @@
   },
 
   "dtsRollup": {
-    "enabled": false
+    "enabled": true,
+    "untrimmedFilePath": "<projectFolder>/lib/typings/puppeteer.d.ts"
   },
 
   "tsdocMetadata": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.2.1-post",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol",
   "main": "./cjs-entry.js",
+  "typings": "./lib/typings/puppeteer.d.ts",
   "repository": "github:puppeteer/puppeteer",
   "engines": {
     "node": ">=10.18.1"
@@ -30,7 +31,8 @@
     "tsc-esm": "tsc -b src/tsconfig.esm.json",
     "apply-next-version": "node utils/apply_next_version.js",
     "test-install": "scripts/test-install.sh",
-    "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
+    "generate-d-ts": "npm run tsc && api-extractor run --local --verbose && ts-node scripts/add-default-export-to-types.ts",
+    "generate-docs": "npm run generate-d-ts && api-documenter markdown -i temp -o new-docs",
     "ensure-new-docs-up-to-date": "npm run generate-docs && git status && exit `git status --porcelain | head -255 | wc -l`",
     "generate-dependency-graph": "echo 'Requires graphviz installed locally!' && depcruise --exclude 'api.ts' --do-not-follow '^node_modules' --output-type dot src/index.ts | dot -T png > dependency-chart.png",
     "ensure-correct-devtools-protocol-revision": "ts-node scripts/ensure-correct-devtools-protocol-package"

--- a/scripts/add-default-export-to-types.ts
+++ b/scripts/add-default-export-to-types.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import packageJson from '../package.json';
+
+const typingsLocation = path.resolve(process.cwd(), packageJson.typings);
+
+const fileContents = fs.readFileSync(typingsLocation, { encoding: 'utf-8' });
+
+const defaultExportCode = `declare const puppeteer: Puppeteer;
+export default puppeteer;`;
+
+const newFileContents = fileContents + `\n${defaultExportCode}`;
+
+fs.writeFileSync(typingsLocation, newFileContents);


### PR DESCRIPTION
This PR:

* uses API-Extractor to generate a large .d.ts file with all the types in. This file is great, but it's missing the default export (e.g. the definition that when you import/require Puppeteer you get an instance of the `Puppeteer` class).
* Therefore, once the file has been generated, we add the required lines to declare the default export to the typings file.
* This _should_ mean that importing from `'puppeteer'` will work in TS land, as all the types will flow in from `puppeteer.d.ts`, as linked to via the `typings` field in our `package.json`.
