### PR TITLE
chore: enable firefox reconnection spec

### DIFF
--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -587,8 +587,7 @@ describe('Launcher specs', function () {
           await browserOne.close();
         }
       );
-      // @see https://github.com/puppeteer/puppeteer/issues/6527
-      itFailsFirefox('should be able to reconnect', async () => {
+      it('should be able to reconnect', async () => {
         const { puppeteer, server } = getTestState();
         const browserOne = await puppeteer.launch();
         const browserWSEndpoint = browserOne.wsEndpoint();


### PR DESCRIPTION
Fixed by https://bugzilla.mozilla.org/show_bug.cgi?id=1701168 in today's Firefox Nightly build. As such we can re-enable the test (was disabled via PR #7062).