### PR TITLE
chore: set `module` to `esnext` in `tsconfig.json`

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "checkJs": true,
     "target": "ES2019",
     "moduleResolution": "node",
-    "module": "ES2015",
     "declaration": true,
     "declarationMap": true,
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,15 @@
 /**
- * This configuration only exists for the API Extractor tool. See the details in
- * CONTRIBUTING.md that describes our TypeScript setup.
-*/
+ * This configuration only exists for the API Extractor tool and for VSCode to use. It is NOT the tsconfig used for compilation.
+ * For CJS builds, `tsconfig.cjs.json` is used, and for ESM, it's `tsconfig.esm.json`.
+ * See the details in CONTRIBUTING.md that describes our TypeScript setup.
+ */
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    // This module setting is just for VSCode so it doesn't error when we use
+    // dynamic imports.
+    "module": "esnext"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
The main `tsconfig.json` file is only used for API Extractor, and by
VSCode to provide type information. It is _not_ used to compile
Puppeteer for shipping. Therefore we can specify `module: "esnext"` in
here so that VSCode knows we can use all the latest and greatest
module features (primarily, dynamic imports). In `tsconfig.cjs.json`
and `tsconfig.esm.json` we set the `module` setting for CJS/ESM
respectively.