### PR TITLE
chore: shorter node checker function

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -14,8 +14,4 @@
  * limitations under the License.
  */
 
-export const isNode = !!(
-  typeof process !== 'undefined' &&
-  process.versions &&
-  process.versions.node
-);
+export const isNode = !!(typeof process !== 'undefined' && process.version);


### PR DESCRIPTION
`isNode` checks for the node version in which the process is running and
it checks for the node key inside the versions. This will be exactly
same to as using `process.version` as they are set in the native code
and `process.version` is just a shorthand for `process.versions.node`.