### PR TITLE
docs(readme): page.pdf format using a4

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const puppeteer = require('puppeteer');
   await page.goto('https://news.ycombinator.com', {
     waitUntil: 'networkidle2',
   });
-  await page.pdf({ path: 'hn.pdf', format: 'A4' });
+  await page.pdf({ path: 'hn.pdf', format: 'a4' });
 
   await browser.close();
 })();


### PR DESCRIPTION
`format` property of the `page.pdf` method was `a4` not `A4`.

ref: `PaperFormat` type.

![image](https://user-images.githubusercontent.com/13595509/108050463-7b8ac380-6ffe-11eb-9333-ad9dcf15e976.png)
