### PR TITLE
firefox: disable experimental cookie feature sameSite=Lax by default.

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -517,6 +517,9 @@ class FirefoxLauncher implements ProductLauncher {
       // jest-puppeteer asserts that no error message is emitted by the console
       'network.cookie.cookieBehavior': 0,
 
+      // Disable experimental feature that is only available in Nightly
+      'network.cookie.sameSite.laxByDefault': false,
+
       // Do not prompt for temporary redirects
       'network.http.prompt-temp-redirect': false,
 


### PR DESCRIPTION
@mathiasbynens can you please review? Thanks.

For details see https://bugzilla.mozilla.org/show_bug.cgi?id=1606604.