### PR TITLE
docs(contributing): fix typo around test directory link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ There are additional considerations for dependencies that are environment agonis
 - Tests should not depend on external services.
 - Tests should work on all three platforms: Mac, Linux and Win. This is especially important for screenshot tests.
 
-Puppeteer tests are located in the test directory ([`test`](https://github.com/puppeteer/puppeteer/blob/main/test/) and are written using Mocha. See [`test/README.md`](https://github.com/puppeteer/puppeteer/blob/main/test/) for more details.
+Puppeteer tests are located in the [`test`](https://github.com/puppeteer/puppeteer/blob/main/test/) directory and are written using Mocha. See [`test/README.md`](https://github.com/puppeteer/puppeteer/blob/main/test/) for more details.
 
 Despite being named 'unit', these are integration tests, making sure public API methods and events work as expected.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ There are additional considerations for dependencies that are environment agonis
 - Tests should not depend on external services.
 - Tests should work on all three platforms: Mac, Linux and Win. This is especially important for screenshot tests.
 
-Puppeteer tests are located in the [`test`](https://github.com/puppeteer/puppeteer/blob/main/test/) directory and are written using Mocha. See [`test/README.md`](https://github.com/puppeteer/puppeteer/blob/main/test/) for more details.
+Puppeteer tests are located in the [`test`](https://github.com/puppeteer/puppeteer/blob/main/test/) directory and are written using Mocha. See [`test/README.md`](https://github.com/puppeteer/puppeteer/blob/main/test/README.md) for more details.
 
 Despite being named 'unit', these are integration tests, making sure public API methods and events work as expected.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ There are additional considerations for dependencies that are environment agonis
 - Tests should not depend on external services.
 - Tests should work on all three platforms: Mac, Linux and Win. This is especially important for screenshot tests.
 
-Puppeteer tests are located in the [`test`](https://github.com/puppeteer/puppeteer/blob/main/test/) directory and are written using Mocha. See [`test/README.md`](https://github.com/puppeteer/puppeteer/blob/main/test/README.md) for more details.
+Puppeteer tests are located in [the `test` directory](https://github.com/puppeteer/puppeteer/blob/main/test/) and are written using Mocha. See [`test/README.md`](https://github.com/puppeteer/puppeteer/blob/main/test/README.md) for more details.
 
 Despite being named 'unit', these are integration tests, making sure public API methods and events work as expected.
 


### PR DESCRIPTION
**Contributing:** in #5616 a typo was introduced to the document: the _"test directory"_ phrase used the word _"test"_ twice, of which once wrapped in an unclosed parenthesis. I merged the two into one and moved the link under the remaining one.  
I also specified the `test/README.md` document's link as it was funny to have two links within one sentence to the same folder, it is more semantic linking like this.