### PR TITLE
feat(typescript): allow using puppeteer without dom lib

### DIFF
--- a/inject-global-type-stubs.js
+++ b/inject-global-type-stubs.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This script is needed because of https://github.com/microsoft/rushstack/issues/1709
+const { promises: fs } = require('fs');
+const { join } = require('path');
+
+async function injctGlobalTypeStubs() {
+  const typesPath = join(__dirname, 'lib', 'types.d.ts');
+  const globalsPath = join(__dirname, 'lib', 'cjs', 'puppeteer', 'global.d.ts');
+  const types = await fs.readFile(typesPath, 'utf-8');
+  const globals = await fs.readFile(globalsPath, 'utf-8');
+  await fs.writeFile(typesPath, `${globals}\n${types}`);
+}
+
+injctGlobalTypeStubs();

--- a/inject-global-type-stubs.js
+++ b/inject-global-type-stubs.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google Inc. All rights reserved.
+ * Copyright 2021 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "apply-next-version": "node utils/apply_next_version.js",
     "test-install": "scripts/test-install.sh",
     "clean-docs": "rimraf website/docs && rimraf docs-api-json",
-    "generate-d-ts": "npm run clean-docs && api-extractor run --local --verbose",
+    "generate-d-ts": "npm run clean-docs && api-extractor run --local --verbose && node inject-global-type-stubs.js",
     "generate-docs": "npm run generate-d-ts && api-documenter markdown -i docs-api-json -o website/docs && node utils/remove-tag.js",
     "ensure-correct-devtools-protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package",
     "ensure-pinned-deps": "ts-node -s scripts/ensure-pinned-deps",

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,0 +1,20 @@
+/**
+ * These global declarations exist so puppeteer can work without the need to use `"dom"`
+ * types.
+ *
+ * To get full type information for these interfaces, add `"types": "dom"`in your
+ * `tsconfig.json` file.
+ */
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Document {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Element {}
+
+  // eslint-disable-next-line max-len
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unused-vars
+  interface NodeListOf<TNode> {}
+}
+
+export {};


### PR DESCRIPTION
The dom lib inserts all dom related types into the project, which is often undesirable when working on a NodeJS project.

This change injects global stubs for the dom types required by puppeteer, so puppeteer can work without users having to add dom types to their project.

Closes #6989