### PR TITLE
fix(FirefoxLauncher): use wait-for-process option on Windows

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -467,6 +467,9 @@ class FirefoxLauncher implements ProductLauncher {
 
   defaultArgs(options: ChromeArgOptions = {}): string[] {
     const firefoxArguments = ['--no-remote', '--foreground'];
+    if (os.platform().startsWith('win')) {
+      firefoxArguments.push('--wait-for-browser');
+    }
     const {
       devtools = false,
       headless = !devtools,

--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -34,9 +34,10 @@ const mkdtempAsync = promisify(fs.mkdtemp);
 const readFileAsync = promisify(fs.readFile);
 const statAsync = promisify(fs.stat);
 const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
+const FIREFOX_TIMEOUT = 30 * 1000;
 
 describe('Launcher specs', function () {
-  if (getTestState().isFirefox) this.timeout(30 * 1000);
+  if (getTestState().isFirefox) this.timeout(FIREFOX_TIMEOUT);
 
   describe('Puppeteer', function () {
     describe('BrowserFetcher', function () {
@@ -477,9 +478,10 @@ describe('Launcher specs', function () {
        * properly with help from the Mozilla folks.
        */
       itFailsWindowsUntilDate(
-        new Date('2020-07-30'),
+        new Date('2020-08-30'),
         'should be able to launch Firefox',
-        async () => {
+        async function () {
+          this.timeout(FIREFOX_TIMEOUT);
           const { puppeteer } = getTestState();
           const browser = await puppeteer.launch({ product: 'firefox' });
           const userAgent = await browser.userAgent();


### PR DESCRIPTION
Without `--wait-for-process`, `puppeteer.launch` returns before Firefox is ready on Windows, so this should be part of the default Firefox arguments on that platform.

On Windows, firefox.exe starts a "launcher process" that is responsible for configuring and starting the "real" browser process. Passing `--wait-for-process` makes that launcher process wait for the entire life of the browser process, and will also propagate the browser process's exit code as its own.

Note that the test highlighted in https://github.com/puppeteer/puppeteer/issues/5673 is still expected to fail because `BrowserRunner` doesn't track the right process on Windows, which breaks its `close` callback.
