### PR TITLE
docs(puppeteer-chromium): remove  alpine freetype-dev dependency

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -335,7 +335,6 @@ RUN apk add --no-cache \
       chromium \
       nss \
       freetype \
-      freetype-dev \
       harfbuzz \
       ca-certificates \
       ttf-freefont \


### PR DESCRIPTION
It was added by  #4643 but looks like it isn't necessary anymore.