### PR TITLE
docs: warning messages

### DIFF
--- a/src/common/Browser.ts
+++ b/src/common/Browser.ts
@@ -550,7 +550,9 @@ export class Browser extends EventEmitter {
     return this._connection.send('Browser.getVersion');
   }
 }
-
+/**
+ * @public
+ */
 export const enum BrowserContextEmittedEvents {
   /**
    * Emitted when the url of a target inside the browser context changes.
@@ -604,6 +606,7 @@ export const enum BrowserContextEmittedEvents {
  * // Dispose context once it's no longer needed.
  * await context.close();
  * ```
+ * @public
  */
 export class BrowserContext extends EventEmitter {
   private _connection: Connection;

--- a/src/common/Connection.ts
+++ b/src/common/Connection.ts
@@ -67,7 +67,7 @@ export class Connection extends EventEmitter {
   }
 
   /**
-   * @param {string} sessionId
+   * @param sessionId -
    * @returns {?CDPSession}
    */
   session(sessionId: string): CDPSession | null {
@@ -167,7 +167,7 @@ export class Connection extends EventEmitter {
   }
 
   /**
-   * @param {Protocol.Target.TargetInfo} targetInfo
+   * @param targetInfo -
    * @returns {!Promise<!CDPSession>}
    */
   async createSession(

--- a/src/common/ConsoleMessage.ts
+++ b/src/common/ConsoleMessage.ts
@@ -38,6 +38,7 @@ export interface ConsoleMessageLocation {
 
 /**
  * The supported types for console messages.
+ * @public
  */
 export type ConsoleMessageType =
   | 'log'

--- a/src/common/DeviceDescriptors.ts
+++ b/src/common/DeviceDescriptors.ts
@@ -1030,7 +1030,9 @@ const devices: Device[] = [
     },
   },
 ];
-
+/**
+ * @public
+ */
 export type DevicesMap = {
   [name: string]: Device;
 };
@@ -1038,5 +1040,7 @@ export type DevicesMap = {
 const devicesMap: DevicesMap = {};
 
 for (const device of devices) devicesMap[device.name] = device;
-
+/**
+ * @public
+ */
 export { devicesMap };

--- a/src/common/Dialog.ts
+++ b/src/common/Dialog.ts
@@ -38,6 +38,7 @@ import { Protocol } from 'devtools-protocol';
  *   page.evaluate(() => alert('1'));
  * })();
  * ```
+ * @public
  */
 export class Dialog {
   private _client: CDPSession;

--- a/src/common/Errors.ts
+++ b/src/common/Errors.ts
@@ -33,9 +33,13 @@ class CustomError extends Error {
  * @public
  */
 export class TimeoutError extends CustomError {}
-
+/**
+ * @public
+ */
 export type PuppeteerErrors = Record<string, typeof CustomError>;
-
+/**
+ * @public
+ */
 export const puppeteerErrors: PuppeteerErrors = {
   TimeoutError,
 };

--- a/src/common/EvalTypes.ts
+++ b/src/common/EvalTypes.ts
@@ -20,7 +20,9 @@ import { JSHandle, ElementHandle } from './JSHandle.js';
  * @public
  */
 export type EvaluateFn<T = any> = string | ((arg1: T, ...args: any[]) => any);
-
+/**
+ * @public
+ */
 export type UnwrapPromiseLike<T> = T extends PromiseLike<infer U> ? U : T;
 
 /**

--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -5,7 +5,7 @@ import mitt, {
 } from '../../vendor/mitt/src/index.js';
 
 /**
- * @internal
+ * @public
  */
 export interface CommonEventEmitter {
   on(event: EventType, handler: Handler): CommonEventEmitter;

--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -22,7 +22,9 @@ import { DOMWorld } from './DOMWorld.js';
 import { Frame } from './FrameManager.js';
 import { Protocol } from 'devtools-protocol';
 import { EvaluateHandleFn, SerializableOrJSHandle } from './EvalTypes.js';
-
+/**
+ * @public
+ */
 export const EVALUATION_SCRIPT_URL = '__puppeteer_evaluation_script__';
 const SOURCE_URL_REGEX = /^[\040\t]*\/\/[@#] sourceURL=\s*(\S*?)\s*$/m;
 

--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -128,8 +128,8 @@ export class ExecutionContext {
    * await twoHandle.dispose();
    * console.log(result); // prints '3'.
    * ```
-   * @param pageFunction a function to be evaluated in the `executionContext`
-   * @param args argument to pass to the page function
+   * @param pageFunction - a function to be evaluated in the `executionContext`
+   * @param args - argument to pass to the page function
    *
    * @returns A promise that resolves to the return value of the given function.
    */
@@ -180,8 +180,8 @@ export class ExecutionContext {
    * await resultHandle.dispose();
    * ```
    *
-   * @param pageFunction a function to be evaluated in the `executionContext`
-   * @param args argument to pass to the page function
+   * @param pageFunction - a function to be evaluated in the `executionContext`
+   * @param args - argument to pass to the page function
    *
    * @returns A promise that resolves to the return value of the given function
    * as an in-page object (a {@link JSHandle}).
@@ -346,7 +346,7 @@ export class ExecutionContext {
    * await mapPrototype.dispose();
    * ```
    *
-   * @param prototypeHandle a handle to the object prototype
+   * @param prototypeHandle - a handle to the object prototype
    *
    * @returns A handle to an array of objects with the given prototype.
    */

--- a/src/common/FileChooser.ts
+++ b/src/common/FileChooser.ts
@@ -34,6 +34,7 @@ import { assert } from './assert.js';
  * **NOTE** In browsers, only one file chooser can be opened at a time.
  * All file choosers must be accepted or canceled. Not doing so will prevent
  * subsequent file choosers from appearing.
+ * @public
  */
 export class FileChooser {
   private _element: ElementHandle;

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -32,7 +32,9 @@ import {
   UnwrapPromiseLike,
 } from './EvalTypes.js';
 import { isNode } from '../environment.js';
-
+/**
+ * @public
+ */
 export interface BoxModel {
   content: Array<{ x: number; y: number }>;
   padding: Array<{ x: number; y: number }>;

--- a/src/common/LifecycleWatcher.ts
+++ b/src/common/LifecycleWatcher.ts
@@ -26,7 +26,9 @@ import { HTTPRequest } from './HTTPRequest.js';
 import { HTTPResponse } from './HTTPResponse.js';
 import { NetworkManagerEmittedEvents } from './NetworkManager.js';
 import { CDPSessionEmittedEvents } from './Connection.js';
-
+/**
+ * @public
+ */
 export type PuppeteerLifeCycleEvent =
   | 'load'
   | 'domcontentloaded'

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -41,7 +41,9 @@ export interface NetworkConditions {
   // Latency (ms)
   latency: number;
 }
-
+/**
+ * @public
+ */
 export interface InternalNetworkConditions extends NetworkConditions {
   offline: boolean;
 }

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1049,13 +1049,13 @@ export class Page extends EventEmitter {
    * );
    * ```
    *
-   * @param selector the
+   * @param selector - the
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors | selector}
    * to query for
-   * @param pageFunction the function to be evaluated in the page context. Will
+   * @param pageFunction - the function to be evaluated in the page context. Will
    * be passed the result of `Array.from(document.querySelectorAll(selector))`
    * as its first argument.
-   * @param args any additional arguments to pass through to `pageFunction`.
+   * @param args - any additional arguments to pass through to `pageFunction`.
    *
    * @returns The result of calling `pageFunction`. If it returns an element it
    * is wrapped in an {@link ElementHandle}, else the raw value itself is
@@ -1548,9 +1548,9 @@ export class Page extends EventEmitter {
    * await page.emulateIdleState();
    * ```
    *
-   * @param overrides Mock idle state. If not set, clears idle overrides
-   * @param isUserActive Mock isUserActive
-   * @param isScreenUnlocked Mock isScreenUnlocked
+   * @param overrides - Mock idle state. If not set, clears idle overrides
+   * @param isUserActive - Mock isUserActive
+   * @param isScreenUnlocked - Mock isScreenUnlocked
    */
   async emulateIdleState(overrides?: {
     isUserActive: boolean;

--- a/src/common/Puppeteer.ts
+++ b/src/common/Puppeteer.ts
@@ -38,7 +38,9 @@ import {
 export interface CommonPuppeteerSettings {
   isPuppeteerCore: boolean;
 }
-
+/**
+ * @public
+ */
 export interface ConnectOptions extends BrowserConnectOptions {
   browserWSEndpoint?: string;
   browserURL?: string;


### PR DESCRIPTION
I solved the (ae-missing-release-tag) warning by adding public tag.  there are a lot of warning:
1. (tsdoc-param-tag-missing-hyphen)
2. (ae-forgotten-export)
3. (tsdoc-escape-right-brace)
4. (tsdoc-escape-greater-than)
5. (tsdoc-characters-after-inline-tag)
5. (tsdoc-reference-missing-dot)
6. (tsdoc-malformed-inline-tag)
7. (tsdoc-param-tag-with-invalid-type)

I tried in number 2 but it seems like nothing is forgotten ! should I silence this warning ?
what about the other warnings, should i silence them too or try to solve them first?
@jackfranklin 