### PR TITLE
chore: run unit tests for Firefox on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,13 @@ jobs:
         run: |
           npm run unit
 
+      - name: Run unit tests on Firefox
+        env:
+          FIREFOX: true
+          MOZ_WEBRENDER: 0
+        run: |
+          npm run funit
+
   windows:
     # https://github.com/actions/virtual-environments#available-environments
     runs-on: windows-latest

--- a/test/keyboard.spec.ts
+++ b/test/keyboard.spec.ts
@@ -127,7 +127,7 @@ describe('Keyboard', function () {
       await page.evaluate(() => document.querySelector('textarea').value)
     ).toBe('嗨a');
   });
-  it('should report shiftKey', async () => {
+  itFailsFirefox('should report shiftKey', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/keyboard.html');


### PR DESCRIPTION
I noticed that the unit tests for Firefox are only run on Linux, but not on MacOS. To get out of experimental state it would be good to have these running as well.