### PR TITLE
feat(chromium): roll Chromium to r818858

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^4.1.0",
-    "devtools-protocol": "0.0.809251",
+    "devtools-protocol": "0.0.818844",
     "extract-zip": "^2.0.0",
     "https-proxy-agent": "^4.0.0",
     "node-fetch": "^2.6.1",

--- a/src/common/Input.ts
+++ b/src/common/Input.ts
@@ -510,15 +510,6 @@ export class Touchscreen {
    * @param y - Vertical position of the tap.
    */
   async tap(x: number, y: number): Promise<void> {
-    // Touches appear to be lost during the first frame after navigation.
-    // This waits a frame before sending the tap.
-    // @see https://crbug.com/613219
-    await this._client.send('Runtime.evaluate', {
-      expression:
-        'new Promise(x => requestAnimationFrame(() => requestAnimationFrame(x)))',
-      awaitPromise: true,
-    });
-
     const touchPoints = [{ x: Math.round(x), y: Math.round(y) }];
     await this._client.send('Input.dispatchTouchEvent', {
       type: 'touchStart',

--- a/src/revisions.ts
+++ b/src/revisions.ts
@@ -20,6 +20,6 @@ type Revisions = Readonly<{
 }>;
 
 export const PUPPETEER_REVISIONS: Revisions = {
-  chromium: '809590',
+  chromium: '818858',
   firefox: 'latest',
 };


### PR DESCRIPTION
This corresponds to Chromium 88.0.4298.0.

This roll includes:

- DevTools: Wait for a frame before sending touch and wheel events
  https://chromium-review.googlesource.com/c/chromium/src/+/2437695
