### PR TITLE
feat: expose other sessions from connection

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -357,6 +357,7 @@
   * [target.url()](#targeturl)
   * [target.worker()](#targetworker)
 - [class: CDPSession](#class-cdpsession)
+  * [cdpSession.connection()](#cdpsessionconnection)
   * [cdpSession.detach()](#cdpsessiondetach)
   * [cdpSession.send(method[, ...paramArgs])](#cdpsessionsendmethod-paramargs)
 - [class: Coverage](#class-coverage)
@@ -4556,6 +4557,12 @@ await client.send('Animation.setPlaybackRate', {
   playbackRate: response.playbackRate / 2,
 });
 ```
+
+#### cdpSession.connection()
+
+- returns: <[Connection]>
+
+Returns the underlying connection associated with the session. Can be used to obtain other related sessions.
 
 #### cdpSession.detach()
 

--- a/src/common/Connection.ts
+++ b/src/common/Connection.ts
@@ -125,11 +125,13 @@ export class Connection extends EventEmitter {
         sessionId
       );
       this._sessions.set(sessionId, session);
+      this.emit('sessionattached', session);
     } else if (object.method === 'Target.detachedFromTarget') {
       const session = this._sessions.get(object.params.sessionId);
       if (session) {
         session._onClosed();
         this._sessions.delete(object.params.sessionId);
+        this.emit('sessiondetached', session);
       }
     }
     if (object.sessionId) {
@@ -251,6 +253,10 @@ export class CDPSession extends EventEmitter {
     this._connection = connection;
     this._targetType = targetType;
     this._sessionId = sessionId;
+  }
+
+  connection(): Connection {
+    return this._connection;
   }
 
   send<T extends keyof ProtocolMapping.Commands>(

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -488,8 +488,16 @@ export class Page extends EventEmitter {
     this._viewport = null;
 
     client.on('Target.attachedToTarget', (event) => {
-      if (event.targetInfo.type !== 'worker') {
+      if (
+        event.targetInfo.type !== 'worker' &&
+        event.targetInfo.type !== 'iframe'
+      ) {
         // If we don't detach from service workers, they will never die.
+        // We still want to attach to workers for emitting events.
+        // We still want to attach to iframes so sessions may interact with them.
+        // We detach from all other types out of an abundance of caution.
+        // See https://source.chromium.org/chromium/chromium/src/+/master:content/browser/devtools/devtools_agent_host_impl.cc?q=f:devtools%20-f:out%20%22::kTypePage%5B%5D%22&ss=chromium
+        // for the complete list of available types.
         client
           .send('Target.detachFromTarget', {
             sessionId: event.sessionId,


### PR DESCRIPTION
This PR is aimed at providing mechanisms to allow puppeteer consumers to workaround OOPIF issues (see #2548). With this PR any consumer with a handle to a CDPSession should be able to find and listen to events from subtargets.

cc @mathiasbynens  @jschfflr  FYI

<details>

<summary><strong>Example Script</strong></summary>

```js
const puppeteer = require('.');

async function go() {
  const browser = await puppeteer.launch({
    headless: false,
  });

  const page = await browser.newPage();

  const session = await page.target().createCDPSession();
  await session.send('Target.setAutoAttach', {
    autoAttach: true,
    flatten: true,
    waitForDebuggerOnStart: true,
  });

  const regularRequests = new Set();
  const oopifRequests = new Set();

  // Listen for regular requests
  session.on('Network.requestWillBeSent', ({ request }) =>
    regularRequests.add(request.url)
  );
  await session.send('Network.enable');

  // Listen for OOPIF requests
  session.connection().on('sessionattached', async (session) => {
    console.log('Session attached!');
    session.on('Network.requestWillBeSent', ({ request }) =>
      oopifRequests.add(request.url)
    );
    await session.send('Network.enable');
  });

  // Any URL with a YouTube embed or some ads should work.
  await page.goto(
    'https://www.theverge.com/22265570/mustang-mach-e-review-electric-ford-ev-photos-video'
  );

  await new Promise((r) => setTimeout(r, 4_000));

  const hiddenRequests = new Set(oopifRequests);
  for (const url of regularRequests) hiddenRequests.delete(url);

  console.log('Found', regularRequests.size, 'regular requests');
  console.log('Found', oopifRequests.size, 'OOPIF requests');
  console.log(hiddenRequests.size, 'were only visible from OOPIFs');
  console.log(
    Array.from(hiddenRequests)
      .map((s) => `  ${s}`)
      .slice(0, 5)
      .join('\n')
  );

  await browser.close();
}

go();
```

</details>


<details>

<summary><strong>Output</strong></summary>

```
Session attached!
# ... and many others

Found 196 regular requests
Found 307 OOPIF requests
305 were only visible from OOPIFs
  https://phonograph2.voxmedia.com/pickup.js
  https://volume.vox-cdn.com/packs/js/2.0/embed.js
  https://volume.vox-cdn.com/packs/js/vendors~embed-chorus~embed-youtube-dca572bb40097a171c0a.chunk.js
  https://volume.vox-cdn.com/packs/js/embed-chorus~embed-youtube-c0dd8b44151457cd8e92.chunk.js
  https://volume.vox-cdn.com/packs/js/embed-youtube-bafee92b3ba0cb37e6d9.chunk.js
```

</details>