### PR TITLE
docs(examples): update selector for search example

### DIFF
--- a/examples/search.js
+++ b/examples/search.js
@@ -30,7 +30,7 @@ const puppeteer = require('puppeteer');
   await page.goto('https://developers.google.com/web/');
 
   // Type into search box.
-  await page.type('#searchbox input', 'Headless Chrome');
+  await page.type('.devsite-searchbox input', 'Headless Chrome');
 
   // Wait for suggest overlay to appear and click "show all results".
   const allResultsSelector = '.devsite-suggest-all-results';

--- a/experimental/puppeteer-firefox/examples/search.js
+++ b/experimental/puppeteer-firefox/examples/search.js
@@ -30,7 +30,7 @@ const puppeteer = require('puppeteer-firefox');
   await page.goto('https://developers.google.com/web/');
 
   // Type into search box.
-  await page.type('#searchbox input', 'Headless Chrome');
+  await page.type('.devsite-searchbox input', 'Headless Chrome');
 
   // Wait for suggest overlay to appear and click "show all results".
   const allResultsSelector = '.devsite-suggest-all-results';


### PR DESCRIPTION
This commit updates the selector used in `examples/search.js` as it was
invalid.

Fixes #6470, Fixes #5071