### PR TITLE
docs(troubleshooting): update dumb-init version

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -272,7 +272,7 @@ RUN apt-get update \
 
 # If running Docker >= 1.13.0 use docker run's --init arg to reap zombie processes, otherwise
 # uncomment the following lines to have `dumb-init` as PID 1
-# ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+# ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_x86_64 /usr/local/bin/dumb-init
 # RUN chmod +x /usr/local/bin/dumb-init
 # ENTRYPOINT ["dumb-init", "--"]
 


### PR DESCRIPTION
The latest released version of dumb-init is 1.2.2.
Binary naming has changed : dumb-init_x.x.x_amd64 became dumb-init_x.x.x_x86_64.