### PR TITLE
feat: support promise as return value for page.waitForResponse predicate

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2255,6 +2255,7 @@ return firstRequest.url();
 ```js
 const firstResponse = await page.waitForResponse('https://example.com/resource');
 const finalResponse = await page.waitForResponse(response => response.url() === 'https://example.com' && response.status() === 200);
+const finalResponse = await page.waitForResponse(async response => { return (await response.text()).includes('<html>') })
 return finalResponse.ok();
 ```
 

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1298,11 +1298,11 @@ export class Page extends EventEmitter {
     return helper.waitForEvent(
       this._frameManager.networkManager(),
       NetworkManagerEmittedEvents.Response,
-      (response) => {
+      async (response) => {
         if (helper.isString(urlOrPredicate))
           return urlOrPredicate === response.url();
         if (typeof urlOrPredicate === 'function')
-          return !!urlOrPredicate(response);
+          return !!(await urlOrPredicate(response));
         return false;
       },
       timeout,

--- a/src/common/helper.ts
+++ b/src/common/helper.ts
@@ -124,7 +124,7 @@ function isNumber(obj: unknown): obj is number {
 async function waitForEvent<T extends any>(
   emitter: CommonEventEmitter,
   eventName: string | symbol,
-  predicate: (event: T) => boolean,
+  predicate: (event: T) => Promise<boolean> | boolean,
   timeout: number,
   abortPromise: Promise<Error>
 ): Promise<T> {
@@ -133,8 +133,8 @@ async function waitForEvent<T extends any>(
     resolveCallback = resolve;
     rejectCallback = reject;
   });
-  const listener = addEventListener(emitter, eventName, (event) => {
-    if (!predicate(event)) return;
+  const listener = addEventListener(emitter, eventName, async (event) => {
+    if (!(await predicate(event))) return;
     resolveCallback(event);
   });
   if (timeout) {

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -712,6 +712,22 @@ describe('Page', function () {
         .catch((error_) => (error = error_));
       expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
+    it('should work with async predicate', async () => {
+      const { page, server } = getTestState();
+      await page.goto(server.EMPTY_PAGE);
+      const [response] = await Promise.all([
+        page.waitForResponse(async (response) => {
+          console.log(response.url());
+          return response.url() === server.PREFIX + '/digits/2.png';
+        }),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }),
+      ]);
+      expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
+    });
     it('should work with no timeout', async () => {
       const { page, server } = getTestState();
 


### PR DESCRIPTION
Fix #4323 

Adaptation of #5008 with example code added to the docs. 