### PR TITLE
chore: skip non-standard cookie asserts on Firefox

### DIFF
--- a/test/cookies.spec.ts
+++ b/test/cookies.spec.ts
@@ -15,6 +15,7 @@
  */
 import expect from 'expect';
 import {
+  expectCookieEquals,
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
@@ -29,15 +30,16 @@ describe('Cookie specs', () => {
     it('should return no cookies in pristine browser context', async () => {
       const { page, server } = getTestState();
       await page.goto(server.EMPTY_PAGE);
-      expect(await page.cookies()).toEqual([]);
+      expectCookieEquals(await page.cookies(), []);
     });
-    itFailsFirefox('should get a cookie', async () => {
+    it('should get a cookie', async () => {
       const { page, server } = getTestState();
       await page.goto(server.EMPTY_PAGE);
       await page.evaluate(() => {
         document.cookie = 'username=John Doe';
       });
-      expect(await page.cookies()).toEqual([
+
+      expectCookieEquals(await page.cookies(), [
         {
           name: 'username',
           value: 'John Doe',
@@ -87,7 +89,7 @@ describe('Cookie specs', () => {
       expect(cookies.length).toBe(1);
       expect(cookies[0].sameSite).toBe('Lax');
     });
-    itFailsFirefox('should get multiple cookies', async () => {
+    it('should get multiple cookies', async () => {
       const { page, server } = getTestState();
       await page.goto(server.EMPTY_PAGE);
       await page.evaluate(() => {
@@ -96,7 +98,7 @@ describe('Cookie specs', () => {
       });
       const cookies = await page.cookies();
       cookies.sort((a, b) => a.name.localeCompare(b.name));
-      expect(cookies).toEqual([
+      expectCookieEquals(cookies, [
         {
           name: 'password',
           value: '1234',
@@ -148,7 +150,7 @@ describe('Cookie specs', () => {
       );
       const cookies = await page.cookies('https://foo.com', 'https://baz.com');
       cookies.sort((a, b) => a.name.localeCompare(b.name));
-      expect(cookies).toEqual([
+      expectCookieEquals(cookies, [
         {
           name: 'birdo',
           value: 'tweets',
@@ -229,12 +231,13 @@ describe('Cookie specs', () => {
           value: 'bar',
         }
       );
-      expect(
+      expectCookieEquals(
         await page.evaluate(() => {
           const cookies = document.cookie.split(';');
           return cookies.map((cookie) => cookie.trim()).sort();
-        })
-      ).toEqual(['foo=bar', 'password=123456']);
+        }),
+        ['foo=bar', 'password=123456']
+      );
     });
     it('should have |expires| set to |-1| for session cookies', async () => {
       const { page, server } = getTestState();
@@ -257,22 +260,25 @@ describe('Cookie specs', () => {
         value: '123456',
       });
       const cookies = await page.cookies();
-      expect(cookies.sort((a, b) => a.name.localeCompare(b.name))).toEqual([
-        {
-          name: 'password',
-          value: '123456',
-          domain: 'localhost',
-          path: '/',
-          sameParty: false,
-          expires: -1,
-          size: 14,
-          httpOnly: false,
-          secure: false,
-          session: true,
-          sourcePort: 80,
-          sourceScheme: 'NonSecure',
-        },
-      ]);
+      expectCookieEquals(
+        cookies.sort((a, b) => a.name.localeCompare(b.name)),
+        [
+          {
+            name: 'password',
+            value: '123456',
+            domain: 'localhost',
+            path: '/',
+            sameParty: false,
+            expires: -1,
+            size: 14,
+            httpOnly: false,
+            secure: false,
+            session: true,
+            sourcePort: 80,
+            sourceScheme: 'NonSecure',
+          },
+        ]
+      );
     });
     itFailsFirefox('should set a cookie with a path', async () => {
       const { page, server } = getTestState();
@@ -283,7 +289,7 @@ describe('Cookie specs', () => {
         value: 'GRID',
         path: '/grid.html',
       });
-      expect(await page.cookies()).toEqual([
+      expectCookieEquals(await page.cookies(), [
         {
           name: 'gridcookie',
           value: 'GRID',
@@ -301,7 +307,7 @@ describe('Cookie specs', () => {
       ]);
       expect(await page.evaluate('document.cookie')).toBe('gridcookie=GRID');
       await page.goto(server.EMPTY_PAGE);
-      expect(await page.cookies()).toEqual([]);
+      expectCookieEquals(await page.cookies(), []);
       expect(await page.evaluate('document.cookie')).toBe('');
       await page.goto(server.PREFIX + '/grid.html');
       expect(await page.evaluate('document.cookie')).toBe('gridcookie=GRID');
@@ -390,8 +396,8 @@ describe('Cookie specs', () => {
         value: 'best',
       });
       expect(await page.evaluate('document.cookie')).toBe('');
-      expect(await page.cookies()).toEqual([]);
-      expect(await page.cookies('https://www.example.com')).toEqual([
+      expectCookieEquals(await page.cookies(), []);
+      expectCookieEquals(await page.cookies('https://www.example.com'), [
         {
           name: 'example-cookie',
           value: 'best',
@@ -432,7 +438,7 @@ describe('Cookie specs', () => {
       );
       expect(await page.frames()[1].evaluate('document.cookie')).toBe('');
 
-      expect(await page.cookies()).toEqual([
+      expectCookieEquals(await page.cookies(), [
         {
           name: 'localhost-cookie',
           value: 'best',
@@ -449,7 +455,7 @@ describe('Cookie specs', () => {
         },
       ]);
 
-      expect(await page.cookies(server.CROSS_PROCESS_PREFIX)).toEqual([
+      expectCookieEquals(await page.cookies(server.CROSS_PROCESS_PREFIX), [
         {
           name: '127-cookie',
           value: 'worst',
@@ -503,23 +509,26 @@ describe('Cookie specs', () => {
           expect(await page.frames()[1].evaluate('document.cookie')).toBe(
             '127-same-site-cookie=best'
           );
-          expect(await page.cookies(httpsServer.CROSS_PROCESS_PREFIX)).toEqual([
-            {
-              name: '127-same-site-cookie',
-              value: 'best',
-              domain: '127.0.0.1',
-              path: '/',
-              sameParty: false,
-              expires: -1,
-              size: 24,
-              httpOnly: false,
-              sameSite: 'None',
-              secure: true,
-              session: true,
-              sourcePort: 443,
-              sourceScheme: 'Secure',
-            },
-          ]);
+          expectCookieEquals(
+            await page.cookies(httpsServer.CROSS_PROCESS_PREFIX),
+            [
+              {
+                name: '127-same-site-cookie',
+                value: 'best',
+                domain: '127.0.0.1',
+                path: '/',
+                sameParty: false,
+                expires: -1,
+                size: 24,
+                httpOnly: false,
+                sameSite: 'None',
+                secure: true,
+                session: true,
+                sourcePort: 443,
+                sourceScheme: 'Secure',
+              },
+            ]
+          );
         } finally {
           await page.close();
           await browser.close();

--- a/test/defaultbrowsercontext.spec.ts
+++ b/test/defaultbrowsercontext.spec.ts
@@ -15,6 +15,7 @@
  */
 import expect from 'expect';
 import {
+  expectCookieEquals,
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
@@ -24,14 +25,14 @@ import {
 describe('DefaultBrowserContext', function () {
   setupTestBrowserHooks();
   setupTestPageAndContextHooks();
-  itFailsFirefox('page.cookies() should work', async () => {
+  it('page.cookies() should work', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.EMPTY_PAGE);
     await page.evaluate(() => {
       document.cookie = 'username=John Doe';
     });
-    expect(await page.cookies()).toEqual([
+    expectCookieEquals(await page.cookies(), [
       {
         name: 'username',
         value: 'John Doe',
@@ -59,7 +60,7 @@ describe('DefaultBrowserContext', function () {
     expect(await page.evaluate(() => document.cookie)).toBe(
       'username=John Doe'
     );
-    expect(await page.cookies()).toEqual([
+    expectCookieEquals(await page.cookies(), [
       {
         name: 'username',
         value: 'John Doe',
@@ -93,7 +94,7 @@ describe('DefaultBrowserContext', function () {
     expect(await page.evaluate('document.cookie')).toBe('cookie1=1; cookie2=2');
     await page.deleteCookie({ name: 'cookie2' });
     expect(await page.evaluate('document.cookie')).toBe('cookie1=1');
-    expect(await page.cookies()).toEqual([
+    expectCookieEquals(await page.cookies(), [
       {
         name: 'cookie1',
         value: '1',

--- a/test/mocha-utils.ts
+++ b/test/mocha-utils.ts
@@ -28,6 +28,7 @@ import { Page } from '../lib/cjs/puppeteer/common/Page.js';
 import { PuppeteerNode } from '../lib/cjs/puppeteer/node/Puppeteer.js';
 import utils from './utils.js';
 import rimraf from 'rimraf';
+import expect from 'expect';
 
 import { trackCoverage } from './coverage-utils.js';
 
@@ -276,4 +277,26 @@ export const mochaHooks = {
   afterEach: () => {
     sinon.restore();
   },
+};
+
+export const expectCookieEquals = (cookies, expectedCookies) => {
+  const { isChrome } = getTestState();
+  if (!isChrome) {
+    // Only keep standard properties when testing on a browser other than Chrome.
+    expectedCookies = expectedCookies.map((cookie) => {
+      return {
+        domain: cookie.domain,
+        expires: cookie.expires,
+        httpOnly: cookie.httpOnly,
+        name: cookie.name,
+        path: cookie.path,
+        secure: cookie.secure,
+        session: cookie.session,
+        size: cookie.size,
+        value: cookie.value,
+      };
+    });
+  }
+
+  expect(cookies).toEqual(expectedCookies);
 };


### PR DESCRIPTION
Fix for https://github.com/puppeteer/puppeteer/issues/6976

This change adds a dedicated assert helper for cookies which will only check the non-standard properties `sameParty`, `sourcePort` and `sourceScheme` when running against chrome.

All cookie asserts are replaced to use this helper.

3 tests marked as failing with Firefox are enabled: 
- Page.cookies should get a cookie
- Page.cookies should get multiple cookies
- DefaultBrowserContext page.cookies() should work