### PR TITLE
chore: improve "Page.close should run beforeunload if asked for" unittest for Firefox

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -67,10 +67,7 @@ describe('Page', function () {
       expect(dialog.type()).toBe('beforeunload');
       expect(dialog.defaultValue()).toBe('');
       if (isChrome) expect(dialog.message()).toBe('');
-      else
-        expect(dialog.message()).toBe(
-          'This page is asking you to confirm that you want to leave - data you have entered may not be saved.'
-        );
+      else expect(dialog.message()).toBeTruthy();
       await dialog.accept();
       await pageClosingPromise;
     });


### PR DESCRIPTION
@jackfranklin, @mathiasbynens, or @jschfflr could we please get this reviewed soon? It's failing in our own CI now due to a change in the message string.