### PR TITLE
fix(launcher): rename TranslateUI to Translate to match Chrome

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -166,7 +166,7 @@ class ChromeLauncher implements ProductLauncher {
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',
-      '--disable-features=TranslateUI',
+      '--disable-features=Translate',
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',


### PR DESCRIPTION
same as https://github.com/GoogleChrome/chrome-launcher/pull/225

> TranslateUI isn't a thing as of several months ago ([chromium-review.googlesource.com/c/chromium/src/+/2404484](https://chromium-review.googlesource.com/c/chromium/src/+/2404484)). 
