### PR TITLE
Add drag-and-drop support.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2988,10 +2988,10 @@ Dispatches a `mousedown` event.
 
 #### mouse.drag(start, target)
 
-- `start` <[Object]>
+- `start` <[Object]> the position to start dragging from
   - `x` <[number]> x coordinate
   - `y` <[number]> y coordinate
-- `target` <[Object]>
+- `target` <[Object]> the position to drag to
   - `x` <[number]> x coordinate
   - `y` <[number]> y coordinate
 - returns: <[Promise<[DragData]>]>
@@ -4142,7 +4142,7 @@ This method creates and captures a drag event from the element.
 
 #### elementHandle.dragAndDrop(target[, options])
 
-- `target` <[Object]>
+- `target` <[ElementHandle]>
 - `options` <[Object]>
   - `delay` <[number]> how long to delay before dropping onto the target element
 - returns: <[Promise]>

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,6 +155,7 @@
   * [page.goto(url[, options])](#pagegotourl-options)
   * [page.hover(selector)](#pagehoverselector)
   * [page.isClosed()](#pageisclosed)
+  * [page.isDragInterceptionEnabled](#pageisdraginterceptionenabled)
   * [page.isJavaScriptEnabled()](#pageisjavascriptenabled)
   * [page.keyboard](#pagekeyboard)
   * [page.mainFrame()](#pagemainframe)
@@ -171,6 +172,7 @@
   * [page.setCookie(...cookies)](#pagesetcookiecookies)
   * [page.setDefaultNavigationTimeout(timeout)](#pagesetdefaultnavigationtimeouttimeout)
   * [page.setDefaultTimeout(timeout)](#pagesetdefaulttimeouttimeout)
+  * [page.setDragInterception(enabled)](#pagesetdraginterceptionenabled)
   * [page.setExtraHTTPHeaders(headers)](#pagesetextrahttpheadersheaders)
   * [page.setGeolocation(options)](#pagesetgeolocationoptions)
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
@@ -215,6 +217,10 @@
   * [mouse.click(x, y[, options])](#mouseclickx-y-options)
   * [mouse.down([options])](#mousedownoptions)
   * [mouse.drag(start, target)](#mousedragstart-target)
+  * [mouse.dragAndDrop(start, target[, options])](#mousedraganddropstart-target-options)
+  * [mouse.dragEnter(target, data)](#mousedragentertarget-data)
+  * [mouse.dragOver(target, data)](#mousedragovertarget-data)
+  * [mouse.drop(target, data)](#mousedroptarget-data)
   * [mouse.move(x, y[, options])](#mousemovex-y-options)
   * [mouse.up([options])](#mouseupoptions)
   * [mouse.wheel([options])](#mousewheeloptions)
@@ -295,9 +301,14 @@
   * [elementHandle.boundingBox()](#elementhandleboundingbox)
   * [elementHandle.boxModel()](#elementhandleboxmodel)
   * [elementHandle.click([options])](#elementhandleclickoptions)
+  * [elementHandle.clickablePoint()](#elementhandleclickablepoint)
   * [elementHandle.contentFrame()](#elementhandlecontentframe)
   * [elementHandle.dispose()](#elementhandledispose)
   * [elementHandle.drag(target)](#elementhandledragtarget)
+  * [elementHandle.dragAndDrop(target[, options])](#elementhandledraganddroptarget-options)
+  * [elementHandle.dragEnter([data])](#elementhandledragenterdata)
+  * [elementHandle.dragOver([data])](#elementhandledragoverdata)
+  * [elementHandle.drop([data])](#elementhandledropdata)
   * [elementHandle.evaluate(pageFunction[, ...args])](#elementhandleevaluatepagefunction-args)
   * [elementHandle.evaluateHandle(pageFunction[, ...args])](#elementhandleevaluatehandlepagefunction-args)
   * [elementHandle.executionContext()](#elementhandleexecutioncontext)
@@ -1921,6 +1932,12 @@ Shortcut for [page.mainFrame().hover(selector)](#framehoverselector).
 
 Indicates that the page has been closed.
 
+#### page.isDragInterceptionEnabled
+
+- returns: <[boolean]>
+
+Indicates that drag events are being intercepted.
+
 #### page.isJavaScriptEnabled()
 
 - returns: <[boolean]>
@@ -2184,6 +2201,13 @@ This setting will change the default maximum time for the following methods and 
 - [page.waitForXPath(xpath[, options])](#pagewaitforxpathxpath-options)
 
 > **NOTE** [`page.setDefaultNavigationTimeout`](#pagesetdefaultnavigationtimeouttimeout) takes priority over [`page.setDefaultTimeout`](#pagesetdefaulttimeouttimeout)
+
+#### page.setDragInterception(enabled)
+
+- `enabled` <[boolean]>
+- returns: <[Promise]>
+
+Enables the Input.drag methods. This provides the capability to cpature drag events emitted on the page, which can then be used to simulate drag-and-drop.
 
 #### page.setExtraHTTPHeaders(headers)
 
@@ -2973,6 +2997,50 @@ Dispatches a `mousedown` event.
 - returns: <[Promise<[DragData]>]>
 
 This method creates and captures a dragevent from a given point.
+
+#### mouse.dragAndDrop(start, target[, options])
+
+- `start` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- `target` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- `options` <[Object]>
+  - `delay` <[number]> how long to delay before dropping onto the target point
+- returns: <[Promise<[DragData]>]>
+
+This method drags from a given start point and drops onto a target point.
+
+#### mouse.dragEnter(target, data)
+
+- `target` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- `data` <[Object]>
+- returns: <[Promise]]>
+
+This method triggers a dragenter event from the target point.
+
+#### mouse.dragOver(target, data)
+
+- `target` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- `data` <[Object]>
+- returns: <[Promise]]>
+
+This method triggers a dragover event from the target point.
+
+#### mouse.drop(target, data)
+
+- `target` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- `data` <[Object]>
+- returns: <[Promise]]>
+
+This method triggers a drop event from the target point.
 
 #### mouse.move(x, y[, options])
 
@@ -4049,6 +4117,10 @@ This method returns boxes of the element, or `null` if the element is not visibl
 This method scrolls element into view if needed, and then uses [page.mouse](#pagemouse) to click in the center of the element.
 If the element is detached from DOM, the method throws an error.
 
+#### elementHandle.clickablePoint()
+
+- returns: <[Promise<[Point]>]> Resolves to the x, y point that describes the element's position.
+
 #### elementHandle.contentFrame()
 
 - returns: <[Promise]<?[Frame]>> Resolves to the content frame for element handles referencing iframe nodes, or null otherwise
@@ -4066,7 +4138,37 @@ The `elementHandle.dispose` method stops referencing the element handle.
   - `y` <[number]> y coordinate
 - returns: <[Promise<[DragData]>]>
 
-This method creates and captures a dragevent from the element.
+This method creates and captures a drag event from the element.
+
+#### elementHandle.dragAndDrop(target[, options])
+
+- `target` <[Object]>
+- `options` <[Object]>
+  - `delay` <[number]> how long to delay before dropping onto the target element
+- returns: <[Promise]>
+
+This method will drag a given element and drop it onto a target element.
+
+#### elementHandle.dragEnter([data])
+
+- `data` <[Object]> drag data created from `element.drag`
+- returns: <[Promise]>
+
+This method will trigger a dragenter event from the given element.
+
+#### elementHandle.dragOver([data])
+
+- `data` <[Object]> drag data created from `element.drag`
+- returns: <[Promise]>
+
+This method will trigger a dragover event from the given element.
+
+#### elementHandle.drop([data])
+
+- `data` <[Object]> drag data created from `element.drag`
+- returns: <[Promise]>
+
+This method will trigger a drop event from the given element.
 
 #### elementHandle.evaluate(pageFunction[, ...args])
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,6 +214,7 @@
 - [class: Mouse](#class-mouse)
   * [mouse.click(x, y[, options])](#mouseclickx-y-options)
   * [mouse.down([options])](#mousedownoptions)
+  * [mouse.drag(start, target)](#mousedragstart-target)
   * [mouse.move(x, y[, options])](#mousemovex-y-options)
   * [mouse.up([options])](#mouseupoptions)
   * [mouse.wheel([options])](#mousewheeloptions)
@@ -296,6 +297,7 @@
   * [elementHandle.click([options])](#elementhandleclickoptions)
   * [elementHandle.contentFrame()](#elementhandlecontentframe)
   * [elementHandle.dispose()](#elementhandledispose)
+  * [elementHandle.drag(target)](#elementhandledragtarget)
   * [elementHandle.evaluate(pageFunction[, ...args])](#elementhandleevaluatepagefunction-args)
   * [elementHandle.evaluateHandle(pageFunction[, ...args])](#elementhandleevaluatehandlepagefunction-args)
   * [elementHandle.executionContext()](#elementhandleexecutioncontext)
@@ -2960,6 +2962,18 @@ Shortcut for [`mouse.move`](#mousemovex-y-options), [`mouse.down`](#mousedownopt
 
 Dispatches a `mousedown` event.
 
+#### mouse.drag(start, target)
+
+- `start` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- `target` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- returns: <[Promise<[DragData]>]>
+
+This method creates and captures a dragevent from a given point.
+
 #### mouse.move(x, y[, options])
 
 - `x` <[number]>
@@ -4044,6 +4058,15 @@ If the element is detached from DOM, the method throws an error.
 - returns: <[Promise]> Promise which resolves when the element handle is successfully disposed.
 
 The `elementHandle.dispose` method stops referencing the element handle.
+
+#### elementHandle.drag(target)
+
+- `target` <[Object]>
+  - `x` <[number]> x coordinate
+  - `y` <[number]> y coordinate
+- returns: <[Promise<[DragData]>]>
+
+This method creates and captures a dragevent from the element.
 
 #### elementHandle.evaluate(pageFunction[, ...args])
 

--- a/src/common/Input.ts
+++ b/src/common/Input.ts
@@ -497,20 +497,13 @@ export class Mouse {
 
   /**
    * Dispatches a `drag` event.
-   * @param client - CDP session
    * @param source - starting point for drag
    * @param destination - point to drag to
    * ```
    */
-  async drag(client: CDPSession, source: Point, destination: Point): Promise<Protocol.Input.DragData> {
-    await client.send('Input.setInterceptDrags', { enabled: true });
+  async drag(source: Point, destination: Point): Promise<Protocol.Input.DragData> {
     const promise = new Promise<Protocol.Input.DragData>((resolve, reject) => {
-        client.once('Input.dragIntercepted', event => {
-          client.send('Input.setInterceptDrags', { enabled: false })
-            .then(() => client.detach())
-            .then(() => resolve(event.data))
-            .catch(error => reject(error));
-        });
+      this._client.once('Input.dragIntercepted', event => resolve(event.data));
     });
     await this.move(source.x, source.y);
     await this.down();

--- a/src/common/Input.ts
+++ b/src/common/Input.ts
@@ -502,13 +502,13 @@ export class Mouse {
    * @param destination - point to drag to
    * ```
    */
-  async drag(client: CDPSession, source: Point, destination: Point): Promise<Protocol.Input.DragInterceptedEvent> {
+  async drag(client: CDPSession, source: Point, destination: Point): Promise<Protocol.Input.DragData> {
     await client.send('Input.setInterceptDrags', { enabled: true });
-    const promise = new Promise<Protocol.Input.DragInterceptedEvent>((resolve, reject) => {
+    const promise = new Promise<Protocol.Input.DragData>((resolve, reject) => {
         client.once('Input.dragIntercepted', event => {
           client.send('Input.setInterceptDrags', { enabled: false })
             .then(() => client.detach())
-            .then(() => resolve(event))
+            .then(() => resolve(event.data))
             .catch(error => reject(error));
         });
     });
@@ -519,7 +519,7 @@ export class Mouse {
   }
 
   /**
-   * Perfoms a dragenter, dragover, and drop.
+   * Performs a dragenter, dragover, and drop in sequence.
    * @param destination - point to drop on
    * @param data - drag data containing items and operations mask
    * ```
@@ -528,6 +528,7 @@ export class Mouse {
         const args = {
             x: destination.x,
             y: destination.y,
+            modifiers: this._keyboard._modifiers,
             data
         }
         await this.move(destination.x, destination.y);

--- a/src/common/Input.ts
+++ b/src/common/Input.ts
@@ -18,7 +18,7 @@ import { assert } from './assert.js';
 import { CDPSession } from './Connection.js';
 import { keyDefinitions, KeyDefinition, KeyInput } from './USKeyboardLayout.js';
 import { Protocol } from 'devtools-protocol';
-import { ElementHandle, Point } from './JSHandle.js';
+import { Point } from './JSHandle.js';
 
 type KeyDescription = Required<
   Pick<KeyDefinition, 'keyCode' | 'key' | 'text' | 'code' | 'location'>
@@ -545,10 +545,7 @@ export class Mouse {
    * Defaults to 0.
    * ```
    */
-  async drop(
-    target: Point,
-    data: Protocol.Input.DragData
-  ): Promise<void> {
+  async drop(target: Point, data: Protocol.Input.DragData): Promise<void> {
     await this._client.send('Input.dispatchDragEvent', {
       type: 'drop',
       x: target.x,

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -502,10 +502,10 @@ export class ElementHandle<
    * This method creates and captures a drag event from the element.
    */
   async drag(destination:Point): Promise<Protocol.Input.DragData> {
+    assert(this._page.isDragInterceptionEnabled, 'Drag Interception is not enabled!');
     await this._scrollIntoViewIfNeeded();
     const source = await this._clickablePoint();
-    const client = await this._page.target().createCDPSession();
-    return await this._page.mouse.drag(client, source, destination);
+    return await this._page.mouse.drag(source, destination);
   }
 
   /**

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -32,6 +32,7 @@ import {
   UnwrapPromiseLike,
 } from './EvalTypes.js';
 import { isNode } from '../environment.js';
+import { Point } from './Input.js';
 /**
  * @public
  */
@@ -495,6 +496,25 @@ export class ElementHandle<
     await this._scrollIntoViewIfNeeded();
     const { x, y } = await this._clickablePoint();
     await this._page.mouse.click(x, y, options);
+  }
+
+  /**
+   * This method creates and captures a drag event from the element.
+   */
+  async drag(destination:Point): Promise<Protocol.Input.DragInterceptedEvent> {
+    await this._scrollIntoViewIfNeeded();
+    const source = await this._clickablePoint();
+    const client = await this._page.target().createCDPSession();
+    return await this._page.mouse.drag(client, source, destination);
+  }
+
+  /**
+   * This method triggers a dragenter, dragover, and drop on the element.
+   */
+  async drop(data:Protocol.Input.DragData = { items: [], dragOperationsMask: 1 }): Promise<void> {
+    await this._scrollIntoViewIfNeeded();
+    const destination = await this._clickablePoint();
+    await this._page.mouse.drop(destination, data);
   }
 
   /**

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -501,7 +501,7 @@ export class ElementHandle<
   /**
    * This method creates and captures a drag event from the element.
    */
-  async drag(destination:Point): Promise<Protocol.Input.DragInterceptedEvent> {
+  async drag(destination:Point): Promise<Protocol.Input.DragData> {
     await this._scrollIntoViewIfNeeded();
     const source = await this._clickablePoint();
     const client = await this._page.target().createCDPSession();

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -551,7 +551,6 @@ export class ElementHandle<
     options?: { delay: number }
   ): Promise<void> {
     await this._scrollIntoViewIfNeeded();
-    const destination = await this.clickablePoint();
     const startPoint = await this.clickablePoint();
     const targetPoint = await target.clickablePoint();
     await this._page.mouse.dragAndDrop(startPoint, targetPoint, options);

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -499,22 +499,50 @@ export class ElementHandle<
   }
 
   /**
-   * This method creates and captures a drag event from the element.
+   * This method creates and captures a dragevent from the element.
    */
-  async drag(destination:Point): Promise<Protocol.Input.DragData> {
-    assert(this._page.isDragInterceptionEnabled, 'Drag Interception is not enabled!');
+  async drag(target: Point): Promise<Protocol.Input.DragData> {
+    assert(
+      this._page.isDragInterceptionEnabled,
+      'Drag Interception is not enabled!'
+    );
     await this._scrollIntoViewIfNeeded();
-    const source = await this._clickablePoint();
-    return await this._page.mouse.drag(source, destination);
+    const start = await this._clickablePoint();
+    return await this._page.mouse.drag(start, target);
+  }
+
+  /**
+   * This method creates a `dragenter` event on the element.
+   */
+  async dragEnter(
+    data: Protocol.Input.DragData = { items: [], dragOperationsMask: 1 }
+  ): Promise<void> {
+    await this._scrollIntoViewIfNeeded();
+    const target = await this._clickablePoint();
+    await this._page.mouse.dragEnter(target, data);
+  }
+
+  /**
+   * This method creates a `dragover` event on the element.
+   */
+  async dragOver(
+    data: Protocol.Input.DragData = { items: [], dragOperationsMask: 1 }
+  ): Promise<void> {
+    await this._scrollIntoViewIfNeeded();
+    const target = await this._clickablePoint();
+    await this._page.mouse.dragOver(target, data);
   }
 
   /**
    * This method triggers a dragenter, dragover, and drop on the element.
    */
-  async drop(data:Protocol.Input.DragData = { items: [], dragOperationsMask: 1 }): Promise<void> {
+  async drop(
+    data: Protocol.Input.DragData = { items: [], dragOperationsMask: 1 },
+    options?: { delay: number }
+  ): Promise<void> {
     await this._scrollIntoViewIfNeeded();
     const destination = await this._clickablePoint();
-    await this._page.mouse.drop(destination, data);
+    await this._page.mouse.drop(destination, data, options);
   }
 
   /**

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -463,6 +463,7 @@ export class Page extends EventEmitter {
   private _fileChooserInterceptors = new Set<Function>();
 
   private _disconnectPromise?: Promise<Error>;
+  private _userDragInterceptionEnabled = false;
 
   /**
    * @internal
@@ -748,6 +749,10 @@ export class Page extends EventEmitter {
     return this._accessibility;
   }
 
+  get isDragInterceptionEnabled(): boolean {
+    return this._userDragInterceptionEnabled;
+  }
+
   /**
    * @returns An array of all frames attached to the page.
    */
@@ -797,6 +802,19 @@ export class Page extends EventEmitter {
    */
   async setRequestInterception(value: boolean): Promise<void> {
     return this._frameManager.networkManager().setRequestInterception(value);
+  }
+
+  /**
+   * @param enabled - Whether to enable drag interception.
+   *
+   * @remarks
+   * Activating drag interception enables the {@link Input.drag},
+   * methods  This provides the capability to capture drag events emitted
+   * on the page, which can then be used to simulate drag-and-drop behaviors.
+   */
+  async setDragInterception(enabled: boolean): Promise<void> {
+    this._userDragInterceptionEnabled = enabled;
+    return this._client.send('Input.setInterceptDrags', { enabled });
   }
 
   /**

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -810,7 +810,7 @@ export class Page extends EventEmitter {
    * @remarks
    * Activating drag interception enables the {@link Input.drag},
    * methods  This provides the capability to capture drag events emitted
-   * on the page, which can then be used to simulate drag-and-drop behaviors.
+   * on the page, which can then be used to simulate drag-and-drop.
    */
   async setDragInterception(enabled: boolean): Promise<void> {
     this._userDragInterceptionEnabled = enabled;

--- a/test/assets/input/drag-and-drop.html
+++ b/test/assets/input/drag-and-drop.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Drag-and-drop test</title>
+    <style>
+      #drop {
+        width: 5em;
+        height: 5em;
+        border: 1px solid black;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="drag" draggable="true">drag me</div>
+    <div id="drop"></div>
+    <script>
+      window.dropped = false;
+      var drag = document.getElementById('drag');
+      var drop = document.getElementById('drop');
+      drag.addEventListener('dragstart', function(e) {
+        e.dataTransfer.setData('id', e.target.id);
+      });
+      drop.addEventListener('dragover', function(e) {
+        e.preventDefault();
+      });
+      drop.addEventListener('drop', function(e) {
+        e.preventDefault();
+        var id = e.dataTransfer.getData('id');
+        var el = document.getElementById(id);
+        if (el) {
+          e.target.appendChild(el);
+          window.dropped = true;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/test/assets/input/drag-and-drop.html
+++ b/test/assets/input/drag-and-drop.html
@@ -14,14 +14,23 @@
     <div id="drag" draggable="true">drag me</div>
     <div id="drop"></div>
     <script>
-      window.dropped = false;
+      window.didDragStart = false;
+      window.didDragEnter = false;
+      window.didDragOver = false;
+      window.didDrop = false;
       var drag = document.getElementById('drag');
       var drop = document.getElementById('drop');
       drag.addEventListener('dragstart', function(e) {
         e.dataTransfer.setData('id', e.target.id);
+        window.didDragStart = true;
+      });
+      drop.addEventListener('dragenter', function(e) {
+        e.preventDefault();
+        window.didDragEnter = true;
       });
       drop.addEventListener('dragover', function(e) {
         e.preventDefault();
+        window.didDragOver = true;
       });
       drop.addEventListener('drop', function(e) {
         e.preventDefault();
@@ -29,7 +38,7 @@
         var el = document.getElementById(id);
         if (el) {
           e.target.appendChild(el);
-          window.dropped = true;
+          window.didDrop = true;
         }
       });
     </script>

--- a/test/drag-and-drop.spec.ts
+++ b/test/drag-and-drop.spec.ts
@@ -99,10 +99,7 @@ describe('Input.drag', function () {
     await page.setDragInterception(true);
     const draggable = await page.$('#drag');
     const dropzone = await page.$('#drop');
-    const data = await draggable.drag({ x: 1, y: 1 });
-    await dropzone.dragEnter(data);
-    await dropzone.dragOver(data);
-    await dropzone.drop(data);
+    await draggable.dragAndDrop(dropzone);
 
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);

--- a/test/drag-and-drop.spec.ts
+++ b/test/drag-and-drop.spec.ts
@@ -19,13 +19,13 @@ import {
   getTestState,
   setupTestPageAndContextHooks,
   setupTestBrowserHooks,
-  itChromeOnly,
+  describeChromeOnly,
 } from './mocha-utils'; // eslint-disable-line import/extensions
 
-describe('Input.drag', function () {
+describeChromeOnly('Input.drag', function () {
   setupTestBrowserHooks();
   setupTestPageAndContextHooks();
-  itChromeOnly('should throw an exception if not enabled before usage', async () => {
+  it('should throw an exception if not enabled before usage', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -37,7 +37,7 @@ describe('Input.drag', function () {
       expect(error.message).toContain('Drag Interception is not enabled!');
     }
   });
-  itChromeOnly('should emit a dragIntercepted event when dragged', async () => {
+  it('should emit a dragIntercepted event when dragged', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -48,7 +48,7 @@ describe('Input.drag', function () {
     expect(data.items.length).toBe(1);
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
   });
-  itChromeOnly('should emit a dragEnter', async () => {
+  it('should emit a dragEnter', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -61,7 +61,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
   });
-  itChromeOnly('should emit a dragOver event', async () => {
+  it('should emit a dragOver event', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -76,7 +76,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
   });
-  itChromeOnly('can be dropped', async () => {
+  it('can be dropped', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -93,7 +93,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDrop)).toBe(true);
   });
-  itChromeOnly('can be dragged and dropped with a single function', async () => {
+  it('can be dragged and dropped with a single function', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -107,7 +107,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDrop)).toBe(true);
   });
-  itChromeOnly('can be disabled', async () => {
+  it('can be disabled', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');

--- a/test/drag-and-drop.spec.ts
+++ b/test/drag-and-drop.spec.ts
@@ -19,12 +19,13 @@ import {
   getTestState,
   setupTestPageAndContextHooks,
   setupTestBrowserHooks,
+  itChromeOnly,
 } from './mocha-utils'; // eslint-disable-line import/extensions
 
 describe('Input.drag', function () {
   setupTestBrowserHooks();
   setupTestPageAndContextHooks();
-  it('should throw an exception if not enabled before usage', async () => {
+  itChromeOnly('should throw an exception if not enabled before usage', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -36,7 +37,7 @@ describe('Input.drag', function () {
       expect(error.message).toContain('Drag Interception is not enabled!');
     }
   });
-  it('should emit a dragIntercepted event when dragged', async () => {
+  itChromeOnly('should emit a dragIntercepted event when dragged', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -47,7 +48,7 @@ describe('Input.drag', function () {
     expect(data.items.length).toBe(1);
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
   });
-  it('should emit a dragEnter', async () => {
+  itChromeOnly('should emit a dragEnter', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -60,7 +61,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
   });
-  it('should emit a dragOver event', async () => {
+  itChromeOnly('should emit a dragOver event', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -75,7 +76,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
   });
-  it('can be dropped', async () => {
+  itChromeOnly('can be dropped', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -92,7 +93,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDrop)).toBe(true);
   });
-  it('can be dragged and dropped with a single function', async () => {
+  itChromeOnly('can be dragged and dropped with a single function', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -106,7 +107,7 @@ describe('Input.drag', function () {
     expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
     expect(await page.evaluate(() => globalThis.didDrop)).toBe(true);
   });
-  it('can be disabled', async () => {
+  itChromeOnly('can be disabled', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');

--- a/test/drag-and-drop.spec.ts
+++ b/test/drag-and-drop.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+import {
+  getTestState,
+  setupTestPageAndContextHooks,
+  setupTestBrowserHooks,
+  itFailsFirefox,
+} from './mocha-utils'; // eslint-disable-line import/extensions
+import utils from './utils.js';
+
+describe('Input.drag', function () {
+  setupTestBrowserHooks();
+  setupTestPageAndContextHooks();
+  it('should emit a dragIntercepted event when dragged', async () => {
+    const { page, server } = getTestState();
+
+    await page.goto(server.PREFIX + '/input/drag-and-drop.html');
+    const draggable = await page.$('#drag');
+    const event = await draggable.drag({ x: 1, y: 1 });
+    expect(event.data.items.length).toBe(1);
+  });
+  it('can be dropped', async () => {
+    const { page, server } = getTestState();
+
+    await page.goto(server.PREFIX + '/input/drag-and-drop.html');
+    const draggable = await page.$('#drag');
+    const dropzone = await page.$('#drop');
+    const { data } = await draggable.drag({ x: 1, y: 1 });
+    await dropzone.drop(data);
+    expect(await page.evaluate(() => globalThis.dropped)).toBe(true);
+  });
+});

--- a/test/drag-and-drop.spec.ts
+++ b/test/drag-and-drop.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2021 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ describe('Input.drag', function () {
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
     const draggable = await page.$('#drag');
-    const event = await draggable.drag({ x: 1, y: 1 });
-    expect(event.data.items.length).toBe(1);
+    const data = await draggable.drag({ x: 1, y: 1 });
+    expect(data.items.length).toBe(1);
+    expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
   });
   it('can be dropped', async () => {
     const { page, server } = getTestState();
@@ -40,8 +41,11 @@ describe('Input.drag', function () {
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
     const draggable = await page.$('#drag');
     const dropzone = await page.$('#drop');
-    const { data } = await draggable.drag({ x: 1, y: 1 });
+    const data = await draggable.drag({ x: 1, y: 1 });
     await dropzone.drop(data);
-    expect(await page.evaluate(() => globalThis.dropped)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDrop)).toBe(true);
   });
 });

--- a/test/drag-and-drop.spec.ts
+++ b/test/drag-and-drop.spec.ts
@@ -19,14 +19,12 @@ import {
   getTestState,
   setupTestPageAndContextHooks,
   setupTestBrowserHooks,
-  itFailsFirefox,
 } from './mocha-utils'; // eslint-disable-line import/extensions
-import utils from './utils.js';
 
 describe('Input.drag', function () {
   setupTestBrowserHooks();
   setupTestPageAndContextHooks();
-  it('should throw exception if not enabled before using', async() => {
+  it('should throw an exception if not enabled before usage', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/drag-and-drop.html');
@@ -34,7 +32,7 @@ describe('Input.drag', function () {
 
     try {
       await draggable.drag({ x: 1, y: 1 });
-    } catch(error) {
+    } catch (error) {
       expect(error.message).toContain('Drag Interception is not enabled!');
     }
   });
@@ -49,6 +47,34 @@ describe('Input.drag', function () {
     expect(data.items.length).toBe(1);
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
   });
+  it('should emit a dragEnter', async () => {
+    const { page, server } = getTestState();
+
+    await page.goto(server.PREFIX + '/input/drag-and-drop.html');
+    await page.setDragInterception(true);
+    const draggable = await page.$('#drag');
+    const data = await draggable.drag({ x: 1, y: 1 });
+    const dropzone = await page.$('#drop');
+    await dropzone.dragEnter(data);
+
+    expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
+  });
+  it('should emit a dragOver event', async () => {
+    const { page, server } = getTestState();
+
+    await page.goto(server.PREFIX + '/input/drag-and-drop.html');
+    await page.setDragInterception(true);
+    const draggable = await page.$('#drag');
+    const data = await draggable.drag({ x: 1, y: 1 });
+    const dropzone = await page.$('#drop');
+    await dropzone.dragEnter(data);
+    await dropzone.dragOver(data);
+
+    expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
+  });
   it('can be dropped', async () => {
     const { page, server } = getTestState();
 
@@ -57,6 +83,25 @@ describe('Input.drag', function () {
     const draggable = await page.$('#drag');
     const dropzone = await page.$('#drop');
     const data = await draggable.drag({ x: 1, y: 1 });
+    await dropzone.dragEnter(data);
+    await dropzone.dragOver(data);
+    await dropzone.drop(data);
+
+    expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragEnter)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDragOver)).toBe(true);
+    expect(await page.evaluate(() => globalThis.didDrop)).toBe(true);
+  });
+  it('can be dragged and dropped with a single function', async () => {
+    const { page, server } = getTestState();
+
+    await page.goto(server.PREFIX + '/input/drag-and-drop.html');
+    await page.setDragInterception(true);
+    const draggable = await page.$('#drag');
+    const dropzone = await page.$('#drop');
+    const data = await draggable.drag({ x: 1, y: 1 });
+    await dropzone.dragEnter(data);
+    await dropzone.dragOver(data);
     await dropzone.drop(data);
 
     expect(await page.evaluate(() => globalThis.didDragStart)).toBe(true);
@@ -75,7 +120,7 @@ describe('Input.drag', function () {
 
     try {
       await draggable.drag({ x: 1, y: 1 });
-    } catch(error) {
+    } catch (error) {
       expect(error.message).toContain('Drag Interception is not enabled!');
     }
   });

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -395,7 +395,7 @@ function compareDocumentations(actual, expected) {
       [
         'Method ElementHandle.dragAndDrop() target',
         {
-          actualName: 'Object',
+          actualName: 'ElementHandle',
           expectedName: 'ElementHandle<Element>',
         },
       ],

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -386,6 +386,13 @@ function compareDocumentations(actual, expected) {
         },
       ],
       [
+        'Method ElementHandle.drag() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
         'Method Keyboard.down() key',
         {
           actualName: 'string',
@@ -411,6 +418,20 @@ function compareDocumentations(actual, expected) {
         {
           actualName: 'Object',
           expectedName: 'MouseOptions',
+        },
+      ],
+      [
+        'Method Mouse.drag() start',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.drag() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
         },
       ],
       [

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -393,6 +393,34 @@ function compareDocumentations(actual, expected) {
         },
       ],
       [
+        'Method ElementHandle.dragAndDrop() target',
+        {
+          actualName: 'Object',
+          expectedName: 'ElementHandle<Element>',
+        },
+      ],
+      [
+        'Method ElementHandle.dragEnter() data',
+        {
+          actualName: 'Object',
+          expectedName: 'DragData',
+        },
+      ],
+      [
+        'Method ElementHandle.dragOver() data',
+        {
+          actualName: 'Object',
+          expectedName: 'DragData',
+        },
+      ],
+      [
+        'Method ElementHandle.drop() data',
+        {
+          actualName: 'Object',
+          expectedName: 'DragData',
+        },
+      ],
+      [
         'Method Keyboard.down() key',
         {
           actualName: 'string',
@@ -432,6 +460,69 @@ function compareDocumentations(actual, expected) {
         {
           actualName: 'Object',
           expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.dragAndDrop() start',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.dragAndDrop() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.dragAndDrop() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.dragEnter() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.dragEnter() data',
+        {
+          actualName: 'Object',
+          expectedName: 'DragData',
+        },
+      ],
+      [
+        'Method Mouse.dragOver() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.dragOver() data',
+        {
+          actualName: 'Object',
+          expectedName: 'DragData',
+        },
+      ],
+      [
+        'Method Mouse.drop() target',
+        {
+          actualName: 'Object',
+          expectedName: 'Point',
+        },
+      ],
+      [
+        'Method Mouse.drop() data',
+        {
+          actualName: 'Object',
+          expectedName: 'DragData',
         },
       ],
       [


### PR DESCRIPTION
This PR adds drag-and-drop support, leveraging new additions to the CDP Input domain (Input.setInterceptDrags, Input.dispatchDragEvent, and Input.dragIntercepted).                                            

Fixes #1376