### PR TITLE
fix: remove redundant await while fetching target

### DIFF
--- a/src/common/Browser.ts
+++ b/src/common/Browser.ts
@@ -433,7 +433,7 @@ export class Browser extends EventEmitter {
       url: 'about:blank',
       browserContextId: contextId || undefined,
     });
-    const target = await this._targets.get(targetId);
+    const target = this._targets.get(targetId);
     assert(
       await target._initializedPromise,
       'Failed to create target for page'


### PR DESCRIPTION
Removed the redundant await from the block while fetching the target.
Since the value of map is of instance `Target` which itself is not an
async resource.
