### PR TITLE
chore: run "should be able to launch Firefox" only with regular install

### DIFF
--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -469,14 +469,17 @@ describe('Launcher specs', function () {
         ]);
       });
 
-      it('should be able to launch Firefox', async function () {
-        this.timeout(FIREFOX_TIMEOUT);
-        const { puppeteer } = getTestState();
-        const browser = await puppeteer.launch({ product: 'firefox' });
-        const userAgent = await browser.userAgent();
-        await browser.close();
-        expect(userAgent).toContain('Firefox');
-      });
+      itOnlyRegularInstall(
+        'should be able to launch Firefox',
+        async function () {
+          this.timeout(FIREFOX_TIMEOUT);
+          const { puppeteer } = getTestState();
+          const browser = await puppeteer.launch({ product: 'firefox' });
+          const userAgent = await browser.userAgent();
+          await browser.close();
+          expect(userAgent).toContain('Firefox');
+        }
+      );
     });
 
     describe('Puppeteer.connect', function () {


### PR DESCRIPTION
Follow-up for PR #6895, which inappropriately enabled the test in all the cases. But similarly to the Chrome test above, it should only run for regular installs.