### PR TITLE
fix: do not use old utility world

### DIFF
--- a/src/common/FrameManager.ts
+++ b/src/common/FrameManager.ts
@@ -322,18 +322,19 @@ export class FrameManager extends EventEmitter {
     await this._client.send('Page.addScriptToEvaluateOnNewDocument', {
       source: `//# sourceURL=${EVALUATION_SCRIPT_URL}`,
       worldName: name,
-    }),
-      await Promise.all(
-        this.frames().map((frame) =>
-          this._client
-            .send('Page.createIsolatedWorld', {
-              frameId: frame._id,
-              grantUniveralAccess: true,
-              worldName: name,
-            })
-            .catch(debugError)
-        )
-      ); // frames might be removed before we send this
+    });
+    // Frames might be removed before we send this.
+    await Promise.all(
+      this.frames().map((frame) =>
+        this._client
+          .send('Page.createIsolatedWorld', {
+            frameId: frame._id,
+            worldName: name,
+            grantUniveralAccess: true,
+          })
+          .catch(debugError)
+      )
+    );
   }
 
   _onFrameNavigatedWithinDocument(frameId: string, url: string): void {
@@ -369,8 +370,6 @@ export class FrameManager extends EventEmitter {
         world = frame._secondaryWorld;
       }
     }
-    if (contextPayload.auxData && contextPayload.auxData['type'] === 'isolated')
-      this._isolatedWorlds.add(contextPayload.name);
     const context = new ExecutionContext(this._client, contextPayload, world);
     if (world) world._setContext(context);
     this._contextIdToContext.set(contextPayload.id, context);


### PR DESCRIPTION
It is being destroyed later when browser reconnects to the page (after page navigation).
See https://github.com/puppeteer/puppeteer/issues/6527
