### PR TITLE
feat(launcher): fix installation error on Apple M1 chips

### DIFF
--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -294,8 +294,8 @@ export class BrowserFetcher {
     if (!(await existsAsync(this._downloadsFolder)))
       await mkdirAsync(this._downloadsFolder);
 
-    // Use intel x86 build on Apple M1 until native MacOS arm64
-    // chromium builds are available
+    // Use Intel x86 builds on Apple M1 until native macOS arm64
+    // Chromium builds are available.
     if (os.platform() !== 'darwin' && os.arch() === 'arm64') {
       handleArm64();
       return;

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -293,7 +293,10 @@ export class BrowserFetcher {
     if (await existsAsync(outputPath)) return this.revisionInfo(revision);
     if (!(await existsAsync(this._downloadsFolder)))
       await mkdirAsync(this._downloadsFolder);
-    if (os.arch() === 'arm64') {
+
+    // Use intel x86 build on Apple M1 until native MacOS arm64
+    // chromium builds are available
+    if (os.platform() !== 'darwin' && os.arch() === 'arm64') {
       handleArm64();
       return;
     }

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -105,7 +105,9 @@ class ChromeLauncher implements ProductLauncher {
 
     let chromeExecutable = executablePath;
     if (!executablePath) {
-      if (os.arch() === 'arm64') {
+      // Use intel x86 build on Apple M1 until native MacOS arm64
+      // chromium builds are available
+      if (os.platform() !== 'darwin' && os.arch() === 'arm64') {
         chromeExecutable = '/usr/bin/chromium-browser';
       } else {
         const { missingText, executablePath } = resolveExecutablePath(this);

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -105,8 +105,8 @@ class ChromeLauncher implements ProductLauncher {
 
     let chromeExecutable = executablePath;
     if (!executablePath) {
-      // Use intel x86 build on Apple M1 until native MacOS arm64
-      // chromium builds are available
+    // Use Intel x86 builds on Apple M1 until native macOS arm64
+    // Chromium builds are available.
       if (os.platform() !== 'darwin' && os.arch() === 'arm64') {
         chromeExecutable = '/usr/bin/chromium-browser';
       } else {

--- a/src/node/install.ts
+++ b/src/node/install.ts
@@ -90,8 +90,8 @@ export async function downloadBrowser() {
     if (NPM_NO_PROXY) process.env.NO_PROXY = NPM_NO_PROXY;
 
     function onSuccess(localRevisions: string[]): void {
-      // Use intel x86 build on Apple M1 until native MacOS arm64
-      // chromium builds are available
+    // Use Intel x86 builds on Apple M1 until native macOS arm64
+    // Chromium builds are available.
       if (os.platform() !== 'darwin' && os.arch() !== 'arm64') {
         logPolitely(
           `${supportedProducts[product]} (${revisionInfo.revision}) downloaded to ${revisionInfo.folderPath}`

--- a/src/node/install.ts
+++ b/src/node/install.ts
@@ -90,7 +90,9 @@ export async function downloadBrowser() {
     if (NPM_NO_PROXY) process.env.NO_PROXY = NPM_NO_PROXY;
 
     function onSuccess(localRevisions: string[]): void {
-      if (os.arch() !== 'arm64') {
+      // Use intel x86 build on Apple M1 until native MacOS arm64
+      // chromium builds are available
+      if (os.platform() !== 'darwin' && os.arch() !== 'arm64') {
         logPolitely(
           `${supportedProducts[product]} (${revisionInfo.revision}) downloaded to ${revisionInfo.folderPath}`
         );


### PR DESCRIPTION
The previous logic assumed that an arm64 arch is only available in Linux. WIth Apple's arm64 M1 Chip this assumption isn't true anymore.

Currently there are no official MacOS arm64 chromium builds available, but we can make use of the excellent Rosetta feature in MacOS that allows us to run x86 binaries on M1.

Once official native MacOS arm64 chromium builds are available we should switch to those.

Fixes #6622