### PR TITLE
fix executablePath (arm64)

### DIFF
--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -114,7 +114,7 @@ function handleArm64(): void {
     if (stats === undefined) {
       fs.stat('/usr/bin/chromium', function (err, stats) {
         if (stats === undefined) {
-          console.error(`The chromium binary is not available for arm64: `);
+          console.error(`The chromium binary is not available for arm64.`);
           console.error(`If you are on Ubuntu, you can install with: `);
           console.error(`\n sudo apt install -y chromium-browser || sudo apt install -y chromium\n`);
           throw new Error();

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -116,7 +116,8 @@ function handleArm64(): void {
         if (stats === undefined) {
           console.error(`The chromium binary is not available for arm64.`);
           console.error(`If you are on Ubuntu, you can install with: `);
-          console.error(`\n sudo apt install -y chromium-browser || sudo apt install -y chromium\n`);
+          console.error(`\n sudo apt install chromium\n`);
+          console.error(`\n sudo apt install chromium-browser\n`);
           throw new Error();
         }
       });

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -112,10 +112,14 @@ function downloadURL(
 function handleArm64(): void {
   fs.stat('/usr/bin/chromium-browser', function (err, stats) {
     if (stats === undefined) {
-      console.error(`The chromium binary is not available for arm64: `);
-      console.error(`If you are on Ubuntu, you can install with: `);
-      console.error(`\n apt-get install chromium-browser\n`);
-      throw new Error();
+      fs.stat('/usr/bin/chromium', function (err, stats) {
+        if (stats === undefined) {
+          console.error(`The chromium binary is not available for arm64: `);
+          console.error(`If you are on Ubuntu, you can install with: `);
+          console.error(`\n apt-get install chromium-browser\n`);
+          throw new Error();
+        }
+      });
     }
   });
 }

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -116,7 +116,7 @@ function handleArm64(): void {
         if (stats === undefined) {
           console.error(`The chromium binary is not available for arm64: `);
           console.error(`If you are on Ubuntu, you can install with: `);
-          console.error(`\n apt-get install chromium-browser\n`);
+          console.error(`\n sudo apt install -y chromium-browser || sudo apt install -y chromium\n`);
           throw new Error();
         }
       });

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -115,12 +115,14 @@ class ChromeLauncher implements ProductLauncher {
     }
 
     let chromeExecutable = executablePath;
-    if (os.arch() === 'arm64') {
-      chromeExecutable = '/usr/bin/chromium-browser';
-    } else if (!executablePath) {
-      const { missingText, executablePath } = resolveExecutablePath(this);
-      if (missingText) throw new Error(missingText);
-      chromeExecutable = executablePath;
+    if (!executablePath) {
+      if (os.arch() === 'arm64') {
+        chromeExecutable = '/usr/bin/chromium-browser';
+	  } else {
+        const { missingText, executablePath } = resolveExecutablePath(this);
+        if (missingText) throw new Error(missingText);
+        chromeExecutable = executablePath;
+      }
     }
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -118,7 +118,7 @@ class ChromeLauncher implements ProductLauncher {
     if (!executablePath) {
       if (os.arch() === 'arm64') {
         chromeExecutable = '/usr/bin/chromium-browser';
-	  } else {
+      } else {
         const { missingText, executablePath } = resolveExecutablePath(this);
         if (missingText) throw new Error(missingText);
         chromeExecutable = executablePath;


### PR DESCRIPTION
```
const puppeteer = require('puppeteer-core');
(async () => {
  const browser = await puppeteer.launch({ executablePath: '/usr/bin/chromium' });
  await browser.close();
})();
```

```
Error: Failed to launch the browser process! spawn /usr/bin/chromium-browser ENOENT
TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md
```