### PR TITLE
chore(agnostic): Remove use of util.promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
     "ensure-new-docs-up-to-date": "npm run generate-docs && git status && exit `git status --porcelain | head -255 | wc -l`",
     "generate-dependency-graph": "echo 'Requires graphviz installed locally!' && depcruise --exclude 'api.ts' --do-not-follow '^node_modules' --output-type dot src/index.ts | dot -T png > dependency-chart.png",
-    "ensure-correct-devtools-protocol-revision": "ts-node scripts/ensure-correct-devtools-protocol-package"
+    "ensure-correct-devtools-protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package"
   },
   "files": [
     "lib/",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS"
   }

--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -275,12 +275,8 @@ export class DOMWorld {
           'Cannot pass a filepath to addScriptTag in the browser environment.'
         );
       }
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const fs = require('fs');
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { promisify } = require('util');
-      const readFileAsync = promisify(fs.readFile);
-      let contents = await readFileAsync(path, 'utf8');
+      const fs = await import('fs');
+      let contents = await fs.promises.readFile(path, 'utf8');
       contents += '//# sourceURL=' + path.replace(/\n/g, '');
       const context = await this.executionContext();
       return (
@@ -361,12 +357,8 @@ export class DOMWorld {
           'Cannot pass a filepath to addStyleTag in the browser environment.'
         );
       }
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const fs = require('fs');
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { promisify } = require('util');
-      const readFileAsync = promisify(fs.readFile);
-      let contents = await readFileAsync(path, 'utf8');
+      const fs = await import('fs');
+      let contents = await fs.promises.readFile(path, 'utf8');
       contents += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';
       const context = await this.executionContext();
       return (

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import { promisify } from 'util';
 import { EventEmitter } from './EventEmitter.js';
 import {
   Connection,
@@ -57,8 +55,7 @@ import {
   UnwrapPromiseLike,
 } from './EvalTypes.js';
 import { PDFOptions, paperFormats } from './PDFOptions.js';
-
-const writeFileAsync = promisify(fs.writeFile);
+import { isNode } from '../environment.js';
 
 /**
  * @public
@@ -1748,7 +1745,13 @@ export class Page extends EventEmitter {
       options.encoding === 'base64'
         ? result.data
         : Buffer.from(result.data, 'base64');
-    if (options.path) await writeFileAsync(options.path, buffer);
+    if (!isNode && options.path) {
+      throw new Error(
+        'Screenshots can only be written to a file path in a Node environment.'
+      );
+    }
+    const fs = await import('fs');
+    if (options.path) await fs.promises.writeFile(options.path, buffer);
     return buffer;
 
     function processClip(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "checkJs": true,
     "target": "ESNext",
     "moduleResolution": "node",
+    "module": "ESNext",
     "declaration": true,
     "declarationMap": true,
     "resolveJsonModule": true


### PR DESCRIPTION

In `src/common` we now use `fs.promises.X` which we can dynamically
`import`. In a browser environment this code will never run because it's
gated on `isNode` (in a future PR we will add tree-shaking to the bundle
step such that this code is eliminated). By using `import`, we ensure
TypeScript still can track types and give good type information.

In `src/node` we continue to use `util.promisify` but that's not a
concern as that code explicitly is never run in the browser.