### PR TITLE
feat(types): expose typedefs to consumers

### DIFF
--- a/cjs-entry.d.ts
+++ b/cjs-entry.d.ts
@@ -1,0 +1,3 @@
+declare const _default: typeof import('./lib/cjs/puppeteer/node').default;
+
+export default _default;

--- a/src/tsconfig.esm.json
+++ b/src/tsconfig.esm.json
@@ -5,7 +5,5 @@
     "outDir": "../lib/esm/puppeteer",
     "module": "esnext"
   },
-  "references": [
-    { "path": "../vendor/tsconfig.esm.json"}
-  ]
+  "references": [{ "path": "../vendor/tsconfig.esm.json" }]
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib/esm",
-    "module": "ES2015",
-  },
-}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,6 @@
     "declaration": true,
     "declarationMap": true,
     "resolveJsonModule": true,
-    "sourceMap": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
This PR replaces https://github.com/puppeteer/puppeteer/pull/6289 and
instead puts all TS typedefs into one folder, lib/typings, which we then
can point TS to via the `types` field in `package.json`.

The previous PR (https://github.com/puppeteer/puppeteer/pull/6289) tried
to merge all our typedefs into one big file via API Extractor, but this
isn't really necessary. We can instead put all the individual `.d.ts`
files into one folder, and TS will still understand them and provide a
good experience to the developer.

One important consideration is that you _could_ consider this a breaking
change. I'm not sure how likely it is, but it could cause problems for:

* Projects that didn't have any type info for Puppeteer and treated all
  its exports as `any` may now start having legitimate type failures.
* Projects that depend on the `@types/puppeteer` package may have issues
  if they now swap to use this one and the types aren't quite aligned.

In addition, once we do ship a release with this change in, it will mean
that we have to treat any changes to any type definitions as
release-note-worthy, and any breaking changes to type definitions will
need to be treated as breaking code changes (nearly always a breaking
type def means a breaking change anyway), but it's worth considering
that once we expose these typedefs we should treat them as first class
citizens of the project just like we would with the actual source code.