### PR TITLE
feat(a11y-query): extend aria handler with waitFor

### DIFF
--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -52,7 +52,10 @@ export class ExecutionContext {
    * @internal
    */
   _world: DOMWorld;
-  private _contextId: number;
+  /**
+   * @internal
+   */
+  _contextId: number;
 
   /**
    * @internal

--- a/test/frame.spec.ts
+++ b/test/frame.spec.ts
@@ -76,7 +76,7 @@ describe('Frame specs', function () {
       let error = null;
       await frame1.evaluate(() => 7 * 8).catch((error_) => (error = error_));
       expect(error.message).toContain(
-        'Execution Context is not available in detached frame'
+        'Execution context is not available in detached frame'
       );
     });
   });


### PR DESCRIPTION
This PR adds `waitFor` to the built-in aria handler (#6307).
This is part 3 of https://github.com/puppeteer/puppeteer/pull/6453.