### PR TITLE
fix type definitions not working when using require()

### DIFF
--- a/cjs-entry.d.ts
+++ b/cjs-entry.d.ts
@@ -1,3 +1,3 @@
 declare const _default: typeof import('./lib/cjs/puppeteer/node').default;
 
-export default _default;
+export = _default;


### PR DESCRIPTION
The type definitions are wrong and don't work at all. 

If you try to use puppeteer v7 in a javascript file using `const puppeteer = require('puppeteer')`, typescript will tell you that it's wrong and you should be doing `const puppeteer = require('puppeteer').default` which is rubbish.

To confirm, enter this into your terminal:
```sh
node -p "require('puppeteer').default"
```

and note how it prints `undefined`. 

Therefore the type definitions are wrong and should be using the `export =` syntax.
