### PR TITLE
fix: dl.google.com should be https

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -272,7 +272,7 @@ FROM node:12-slim
 RUN apt-get update \
     && apt-get install -y wget gnupg \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && sh -c 'echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
     && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
       --no-install-recommends \


### PR DESCRIPTION
when using http, I meet the error

```
W: Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/InRelease  Connection failed [IP: 58.254.137.161 80]
W: Some index files failed to download. They have been ignored, or old ones used instead.
```

then, I change http to https, it worked