### PR TITLE
test: fix Browser.pages should return all of the pages

### DIFF
--- a/test/target.spec.ts
+++ b/test/target.spec.ts
@@ -48,7 +48,6 @@ describe('Target', function () {
     const allPages = await context.pages();
     expect(allPages.length).toBe(1);
     expect(allPages).toContain(page);
-    expect(allPages[0]).not.toBe(allPages[1]);
   });
   it('should contain browser target', async () => {
     const { browser } = getTestState();


### PR DESCRIPTION
If `expect(allPages.length).toBe(1);`, `allPages[1]` will be undefined, therefore, that `expect` makes no sense.