### PR TITLE
chore: remove redundant run config for depend-prah

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,5 @@ yarn.lock
 /lib
 test/coverage.json
 temp/
-dependency-chart.png
 puppeteer-core-*.tgz
 new-docs/

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "apply-next-version": "node utils/apply_next_version.js",
     "test-install": "scripts/test-install.sh",
     "generate-docs": "npm run tsc && api-extractor run --local --verbose && api-documenter markdown -i temp -o new-docs",
-    "generate-dependency-graph": "echo 'Requires graphviz installed locally!' && depcruise --exclude 'api.ts' --do-not-follow '^node_modules' --output-type dot src/index.ts | dot -T png > dependency-chart.png",
     "ensure-correct-devtools-protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package",
     "release": "standard-version"
   },
@@ -79,7 +78,6 @@
     "@web/test-runner": "^0.9.2",
     "commonmark": "^0.28.1",
     "cross-env": "^7.0.2",
-    "dependency-cruiser": "^9.7.0",
     "eslint": "^7.10.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-import": "^2.22.0",


### PR DESCRIPTION
Remove the redundant rule for dependency graph as the `src/index.ts` is
not required. This was introduced in 64c9c709, but the filestructure has
changed from since then and it doesn't work as `src/index.ts` is
replaced with `src/node.ts` and `src/web.ts` as per the use case.