### PR TITLE
fix(launcher): also support relative userDataDir on headless Windows

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -189,7 +189,8 @@ class ChromeLauncher implements ProductLauncher {
       args = [],
       userDataDir = null,
     } = options;
-    if (userDataDir) chromeArguments.push(`--user-data-dir=${userDataDir}`);
+    if (userDataDir)
+      chromeArguments.push(`--user-data-dir=${path.resolve(userDataDir)}`);
     if (devtools) chromeArguments.push('--auto-open-devtools-for-tabs');
     if (headless) {
       chromeArguments.push('--headless', '--hide-scrollbars', '--mute-audio');

--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -306,7 +306,7 @@ describe('Launcher specs', function () {
             '--headless'
           );
           expect(puppeteer.defaultArgs({ userDataDir: 'foo' })).toContain(
-            '--user-data-dir=foo'
+            `--user-data-dir=${path.resolve('foo')}`
           );
         } else if (isFirefox) {
           expect(puppeteer.defaultArgs()).toContain('--headless');
@@ -330,7 +330,7 @@ describe('Launcher specs', function () {
             '-profile'
           );
           expect(puppeteer.defaultArgs({ userDataDir: 'foo' })).toContain(
-            'foo'
+            path.resolve('foo')
           );
         }
       });


### PR DESCRIPTION
Launching headless with a relative `userDataDir` hangs on Windows.
Fix by calling `path.resolve` (idempotent) to add an absolute path
instead in `defaultArgs`.

Issues: #3453