### PR TITLE
chore: troubleshooting.md - update Alpine section

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -316,14 +316,14 @@ how to run this Dockerfile from a webserver running on App Engine Flex (Node).
 
 ### Running on Alpine
 
-The [newest Chromium package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium) supported on Alpine is 85, which corresponds to [Puppeteer v5.2.1](https://github.com/puppeteer/puppeteer/releases/tag/v5.2.1).
+The [newest Chromium package](https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium) supported on Alpine is 89, which corresponds to [Puppeteer v6.0.0](https://github.com/puppeteer/puppeteer/releases/tag/v6.0.0).
 
 Example Dockerfile:
 
 ```Dockerfile
 FROM alpine:edge
 
-# Installs latest Chromium (85) package.
+# Installs latest Chromium (89) package.
 RUN apk add --no-cache \
       chromium \
       nss \
@@ -341,8 +341,8 @@ RUN apk add --no-cache \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-# Puppeteer v5.2.1 works with Chromium 85.
-RUN yarn add puppeteer@5.2.1
+# Puppeteer v6.0.0 works with Chromium 89.
+RUN yarn add puppeteer@6.0.0
 
 # Add user so we don't need --no-sandbox.
 RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \


### PR DESCRIPTION
The latest Chromium provided by Alpine is at version 89.