### PR TITLE
chore(agnostification): common/helper.ts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ jobs:
 
     - node_js: "12.16.3"
       name: 'Browser tests: Linux/Chromium'
+      addons:
+        chrome: stable
       env:
         - CHROMIUM=true
       script:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
-    "@web/test-runner": "^0.8.4",
+    "@web/test-runner": "^0.9.2",
     "commonmark": "^0.28.1",
     "cross-env": "^7.0.2",
     "dependency-cruiser": "^9.7.0",

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -15,11 +15,11 @@
  */
 import { TimeoutError } from './Errors.js';
 import { debug } from './Debug.js';
-import * as fs from 'fs';
 import { CDPSession } from './Connection.js';
 import { Protocol } from 'devtools-protocol';
 import { CommonEventEmitter } from './EventEmitter.js';
 import { assert } from './assert.js';
+import { isNode } from '../environment.js';
 
 export const debugError = debug('puppeteer:error');
 
@@ -309,9 +309,16 @@ async function readProtocolStream(
   handle: string,
   path?: string
 ): Promise<Buffer> {
+  if (!isNode && path) {
+    throw new Error('Cannot write to a path outside of Node.js environment.');
+  }
+
+  const fs = isNode ? await import('fs') : null;
+
   let eof = false;
-  let fileHandle: fs.promises.FileHandle;
-  if (path) {
+  let fileHandle: import('fs').promises.FileHandle;
+
+  if (path && fs) {
     fileHandle = await fs.promises.open(path, 'w');
   }
   const bufs = [];
@@ -323,7 +330,9 @@ async function readProtocolStream(
       response.base64Encoded ? 'base64' : undefined
     );
     bufs.push(buf);
-    if (path) await fs.promises.writeFile(fileHandle, buf);
+    if (path && fs) {
+      await fs.promises.writeFile(fileHandle, buf);
+    }
   }
   if (path) await fileHandle.close();
   await client.send('IO.close', { handle });


### PR DESCRIPTION

The `readProtocolStream` method uses `fs` only if you want to write to a
file. So we gate at the start of the function and ensure that if we got
given a path we are not in a Node environment.

We then use `import('fs')` to lazily load fs. We have multiple calls but
they will be cached so I don't believe that it's going to be a perf hit.