### PR TITLE
chore(agnostify): Create Node and Web initializer.

### DIFF
--- a/src/common/Puppeteer.ts
+++ b/src/common/Puppeteer.ts
@@ -67,7 +67,8 @@ import { PUPPETEER_REVISIONS } from '../revisions.js';
  * @public
  */
 export class Puppeteer {
-  private _projectRoot: string;
+  // Will be undefined in a browser environment
+  private _projectRoot?: string;
   private _isPuppeteerCore: boolean;
   private _changedProduct = false;
   private __productName: string;

--- a/src/index-core.ts
+++ b/src/index-core.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { initializePuppeteer } from './initialize.js';
+import { initializePuppeteerNode } from './initialize-node.js';
+import { isNode } from './environment.js';
+import { initializePuppeteerWeb } from './initialize-web.js';
 
-const puppeteer = initializePuppeteer('puppeteer-core');
+const initializeFunc = isNode
+  ? initializePuppeteerNode
+  : initializePuppeteerWeb;
+const puppeteer = initializeFunc('puppeteer-core');
 export default puppeteer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { initializePuppeteer } from './initialize.js';
+import { initializePuppeteerNode } from './initialize-node.js';
+import { isNode } from './environment.js';
+import { initializePuppeteerWeb } from './initialize-web.js';
 
-const puppeteer = initializePuppeteer('puppeteer');
+const initializeFunc = isNode
+  ? initializePuppeteerNode
+  : initializePuppeteerWeb;
+const puppeteer = initializeFunc('puppeteer');
 export default puppeteer;

--- a/src/initialize-node.ts
+++ b/src/initialize-node.ts
@@ -18,7 +18,7 @@ import { Puppeteer } from './common/Puppeteer.js';
 import { PUPPETEER_REVISIONS } from './revisions.js';
 import pkgDir from 'pkg-dir';
 
-export const initializePuppeteer = (packageName: string): Puppeteer => {
+export const initializePuppeteerNode = (packageName: string): Puppeteer => {
   const puppeteerRootDirectory = pkgDir.sync(__dirname);
 
   let preferredRevision = PUPPETEER_REVISIONS.chromium;

--- a/src/initialize-web.ts
+++ b/src/initialize-web.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Puppeteer } from './common/Puppeteer.js';
+
+export const initializePuppeteerWeb = (packageName: string): Puppeteer => {
+  const isPuppeteerCore = packageName === 'puppeteer-core';
+
+  // puppeteer-core ignores environment variables
+  return new Puppeteer(
+    // Product root directory is undefined as we're not concerned about
+    // downloading and installing browsers in the web environment.
+    undefined,
+    // Preferred revision is undefined as we use the browser we are running in.
+    undefined,
+    isPuppeteerCore,
+    // Preferred product is undefined as we use the browser we are
+    // running in.
+    undefined
+  );
+};


### PR DESCRIPTION

This PR splits `initialize.ts` into two files, one for web, and one for
Node. The Node initializer requires much more information as it needs to
know which browser(s) to download and where to store them, whereas the
web one does not.

A future PR that I'm working on will tidy up `src/common/Puppeteer.ts`
(as it contains a lot of Node specific logic around downloading and
installing browsers), but this change enables us to stop the browser
bundle attempting to use the `pkg-dir` dependency, which wouldn't work
within a browser, as well as keeping the size of the PRs down and
avoiding one mammoth PR.