### PR TITLE
docs(troubleshooting): update broken Dockerfile link to historical one

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,7 +247,7 @@ Running Puppeteer smoothly on CircleCI requires the following steps:
 
 ## Running Puppeteer in Docker
 
-> 👋 We use [Cirrus Ci](https://cirrus-ci.org/) to run our tests for Puppeteer in a Docker container - see our [`Dockerfile.linux`](https://github.com/puppeteer/puppeteer/blob/main/.ci/node10/Dockerfile.linux) for reference.
+> 👋 We used [Cirrus Ci](https://cirrus-ci.org/) to ran our tests for Puppeteer in a Docker container until v3.0.x - see our historical [`Dockerfile.linux` (v3.0.1)](https://github.com/puppeteer/puppeteer/blob/v3.0.1/.ci/node12/Dockerfile.linux) for reference.
 
 Getting headless Chrome up and running in Docker can be tricky.
 The bundled Chromium that Puppeteer installs is missing the necessary

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,7 +247,7 @@ Running Puppeteer smoothly on CircleCI requires the following steps:
 
 ## Running Puppeteer in Docker
 
-> 👋 We used [Cirrus Ci](https://cirrus-ci.org/) to ran our tests for Puppeteer in a Docker container until v3.0.x - see our historical [`Dockerfile.linux` (v3.0.1)](https://github.com/puppeteer/puppeteer/blob/v3.0.1/.ci/node12/Dockerfile.linux) for reference.
+> 👋 We used [Cirrus Ci](https://cirrus-ci.org/) to run our tests for Puppeteer in a Docker container until v3.0.x - see our historical [`Dockerfile.linux` (v3.0.1)](https://github.com/puppeteer/puppeteer/blob/v3.0.1/.ci/node12/Dockerfile.linux) for reference.
 
 Getting headless Chrome up and running in Docker can be tricky.
 The bundled Chromium that Puppeteer installs is missing the necessary


### PR DESCRIPTION
**Troubleshooting:** I've reword the present to past tense about _Cirrus Ci usage on Puppeteer_ and replaced the now broken `Dockerfile.linux` link to a historical one (from [v3.0.1](v3.0.1), the `.cirrus.yml` was already removed in v3.0.0, but the Dockerfiles were still updated in v3.0.1 #5693), I changed the given example Dockerfile's link Node version from 10 to 12 (The two files are identical except for the Node version). I've found keeping this note more useful than completely removing the reference.