### PR TITLE
Remove broken executable "resolver" for arm64 arch

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -105,13 +105,9 @@ class ChromeLauncher implements ProductLauncher {
 
     let chromeExecutable = executablePath;
     if (!executablePath) {
-      if (os.arch() === 'arm64') {
-        chromeExecutable = '/usr/bin/chromium-browser';
-      } else {
-        const { missingText, executablePath } = resolveExecutablePath(this);
-        if (missingText) throw new Error(missingText);
-        chromeExecutable = executablePath;
-      }
+      const { missingText, executablePath } = resolveExecutablePath(this);
+      if (missingText) throw new Error(missingText);
+      chromeExecutable = executablePath;
     }
 
     const usePipe = chromeArguments.includes('--remote-debugging-pipe');


### PR DESCRIPTION
There was never any reasonable excuse for this branch to exist. There is no arch where a hardcoded executable path should be used in preference to the path resolver, as it simply prevents you from using PUPPETEER_EXECUTABLE_PATH, which is the preferred option for not hardcoding the executable path in usage. Removing this also provides better error handling, as the resolver provides an error message, whereas this broken behaviour just fails.


workaround for users with this existing problem:
Use launch option of `{ executablePath: process.env.PUPPETEER_EXECUTABLE_PATH }`. This will use the documented env var if present, and fall back to existing behaviour (broken on arm64, resolver on other arch).