### PR TITLE
chore: automate versioning + changelog

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,3 @@
+{
+  "releaseCommitMessageFormat": "chore(release): mark v{{currentTag}}"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,20 +275,18 @@ node utils/bisect.js --good 686378 --bad 706915 script.js
 Releasing to npm consists of the following phases:
 
 1. Source Code: mark a release.
-    1. Bump `package.json` version following the SEMVER rules.
-        - **NOTE**: bump major version in case of breaking changes. Bump minor version in case of rolling chrome.
-    2. Run `npm run doc` to update the docs accordingly.
-    3. Update the “Releases per Chromium Version” list in [`docs/api.md`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md) to include the new version. Note: only do this when the Chrome revision is different from the previous release.
-    4. Send a PR titled `'chore: mark version vXXX.YYY.ZZZ'` ([example](https://github.com/puppeteer/puppeteer/pull/5078)).
-    5. Make sure the PR passes **all checks**.
+    1. Run `npm run release` to bump the version number in `package.json` and populate the changelog.
+    1. Run `npm run doc` to update the docs accordingly.
+    1. Update the “Releases per Chromium Version” list in [`docs/api.md`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md) to include the new version. Note: only do this when the Chrome revision is different from the previous release.
+    1. Send a PR titled `'chore(release): mark vXXX.YYY.ZZZ'` ([example](https://github.com/puppeteer/puppeteer/pull/5078)).
+    1. Make sure the PR passes **all checks**.
         - **WHY**: there are linters in place that help to avoid unnecessary errors, e.g. [like this](https://github.com/puppeteer/puppeteer/pull/2446)
-    6. Merge the PR.
-    7. Once merged, publish the release notes using [GitHub's “draft new release tag” option](https://github.com/puppeteer/puppeteer/releases/new).
+    1. Merge the PR.
+    1. Once merged, publish the release notes from `CHANGELOG.md` using [GitHub’s “draft new release tag” option](https://github.com/puppeteer/puppeteer/releases/new).
         - **NOTE**: tag names are prefixed with `'v'`, e.g. for version `1.4.0` the tag is `v1.4.0`.
-        - For the “raw notes” section, use `git log --pretty="%h - %s" v2.0.0..HEAD`.
-    8. As soon as the Git tag is created by completing the previous step, our CI automatically `npm publish`es the new releases for both the `puppeteer` and `puppeteer-core` packages.
-2. Source Code: mark post-release.
-    1. Bump `package.json` version to `-post` version, run `npm run doc` to update the “released APIs” section at the top of `docs/api.md` accordingly, and send a PR titled `'chore: bump version to vXXX.YYY.ZZZ-post'` ([example](https://github.com/puppeteer/puppeteer/commit/d02440d1eac98028e29f4e1cf55413062a259156))
+    1. As soon as the Git tag is created by completing the previous step, our CI automatically `npm publish`es the new releases for both the `puppeteer` and `puppeteer-core` packages.
+1. Source Code: mark post-release.
+    1. Bump `package.json` version to the `-post` version, run `npm run doc` to update the “released APIs” section at the top of `docs/api.md` accordingly, and send a PR titled `'chore: bump version to vXXX.YYY.ZZZ-post'` ([example](https://github.com/puppeteer/puppeteer/commit/d02440d1eac98028e29f4e1cf55413062a259156))
         - **NOTE**: no other commits should be landed in-between release commit and bump commit.
 
 ## Updating npm dist tags

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -17,5 +17,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'body-max-line-length': [0, 'always', 100],
+    'footer-max-line-length': [0, 'always', 100],
   },
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test-install": "scripts/test-install.sh",
     "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
     "generate-dependency-graph": "echo 'Requires graphviz installed locally!' && depcruise --exclude 'api.ts' --do-not-follow '^node_modules' --output-type dot src/index.ts | dot -T png > dependency-chart.png",
-    "ensure-correct-devtools-protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package"
+    "ensure-correct-devtools-protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package",
+    "release": "standard-version"
   },
   "files": [
     "lib/",
@@ -97,6 +98,7 @@
     "pngjs": "^5.0.0",
     "prettier": "^2.1.2",
     "sinon": "^9.0.2",
+    "standard-version": "^9.0.0",
     "text-diff": "^1.0.1",
     "ts-node": "^9.0.0",
     "typescript": "3.9.5"
@@ -104,6 +106,12 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint --env HUSKY_GIT_PARAMS"
+    }
+  },
+  "standard-version": {
+    "skip": {
+      "commit": true,
+      "tag": true
     }
   }
 }


### PR DESCRIPTION
As long as we follow Conventional Commits for our commit messages (which is now enforced since #6483), we can automate the maintenance of this new changelog, which enables us to later automate the release process altogether.

This patch also eliminates the versioning decision-making process by automating it based on our commit messages.

Issue: #6482