### PR TITLE
docs: fix TSDoc warning message for WebWorker

### DIFF
--- a/src/common/WebWorker.ts
+++ b/src/common/WebWorker.ts
@@ -24,7 +24,7 @@ import { EvaluateHandleFn, SerializableOrJSHandle } from './EvalTypes.js';
 /**
  * @internal
  */
-type ConsoleAPICalledCallback = (
+export type ConsoleAPICalledCallback = (
   eventType: string,
   handles: JSHandle[],
   trace: Protocol.Runtime.StackTrace
@@ -33,7 +33,7 @@ type ConsoleAPICalledCallback = (
 /**
  * @internal
  */
-type ExceptionThrownCallback = (
+export type ExceptionThrownCallback = (
   details: Protocol.Runtime.ExceptionDetails
 ) => void;
 type JSHandleFactory = (obj: Protocol.Runtime.RemoteObject) => JSHandle;


### PR DESCRIPTION
Fix warning from `WebWorker.ts` 

<img width="1336" alt="Screenshot 2021-04-11 at 8 20 26 PM" src="https://user-images.githubusercontent.com/46647141/114309028-695f6a00-9b03-11eb-9d93-fb22137ee2b5.png">
