### PR TITLE
fix(docs): deploy includes website documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Build
         run: |
           npm install
+          npm run generate-docs
           npm run build-docs-production
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.4.1

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tsc-esm": "tsc -b src/tsconfig.esm.json",
     "apply-next-version": "node utils/apply_next_version.js",
     "test-install": "scripts/test-install.sh",
-    "clean-docs": "rimraf new-docs && rimraf docs-api-json",
+    "clean-docs": "rimraf website/docs && rimraf docs-api-json",
     "generate-d-ts": "npm run clean-docs && api-extractor run --local --verbose",
     "generate-docs": "npm run generate-d-ts && api-documenter markdown -i docs-api-json -o website/docs && node utils/remove-tag.js",
     "ensure-correct-devtools-protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package",


### PR DESCRIPTION
We now generate the docs into `website/docs` such that it's used by
Docusaurus when we build the site, we need to update the deploy script
to generate those docs first.