### PR TITLE
chore: run unit tests on node 10.15 + fix fs.promises access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,20 @@ jobs:
         - npm run tsc
         - travis_retry npm run unit
 
-    # Runs unit tests on Linux + Chromium
+    # Node <10.17's fs.promises module was experimental and doesn't behave as
+    # expected. This problem was fixed in Node 10.19, but we run the unit tests
+    # through on 10.15 to make sure we don't cause any regressions when using
+    # fs.promises. See https://github.com/puppeteer/puppeteer/issues/6548 for an
+    # example.
+    - node_js: '10.15.0'
+      name: 'Node 10.15 Unit tests: Linux/Chromium'
+      env:
+        - CHROMIUM=true
+      before_install:
+        - PUPPETEER_PRODUCT=firefox npm install
+      script:
+        - npm run unit
+
     - node_js: '10.19.0'
       name: 'Unit tests [with coverage]: Linux/Chromium'
       env:

--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -288,7 +288,7 @@ export class DOMWorld {
           'Cannot pass a filepath to addScriptTag in the browser environment.'
         );
       }
-      const fs = await import('fs');
+      const fs = await helper.importFSModule();
       let contents = await fs.promises.readFile(path, 'utf8');
       contents += '//# sourceURL=' + path.replace(/\n/g, '');
       const context = await this.executionContext();
@@ -370,7 +370,7 @@ export class DOMWorld {
           'Cannot pass a filepath to addStyleTag in the browser environment.'
         );
       }
-      const fs = await import('fs');
+      const fs = await helper.importFSModule();
       let contents = await fs.promises.readFile(path, 'utf8');
       contents += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';
       const context = await this.executionContext();

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -563,8 +563,7 @@ export class ElementHandle<
     // This import is only needed for `uploadFile`, so keep it scoped here to avoid paying
     // the cost unnecessarily.
     const path = await import('path');
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = await import('fs');
+    const fs = await helper.importFSModule();
     // Locate all files and confirm that they exist.
     const files = await Promise.all(
       filePaths.map(async (filePath) => {

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1709,7 +1709,7 @@ export class Page extends EventEmitter {
         'Screenshots can only be written to a file path in a Node environment.'
       );
     }
-    const fs = await import('fs');
+    const fs = await helper.importFSModule();
     if (options.path) await fs.promises.writeFile(options.path, buffer);
     return buffer;
 


### PR DESCRIPTION
We saw in https://github.com/puppeteer/puppeteer/issues/6548 that the
`fs.promises` module was experimental in Node <10.17 and as such we
introduced issues for users on 10.15.

Until we can drop Node v10 (it's EOL is 30-04-20201
https://github.com/nodejs/Release#release-schedule) we should run our
tests on an old Node 10 to avoid regressing in this area.

Closes #6548 .