### PR TITLE
docs: add lowercasing of HTTP headers to documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2189,6 +2189,8 @@ This setting will change the default maximum time for the following methods and 
 
 The extra HTTP headers will be sent with every request the page initiates.
 
+> **NOTE** All headers are lowercased, since HTTP headers are case insensitive.
+
 > **NOTE** page.setExtraHTTPHeaders does not guarantee the order of headers in the outgoing requests.
 
 #### page.setGeolocation(options)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2189,7 +2189,7 @@ This setting will change the default maximum time for the following methods and 
 
 The extra HTTP headers will be sent with every request the page initiates.
 
-> **NOTE** All headers are lowercased, since HTTP headers are case insensitive.
+> **NOTE** All HTTP header names are lowercased. (HTTP headers are case-insensitive, so this shouldn’t impact your server code.)
 
 > **NOTE** page.setExtraHTTPHeaders does not guarantee the order of headers in the outgoing requests.
 


### PR DESCRIPTION
I was adding extra HTTP headers that were case-sensitive and my
server wasn't seeing the corresponding headers. Turns out that
Puppeteer lowercases the headers, which was not written in the
documentation.