### PR TITLE
feat(requestinterception): don't disable cache by default

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2219,7 +2219,7 @@ await page.setGeolocation({ latitude: 59.95, longitude: 30.31667 });
 #### page.setRequestInterception(value[, cacheSafe])
 
 - `value` <[boolean]> Whether to enable request interception.
-- `cacheSafe` <[boolean]> Whether to trust browser caching. If set to false, enabling request interception disables page caching. Defaults to false.
+- `cacheSafe` <[boolean]> Whether to trust browser caching. If set to false, enabling request interception disables page caching. Defaults to true.
 - returns: <[Promise]>
 
 Activating request interception enables `request.abort`, `request.continue` and

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -114,7 +114,7 @@ export class NetworkManager extends EventEmitter {
   _credentials?: Credentials = null;
   _attemptedAuthentications = new Set<string>();
   _userRequestInterceptionEnabled = false;
-  _userRequestInterceptionCacheSafe = false;
+  _userRequestInterceptionCacheSafe = true;
   _protocolRequestInterceptionEnabled = false;
   _userCacheDisabled = false;
   _emulatedNetworkConditions: InternalNetworkConditions = {
@@ -230,7 +230,7 @@ export class NetworkManager extends EventEmitter {
 
   async setRequestInterception(
     value: boolean,
-    cacheSafe = false
+    cacheSafe = true
   ): Promise<void> {
     this._userRequestInterceptionEnabled = value;
     this._userRequestInterceptionCacheSafe = cacheSafe;

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -767,7 +767,7 @@ export class Page extends EventEmitter {
   /**
    * @param value - Whether to enable request interception.
    * @param cacheSafe - Whether to trust browser caching. If set to false,
-   * enabling request interception disables page caching. Defaults to false.
+   * enabling request interception disables page caching. Defaults to true.
    *
    * @remarks
    * Activating request interception enables {@link HTTPRequest.abort},
@@ -799,7 +799,7 @@ export class Page extends EventEmitter {
    */
   async setRequestInterception(
     value: boolean,
-    cacheSafe = false
+    cacheSafe = true
   ): Promise<void> {
     return this._frameManager
       .networkManager()


### PR DESCRIPTION
Reverts #1154 @aslushnikov disabling the cache by default.

People don't expect this behavior, see tickets like: #2905, #3403. #4055, #4620, #5176, #6915, ...

There were two reasons for this change:
- Some sites did not fire the `load` event with caching enabled.
    - analysed in #7038 @starrify 
    - fixed in #7060
- We cannot intercept requests that are answered from the cache.
    - Most people are willing to accept cached resources not being intercepted.

This flag has been introduced in #6996.