### PR TITLE
fix(page): fix Mouse.click method

### DIFF
--- a/src/common/Input.ts
+++ b/src/common/Input.ts
@@ -409,15 +409,14 @@ export class Mouse {
   ): Promise<void> {
     const { delay = null } = options;
     if (delay !== null) {
-      await Promise.all([this.move(x, y), this.down(options)]);
+      await this.move(x, y);
+      await this.down(options);
       await new Promise((f) => setTimeout(f, delay));
       await this.up(options);
     } else {
-      await Promise.all([
-        this.move(x, y),
-        this.down(options),
-        this.up(options),
-      ]);
+      await this.move(x, y);
+      await this.down(options);
+      await this.up(options);
     }
   }
 


### PR DESCRIPTION
page.click method relies on Mouse.click method for execution. Mouse.click triggers the move, down and up methods in parallel waiting for all of them to finish, when they should be called sequentially instead.

Issues: #6462 (related), #3347 (left a comment in it).