### PR TITLE
test(firefox): ignore false positive

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -37,13 +37,17 @@ describe('Page', function () {
       const { context } = getTestState();
 
       const newPage = await context.newPage();
+      const evaluatePromise = newPage
+        .evaluate(() => new Promise(() => {}))
+        .catch((error_) => (error = error_));
+
+      await newPage.evaluate(() =>
+        console.log('make sure that the previous eval got to the browser')
+      );
+
       let error = null;
-      await Promise.all([
-        newPage
-          .evaluate(() => new Promise(() => {}))
-          .catch((error_) => (error = error_)),
-        newPage.close(),
-      ]);
+      await Promise.all([evaluatePromise, newPage.close()]);
+
       expect(error.message).toContain('Protocol error');
     });
     it('should not be visible in browser.pages', async () => {

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -35,6 +35,7 @@ describe('Page', function () {
   describe('Page.close', function () {
     it('should reject all promises when page is closed', async () => {
       const { context } = getTestState();
+      let error = null;
 
       const newPage = await context.newPage();
       const evaluatePromise = newPage
@@ -45,7 +46,6 @@ describe('Page', function () {
         console.log('make sure that the previous eval got to the browser')
       );
 
-      let error = null;
       await Promise.all([evaluatePromise, newPage.close()]);
 
       expect(error.message).toContain('Protocol error');


### PR DESCRIPTION
In Firefox a `Protocol error` is thrown but because the evaluate command was failing (error below) not because the promises were being rejected.

`'Protocol error (Runtime.callFunctionOn): can't access property "sendAsyncMessage", this.mm is null executeInChild/<@chrome://remote/content/cdp/sessions/TabSession.jsm:78:7\nexecuteInChild@chrome://remote/content/cdp/sessions/TabSession.jsm:73:12\nexecute@chrome://remote/content/cdp/sessions/TabSession.jsm:69:17\nonPacket@chrome://remote/content/cdp/Connection.jsm:227:36\nonMessage@chrome://remote/content/server/WebSocketTransport.jsm:85:18\nhandleEvent@chrome://remote/content/server/WebSocketTransport.jsm:67:14\n'`