### PR TITLE
fix: move CI npm config out of .npmrc

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -19,6 +19,7 @@ jobs:
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER}}
         run: |
+          npm config set registry 'https://wombat-dressing-room.appspot.com/'
           npm config set '//wombat-dressing-room.appspot.com/:_authToken' '${NPM_TOKEN}'
           npm publish
       - name: Publish puppeteer-core
@@ -26,5 +27,6 @@ jobs:
           NPM_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER_CORE}}
         run: |
           utils/prepare_puppeteer_core.js
+          npm config set registry 'https://wombat-dressing-room.appspot.com/'
           npm config set '//wombat-dressing-room.appspot.com/:_authToken' '${NPM_TOKEN}'
           npm publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-registry=https://wombat-dressing-room.appspot.com/
 access=public


### PR DESCRIPTION
This avoids issues with local `npm commands` trying to use the Wombat registry.