### PR TITLE
Correct `createPDFStream` documentation example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1542,7 +1542,9 @@ const puppeteer = require('puppeteer');
   const pdfStream = await page.createPDFStream();
   const writeStream = fs.createWriteStream('test.pdf');
   pdfStream.pipe(writeStream);
-  await browser.close();
+  pdfStream.on('end', async () => {
+    await browser.close();
+  });
 })();
 ```
 


### PR DESCRIPTION
Using existing example results in `browser.close()` being executed before the file is generated/written to disk. One needs to listen for the `end` event on the `Readable` stream before closing the browser, otherwise `UnhandledPromiseRejectionWarning: Error: Protocol error (IO.read): Target closed` exception is raised.