### PR TITLE
chore(ci): use GitHub Actions to run unit tests on Windows and macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,9 +135,11 @@ jobs:
         run: |
           # Test platform-specific browser binary fetching for both
           # Chromium and Firefox.
-          PUPPETEER_PRODUCT=firefox npm install
+          $env:PUPPETEER_PRODUCT='firefox'
           npm install
-          ls .local-chromium .local-firefox
+          Remove-Item Env:\PUPPETEER_PRODUCT
+          npm install
+          Get-ChildItem -Path .local-chromium,.local-firefox
 
       - name: Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ on:
       - main
 
 jobs:
-  checks:
+  linux-main-checks:
+    # https://github.com/actions/virtual-environments#available-environments
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -77,3 +78,73 @@ jobs:
           npm run test-install
           # Undo those changes.
           git checkout --force
+
+  macos:
+    # https://github.com/actions/virtual-environments#available-environments
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          # Test only the oldest maintenance LTS Node.js version.
+          # https://github.com/nodejs/Release#release-schedule
+          node-version: 10
+
+      - name: Install dependencies
+        run: |
+          # Test platform-specific browser binary fetching for both
+          # Chromium and Firefox.
+          PUPPETEER_PRODUCT=firefox npm install
+          npm install
+          ls .local-chromium .local-firefox
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Run unit tests
+        env:
+          CHROMIUM: true
+        run: |
+          npm run unit
+
+  windows:
+    # https://github.com/actions/virtual-environments#available-environments
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          # Test only the oldest maintenance LTS Node.js version.
+          # https://github.com/nodejs/Release#release-schedule
+          node-version: 10
+
+      - name: Install dependencies
+        run: |
+          # Test platform-specific browser binary fetching for both
+          # Chromium and Firefox.
+          PUPPETEER_PRODUCT=firefox npm install
+          npm install
+          ls .local-chromium .local-firefox
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Run unit tests
+        env:
+          CHROMIUM: true
+        run: |
+          npm run unit


### PR DESCRIPTION
Similar to our earlier Travis CI setup, we continue to run exhaustive checks on Linux, while also verifying the build + unit tests still work on other platforms.

Issue: #6726