### PR TITLE
Running Puppeteer in an EC2 instance with Amazon-Linux

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,6 +17,7 @@
   * [Running Puppeteer on Google Cloud Functions](#running-puppeteer-on-google-cloud-functions)
   * [Running Puppeteer on Heroku](#running-puppeteer-on-heroku)
   * [Running Puppeteer on AWS Lambda](#running-puppeteer-on-aws-lambda)
+  * [Running Puppeteer on AWS EC 2 instance running Amazon-Linux](#running-puppeteer-on-aws-ec2-instance-running-amazon-linux)
 - [Code Transpilation Issues](#code-transpilation-issues)
 <!-- GEN:stop -->
 
@@ -414,6 +415,22 @@ AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) de
 
 - https://github.com/alixaxel/chrome-aws-lambda (kept updated with the latest stable release of puppeteer)
 - https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (serverless plugin - outdated)
+
+### Running Puppeteer on AWS EC 2 instance running Amazon-Linux
+If you are using EC2 instance running amazon-linux in your CI/CD pipeline, and if you want to run  Puppeteer tests in amazon-linux. To install chromium, you have to first enable amazon-linux-extras which comes as part of EPEL [Extra Packages for Enterprise Linux](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/) . 
+
+To do that you have to run 
+```
+sudo amazon-linux-extras install epel -y
+```
+
+Next if you install chromium 
+```
+sudo yum install -y chromium
+
+```
+
+Puppeteer can easily launch chromium to run your tests. If you do not enable EPEL and if you continue installing chromium as part of '''npm install''', Puppeteer cannot launch chromium due to unavailablity of libatk-1.0.so.0 and many more packages. 
 
 ## Code Transpilation Issues
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -416,21 +416,23 @@ AWS Lambda [limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html) de
 - https://github.com/alixaxel/chrome-aws-lambda (kept updated with the latest stable release of puppeteer)
 - https://github.com/adieuadieu/serverless-chrome/blob/master/docs/chrome.md (serverless plugin - outdated)
 
-### Running Puppeteer on AWS EC 2 instance running Amazon-Linux
-If you are using EC2 instance running amazon-linux in your CI/CD pipeline, and if you want to run  Puppeteer tests in amazon-linux. To install chromium, you have to first enable amazon-linux-extras which comes as part of EPEL [Extra Packages for Enterprise Linux](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/) . 
+### Running Puppeteer on AWS EC2 instance running Amazon-Linux
 
-To do that you have to run 
-```
-sudo amazon-linux-extras install epel -y
-```
+If you are using an EC2 instance running amazon-linux in your CI/CD pipeline, and if you want to run Puppeteer tests in amazon-linux, follow these steps.
 
-Next if you install chromium 
-```
-sudo yum install -y chromium
+1. To install Chromium, you have to first enable `amazon-linux-extras` which comes as part of [EPEL (Extra Packages for Enterprise Linux)](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/):
 
-```
+    ```sh
+    sudo amazon-linux-extras install epel -y
+    ```
 
-Puppeteer can easily launch chromium to run your tests. If you do not enable EPEL and if you continue installing chromium as part of '''npm install''', Puppeteer cannot launch chromium due to unavailablity of libatk-1.0.so.0 and many more packages. 
+1. Next, install Chromium:
+
+    ```sh
+    sudo yum install -y chromium
+    ```
+
+Now Puppeteer can launch Chromium to run your tests. If you do not enable EPEL and if you continue installing chromium as part of `npm install`, Puppeteer cannot launch Chromium due to unavailablity of `libatk-1.0.so.0` and many more packages. 
 
 ## Code Transpilation Issues
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,7 @@
   * [Running Puppeteer on Google Cloud Functions](#running-puppeteer-on-google-cloud-functions)
   * [Running Puppeteer on Heroku](#running-puppeteer-on-heroku)
   * [Running Puppeteer on AWS Lambda](#running-puppeteer-on-aws-lambda)
-  * [Running Puppeteer on AWS EC 2 instance running Amazon-Linux](#running-puppeteer-on-aws-ec2-instance-running-amazon-linux)
+  * [Running Puppeteer on AWS EC2 instance running Amazon-Linux](#running-puppeteer-on-aws-ec2-instance-running-amazon-linux)
 - [Code Transpilation Issues](#code-transpilation-issues)
 <!-- GEN:stop -->
 


### PR DESCRIPTION
Dear Puppeteer Founders, Developers in general,

Thank you for creating such an wonderful tool which enables people to easily perform E2E acceptance tests with out any huzzle. I recently encountered a huge problem in running Puppeteer because puppeteer was not able to spin up chromium instance in an EC2 instance with amazon-linux and I found a way to troubleshoot that, felt like adding this to troubleshooting guide. 

I hope this helps others who are consuming it. I went through your contributing guidelines, I did not find anything specific for adding things to Troubleshooting guide. Please kindly let me know if I have missed anything. 

Thank you