### PR TITLE
fix: make screenshots work in the web

### DIFF
--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1740,13 +1740,16 @@ export class Page extends EventEmitter {
       options.encoding === 'base64'
         ? result.data
         : Buffer.from(result.data, 'base64');
-    if (!isNode && options.path) {
-      throw new Error(
-        'Screenshots can only be written to a file path in a Node environment.'
-      );
+
+    if (options.path) {
+      if (!isNode) {
+        throw new Error(
+          'Screenshots can only be written to a file path in a Node environment.'
+        );
+      }
+      const fs = await helper.importFSModule();
+      await fs.promises.writeFile(options.path, buffer);
     }
-    const fs = await helper.importFSModule();
-    if (options.path) await fs.promises.writeFile(options.path, buffer);
     return buffer;
 
     function processClip(


### PR DESCRIPTION
On web, the `fs` module is always imported when doing screenshots wo a path. This PR addresses that by reworking the flow of condition checks. Open to nitpicks, and thanks!