### PR TITLE
fix: revise interesting/uninteresting classification for AXNodes

### DIFF
--- a/new-docs/puppeteer.snapshotoptions.interestingonly.md
+++ b/new-docs/puppeteer.snapshotoptions.interestingonly.md
@@ -4,7 +4,7 @@
 
 ## SnapshotOptions.interestingOnly property
 
-Prune unintersting nodes from the tree.
+Prune uninteresting nodes from the tree.
 
 <b>Signature:</b>
 

--- a/new-docs/puppeteer.snapshotoptions.md
+++ b/new-docs/puppeteer.snapshotoptions.md
@@ -15,6 +15,6 @@ export interface SnapshotOptions
 
 |  Property | Type | Description |
 |  --- | --- | --- |
-|  [interestingOnly](./puppeteer.snapshotoptions.interestingonly.md) | boolean | Prune unintersting nodes from the tree. |
-|  [root](./puppeteer.snapshotoptions.root.md) | [ElementHandle](./puppeteer.elementhandle.md) | Prune unintersting nodes from the tree. |
+|  [interestingOnly](./puppeteer.snapshotoptions.interestingonly.md) | boolean | Prune uninteresting nodes from the tree. |
+|  [root](./puppeteer.snapshotoptions.root.md) | [ElementHandle](./puppeteer.elementhandle.md) | Root node to get the accessibility tree for |
 

--- a/new-docs/puppeteer.snapshotoptions.root.md
+++ b/new-docs/puppeteer.snapshotoptions.root.md
@@ -4,7 +4,7 @@
 
 ## SnapshotOptions.root property
 
-Prune unintersting nodes from the tree.
+Root node to get the accessibility tree for
 
 <b>Signature:</b>
 

--- a/src/common/Accessibility.ts
+++ b/src/common/Accessibility.ts
@@ -96,12 +96,12 @@ export interface SerializedAXNode {
  */
 export interface SnapshotOptions {
   /**
-   * Prune unintersting nodes from the tree.
+   * Prune uninteresting nodes from the tree.
    * @defaultValue true
    */
   interestingOnly?: boolean;
   /**
-   * Prune unintersting nodes from the tree.
+   * Root node to get the accessibility tree for
    * @defaultValue The root node of the entire page.
    */
   root?: ElementHandle;
@@ -244,12 +244,14 @@ class AXNode {
   private _hidden = false;
   private _name: string;
   private _role: string;
+  private _ignored: boolean;
   private _cachedHasFocusableChild?: boolean;
 
   constructor(payload: Protocol.Accessibility.AXNode) {
     this.payload = payload;
     this._name = this.payload.name ? this.payload.name.value : '';
     this._role = this.payload.role ? this.payload.role.value : 'Unknown';
+    this._ignored = this.payload.ignored;
 
     for (const property of this.payload.properties || []) {
       if (property.name === 'editable') {
@@ -264,11 +266,7 @@ class AXNode {
   private _isPlainTextField(): boolean {
     if (this._richlyEditable) return false;
     if (this._editable) return true;
-    return (
-      this._role === 'textbox' ||
-      this._role === 'ComboBox' ||
-      this._role === 'searchbox'
-    );
+    return this._role === 'textbox' || this._role === 'searchbox';
   }
 
   private _isTextOnlyObject(): boolean {
@@ -354,6 +352,7 @@ class AXNode {
       case 'tab':
       case 'textbox':
       case 'tree':
+      case 'treeitem':
         return true;
       default:
         return false;
@@ -362,7 +361,7 @@ class AXNode {
 
   public isInteresting(insideControl: boolean): boolean {
     const role = this._role;
-    if (role === 'Ignored' || this._hidden) return false;
+    if (role === 'Ignored' || this._hidden || this._ignored) return false;
 
     if (this._focusable || this._richlyEditable) return true;
 


### PR DESCRIPTION
Minor changes to the logic for determining if an AXNode is interesting.
We might want to consider skipping this logic altogether and simply rely on CDP's `ignored` property on [AXNodes](https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#type-AXNode)