### PR TITLE
feat(a11y-query): add aria query handler

### DIFF
--- a/src/common/AriaQueryHandler.ts
+++ b/src/common/AriaQueryHandler.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InternalQueryHandler } from './QueryHandler.js';
+import { ElementHandle } from './JSHandle.js';
+import { Protocol } from 'devtools-protocol';
+import { CDPSession } from './Connection.js';
+import { DOMWorld } from './DOMWorld.js';
+
+async function queryAXTree(
+  client: CDPSession,
+  element: ElementHandle,
+  accessibleName?: string,
+  role?: string
+): Promise<Protocol.Accessibility.AXNode[]> {
+  // @ts-ignore
+  const { nodes } = await client.send(
+    // @ts-ignore
+    'Accessibility.queryAXTree',
+    {
+      objectId: element._remoteObject.objectId,
+      accessibleName,
+      role,
+    }
+  );
+  // @ts-ignore
+  const filteredNodes: Protocol.Accessibility.AXNode[] = nodes.filter(
+    (node: Protocol.Accessibility.AXNode) => node.role.value !== 'text'
+  );
+  return filteredNodes;
+}
+
+/*
+ * The aria selectors are on the form '<computed name>&<computed role>'.
+ * The following examples showcase how the syntax works wrt. querying:
+ * - 'title&heading' queries for elements with computed name 'title' and role 'heading'.
+ * - '&img' queries for elements with role 'img' and any name.
+ * - 'label' queries for elements with name 'label' and any role.
+ */
+function parseAriaSelector(selector: string): { name?: string; role?: string } {
+  const s = selector.split('&');
+  const name = s[0] || undefined;
+  const role = s.length > 1 ? s[1] : undefined;
+  return { name, role };
+}
+
+const queryOne = async (element: ElementHandle, selector: string) => {
+  const exeCtx = element.executionContext();
+  const { name, role } = parseAriaSelector(selector);
+  const res = await queryAXTree(exeCtx._client, element, name, role);
+  if (res.length < 1) {
+    return null;
+  }
+  const handle = await exeCtx._adoptBackendNodeId(res[0].backendDOMNodeId);
+  return handle;
+};
+
+const queryAll = async (element: ElementHandle, selector: string) => {
+  const exeCtx = element.executionContext();
+  const { name, role } = parseAriaSelector(selector);
+  const res = await queryAXTree(exeCtx._client, element, name, role);
+  const resHandles = Promise.all(
+    res.map((axNode) => exeCtx._adoptBackendNodeId(axNode.backendDOMNodeId))
+  );
+  return resHandles;
+};
+
+// If multiple waitFor are set up asynchronously, we need to wait for the first
+// one to set up the binding in the page before running the others.
+let settingUpBinding = null;
+
+async function addHandlerToWorld(domWorld: DOMWorld) {
+  if (settingUpBinding) {
+    await settingUpBinding;
+  }
+  if (!domWorld.hasBinding('ariaQuerySelector')) {
+    let done: () => void | null = null;
+    settingUpBinding = new Promise((resolve) => {
+      done = resolve;
+    });
+    await domWorld.addBinding('ariaQuerySelector', async (selector: string) => {
+      const document = await domWorld._document();
+      const element = await queryOne(document, selector);
+      return element;
+    });
+    done();
+    settingUpBinding = null;
+  }
+}
+
+/**
+ * @internal
+ */
+export const ariaHandler: InternalQueryHandler = {
+  queryOne,
+  waitFor: async (domWorld, selector, options) => {
+    await addHandlerToWorld(domWorld);
+    return domWorld.waitForSelectorInPage(
+      (_: Element, selector: string) => globalThis.ariaQuerySelector(selector),
+      selector,
+      options
+    );
+  },
+  queryAll,
+  queryAllArray: async (element, selector) => {
+    const elementHandles = await queryAll(element, selector);
+    const exeCtx = element.executionContext();
+    const jsHandle = exeCtx.evaluateHandle(
+      (...elements) => Array.from(elements),
+      ...elementHandles
+    );
+    return jsHandle;
+  },
+};

--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -52,7 +52,10 @@ export class ExecutionContext {
    * @internal
    */
   _world: DOMWorld;
-  private _contextId: number;
+  /**
+   * @internal
+   */
+  _contextId: number;
 
   /**
    * @internal

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1053,7 +1053,7 @@ export class Page extends EventEmitter {
       );
     this._pageBindings.set(name, puppeteerFunction);
 
-    const expression = helper.evaluationString(addPageBinding, name);
+    const expression = helper.pageBindingInitString('exposedFun', name);
     await this._client.send('Runtime.addBinding', { name: name });
     await this._client.send('Page.addScriptToEvaluateOnNewDocument', {
       source: expression,
@@ -1061,30 +1061,6 @@ export class Page extends EventEmitter {
     await Promise.all(
       this.frames().map((frame) => frame.evaluate(expression).catch(debugError))
     );
-
-    function addPageBinding(bindingName): void {
-      /* Cast window to any here as we're about to add properties to it
-       * via win[bindingName] which TypeScript doesn't like.
-       */
-      const win = window as any;
-      const binding = win[bindingName];
-
-      win[bindingName] = (...args: unknown[]): Promise<unknown> => {
-        const me = window[bindingName];
-        let callbacks = me['callbacks'];
-        if (!callbacks) {
-          callbacks = new Map();
-          me['callbacks'] = callbacks;
-        }
-        const seq = (me['lastSeq'] || 0) + 1;
-        me['lastSeq'] = seq;
-        const promise = new Promise((resolve, reject) =>
-          callbacks.set(seq, { resolve, reject })
-        );
-        binding(JSON.stringify({ name: bindingName, seq, args }));
-        return promise;
-      };
-    }
   }
 
   async authenticate(credentials: Credentials): Promise<void> {
@@ -1159,23 +1135,30 @@ export class Page extends EventEmitter {
   private async _onBindingCalled(
     event: Protocol.Runtime.BindingCalledEvent
   ): Promise<void> {
-    const { name, seq, args } = JSON.parse(event.payload);
+    let jsonPayload = null;
+    try {
+      jsonPayload = JSON.parse(event.payload);
+    } catch {
+      // Binding must have been called before initializing the wrapper.
+      // Ignore event for now. TODO: figure out how to avoid this situation
+      return;
+    }
+    const { type, name, seq, args } = jsonPayload;
+    if (type !== 'exposedFun' || !this._pageBindings.has(name)) return;
     let expression = null;
     try {
       const result = await this._pageBindings.get(name)(...args);
-      expression = helper.evaluationString(deliverResult, name, seq, result);
+      expression = helper.pageBindingDeliverResultString(name, seq, result);
     } catch (error) {
       if (error instanceof Error)
-        expression = helper.evaluationString(
-          deliverError,
+        expression = helper.pageBindingDeliverErrorString(
           name,
           seq,
           error.message,
           error.stack
         );
       else
-        expression = helper.evaluationString(
-          deliverErrorValue,
+        expression = helper.pageBindingDeliverErrorValueString(
           name,
           seq,
           error
@@ -1187,32 +1170,6 @@ export class Page extends EventEmitter {
         contextId: event.executionContextId,
       })
       .catch(debugError);
-
-    function deliverResult(name: string, seq: number, result: unknown): void {
-      window[name]['callbacks'].get(seq).resolve(result);
-      window[name]['callbacks'].delete(seq);
-    }
-
-    function deliverError(
-      name: string,
-      seq: number,
-      message: string,
-      stack: string
-    ): void {
-      const error = new Error(message);
-      error.stack = stack;
-      window[name]['callbacks'].get(seq).reject(error);
-      window[name]['callbacks'].delete(seq);
-    }
-
-    function deliverErrorValue(
-      name: string,
-      seq: number,
-      value: unknown
-    ): void {
-      window[name]['callbacks'].get(seq).reject(value);
-      window[name]['callbacks'].delete(seq);
-    }
   }
 
   private _addConsoleMessage(

--- a/src/common/QueryHandler.ts
+++ b/src/common/QueryHandler.ts
@@ -16,11 +16,12 @@
 
 import { WaitForSelectorOptions, DOMWorld } from './DOMWorld.js';
 import { ElementHandle, JSHandle } from './JSHandle.js';
+import { ariaHandler } from './AriaQueryHandler.js';
 
 /**
  * @internal
  */
-interface InternalQueryHandler {
+export interface InternalQueryHandler {
   queryOne?: (
     element: ElementHandle,
     selector: string
@@ -93,13 +94,18 @@ function makeQueryHandler(handler: CustomQueryHandler): InternalQueryHandler {
   return internalHandler;
 }
 
-const _queryHandlers = new Map<string, InternalQueryHandler>();
 const _defaultHandler = makeQueryHandler({
   queryOne: (element: Element, selector: string) =>
     element.querySelector(selector),
   queryAll: (element: Element, selector: string) =>
     element.querySelectorAll(selector),
 });
+
+const _builtInHandlers: Array<[string, InternalQueryHandler]> = [
+  ['aria', ariaHandler],
+];
+
+const _queryHandlers = new Map<string, InternalQueryHandler>(_builtInHandlers);
 
 export function registerCustomQueryHandler(
   name: string,

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -182,6 +182,115 @@ function evaluationString(fun: Function | string, ...args: unknown[]): string {
   return `(${fun})(${args.map(serializeArgument).join(',')})`;
 }
 
+function pageBindingInitString(type: string, name: string): string {
+  return evaluationString(addPageBinding, type, name);
+
+  function addPageBinding(type: string, bindingName: string): void {
+    /* Cast window to any here as we're about to add properties to it
+     * via win[bindingName] which TypeScript doesn't like.
+     */
+    const win = window as any;
+    const binding = win[bindingName];
+
+    win[bindingName] = (...args: unknown[]): Promise<unknown> => {
+      const me = window[bindingName];
+      let callbacks = me.callbacks;
+      if (!callbacks) {
+        callbacks = new Map();
+        me.callbacks = callbacks;
+      }
+      const seq = (me.lastSeq || 0) + 1;
+      me.lastSeq = seq;
+      const promise = new Promise((resolve, reject) =>
+        callbacks.set(seq, { resolve, reject })
+      );
+      binding(JSON.stringify({ type, name: bindingName, seq, args }));
+      return promise;
+    };
+  }
+}
+
+function pageBindingDeliverResultString(
+  name: string,
+  seq: number,
+  result: unknown
+): string {
+  return evaluationString(deliverResult, name, seq, result);
+  function deliverResult(name: string, seq: number, result: unknown): void {
+    window[name].callbacks.get(seq).resolve(result);
+    window[name].callbacks.delete(seq);
+  }
+}
+
+function pageBindingDeliverErrorString(
+  name: string,
+  seq: number,
+  message: string,
+  stack: string
+): string {
+  return evaluationString(deliverError, name, seq, message, stack);
+  function deliverError(
+    name: string,
+    seq: number,
+    message: string,
+    stack: string
+  ): void {
+    const error = new Error(message);
+    error.stack = stack;
+    window[name].callbacks.get(seq).reject(error);
+    window[name].callbacks.delete(seq);
+  }
+}
+
+function pageBindingDeliverErrorValueString(
+  name: string,
+  seq: number,
+  value: unknown
+): string {
+  return evaluationString(deliverErrorValue, name, seq, value);
+  function deliverErrorValue(name: string, seq: number, value: unknown): void {
+    window[name].callbacks.get(seq).reject(value);
+    window[name].callbacks.delete(seq);
+  }
+}
+
+function makePredicateString(
+  predicate: Function,
+  predicateQueryHandler?: Function
+): string {
+  const predicateQueryHandlerDef = predicateQueryHandler
+    ? `const predicateQueryHandler = ${predicateQueryHandler};`
+    : '';
+  return `
+    (() => {
+      ${predicateQueryHandlerDef}
+      const checkWaitForOptions = ${checkWaitForOptions};
+      return (${predicate})(...args)
+    })() `;
+  function checkWaitForOptions(
+    node: Node,
+    waitForVisible: boolean,
+    waitForHidden: boolean
+  ): Node | null | boolean {
+    if (!node) return waitForHidden;
+    if (!waitForVisible && !waitForHidden) return node;
+    const element =
+      node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as Element);
+
+    const style = window.getComputedStyle(element);
+    const isVisible =
+      style && style.visibility !== 'hidden' && hasVisibleBoundingBox();
+    const success =
+      waitForVisible === isVisible || waitForHidden === !isVisible;
+    return success ? node : null;
+
+    function hasVisibleBoundingBox(): boolean {
+      const rect = element.getBoundingClientRect();
+      return !!(rect.top || rect.bottom || rect.width || rect.height);
+    }
+  }
+}
+
 async function waitWithTimeout<T extends any>(
   promise: Promise<T>,
   taskName: string,
@@ -232,6 +341,11 @@ async function readProtocolStream(
 
 export const helper = {
   evaluationString,
+  pageBindingInitString,
+  pageBindingDeliverResultString,
+  pageBindingDeliverErrorString,
+  pageBindingDeliverErrorValueString,
+  makePredicateString,
   readProtocolStream,
   waitWithTimeout,
   waitForEvent,

--- a/src/revisions.ts
+++ b/src/revisions.ts
@@ -20,6 +20,6 @@ type Revisions = Readonly<{
 }>;
 
 export const PUPPETEER_REVISIONS: Revisions = {
-  chromium: '800071',
+  chromium: '809590',
   firefox: 'latest',
 };

--- a/test/ariaqueryhandler.spec.ts
+++ b/test/ariaqueryhandler.spec.ts
@@ -1,0 +1,526 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+import {
+  getTestState,
+  setupTestBrowserHooks,
+  setupTestPageAndContextHooks,
+} from './mocha-utils'; // eslint-disable-line import/extensions
+
+import { ElementHandle } from '../lib/cjs/puppeteer/common/JSHandle.js';
+import utils from './utils.js';
+
+describe('AriaQueryHandler', () => {
+  setupTestBrowserHooks();
+  setupTestPageAndContextHooks();
+
+  describe('can find button element', () => {
+    beforeEach(async () => {
+      const { page } = getTestState();
+      await page.setContent(
+        '<div id="div"><button id="btn" role="button">Submit</button></div>'
+      );
+    });
+
+    it('should find button by role', async () => {
+      const { page } = getTestState();
+      const button = await page.$('aria/&button');
+      const id = await button.evaluate((b: Element) => b.id);
+      expect(id).toBe('btn');
+    });
+
+    it('should find button by name and role', async () => {
+      const { page } = getTestState();
+      const button = await page.$('aria/Submit&button');
+      const id = await button.evaluate((b: Element) => b.id);
+      expect(id).toBe('btn');
+    });
+  });
+
+  describe('should find first matching element', () => {
+    beforeEach(async () => {
+      const { page } = getTestState();
+      await page.setContent(
+        `
+        <div role="menu" id="mnu1" aria-label="menu div"></div>
+        <div role="menu" id="mnu2" aria-label="menu div"></div>
+        `
+      );
+    });
+
+    it('should find by name', async () => {
+      const { page } = getTestState();
+      const div = await page.$('aria/menu div');
+      const id = await div.evaluate((b: Element) => b.id);
+      expect(id).toBe('mnu1');
+    });
+  });
+
+  describe('should find all matching elements', () => {
+    beforeEach(async () => {
+      const { page } = getTestState();
+      await page.setContent(
+        `
+        <div role="menu" id="mnu1" aria-label="menu div"></div>
+        <div role="menu" id="mnu2" aria-label="menu div"></div>
+        `
+      );
+    });
+
+    it('should find menu by name', async () => {
+      const { page } = getTestState();
+      const divs = await page.$$('aria/menu div');
+      const ids = await Promise.all(
+        divs.map((n) => n.evaluate((b: Element) => b.id))
+      );
+      expect(ids.join(', ')).toBe('mnu1, mnu2');
+    });
+  });
+
+  describe('should find name sourced from aria-label', () => {
+    beforeEach(async () => {
+      const { page } = getTestState();
+      await page.setContent(
+        `
+        <div role="menu" id="mnu1" aria-label="menu-label1">menu div</div>
+        <div role="menu" id="mnu2" aria-label="menu-label2">menu div</div>
+        `
+      );
+    });
+
+    it('should find by name', async () => {
+      const { page } = getTestState();
+      const menu = await page.$('aria/menu-label1');
+      const id = await menu.evaluate((b: Element) => b.id);
+      expect(id).toBe('mnu1');
+    });
+
+    it('should find by name', async () => {
+      const { page } = getTestState();
+      const menu = await page.$('aria/menu-label2');
+      const id = await menu.evaluate((b: Element) => b.id);
+      expect(id).toBe('mnu2');
+    });
+
+    it('$$eval should handle many elements (aria)', async () => {
+      const { page } = getTestState();
+      await page.evaluate(
+        `
+        for (var i = 0; i <= 10000; i++) {
+            const button = document.createElement('button');
+            button.textContent = i;
+            document.body.appendChild(button);
+        }
+        `
+      );
+      const sum = await page.$$eval('aria/&button', (buttons) =>
+        buttons.reduce((acc, button) => acc + Number(button.textContent), 0)
+      );
+      expect(sum).toBe(50005000);
+    });
+  });
+
+  describe('waitForSelector (aria)', function () {
+    const addElement = (tag) =>
+      document.body.appendChild(document.createElement(tag));
+
+    it('should immediately resolve promise if node exists', async () => {
+      const { page, server } = getTestState();
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(addElement, 'button');
+      await page.waitForSelector('aria/&button');
+    });
+
+    it('should work independently of `exposeFunction`', async () => {
+      const { page, server } = getTestState();
+      await page.goto(server.EMPTY_PAGE);
+      await page.exposeFunction('ariaQuerySelector', (a, b) => a + b);
+      await page.evaluate(addElement, 'button');
+      await page.waitForSelector('aria/&button');
+      const result = await page.evaluate('globalThis.ariaQuerySelector(2,8)');
+      expect(result).toBe(10);
+    });
+
+    it('should work with removed MutationObserver', async () => {
+      const { page } = getTestState();
+
+      await page.evaluate(() => delete window.MutationObserver);
+      const [handle] = await Promise.all([
+        page.waitForSelector('aria/anything'),
+        page.setContent(`<h1>anything</h1>`),
+      ]);
+      expect(
+        await page.evaluate((x: HTMLElement) => x.textContent, handle)
+      ).toBe('anything');
+    });
+
+    it('should resolve promise when node is added', async () => {
+      const { page, server } = getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      const frame = page.mainFrame();
+      const watchdog = frame.waitForSelector('aria/&heading');
+      await frame.evaluate(addElement, 'br');
+      await frame.evaluate(addElement, 'h1');
+      const elementHandle = await watchdog;
+      const tagName = await elementHandle
+        .getProperty('tagName')
+        .then((element) => element.jsonValue());
+      expect(tagName).toBe('H1');
+    });
+
+    it('should work when node is added through innerHTML', async () => {
+      const { page, server } = getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      const watchdog = page.waitForSelector('aria/name');
+      await page.evaluate(addElement, 'span');
+      await page.evaluate(
+        () =>
+          (document.querySelector('span').innerHTML =
+            '<h3><div aria-label="name"></div></h3>')
+      );
+      await watchdog;
+    });
+
+    it('Page.waitForSelector is shortcut for main frame', async () => {
+      const { page, server } = getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      const otherFrame = page.frames()[1];
+      const watchdog = page.waitForSelector('aria/&button');
+      await otherFrame.evaluate(addElement, 'button');
+      await page.evaluate(addElement, 'button');
+      const elementHandle = await watchdog;
+      expect(elementHandle.executionContext().frame()).toBe(page.mainFrame());
+    });
+
+    it('should run in specified frame', async () => {
+      const { page, server } = getTestState();
+
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'frame2', server.EMPTY_PAGE);
+      const frame1 = page.frames()[1];
+      const frame2 = page.frames()[2];
+      const waitForSelectorPromise = frame2.waitForSelector('aria/&button');
+      await frame1.evaluate(addElement, 'button');
+      await frame2.evaluate(addElement, 'button');
+      const elementHandle = await waitForSelectorPromise;
+      expect(elementHandle.executionContext().frame()).toBe(frame2);
+    });
+
+    it('should throw when frame is detached', async () => {
+      const { page, server } = getTestState();
+
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      const frame = page.frames()[1];
+      let waitError = null;
+      const waitPromise = frame
+        .waitForSelector('aria/does-not-exist')
+        .catch((error) => (waitError = error));
+      await utils.detachFrame(page, 'frame1');
+      await waitPromise;
+      expect(waitError).toBeTruthy();
+      expect(waitError.message).toContain(
+        'waitForFunction failed: frame got detached.'
+      );
+    });
+
+    it('should survive cross-process navigation', async () => {
+      const { page, server } = getTestState();
+
+      let imgFound = false;
+      const waitForSelector = page
+        .waitForSelector('aria/&img')
+        .then(() => (imgFound = true));
+      await page.goto(server.EMPTY_PAGE);
+      expect(imgFound).toBe(false);
+      await page.reload();
+      expect(imgFound).toBe(false);
+      await page.goto(server.CROSS_PROCESS_PREFIX + '/grid.html');
+      await waitForSelector;
+      expect(imgFound).toBe(true);
+    });
+
+    it('should wait for visible', async () => {
+      const { page } = getTestState();
+
+      let divFound = false;
+      const waitForSelector = page
+        .waitForSelector('aria/name', { visible: true })
+        .then(() => (divFound = true));
+      await page.setContent(
+        `<div aria-label='name' style='display: none; visibility: hidden;'>1</div>`
+      );
+      expect(divFound).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').style.removeProperty('display')
+      );
+      expect(divFound).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').style.removeProperty('visibility')
+      );
+      expect(await waitForSelector).toBe(true);
+      expect(divFound).toBe(true);
+    });
+
+    it('should wait for visible recursively', async () => {
+      const { page } = getTestState();
+
+      let divVisible = false;
+      const waitForSelector = page
+        .waitForSelector('aria/inner', { visible: true })
+        .then(() => (divVisible = true));
+      await page.setContent(
+        `<div style='display: none; visibility: hidden;'><div aria-label="inner">hi</div></div>`
+      );
+      expect(divVisible).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').style.removeProperty('display')
+      );
+      expect(divVisible).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').style.removeProperty('visibility')
+      );
+      expect(await waitForSelector).toBe(true);
+      expect(divVisible).toBe(true);
+    });
+
+    it('hidden should wait for visibility: hidden', async () => {
+      const { page } = getTestState();
+
+      let divHidden = false;
+      await page.setContent(
+        `<div role='button' style='display: block;'></div>`
+      );
+      const waitForSelector = page
+        .waitForSelector('aria/&button', { hidden: true })
+        .then(() => (divHidden = true));
+      await page.waitForSelector('aria/&button'); // do a round trip
+      expect(divHidden).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').style.setProperty('visibility', 'hidden')
+      );
+      expect(await waitForSelector).toBe(true);
+      expect(divHidden).toBe(true);
+    });
+
+    it('hidden should wait for display: none', async () => {
+      const { page } = getTestState();
+
+      let divHidden = false;
+      await page.setContent(`<div role='main' style='display: block;'></div>`);
+      const waitForSelector = page
+        .waitForSelector('aria/&main', { hidden: true })
+        .then(() => (divHidden = true));
+      await page.waitForSelector('aria/&main'); // do a round trip
+      expect(divHidden).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').style.setProperty('display', 'none')
+      );
+      expect(await waitForSelector).toBe(true);
+      expect(divHidden).toBe(true);
+    });
+
+    it('hidden should wait for removal', async () => {
+      const { page } = getTestState();
+
+      await page.setContent(`<div role='main'></div>`);
+      let divRemoved = false;
+      const waitForSelector = page
+        .waitForSelector('aria/&main', { hidden: true })
+        .then(() => (divRemoved = true));
+      await page.waitForSelector('aria/&main'); // do a round trip
+      expect(divRemoved).toBe(false);
+      await page.evaluate(() => document.querySelector('div').remove());
+      expect(await waitForSelector).toBe(true);
+      expect(divRemoved).toBe(true);
+    });
+
+    it('should return null if waiting to hide non-existing element', async () => {
+      const { page } = getTestState();
+
+      const handle = await page.waitForSelector('aria/non-existing', {
+        hidden: true,
+      });
+      expect(handle).toBe(null);
+    });
+
+    it('should respect timeout', async () => {
+      const { page, puppeteer } = getTestState();
+
+      let error = null;
+      await page
+        .waitForSelector('aria/&button', { timeout: 10 })
+        .catch((error_) => (error = error_));
+      expect(error).toBeTruthy();
+      expect(error.message).toContain(
+        'waiting for selector `&button` failed: timeout'
+      );
+      expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
+    });
+
+    it('should have an error message specifically for awaiting an element to be hidden', async () => {
+      const { page } = getTestState();
+
+      await page.setContent(`<div role='main'></div>`);
+      let error = null;
+      await page
+        .waitForSelector('aria/&main', { hidden: true, timeout: 10 })
+        .catch((error_) => (error = error_));
+      expect(error).toBeTruthy();
+      expect(error.message).toContain(
+        'waiting for selector `&main` to be hidden failed: timeout'
+      );
+    });
+
+    it('should respond to node attribute mutation', async () => {
+      const { page } = getTestState();
+
+      let divFound = false;
+      const waitForSelector = page
+        .waitForSelector('aria/zombo')
+        .then(() => (divFound = true));
+      await page.setContent(`<div aria-label='notZombo'></div>`);
+      expect(divFound).toBe(false);
+      await page.evaluate(() =>
+        document.querySelector('div').setAttribute('aria-label', 'zombo')
+      );
+      expect(await waitForSelector).toBe(true);
+    });
+
+    it('should return the element handle', async () => {
+      const { page } = getTestState();
+
+      const waitForSelector = page.waitForSelector('aria/zombo');
+      await page.setContent(`<div aria-label='zombo'>anything</div>`);
+      expect(
+        await page.evaluate(
+          (x: HTMLElement) => x.textContent,
+          await waitForSelector
+        )
+      ).toBe('anything');
+    });
+
+    // TODO: Figure out what the stack trace should look like for custom handlers
+    it.skip('should have correct stack trace for timeout', async () => {
+      const { page } = getTestState();
+
+      let error;
+      await page
+        .waitForSelector('aria/zombo', { timeout: 10 })
+        .catch((error_) => (error = error_));
+      expect(error.stack).toContain('waiting for selector `zombo` failed');
+      // The extension is ts here as Mocha maps back via sourcemaps.
+      expect(error.stack).toContain('ariaqueryhandler.spec.ts');
+    });
+  });
+
+  describe('web tests', async () => {
+    beforeEach(async () => {
+      const { page } = getTestState();
+      await page.setContent(
+        `
+          <h2 id="shown">title</h2>
+          <h2 id="hidden" aria-hidden="true">title</h2>
+          <div id="node1" aria-labeledby="node2"></div>
+          <div id="node2" aria-label="bar"></div>
+          <div id="node3" aria-label="foo"></div>
+          <div id="node4" class="container">
+          <div id="node5" role="button" aria-label="foo"></div>
+          <div id="node6" role="button" aria-label="foo"></div>
+          <!-- Accessible name not available when element is hidden -->
+          <div id="node7" hidden role="button" aria-label="foo"></div>
+          <div id="node8" role="button" aria-label="bar"></div>
+          </div>
+          <button id="node10">text content</button>
+          <h1 id="node11">text content</h1>
+          <!-- Accessible name not available when role is "presentation" -->
+          <h1 id="node12" role="presentation">text content</h1>
+          <!-- Elements inside shadow dom should be found -->
+          <script>
+          const div = document.createElement('div');
+          const shadowRoot = div.attachShadow({mode: 'open'});
+          const h1 = document.createElement('h1');
+          h1.textContent = 'text content';
+          h1.id = 'node13';
+          shadowRoot.appendChild(h1);
+          document.documentElement.appendChild(div);
+          </script>
+          <img id="node20" src="" alt="Accessible Name">
+          <input id="node21" type="submit" value="Accessible Name">
+          <label id="node22" for="node23">Accessible Name</label>
+          <!-- Accessible name for the <input> is "Accessible Name" -->
+          <input id="node23">
+          <div id="node24" title="Accessible Name"></div>
+          <div role="treeitem" id="node30">
+          <div role="treeitem" id="node31">
+          <div role="treeitem" id="node32">item1</div>
+          <div role="treeitem" id="node33">item2</div>
+          </div>
+          <div role="treeitem" id="node34">item3</div>
+          </div>
+          <!-- Accessible name for the <div> is "item1 item2 item3" -->
+          <div aria-describedby="node30"></div>
+          `
+      );
+    });
+    const getIds = async (elements: ElementHandle[]) =>
+      Promise.all(
+        elements.map((element) =>
+          element.evaluate((element: Element) => element.id)
+        )
+      );
+    it('should find by name "foo"', async () => {
+      const { page } = getTestState();
+      const found = await page.$$('aria/foo');
+      const ids = await getIds(found);
+      expect(ids).toEqual(['node3', 'node5', 'node6']);
+    });
+    it('should find by name "bar"', async () => {
+      const { page } = getTestState();
+      const found = await page.$$('aria/bar');
+      const ids = await getIds(found);
+      expect(ids).toEqual(['node1', 'node2', 'node8']);
+    });
+    it('should find treeitem by name', async () => {
+      const { page } = getTestState();
+      const found = await page.$$('aria/item1 item2 item3');
+      const ids = await getIds(found);
+      expect(ids).toEqual(['node30']);
+    });
+    it('should find by role "button"', async () => {
+      const { page } = getTestState();
+      const found = await page.$$('aria/&button');
+      const ids = await getIds(found);
+      expect(ids).toEqual(['node5', 'node6', 'node8', 'node10', 'node21']);
+    });
+    it('should find by role "heading"', async () => {
+      const { page } = getTestState();
+      const found = await page.$$('aria/&heading');
+      const ids = await getIds(found);
+      expect(ids).toEqual(['shown', 'hidden', 'node11', 'node13']);
+    });
+    it('should find both ignored and unignored', async () => {
+      const { page } = getTestState();
+      const found = await page.$$('aria/title');
+      const ids = await getIds(found);
+      expect(ids).toEqual(['shown', 'hidden']);
+    });
+  });
+});

--- a/test/idle_override.spec.ts
+++ b/test/idle_override.spec.ts
@@ -40,7 +40,7 @@ describeFailsFirefox('Emulate idle state', () => {
     expect(actualState).toEqual(expectedState);
   }
 
-  it('changing idle state emulation causes change of the IdleDetector state', async () => {
+  it.skip('changing idle state emulation causes change of the IdleDetector state', async () => {
     const { page, server, context } = getTestState();
     await context.overridePermissions(server.PREFIX + '/idle-detector.html', [
       'notifications',


### PR DESCRIPTION
This PR adds an alternative built-in handler `aria/` that allows querying by accessible name and role.
This draft PR is mostly for reference to showcase the full implementation.
I will split this into 3 PRs:
- [ ] Roll Chromium revision 809590.
- [ ] Introduce aria handler with queryOne and queryAll support (but no waitFor).
- [ ] Add waitFor support to the aria query handler.