### PR TITLE
Disable Firefox Windows launcher test until Nov

### DIFF
--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -478,7 +478,7 @@ describe('Launcher specs', function () {
        * properly with help from the Mozilla folks.
        */
       itFailsWindowsUntilDate(
-        new Date('2020-09-30'),
+        new Date('2020-10-31'),
         'should be able to launch Firefox',
         async function () {
           this.timeout(FIREFOX_TIMEOUT);


### PR DESCRIPTION
I think I'll have some bandwidth to take a look at https://github.com/puppeteer/puppeteer/issues/5673#issuecomment-670141377 some time in October.