### PR TITLE
feat(requestinterception): remove cacheSafe flag

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -174,7 +174,7 @@
   * [page.setGeolocation(options)](#pagesetgeolocationoptions)
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
   * [page.setOfflineMode(enabled)](#pagesetofflinemodeenabled)
-  * [page.setRequestInterception(value[, cacheSafe])](#pagesetrequestinterceptionvalue-cachesafe)
+  * [page.setRequestInterception(value)](#pagesetrequestinterceptionvalue)
   * [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
   * [page.setViewport(viewport)](#pagesetviewportviewport)
   * [page.tap(selector)](#pagetapselector)
@@ -2218,10 +2218,9 @@ await page.setGeolocation({ latitude: 59.95, longitude: 30.31667 });
 - `enabled` <[boolean]> When `true`, enables offline mode for the page.
 - returns: <[Promise]>
 
-#### page.setRequestInterception(value[, cacheSafe])
+#### page.setRequestInterception(value)
 
 - `value` <[boolean]> Whether to enable request interception.
-- `cacheSafe` <[boolean]> Whether to trust browser caching. If set to false, enabling request interception disables page caching. Defaults to false.
 - returns: <[Promise]>
 
 Activating request interception enables `request.abort`, `request.continue` and

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -114,7 +114,6 @@ export class NetworkManager extends EventEmitter {
   _credentials?: Credentials = null;
   _attemptedAuthentications = new Set<string>();
   _userRequestInterceptionEnabled = false;
-  _userRequestInterceptionCacheSafe = false;
   _protocolRequestInterceptionEnabled = false;
   _userCacheDisabled = false;
   _emulatedNetworkConditions: InternalNetworkConditions = {
@@ -228,12 +227,8 @@ export class NetworkManager extends EventEmitter {
     await this._updateProtocolCacheDisabled();
   }
 
-  async setRequestInterception(
-    value: boolean,
-    cacheSafe = false
-  ): Promise<void> {
+  async setRequestInterception(value: boolean): Promise<void> {
     this._userRequestInterceptionEnabled = value;
-    this._userRequestInterceptionCacheSafe = cacheSafe;
     await this._updateProtocolRequestInterception();
   }
 
@@ -258,11 +253,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   _cacheDisabled(): boolean {
-    return (
-      this._userCacheDisabled ||
-      (this._userRequestInterceptionEnabled &&
-        !this._userRequestInterceptionCacheSafe)
-    );
+    return this._userCacheDisabled;
   }
 
   async _updateProtocolCacheDisabled(): Promise<void> {

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -766,8 +766,6 @@ export class Page extends EventEmitter {
 
   /**
    * @param value - Whether to enable request interception.
-   * @param cacheSafe - Whether to trust browser caching. If set to false,
-   * enabling request interception disables page caching. Defaults to false.
    *
    * @remarks
    * Activating request interception enables {@link HTTPRequest.abort},
@@ -797,13 +795,8 @@ export class Page extends EventEmitter {
    * })();
    * ```
    */
-  async setRequestInterception(
-    value: boolean,
-    cacheSafe = false
-  ): Promise<void> {
-    return this._frameManager
-      .networkManager()
-      .setRequestInterception(value, cacheSafe);
+  async setRequestInterception(value: boolean): Promise<void> {
+    return this._frameManager.networkManager().setRequestInterception(value);
   }
 
   /**

--- a/test/requestinterception.spec.ts
+++ b/test/requestinterception.spec.ts
@@ -495,13 +495,14 @@ describe('request interception', function () {
       expect(urls.has('one-style.html')).toBe(true);
       expect(urls.has('one-style.css')).toBe(true);
     });
-    it('should not cache if not cache-safe', async () => {
+    it('should not cache if cache disabled', async () => {
       const { page, server } = getTestState();
 
       // Load and re-load to make sure it's cached.
       await page.goto(server.PREFIX + '/cached/one-style.html');
 
-      await page.setRequestInterception(true, false);
+      await page.setRequestInterception(true);
+      await page.setCacheEnabled(false);
       page.on('request', (request) => request.continue());
 
       const cached = [];
@@ -510,13 +511,14 @@ describe('request interception', function () {
       await page.reload();
       expect(cached.length).toBe(0);
     });
-    it('should cache if cache-safe', async () => {
+    it('should cache if cache enabled', async () => {
       const { page, server } = getTestState();
 
       // Load and re-load to make sure it's cached.
       await page.goto(server.PREFIX + '/cached/one-style.html');
 
-      await page.setRequestInterception(true, true);
+      await page.setRequestInterception(true);
+      await page.setCacheEnabled(true);
       page.on('request', (request) => request.continue());
 
       const cached = [];
@@ -525,10 +527,11 @@ describe('request interception', function () {
       await page.reload();
       expect(cached.length).toBe(1);
     });
-    it('should load fonts if cache-safe', async () => {
+    it('should load fonts if cache enabled', async () => {
       const { page, server } = getTestState();
 
-      await page.setRequestInterception(true, true);
+      await page.setRequestInterception(true);
+      await page.setCacheEnabled(true);
       page.on('request', (request) => request.continue());
 
       await page.goto(server.PREFIX + '/cached/one-style-font.html');


### PR DESCRIPTION
Reverts #6996 

#1154 @aslushnikov disabled the cache by default.

There were two reasons for this change:
- Some sites did not fire the `load` event with caching enabled.
    - analysed in #7038 @starrify 
    - fixed in #7060
- We cannot intercept requests that are answered from the cache.
    - Use `setCacheDisabled` instead.