### PR TITLE
Npm: Update ws to a non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rimraf": "3.0.2",
     "tar-fs": "2.0.0",
     "unbzip2-stream": "1.3.3",
-    "ws": "7.4.5"
+    "ws": "7.4.6"
   },
   "devDependencies": {
     "@commitlint/cli": "11.0.0",


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-6fc8-4gx4-v693.