### PR TITLE
chore(node): move install.ts into node/

### DIFF
--- a/install.js
+++ b/install.js
@@ -32,7 +32,7 @@ async function download() {
   const {
     downloadBrowser,
     logPolitely,
-  } = require('./lib/cjs/puppeteer/install');
+  } = require('./lib/cjs/puppeteer/node/install');
 
   if (process.env.PUPPETEER_SKIP_DOWNLOAD) {
     logPolitely(

--- a/src/node/install.ts
+++ b/src/node/install.ts
@@ -17,8 +17,8 @@
 import os from 'os';
 import https from 'https';
 import ProgressBar from 'progress';
-import puppeteer from './index.js';
-import { PUPPETEER_REVISIONS } from './revisions.js';
+import puppeteer from '../index.js';
+import { PUPPETEER_REVISIONS } from '../revisions.js';
 
 const supportedProducts = {
   chrome: 'Chromium',


### PR DESCRIPTION
This file contains logic that is unique to the Node environment
and therefore should be moved into the node sub-folder.

@jackfranklin 