### PR TITLE
fix(network): don't disable cache for auth challenge

### DIFF
--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -217,7 +217,7 @@ export class NetworkManager extends EventEmitter {
   async _updateProtocolCacheDisabled(): Promise<void> {
     await this._client.send('Network.setCacheDisabled', {
       cacheDisabled:
-        this._userCacheDisabled || this._protocolRequestInterceptionEnabled,
+        this._userCacheDisabled || this._userRequestInterceptionEnabled,
     });
   }
 

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -224,7 +224,7 @@ export class NetworkManager extends EventEmitter {
   _onRequestWillBeSent(event: Protocol.Network.RequestWillBeSentEvent): void {
     // Request interception doesn't happen for data URLs with Network Service.
     if (
-      this._protocolRequestInterceptionEnabled &&
+      this._userRequestInterceptionEnabled &&
       !event.request.url.startsWith('data:')
     ) {
       const requestId = event.requestId;

--- a/test/network.spec.ts
+++ b/test/network.spec.ts
@@ -581,11 +581,7 @@ describe('network', function () {
       });
 
       const responses = new Map();
-      page.on(
-        'response',
-        (r) =>
-          responses.set(r.url().split('/').pop(), r)
-      );
+      page.on('response', (r) => responses.set(r.url().split('/').pop(), r));
 
       // Load and re-load to make sure it's cached.
       await page.goto(server.PREFIX + '/cached/one-style.html');

--- a/test/network.spec.ts
+++ b/test/network.spec.ts
@@ -569,5 +569,32 @@ describe('network', function () {
       response = await page.goto(server.CROSS_PROCESS_PREFIX + '/empty.html');
       expect(response.status()).toBe(401);
     });
+    it('should not disable caching', async () => {
+      const { page, server } = getTestState();
+
+      // Use unique user/password since Chrome caches credentials per origin.
+      server.setAuth('/cached/one-style.css', 'user4', 'pass4');
+      server.setAuth('/cached/one-style.html', 'user4', 'pass4');
+      await page.authenticate({
+        username: 'user4',
+        password: 'pass4',
+      });
+
+      const responses = new Map();
+      page.on(
+        'response',
+        (r) =>
+          responses.set(r.url().split('/').pop(), r)
+      );
+
+      // Load and re-load to make sure it's cached.
+      await page.goto(server.PREFIX + '/cached/one-style.html');
+      await page.reload();
+
+      expect(responses.get('one-style.css').status()).toBe(200);
+      expect(responses.get('one-style.css').fromCache()).toBe(true);
+      expect(responses.get('one-style.html').status()).toBe(304);
+      expect(responses.get('one-style.html').fromCache()).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
#729 introduced `_updateProtocolRequestInterception`
Objective: Call `Network.setRequestInterceptionEnabled` for auth challenge or if requested by user

#1154 introduced `Network.setCacheDisabled`
Objective: Ensure custom user response handling is always called

#4260 introduced `_updateProtocolCacheDisabled`
Objective: Call `Network.setCacheDisabled` if requested by user

The cache and request interception work on the network level, while we want the custom user response handling to work independent of the network, which is why we're currently forced to disable the cache in some cases.

As long as there is no custom user response handling, it should be unnecessary to disable the cache for the auth challenge, since it only needs to be called in case of an actual network request anyway.

Related issue: #2905