### PR TITLE
[Firefox] Force disable Fission (Site Isolation mode)

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -494,6 +494,9 @@ class FirefoxLauncher implements ProductLauncher {
       // Make sure opening about:addons will not hit the network
       'extensions.webservice.discoverURL': `http://${server}/dummy/discoveryURL`,
 
+      // Force disable Fission until the Remote Agent is compatible
+      'fission.autostart': false,
+
       // Allow the application to have focus even it runs in the background
       'focusmanager.testmode': true,
       // Disable useragent updates


### PR DESCRIPTION
@mathiasbynens can you please review and land? With enabling Fission step by step for more Nightly users we have to force disabling our site isolation mode until our implementation is compatible. Thanks.