### PR TITLE
fix: change kill to signal the whole process group to terminate 

### DIFF
--- a/src/node/BrowserRunner.ts
+++ b/src/node/BrowserRunner.ts
@@ -186,7 +186,7 @@ export class BrowserRunner {
     if (this.proc && this.proc.pid && pidExists(this.proc.pid)) {
       try {
         if (process.platform === 'win32') {
-          childProcess.execSync(`taskkill /pid ${this.proc.pid} /T /F`);
+          childProcess.exec(`taskkill /pid ${this.proc.pid} /T /F`, () => {});
         } else {
           // on linux the process group can be killed with the group id prefixed with
           // a minus sign. The process group id is the group leader's pid.

--- a/src/node/BrowserRunner.ts
+++ b/src/node/BrowserRunner.ts
@@ -183,9 +183,16 @@ export class BrowserRunner {
     // If the process failed to launch (for example if the browser executable path
     // is invalid), then the process does not get a pid assigned. A call to
     // `proc.kill` would error, as the `pid` to-be-killed can not be found.
-    if (this.proc && this.proc.pid && !this.proc.killed) {
+    if (this.proc && this.proc.pid && pidExists(this.proc.pid)) {
       try {
-        this.proc.kill('SIGKILL');
+        if (process.platform === 'win32') {
+          childProcess.execSync(`taskkill /pid ${this.proc.pid} /T /F`);
+        } else {
+          // on linux the process group can be killed with the group id prefixed with
+          // a minus sign. The process group id is the group leader's pid.
+          const processGroupId = -this.proc.pid;
+          process.kill(processGroupId, 'SIGKILL');
+        }
       } catch (error) {
         throw new Error(
           `${PROCESS_ERROR_EXPLANATION}\nError cause: ${error.stack}`
@@ -293,4 +300,16 @@ function waitForWSEndpoint(
       helper.removeEventListeners(listeners);
     }
   });
+}
+
+function pidExists(pid: number): boolean {
+  try {
+    return process.kill(pid, 0);
+  } catch (error) {
+    if (error && error.code && error.code === 'ESRCH') {
+      return false;
+    } else {
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION

In the [PR](https://github.com/puppeteer/puppeteer/pull/6011) that improves the `ctrl+c`, the signal handling may have been accidentally changed to kill just the process instead of the process group.

We are using puppeteer to launch a bash script that starts xvfb and then chrome. Since the bash script receives the SIGKILL, it has no change to do cleanup, leaving a dangling xvfb. Signaling the process group fixes the issue.

Note: I'm not familiar with Windows. The code in this PR is from BrowserRunner.ts before PR6011 was applied. It seems like it should be right based on this: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill

Note2: The nodejs documentation states: "Sending signal 0 can be used as a platform independent way to test for the existence of a process." However the documentation does not state whether it will throw an error with code `ESRCH` on Windows.