### PR TITLE
fix: defaultViewport can be null in BrowserConnectOptions

### DIFF
--- a/src/common/BrowserConnector.ts
+++ b/src/common/BrowserConnector.ts
@@ -37,7 +37,7 @@ export interface BrowserConnectOptions {
   /**
    * Sets the viewport for each page.
    */
-  defaultViewport?: Viewport;
+  defaultViewport?: Viewport | null;
   /**
    * Slows down Puppeteer operations by the specified amount of milliseconds to
    * aid debugging.


### PR DESCRIPTION
### Steps to reproduce

**Description:**

As per API `defaultViewport` field in launch options ( `puppeteer.lauch( { defaultViewport: ... } )` [link](https://pptr.dev/#?product=Puppeteer&version=v8.0.0&show=api-puppeteerlaunchoptions) ) can have the three below values:
* `Viewport` object - The specified viewport will be applied.
* `undefined` (i.e. `defaultViewport` field is absent) - Default viewport will be applied.
* `null` - No viewport will be applied. Useful in headful mode, because page content will accomodate to browser extent.

**Tell us about your environment:**

* Puppeteer version: 8.0.0
* Platform / OS version: N/A
* URLs (if applicable): https://github.com/puppeteer/puppeteer/blob/0b5969dea9048dc34a4d2e109e96c42e8928182c/src/common/BrowserConnector.ts#L40
* Node.js version: N/A

**What steps will reproduce the problem?**

1. Create a TypeScript project that launches a Chromium instance using `puppeteer.launch(options)` function.
2. Among options specify `defaultViewport` field as `null`.

_Please include code that reproduces the issue._

```javascript
puppeteer.lauch({
  headless: false,
  defaultViewport: null,
});
```

**What is the expected result?**

Code is accepted as valid, no type error raises.

**What happens instead?**

Type error raises, which tells that `null` is not valid value for `defaultViewport`.