### PR TITLE
fix(filechooser): cancel is sync

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2790,7 +2790,6 @@ await fileChooser.accept(['/tmp/myfile.pdf']);
 - returns: <[Promise]>
 
 #### fileChooser.cancel()
-- returns: <[Promise]>
 
 Closes the file chooser without selecting any files.
 

--- a/src/common/FileChooser.ts
+++ b/src/common/FileChooser.ts
@@ -75,7 +75,7 @@ export class FileChooser {
   /**
    * Closes the file chooser without selecting any files.
    */
-  async cancel(): Promise<void> {
+  cancel() {
     assert(
       !this._handled,
       'Cannot cancel FileChooser which is already handled!'

--- a/test/input.spec.ts
+++ b/test/input.spec.ts
@@ -295,7 +295,13 @@ describe('input tests', function () {
       ]);
       await fileChooser.cancel();
       let error = null;
-      await fileChooser.cancel().catch((error_) => (error = error_));
+
+      try {
+        fileChooser.cancel();
+      } catch (error_) {
+        error = error_;
+      }
+
       expect(error.message).toBe(
         'Cannot cancel FileChooser which is already handled!'
       );


### PR DESCRIPTION
Cancel doesn't have async code.
This should be considered a breaking change.