### PR TITLE
chore: temporarily disable FF tests on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,11 +60,12 @@ jobs:
           xvfb-run --auto-servernum npm run unit-with-coverage
           xvfb-run --auto-servernum npm run assert-unit-coverage
 
-      - name: Run unit tests on Firefox
-        env:
-          FIREFOX: true
-        run: |
-          xvfb-run --auto-servernum npm run funit
+      # Temporarily disabled due to Firefox Nightly flakes.
+      # - name: Run unit tests on Firefox
+      #   env:
+      #     FIREFOX: true
+      #   run: |
+      #     xvfb-run --auto-servernum npm run funit
 
       - name: Run browser tests
         run: |


### PR DESCRIPTION
The tests are regularly flaking (see #6861 for some investigation). In
the mean time it's blocking us landing and releasing, so we'll
temporarily skip FF tests for now.
