### PR TITLE
chore: cleanup remaining Travis references

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,7 +194,7 @@ export CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox
 
 ## Running Puppeteer on Travis CI
 
-> 👋 We ran our tests for Puppeteer on Travis CI until v6.0.0 (when we’ve migrated to GitHub Actions) - see our historical [`.travis.yml` (v5.5.0)](https://github.com/puppeteer/puppeteer/blob/v5.5.0/.travis.yml) for reference.
+> 👋 We ran our tests for Puppeteer on Travis CI until v6.0.0 (when we've migrated to GitHub Actions) - see our historical [`.travis.yml` (v5.5.0)](https://github.com/puppeteer/puppeteer/blob/v5.5.0/.travis.yml) for reference.
 
 Tips-n-tricks:
 - [xvfb](https://en.wikipedia.org/wiki/Xvfb) service should be launched in order to run Chromium in non-headless mode

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,7 +194,7 @@ export CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox
 
 ## Running Puppeteer on Travis CI
 
-> 👋 We run our tests for Puppeteer on Travis CI - see our [`.travis.yml`](https://github.com/puppeteer/puppeteer/blob/main/.travis.yml) for reference.
+> 👋 We ran our tests for Puppeteer on Travis CI until v6.0.0 (when we’ve migrated to GitHub Actions) - see our historical [`.travis.yml` (v5.5.0)](https://github.com/puppeteer/puppeteer/blob/v5.5.0/.travis.yml) for reference.
 
 Tips-n-tricks:
 - [xvfb](https://en.wikipedia.org/wiki/Xvfb) service should be launched in order to run Chromium in non-headless mode

--- a/experimental/puppeteer-firefox/.npmignore
+++ b/experimental/puppeteer-firefox/.npmignore
@@ -31,7 +31,6 @@ yarn.lock
 .editorconfig
 .eslintignore
 .eslintrc.js
-.travis.yml
 README.md
 tsconfig.json
 

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -128,9 +128,11 @@ async function run() {
     clearExit = false;
   }
   console.log(`${errors.length} failures, ${warnings.length} warnings.`);
-  
+
   if (!clearExit && !process.env.GITHUB_ACTIONS)
-    console.log('\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n');
+  console.log(
+    '\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n'
+  );
 
   const runningTime = Date.now() - startTime;
   console.log(`DocLint Finished in ${runningTime / 1000} seconds`);

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -128,12 +128,6 @@ async function run() {
     clearExit = false;
   }
   console.log(`${errors.length} failures, ${warnings.length} warnings.`);
-
-  if (!clearExit && !process.env.TRAVIS)
-    console.log(
-      '\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n'
-    );
-
   const runningTime = Date.now() - startTime;
   console.log(`DocLint Finished in ${runningTime / 1000} seconds`);
   process.exit(clearExit || IS_RELEASE ? 0 : 1);

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -130,9 +130,9 @@ async function run() {
   console.log(`${errors.length} failures, ${warnings.length} warnings.`);
 
   if (!clearExit && !process.env.GITHUB_ACTIONS)
-  console.log(
-    '\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n'
-  );
+    console.log(
+      '\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n'
+    );
 
   const runningTime = Date.now() - startTime;
   console.log(`DocLint Finished in ${runningTime / 1000} seconds`);

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -128,6 +128,10 @@ async function run() {
     clearExit = false;
   }
   console.log(`${errors.length} failures, ${warnings.length} warnings.`);
+  
+  if (!clearExit && !process.env.GITHUB_ACTIONS)
+    console.log('\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n');
+
   const runningTime = Date.now() - startTime;
   console.log(`DocLint Finished in ${runningTime / 1000} seconds`);
   process.exit(clearExit || IS_RELEASE ? 0 : 1);


### PR DESCRIPTION
As it was dropped completely in [v6.0.0](v5.5.0...v6.0.0) the remaining references can be cleaned up about Travis by now:

- **Troubleshooting:** I've reword the present to past tense about _Travis usage on Puppeteer_ and replaced the now broken `.travis.yml` link to a historical one (from [v5.5.0](https://github.com/puppeteer/puppeteer/releases/tag/v5.5.0)). I've found it more useful like this than completely removing the reference.
- **`.npmignore`:** Cleaned up the `.npmignore` from `experimental/puppeteer-firefox`.
- **`doclint/cli.js`:** I also removed the Travis-related condition in _log reminder about tsc (in case of DocLint fails locally)_ introduced with #5652, replaced it with GitHub Actions environment variable.

Follow up to: #6726