### PR TITLE
Replace erroneous `PUPPETEER_SKIP_DOWNLOAD`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -565,7 +565,7 @@ try {
 > **NOTE** The old way (Puppeteer versions <= v1.14.0) errors can be obtained with `require('puppeteer/Errors')`.
 
 #### puppeteer.executablePath()
-- returns: <[string]> A path where Puppeteer expects to find the bundled browser. The browser binary might not be there if the download was skipped with [`PUPPETEER_SKIP_DOWNLOAD`](#environment-variables).
+- returns: <[string]> A path where Puppeteer expects to find the bundled browser. The browser binary might not be there if the download was skipped with [`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`](#environment-variables).
 
 > **NOTE** `puppeteer.executablePath()` is affected by the `PUPPETEER_EXECUTABLE_PATH` and `PUPPETEER_CHROMIUM_REVISION` env variables. See [Environment Variables](#environment-variables) for details.
 


### PR DESCRIPTION
`PUPPETEER_SKIP_DOWNLOAD ~ PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`.