### PR TITLE
Proposal: fetch elements within shadow root with `shadow$` and `shadow$$`

### DIFF
--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -789,6 +789,26 @@ export class ElementHandle<
   }
 
   /**
+   * Runs `element.shadowRoot.querySelector` within the page. If no element matches the selector,
+   * the return value resolves to `null`.
+   */
+  async $shadow(selector: string[]): Promise<ElementHandle | null> {
+    const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
+      selector.join(', ')
+    );
+
+    const handle = await this.evaluateHandle(
+      queryHandler.shadowQueryOne,
+      updatedSelector
+    );
+
+    const element = handle.asElement();
+    if (element) return element;
+    await handle.dispose();
+    return null;
+  }
+
+  /**
    * Runs `element.querySelectorAll` within the page. If no elements match the selector,
    * the return value resolves to `[]`.
    */
@@ -799,6 +819,29 @@ export class ElementHandle<
 
     const handles = await this.evaluateHandle(
       queryHandler.queryAll,
+      updatedSelector
+    );
+    const properties = await handles.getProperties();
+    await handles.dispose();
+    const result = [];
+    for (const property of properties.values()) {
+      const elementHandle = property.asElement();
+      if (elementHandle) result.push(elementHandle);
+    }
+    return result;
+  }
+
+  /**
+   * Runs `element.shadowRoot.querySelectorAll` within the page. If no elements match the selector,
+   * the return value resolves to `[]`.
+   */
+  async shadow$$(selector: string): Promise<ElementHandle[]> {
+    const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
+      selector
+    );
+
+    const handles = await this.evaluateHandle(
+      queryHandler.shadowQueryAll,
       updatedSelector
     );
     const properties = await handles.getProperties();

--- a/src/common/QueryHandler.ts
+++ b/src/common/QueryHandler.ts
@@ -20,6 +20,14 @@ export interface QueryHandler {
     element: Element | Document,
     selector: string
   ) => Element[] | NodeListOf<Element>;
+  shadowQueryOne?: (
+    element: Element | Document,
+    selector: string
+  ) => Element | null;
+  shadowQueryAll?: (
+    element: Element | Document,
+    selector: string
+  ) => Element[] | NodeListOf<Element>;
 }
 
 const _customQueryHandlers = new Map<string, QueryHandler>();
@@ -61,6 +69,36 @@ export function getQueryHandlerAndSelector(
       element.querySelector(selector),
     queryAll: (element: Element, selector: string) =>
       element.querySelectorAll(selector),
+    shadowQueryOne: (element: Element, selector: string) => {
+      const selectors = selector.split(',');
+      let rootElement = element;
+
+      for (const query of selectors) {
+        rootElement = rootElement.shadowRoot.querySelector(query);
+
+        if (!rootElement) {
+          return null;
+        }
+      }
+
+      return rootElement;
+    },
+    shadowQueryAll: (element: Element, selector: string) => {
+      const selectors = selector.split(',');
+      let rootElement = [element];
+
+      for (const query of selectors) {
+        const elements = rootElement[0].shadowRoot.querySelectorAll(query);
+
+        if (elements.length === 0) {
+          return elements;
+        }
+
+        rootElement = [...elements];
+      }
+
+      return rootElement;
+    },
   };
   const hasCustomQueryHandler = /^[a-zA-Z]+\//.test(selector);
   if (!hasCustomQueryHandler)


### PR DESCRIPTION
There are various issues on missing support for fetching elements within the shadow DOM of elements. Some related issues are:

- https://github.com/puppeteer/puppeteer/issues/6217
- https://github.com/puppeteer/puppeteer/issues/5405
- https://github.com/puppeteer/puppeteer/issues/4171

Also for Puppeteer embedder projects like WebdriverIO:

- https://github.com/webdriverio/webdriverio/issues/4484

This PR proposes `shadow$` and `shadow$$` to allow query an element through element shadow roots. Given the following DOM structure:

```html
<html>
<body>
  <div id="elem">
    #shadow-root
    <customA></customA>
    <customA>
      #shadow-root
      <subCustomB>
        #shadow-root
        <div class="container"></div>
      </subCustomB>
    </customA>
  </div>
</body>
</html>
```

Given someone would fetch the root of an shadow element:

```js
const elem = await page.$('#elem')
```

The following queries would give following results:

- ```js
  elem.shadow$(['customA', 'subCustomB', '.container'])
  ```
  would return `null` because we would always pick the first element being found
- ```js
  const customAs = await elem.shadow$$(['customA'])
  return customAs[1].shadow$(['subCustomB', '.container'])
  ```
  would return `div.container`

One idea could be to always use `Element.querySelectorAll` and iterate through all nodes. This could be potentially a very expensive operation though and would only make sense for `shadow$$`.

WDYAT?