### PR TITLE
feat(page): add omitBackground option for page.pdf method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1825,6 +1825,7 @@ Page is guaranteed to have a main frame which persists during navigations.
     - `bottom` <[string]|[number]> Bottom margin, accepts values labeled with units.
     - `left` <[string]|[number]> Left margin, accepts values labeled with units.
   - `preferCSSPageSize` <[boolean]> Give any CSS `@page` size declared in the page priority over what is declared in `width` and `height` or `format` options. Defaults to `false`, which will scale the content to fit the paper size.
+  - `omitBackground` <[boolean]> Hides default white background and allows capturing screenshots with transparency. Defaults to `false`.
 - returns: <[Promise]<[Buffer]>> Promise which resolves with PDF buffer.
 
 > **NOTE** Generating a pdf is currently only supported in Chrome headless.

--- a/src/common/PDFOptions.ts
+++ b/src/common/PDFOptions.ts
@@ -151,6 +151,11 @@ export interface PDFOptions {
    * @defaultValue the empty string, which means the PDF will not be written to disk.
    */
   path?: string;
+  /**
+   * Hides default white background and allows generating pdfs with transparency.
+   * @defaultValue false
+   */
+  omitBackground?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adds `omitBackground` option for Page.pdf to allow for transparent backgrounds. This option is available in the screenshot api, this change unifies this for both `.screenshot` and `.pdf`.

Related issues: #6906  #2545 