### PR TITLE
fix(aria): fix parsing of ARIA selectors

### DIFF
--- a/src/common/AriaQueryHandler.ts
+++ b/src/common/AriaQueryHandler.ts
@@ -52,15 +52,13 @@ function parseAriaSelector(selector: string): ariaQueryOption {
   const normalize = (value: string): string => value.replace(/ +/g, ' ').trim();
   const knownAttributes = new Set(['name', 'role']);
   const queryOptions: ariaQueryOption = {};
-  const attributeRegexp = /\[\s*(?<attribute>\w+)\s*=\s*"(?<value>\\.|[^"\\]*)"\s*\]/;
+  const attributeRegexp = /\[\s*(?<attribute>\w+)\s*=\s*"(?<value>\\.|[^"\\]*)"\s*\]/g;
   const defaultName = selector.replace(
     attributeRegexp,
     (_, attribute: string, value: string) => {
       attribute = attribute.trim();
       if (!knownAttributes.has(attribute))
-        throw new Error(
-          'Unknown aria attribute "${groups.attribute}" in selector'
-        );
+        throw new Error(`Unknown aria attribute "${attribute}" in selector`);
       queryOptions[attribute] = normalize(value);
       return '';
     }

--- a/test/ariaqueryhandler.spec.ts
+++ b/test/ariaqueryhandler.spec.ts
@@ -74,6 +74,9 @@ describeChromeOnly('AriaQueryHandler', () => {
         'aria/ignored[name="Submit  button and some  spaces"][role="button"]'
       );
       await expectFound(button);
+      await expect(page.$('aria/smth[smth="true"]')).rejects.toThrow(
+        'Unknown aria attribute "smth" in selector'
+      );
     });
   });
 


### PR DESCRIPTION
- adds a g flag so that the replacer is called for every match.
- fixes the reported error message and adds a test.