### PR TITLE
chore(agnostification): agnostify web socket connections

### DIFF
--- a/src/common/BrowserWebSocketTransport.ts
+++ b/src/common/BrowserWebSocketTransport.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2020 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 import { ConnectionTransport } from './ConnectionTransport.js';
-import NodeWebSocket from 'ws';
 
-export class WebSocketTransport implements ConnectionTransport {
-  static create(url: string): Promise<WebSocketTransport> {
+export class BrowserWebSocketTransport implements ConnectionTransport {
+  static create(url: string): Promise<BrowserWebSocketTransport> {
     return new Promise((resolve, reject) => {
-      const ws = new NodeWebSocket(url, [], {
-        perMessageDeflate: false,
-        maxPayload: 256 * 1024 * 1024, // 256Mb
-      });
+      const ws = new WebSocket(url);
 
-      ws.addEventListener('open', () => resolve(new WebSocketTransport(ws)));
+      ws.addEventListener('open', () =>
+        resolve(new BrowserWebSocketTransport(ws))
+      );
       ws.addEventListener('error', reject);
     });
   }
 
-  _ws: NodeWebSocket;
+  private _ws: WebSocket;
   onmessage?: (message: string) => void;
   onclose?: () => void;
 
-  constructor(ws: NodeWebSocket) {
+  constructor(ws: WebSocket) {
     this._ws = ws;
     this._ws.addEventListener('message', (event) => {
       if (this.onmessage) this.onmessage.call(null, event.data);
@@ -47,7 +45,7 @@ export class WebSocketTransport implements ConnectionTransport {
     this.onclose = null;
   }
 
-  send(message): void {
+  send(message: string): void {
     this._ws.send(message);
   }
 

--- a/src/node/BrowserRunner.ts
+++ b/src/node/BrowserRunner.ts
@@ -22,7 +22,7 @@ import { assert } from '../common/assert.js';
 import { helper, debugError } from '../common/helper.js';
 import { LaunchOptions } from './LaunchOptions.js';
 import { Connection } from '../common/Connection.js';
-import { WebSocketTransport } from '../common/WebSocketTransport.js';
+import { NodeWebSocketTransport as WebSocketTransport } from '../node/NodeWebSocketTransport.js';
 import { PipeTransport } from './PipeTransport.js';
 import * as readline from 'readline';
 import { TimeoutError } from '../common/Errors.js';

--- a/src/node/NodeWebSocketTransport.ts
+++ b/src/node/NodeWebSocketTransport.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ConnectionTransport } from '../common/ConnectionTransport.js';
+import NodeWebSocket from 'ws';
+
+export class NodeWebSocketTransport implements ConnectionTransport {
+  static create(url: string): Promise<NodeWebSocketTransport> {
+    return new Promise((resolve, reject) => {
+      const ws = new NodeWebSocket(url, [], {
+        perMessageDeflate: false,
+        maxPayload: 256 * 1024 * 1024, // 256Mb
+      });
+
+      ws.addEventListener('open', () =>
+        resolve(new NodeWebSocketTransport(ws))
+      );
+      ws.addEventListener('error', reject);
+    });
+  }
+
+  private _ws: NodeWebSocket;
+  onmessage?: (message: string) => void;
+  onclose?: () => void;
+
+  constructor(ws: NodeWebSocket) {
+    this._ws = ws;
+    this._ws.addEventListener('message', (event) => {
+      if (this.onmessage) this.onmessage.call(null, event.data);
+    });
+    this._ws.addEventListener('close', () => {
+      if (this.onclose) this.onclose.call(null);
+    });
+    // Silently ignore all errors - we don't know what to do with them.
+    this._ws.addEventListener('error', () => {});
+    this.onmessage = null;
+    this.onclose = null;
+  }
+
+  send(message: string): void {
+    this._ws.send(message);
+  }
+
+  close(): void {
+    this._ws.close();
+  }
+}

--- a/test-browser/helper.js
+++ b/test-browser/helper.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns the web socket endpoint for the backend of the browser the tests run
+ * in. Used to create connections to that browser in Puppeteer for unit tests.
+ *
+ * It's available on window.__ENV__ because setup code in
+ * web-test-runner.config.js puts it there. If you're changing this code (or
+ * that code), make sure the other is updated accordingly.
+ */
+export function getWebSocketEndpoint() {
+  return window.__ENV__.wsEndpoint;
+}

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -13,9 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const { chromeLauncher } = require('@web/test-runner-chrome');
 
 module.exports = {
   files: ['test-browser/**/*.spec.js'],
+  browsers: [
+    chromeLauncher({
+      async createPage({ browser }) {
+        const page = await browser.newPage();
+        page.evaluateOnNewDocument((wsEndpoint) => {
+          window.__ENV__ = { wsEndpoint };
+        }, browser.wsEndpoint());
+
+        return page;
+      },
+    }),
+  ],
   plugins: [
     {
       // turn expect UMD into an es module


### PR DESCRIPTION
This PR updates the socket transport code to swap between a Node web socket transport or a web one based on `isNode`. It also adds unit tests to the browser tests that show we can connect in a browser.