### PR TITLE
chore: improve TS automated type tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ yarn.lock
 /lib
 test/coverage.json
 temp/
-puppeteer-core-*.tgz
 new-docs/
-puppeteer-*.tgz
+puppeteer.tgz

--- a/test-ts-types/js-cjs-import-cjs-output/package.json
+++ b/test-ts-types/js-cjs-import-cjs-output/package.json
@@ -7,6 +7,6 @@
     "compile": "../../node_modules/.bin/tsc"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }

--- a/test-ts-types/js-cjs-import-esm-output/package.json
+++ b/test-ts-types/js-cjs-import-esm-output/package.json
@@ -10,6 +10,6 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }

--- a/test-ts-types/js-esm-import-cjs-output/package.json
+++ b/test-ts-types/js-esm-import-cjs-output/package.json
@@ -10,6 +10,6 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }

--- a/test-ts-types/js-esm-import-esm-output/package.json
+++ b/test-ts-types/js-esm-import-esm-output/package.json
@@ -10,6 +10,6 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }

--- a/test-ts-types/ts-cjs-import-cjs-output/package.json
+++ b/test-ts-types/ts-cjs-import-cjs-output/package.json
@@ -10,6 +10,6 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }

--- a/test-ts-types/ts-esm-import-cjs-output/package.json
+++ b/test-ts-types/ts-esm-import-cjs-output/package.json
@@ -10,6 +10,6 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }

--- a/test-ts-types/ts-esm-import-esm-output/package.json
+++ b/test-ts-types/ts-esm-import-esm-output/package.json
@@ -10,6 +10,6 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "puppeteer": "file:../../puppeteer-7.0.4-post.tgz"
+    "puppeteer": "file:../../puppeteer.tgz"
   }
 }


### PR DESCRIPTION
This PR:

1. Makes sure we remove and freshly install Puppeteer before testing our
   type defs, to avoid running on stale files.
2. Makes the tests run off `puppeteer.tgz` to avoid having version
   numbers in the file name and therefore having to update it when we
   bump versions.
