### PR TITLE
chore: enforce Conventional Commits through commitlint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,40 +139,19 @@ When authoring new API methods, consider the following:
 
 ## Commit Messages
 
-Commit messages should follow the Semantic Commit Messages format:
+Commit messages should follow [the Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/#summary). This is enforced via `npm run lint`.
 
-```
-label(namespace): title
-
-description
-
-footer
-```
-
-1. *label* is one of the following:
-    - `fix` - puppeteer bug fixes.
-    - `feat` - puppeteer features.
-    - `docs` - changes to docs, e.g. `docs(api.md): ..` to change documentation.
-    - `test` - changes to puppeteer tests infrastructure.
-    - `style` - puppeteer code style: spaces/alignment/wrapping etc.
-    - `chore` - build-related work, e.g. doclint changes / travis / appveyor.
-2. *namespace* is put in parenthesis after label and is optional. Must be lowercase.
-3. *title* is a brief summary of changes.
-4. *description* is **optional**, new-line separated from title and is in present tense.
-5. *footer* is **optional**, new-line separated from *description* and contains "fixes" / "references" attribution to github issues.
-6. *footer* should also include "BREAKING CHANGE" if current API clients will break due to this change. It should explain what changed and how to get the old behavior.
-
-Example:
+In particular, breaking changes should clearly be noted as “BREAKING CHANGE:” in the commit message footer. Example:
 
 ```
 fix(page): fix page.pizza method
 
 This patch fixes page.pizza so that it works with iframes.
 
-Fixes #123, Fixes #234
+Issues: #123, #234
 
 BREAKING CHANGE: page.pizza now delivers pizza at home by default.
-To deliver to a different location, use "deliver" option:
+To deliver to a different location, use the "deliver" option:
   `page.pizza({deliver: 'work'})`.
 ```
 
@@ -296,7 +275,7 @@ node utils/bisect.js --good 686378 --bad 706915 script.js
 Releasing to npm consists of the following phases:
 
 1. Source Code: mark a release.
-    1. Bump `package.json` version following the SEMVER rules. 
+    1. Bump `package.json` version following the SEMVER rules.
         - **NOTE**: bump major version in case of breaking changes. Bump minor version in case of rolling chrome.
     2. Run `npm run doc` to update the docs accordingly.
     3. Update the “Releases per Chromium Version” list in [`docs/api.md`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md) to include the new version. Note: only do this when the Chrome revision is different from the previous release.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always', 100],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "install": "node install.js",
     "eslint": "([ \"$CI\" = true ] && eslint --ext js --ext ts --quiet -f codeframe . || eslint --ext js --ext ts .)",
     "eslint-fix": "eslint --ext js --ext ts --fix .",
-    "lint": "npm run eslint && npm run tsc && npm run doc",
+    "commitlint": "commitlint --from=HEAD~1",
+    "lint": "npm run eslint && npm run tsc && npm run doc && npm run commitlint",
     "doc": "node utils/doclint/cli.js",
     "clean-lib": "rm -rf lib",
     "tsc": "npm run clean-lib && tsc --version && npm run tsc-cjs && npm run tsc-esm",
@@ -58,6 +59,8 @@
     "ws": "^7.2.3"
   },
   "devDependencies": {
+    "@commitlint/cli": "^11.0.0",
+    "@commitlint/config-conventional": "^11.0.0",
     "@microsoft/api-documenter": "7.8.14",
     "@microsoft/api-extractor": "7.8.12",
     "@types/debug": "0.0.31",
@@ -83,6 +86,7 @@
     "eslint-plugin-unicorn": "^19.0.1",
     "esprima": "^4.0.0",
     "expect": "^25.2.7",
+    "husky": "^4.3.0",
     "jpeg-js": "^0.3.7",
     "mime": "^2.0.3",
     "minimist": "^1.2.0",
@@ -103,5 +107,10 @@
     "child_process": false,
     "rimraf": false,
     "readline": false
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint --env HUSKY_GIT_PARAMS"
+    }
   }
 }


### PR DESCRIPTION
This patch sets up commitlint to enforce [the Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/#summary). This check runs with the other lint checks as part of `npm run lint`, and a Git commit hook is set up via Husky for automated local checks.

Issue: #6482