### PR TITLE
chore: bump misc dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@microsoft/api-documenter": "7.8.14",
-    "@microsoft/api-extractor": "7.8.12",
+    "@microsoft/api-documenter": "7.9.7",
+    "@microsoft/api-extractor": "7.10.4",
     "@types/debug": "0.0.31",
     "@types/mime": "^2.0.0",
     "@types/mocha": "^7.0.2",
@@ -74,9 +74,9 @@
     "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
-    "@web/test-runner": "^0.6.40",
+    "@web/test-runner": "^0.8.4",
     "commonmark": "^0.28.1",
-    "cross-env": "^5.0.5",
+    "cross-env": "^7.0.2",
     "dependency-cruiser": "^9.7.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
@@ -90,23 +90,15 @@
     "jpeg-js": "^0.3.7",
     "mime": "^2.0.3",
     "minimist": "^1.2.0",
-    "mocha": "^8.0.1",
+    "mocha": "^8.1.3",
     "ncp": "^2.0.0",
     "pixelmatch": "^4.0.2",
     "pngjs": "^5.0.0",
     "prettier": "^2.0.5",
     "sinon": "^9.0.2",
     "text-diff": "^1.0.1",
-    "ts-node": "^8.10.2",
+    "ts-node": "^9.0.0",
     "typescript": "3.9.5"
-  },
-  "browser": {
-    "./lib/BrowserFetcher.js": false,
-    "ws": "./utils/browser/WebSocket",
-    "fs": false,
-    "child_process": false,
-    "rimraf": false,
-    "readline": false
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION

This commit updates some miscellaneous dependencies to their latest
versions (with no other changes required) and also removes the `browser`
section, which was used by Browserify for the now long gone
Puppeteer-Web package that we used to publish.