### PR TITLE
Useragentdata support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2349,15 +2349,15 @@ const puppeteer = require('puppeteer');
 - `userAgent` <[string]> Specific user agent to use in this page
 - `userAgentMetadata` <[Object]> Optional user agent data to use in this page. Any
   values not provided will use the client's default.
-  - `brands` <...[Object]>
-    - `brand` <[string|> Browser or client brand name.
-    - `version` <[string|> Browser or client major version.
-  - `fullVersion` <[string|> Browser or client full version.
-  - `platform` <[string|> Operating system name.
-  - `platformVersion` <[string|> Operating system version.
-  - `architecture` <[string|> CPU architecture.
-  - `model` <[string|> Device model.
-  - `mobile` <[boolean|> Indicate if this is a mobile device.
+  - `brands` <[Array]<[Object]>> Optional brand information
+    - `brand` <[string]> Browser or client brand name.
+    - `version` <[string]> Browser or client major version.
+  - `fullVersion` <[string]> Optional browser or client full version.
+  - `platform` <[string]> Operating system name.
+  - `platformVersion` <[string]> Operating system version.
+  - `architecture` <[string]> CPU architecture.
+  - `model` <[string]> Device model.
+  - `mobile` <[boolean]> Indicate if this is a mobile device.
 - returns: <[Promise]> Promise which resolves when the user agent is set.
 
 #### page.setViewport(viewport)

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,7 +180,7 @@
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
   * [page.setOfflineMode(enabled)](#pagesetofflinemodeenabled)
   * [page.setRequestInterception(value)](#pagesetrequestinterceptionvalue)
-  * [page.setUserAgent(userAgent[, userAgentData])](#pagesetuseragentuseragent-useragentdata)
+  * [page.setUserAgent(userAgent[, userAgentMetadata])](#pagesetuseragentuseragent-useragentmetadata)
   * [page.setViewport(viewport)](#pagesetviewportviewport)
   * [page.tap(selector)](#pagetapselector)
   * [page.target()](#pagetarget)
@@ -2344,10 +2344,10 @@ const puppeteer = require('puppeteer');
 })();
 ```
 
-#### page.setUserAgent(userAgent[, userAgentData])
+#### page.setUserAgent(userAgent[, userAgentMetadata])
 
 - `userAgent` <[string]> Specific user agent to use in this page
-- `userAgentData` <[Object]> Optional user agent data to use in this page. Any
+- `userAgentMetadata` <[Object]> Optional user agent data to use in this page. Any
   values not provided will use the client's default.
   - `brands` <...[Object]>
     - `brand` <[string|> Browser or client brand name.

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,7 +180,7 @@
   * [page.setJavaScriptEnabled(enabled)](#pagesetjavascriptenabledenabled)
   * [page.setOfflineMode(enabled)](#pagesetofflinemodeenabled)
   * [page.setRequestInterception(value)](#pagesetrequestinterceptionvalue)
-  * [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
+  * [page.setUserAgent(userAgent[, userAgentData])](#pagesetuseragentuseragent-useragentdata)
   * [page.setViewport(viewport)](#pagesetviewportviewport)
   * [page.tap(selector)](#pagetapselector)
   * [page.target()](#pagetarget)
@@ -942,7 +942,7 @@ the method will return an array with all the targets in all browser contexts.
 
 - returns: <[Promise]<[string]>> Promise which resolves to the browser's original user agent.
 
-> **NOTE** Pages can override browser user agent with [page.setUserAgent](#pagesetuseragentuseragent)
+> **NOTE** Pages can override browser user agent with [page.setUserAgent](#pagesetuseragentuseragent-useragentdata)
 
 #### browser.version()
 
@@ -1558,7 +1558,7 @@ const puppeteer = require('puppeteer');
 
 Emulates given device metrics and user agent. This method is a shortcut for calling two methods:
 
-- [page.setUserAgent(userAgent)](#pagesetuseragentuseragent)
+- [page.setUserAgent(userAgent)](#pagesetuseragentuseragent-useragentdata)
 - [page.setViewport(viewport)](#pagesetviewportviewport)
 
 To aid emulation, Puppeteer provides a list of device descriptors that can be obtained via the [`puppeteer.devices`](#puppeteerdevices).
@@ -2344,9 +2344,20 @@ const puppeteer = require('puppeteer');
 })();
 ```
 
-#### page.setUserAgent(userAgent)
+#### page.setUserAgent(userAgent[, userAgentData])
 
 - `userAgent` <[string]> Specific user agent to use in this page
+- `userAgentData` <[Object]> Optional user agent data to use in this page. Any
+  values not provided will use the client's default.
+  - `brands` <...[Object]>
+    - `brand` <[string|> Browser or client brand name.
+    - `version` <[string|> Browser or client major version.
+  - `fullVersion` <[string|> Browser or client full version.
+  - `platform` <[string|> Operating system name.
+  - `platformVersion` <[string|> Operating system version.
+  - `architecture` <[string|> CPU architecture.
+  - `model` <[string|> Device model.
+  - `mobile` <[boolean|> Indicate if this is a mobile device.
 - returns: <[Promise]> Promise which resolves when the user agent is set.
 
 #### page.setViewport(viewport)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2360,6 +2360,23 @@ const puppeteer = require('puppeteer');
   - `mobile` <[boolean]> Indicate if this is a mobile device.
 - returns: <[Promise]> Promise which resolves when the user agent is set.
 
+> **NOTE** support for `userAgentMetadata` is experimental in the DevTools
+> protocol and more properties will be added.
+
+Providing the optional `userAgentMetadata` header will update the related
+entries in `navigator.userAgentData` and associated `Sec-CH-UA`* headers.
+
+```js
+const page = await browser.newPage();
+await page.setUserAgent('MyBrowser', {
+  architecture: 'My1',
+  mobile: false,
+  model: 'Mybook',
+  platform: 'MyOS',
+  platformVersion: '3.1',
+});
+```
+
 #### page.setViewport(viewport)
 
 - `viewport` <[Object]>

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -47,7 +47,6 @@ export interface NetworkConditions {
 export interface InternalNetworkConditions extends NetworkConditions {
   offline: boolean;
 }
-
 /**
  * We use symbols to prevent any external parties listening to these events.
  * They are internal to Puppeteer.
@@ -218,8 +217,17 @@ export class NetworkManager extends EventEmitter {
     });
   }
 
-  async setUserAgent(userAgent: string): Promise<void> {
-    await this._client.send('Network.setUserAgentOverride', { userAgent });
+  async setUserAgent(
+    userAgent: string,
+    userAgentData?: Protocol.Emulation.UserAgentMetadata
+  ): Promise<void> {
+    const params = { userAgent: userAgent };
+
+    if (userAgentData !== undefined) {
+      params['userAgentData'] = userAgentData;
+    }
+
+    await this._client.send('Network.setUserAgentOverride', params);
   }
 
   async setCacheEnabled(enabled: boolean): Promise<void> {

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -47,6 +47,7 @@ export interface NetworkConditions {
 export interface InternalNetworkConditions extends NetworkConditions {
   offline: boolean;
 }
+
 /**
  * We use symbols to prevent any external parties listening to these events.
  * They are internal to Puppeteer.
@@ -221,13 +222,10 @@ export class NetworkManager extends EventEmitter {
     userAgent: string,
     userAgentMetadata?: Protocol.Emulation.UserAgentMetadata
   ): Promise<void> {
-    const params = { userAgent: userAgent };
-
-    if (userAgentMetadata !== undefined) {
-      params['userAgentMetadata'] = userAgentMetadata;
-    }
-
-    await this._client.send('Network.setUserAgentOverride', params);
+    await this._client.send('Network.setUserAgentOverride', {
+      userAgent: userAgent,
+      userAgentMetadata: userAgentMetadata,
+    });
   }
 
   async setCacheEnabled(enabled: boolean): Promise<void> {

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -219,12 +219,12 @@ export class NetworkManager extends EventEmitter {
 
   async setUserAgent(
     userAgent: string,
-    userAgentData?: Protocol.Emulation.UserAgentMetadata
+    userAgentMetadata?: Protocol.Emulation.UserAgentMetadata
   ): Promise<void> {
     const params = { userAgent: userAgent };
 
-    if (userAgentData !== undefined) {
-      params['userAgentData'] = userAgentData;
+    if (userAgentMetadata !== undefined) {
+      params['userAgentMetadata'] = userAgentMetadata;
     }
 
     await this._client.send('Network.setUserAgentOverride', params);

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1362,10 +1362,17 @@ export class Page extends EventEmitter {
 
   /**
    * @param userAgent - Specific user agent to use in this page
+   * @param userAgentData - Specific user agent client hint data to use in this
+   * page
    * @returns Promise which resolves when the user agent is set.
    */
-  async setUserAgent(userAgent: string): Promise<void> {
-    return this._frameManager.networkManager().setUserAgent(userAgent);
+  async setUserAgent(
+    userAgent: string,
+    userAgentData?: Protocol.Emulation.UserAgentMetadata
+  ): Promise<void> {
+    return this._frameManager
+      .networkManager()
+      .setUserAgent(userAgent, userAgentData);
   }
 
   /**

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -1368,11 +1368,11 @@ export class Page extends EventEmitter {
    */
   async setUserAgent(
     userAgent: string,
-    userAgentData?: Protocol.Emulation.UserAgentMetadata
+    userAgentMetadata?: Protocol.Emulation.UserAgentMetadata
   ): Promise<void> {
     return this._frameManager
       .networkManager()
-      .setUserAgent(userAgent, userAgentData);
+      .setUserAgent(userAgent, userAgentMetadata);
   }
 
   /**

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -998,6 +998,37 @@ describe('Page', function () {
         'iPhone'
       );
     });
+    it('should work with additional userAgentMetdata', async () => {
+      const { page, server } = getTestState();
+
+
+      await page.setUserAgent('MockBrowser', {
+        architecture: 'Mock1',
+        mobile: false,
+        model: 'Mockbook',
+        platform: 'MockOS',
+        platformVersion: '3.1',
+      });
+      const [request] = await Promise.all([
+        server.waitForRequest('/empty.html'),
+        page.goto(server.EMPTY_PAGE),
+      ]);
+      const uaData = await page.evaluate(() =>
+        // @ts-ignore: userAgentData not yet in TypeScript DOM API
+        navigator.userAgentData.getHighEntropyValues([
+          'architecture',
+          'model',
+          'platform',
+          'platformVersion',
+        ])
+      );
+      expect(uaData['architecture']).toBe('Mock1');
+      expect(uaData.mobile).toBeFalsy();
+      expect(uaData['model']).toBe('Mockbook');
+      expect(uaData['platform']).toBe('MockOS');
+      expect(uaData['platformVersion']).toBe('3.1');
+      expect(request.headers['user-agent']).toBe('MockBrowser');
+    });
   });
 
   describe('Page.setContent', function () {

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -998,7 +998,7 @@ describe('Page', function () {
         'iPhone'
       );
     });
-    it('should work with additional userAgentMetdata', async () => {
+    itFailsFirefox('should work with additional userAgentMetdata', async () => {
       const { page, server } = getTestState();
 
       await page.setUserAgent('MockBrowser', {

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -1001,7 +1001,6 @@ describe('Page', function () {
     it('should work with additional userAgentMetdata', async () => {
       const { page, server } = getTestState();
 
-
       await page.setUserAgent('MockBrowser', {
         architecture: 'Mock1',
         mobile: false,
@@ -1013,17 +1012,25 @@ describe('Page', function () {
         server.waitForRequest('/empty.html'),
         page.goto(server.EMPTY_PAGE),
       ]);
-      const uaData = await page.evaluate(() =>
+      expect(
+        await page.evaluate(() => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore: userAgentData not yet in TypeScript DOM API
+          return navigator.userAgentData.mobile;
+        })
+      ).toBe(false);
+
+      const uaData = await page.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: userAgentData not yet in TypeScript DOM API
-        navigator.userAgentData.getHighEntropyValues([
+        return navigator.userAgentData.getHighEntropyValues([
           'architecture',
           'model',
           'platform',
           'platformVersion',
-        ])
-      );
+        ]);
+      });
       expect(uaData['architecture']).toBe('Mock1');
-      expect(uaData.mobile).toBeFalsy();
       expect(uaData['model']).toBe('Mockbook');
       expect(uaData['platform']).toBe('MockOS');
       expect(uaData['platformVersion']).toBe('3.1');

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -698,6 +698,13 @@ function compareDocumentations(actual, expected) {
         },
       ],
       [
+        'Method Page.setUserAgent() userAgentMetadata',
+        {
+          actualName: 'Object',
+          expectedName: 'UserAgentMetadata',
+        },
+      ],
+      [
         'Method Page.setViewport() options.viewport',
         {
           actualName: 'Object',


### PR DESCRIPTION
Context: #7269

**Review requests**

- `npm run doc` complains about `[MarkDown] Method Page.setUserAgent() userAgentData Object != UserAgentMetadata`. Not really clear how to resolve. Other methods that are using a DevTools protocol type are also just referrring to `Object`.
- Not sure if you have a preferred convention on setting an optional key in an array. I've erred on the side of being more verbose, but perhaps there's something more elegant to do.

Adds userAgentData to setUserAgent that supports specifying user agent
data for the new navigator.userAgentData and Client Hints headers.