### PR TITLE
fix(common): fix generic type of `_isClosedPromise`

### DIFF
--- a/src/common/Target.ts
+++ b/src/common/Target.ts
@@ -44,7 +44,7 @@ export class Target {
   /**
    * @internal
    */
-  _isClosedPromise: Promise<boolean>;
+  _isClosedPromise: Promise<void>;
   /**
    * @internal
    */
@@ -91,7 +91,7 @@ export class Target {
       openerPage.emit(PageEmittedEvents.Popup, popupPage);
       return true;
     });
-    this._isClosedPromise = new Promise<boolean>(
+    this._isClosedPromise = new Promise<void>(
       (fulfill) => (this._closedCallback = fulfill)
     );
     this._isInitialized =


### PR DESCRIPTION
See <https://github.com/microsoft/TypeScript/issues/41359#issue-734064093> and <https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-rc/#resolves-parameters-are-no-longer-optional-in-promises>.