### PR TITLE
feat(a11y-query): differentiate between user-defined and internal query handlers

### DIFF
--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -466,6 +466,20 @@ export class DOMWorld {
     selector: string,
     options: WaitForSelectorOptions
   ): Promise<ElementHandle | null> {
+    const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
+      selector
+    );
+    return queryHandler.waitFor(this, updatedSelector, options);
+  }
+
+  /**
+   * @internal
+   */
+  async waitForSelectorInPage(
+    queryOne: Function,
+    selector: string,
+    options: WaitForSelectorOptions
+  ): Promise<ElementHandle | null> {
     const {
       visible: waitForVisible = false,
       hidden: waitForHidden = false,
@@ -475,9 +489,6 @@ export class DOMWorld {
     const title = `selector \`${selector}\`${
       waitForHidden ? ' to be hidden' : ''
     }`;
-    const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
-      selector
-    );
     function predicate(
       selector: string,
       waitForVisible: boolean,
@@ -490,11 +501,11 @@ export class DOMWorld {
     }
     const waitTask = new WaitTask(
       this,
-      this._makePredicateString(predicate, queryHandler.queryOne),
+      this._makePredicateString(predicate, queryOne),
       title,
       polling,
       timeout,
-      updatedSelector,
+      selector,
       waitForVisible,
       waitForHidden
     );

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -777,15 +777,7 @@ export class ElementHandle<
     const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
       selector
     );
-
-    const handle = await this.evaluateHandle(
-      queryHandler.queryOne,
-      updatedSelector
-    );
-    const element = handle.asElement();
-    if (element) return element;
-    await handle.dispose();
-    return null;
+    return queryHandler.queryOne(this, updatedSelector);
   }
 
   /**
@@ -796,19 +788,7 @@ export class ElementHandle<
     const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
       selector
     );
-
-    const handles = await this.evaluateHandle(
-      queryHandler.queryAll,
-      updatedSelector
-    );
-    const properties = await handles.getProperties();
-    await handles.dispose();
-    const result = [];
-    for (const property of properties.values()) {
-      const elementHandle = property.asElement();
-      if (elementHandle) result.push(elementHandle);
-    }
-    return result;
+    return queryHandler.queryAll(this, updatedSelector);
   }
 
   /**
@@ -892,15 +872,7 @@ export class ElementHandle<
     const { updatedSelector, queryHandler } = getQueryHandlerAndSelector(
       selector
     );
-    const queryHandlerToArray = Function(
-      'element',
-      'selector',
-      `return Array.from((${queryHandler.queryAll})(element, selector));`
-    ) as (...args: unknown[]) => unknown;
-    const arrayHandle = await this.evaluateHandle(
-      queryHandlerToArray,
-      updatedSelector
-    );
+    const arrayHandle = await queryHandler.queryAllArray(this, updatedSelector);
     const result = await arrayHandle.evaluate<
       (
         elements: Element[],

--- a/src/common/Puppeteer.ts
+++ b/src/common/Puppeteer.ts
@@ -31,9 +31,9 @@ import { Browser } from './Browser.js';
 import {
   registerCustomQueryHandler,
   unregisterCustomQueryHandler,
-  customQueryHandlers,
-  clearQueryHandlers,
-  QueryHandler,
+  customQueryHandlerNames,
+  clearCustomQueryHandlers,
+  CustomQueryHandler,
 } from './QueryHandler.js';
 import { PUPPETEER_REVISIONS } from '../revisions.js';
 
@@ -289,7 +289,7 @@ export class Puppeteer {
   // eslint-disable-next-line @typescript-eslint/camelcase
   __experimental_registerCustomQueryHandler(
     name: string,
-    queryHandler: QueryHandler
+    queryHandler: CustomQueryHandler
   ): void {
     registerCustomQueryHandler(name, queryHandler);
   }
@@ -306,8 +306,8 @@ export class Puppeteer {
    * @internal
    */
   // eslint-disable-next-line @typescript-eslint/camelcase
-  __experimental_customQueryHandlers(): Map<string, QueryHandler> {
-    return customQueryHandlers();
+  __experimental_customQueryHandlerNames(): string[] {
+    return customQueryHandlerNames();
   }
 
   /**
@@ -315,6 +315,6 @@ export class Puppeteer {
    */
   // eslint-disable-next-line @typescript-eslint/camelcase
   __experimental_clearQueryHandlers(): void {
-    clearQueryHandlers();
+    clearCustomQueryHandlers();
   }
 }


### PR DESCRIPTION
This PR changes the internal representation of query handlers to contain Puppeteer-level code instead of page functions.
The interface `CustomQueryHandler` is introduced for user-defined query handlers. When a `CustomQueryHandler` is registered using  `registerCustomQueryHandler` a corresponding Puppeteer-level handler is created through `makeQueryHandler` by wrapping the page functions as appropriate.
The internal query handlers (defined by the interface `QueryHandler`) contain two new functions: `waitFor` and `queryAllArray`.
- `waitFor` allows page-based handlers to make use of the `WaitTask`-backed implementation in `DOMWorld`, whereas purely Puppeteer-based handlers can define an alternative approach instead.
- `queryAllArray` is similar to `queryAll` but with a slightly different interface; it returns a `JSHandle` to an array with the results as opposed to an array of `ElementHandle`. It is used by `$$eval`. 

After this change, we can introduce built-in query handlers that are not executed in the page context (#6307).