### PR TITLE
chore: Re-enable Firefox unit tests on Linux with WebRender disabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,13 +60,12 @@ jobs:
           xvfb-run --auto-servernum npm run unit-with-coverage
           xvfb-run --auto-servernum npm run assert-unit-coverage
 
-      # Temporarily disabled due to Firefox Nightly flakes.
-      # - name: Run unit tests on Firefox
-      #   env:
-      #     FIREFOX: true
-      #   run: |
-      #     xvfb-run --auto-servernum npm run funit
-
+      - name: Run unit tests on Firefox
+        env:
+          FIREFOX: true
+          MOZ_WEBRENDER: 0
+        run: |
+          xvfb-run --auto-servernum npm run funit
       - name: Run browser tests
         run: |
           npm run test-browser


### PR DESCRIPTION
Trying to debug some of the Firefox test failures we're seeing in:

* https://github.com/puppeteer/puppeteer/pull/6856/
* https://github.com/puppeteer/puppeteer/pull/6857

What's odd is that the failures are always in the `beforeEach`, so it's hard to know exactly what's causing the failures, but they are consistently within this block of tests.
