### PR TITLE
chore(docs): stop generating devtools-protocol docs

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "mainEntryPointFilePath": "<projectFolder>/lib/cjs/puppeteer/api-docs-entry.d.ts",
-  "bundledPackages": ["devtools-protocol"],
+  "bundledPackages": [],
 
   "apiReport": {
     "enabled": false

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -813,8 +813,7 @@ function compareDocumentations(actual, expected) {
         'Method Page.emulateVisionDeficiency() type',
         {
           actualName: 'string',
-          expectedName:
-            '"none"|"achromatopsia"|"blurredVision"|"deuteranopia"|"protanopia"|"tritanopia"',
+          expectedName: 'Object',
         },
       ],
       [
@@ -1072,6 +1071,7 @@ function compareDocumentations(actual, expected) {
       'Method Page.deleteCookie() ...cookies',
       'Method Page.setCookie() ...cookies',
       'Method Puppeteer.connect() options',
+      'Method Page.setUserAgent() userAgentMetadata',
     ]);
     if (skipPropertyChecksOnMethods.has(source)) return;
 


### PR DESCRIPTION
This CL changes our docs generation to not include automatic docs from
devtools-protocol. Long term we probably want this, but for now it's
generating a vast amount of documentation and it's making setting up the
new website and docs harder. Let's focus just on the pptr docs for now
and revisit this once the foundations have been laid.