### PR TITLE
Update firefox prefs documentation link

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -649,7 +649,7 @@ try {
   - `env` <[Object]> Specify environment variables that will be visible to the browser. Defaults to `process.env`.
   - `devtools` <[boolean]> Whether to auto-open a DevTools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
   - `pipe` <[boolean]> Connects to the browser over a pipe instead of a WebSocket. Defaults to `false`.
-  - `extraPrefsFirefox` <[Object]> Additional [preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed to Firefox (see `PUPPETEER_PRODUCT`)
+  - `extraPrefsFirefox` <[Object]> Additional [preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed to Firefox (see `PUPPETEER_PRODUCT`)
   - `targetFilter` <?[function]\([Protocol.Target.TargetInfo]\):[boolean]> Use this function to decide if Puppeteer should connect to the given target. If a `targetFilter` is provided, Puppeteer only connects to targets for which `targetFilter` returns `true`. By default, Puppeteer connects to all available targets.
   - `waitForInitialPage` <[boolean]> Whether to wait for the initial page to be ready. Defaults to `true`.
 - returns: <[Promise]<[Browser]>> Promise which resolves to browser instance.

--- a/src/node/LaunchOptions.ts
+++ b/src/node/LaunchOptions.ts
@@ -119,7 +119,7 @@ export interface LaunchOptions {
    */
   product?: Product;
   /**
-   * {@link https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference | Additional preferences } that can be passed when launching with Firefox.
+   * {@link https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js | Additional preferences } that can be passed when launching with Firefox.
    */
   extraPrefsFirefox?: Record<string, unknown>;
   /**

--- a/website/versioned_docs/version-10.0.0/puppeteer.launchoptions.extraprefsfirefox.md
+++ b/website/versioned_docs/version-10.0.0/puppeteer.launchoptions.extraprefsfirefox.md
@@ -4,7 +4,7 @@
 
 ## LaunchOptions.extraPrefsFirefox property
 
-[Additional preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed when launching with Firefox.
+[Additional preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed when launching with Firefox.
 
 <b>Signature:</b>
 

--- a/website/versioned_docs/version-10.0.0/puppeteer.launchoptions.md
+++ b/website/versioned_docs/version-10.0.0/puppeteer.launchoptions.md
@@ -20,7 +20,7 @@ export interface LaunchOptions
 |  [dumpio?](./puppeteer.launchoptions.dumpio.md) | boolean | <i>(Optional)</i> If true, pipes the browser process stdout and stderr to <code>process.stdout</code> and <code>process.stderr</code>. |
 |  [env?](./puppeteer.launchoptions.env.md) | Record&lt;string, string \| undefined&gt; | <i>(Optional)</i> Specify environment variables that will be visible to the browser. |
 |  [executablePath?](./puppeteer.launchoptions.executablepath.md) | string | <i>(Optional)</i> Path to a browser executable to use instead of the bundled Chromium. Note that Puppeteer is only guaranteed to work with the bundled Chromium, so use this setting at your own risk. |
-|  [extraPrefsFirefox?](./puppeteer.launchoptions.extraprefsfirefox.md) | Record&lt;string, unknown&gt; | <i>(Optional)</i> [Additional preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed when launching with Firefox. |
+|  [extraPrefsFirefox?](./puppeteer.launchoptions.extraprefsfirefox.md) | Record&lt;string, unknown&gt; | <i>(Optional)</i> [Additional preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed when launching with Firefox. |
 |  [handleSIGHUP?](./puppeteer.launchoptions.handlesighup.md) | boolean | <i>(Optional)</i> Close the browser process on <code>SIGHUP</code>. |
 |  [handleSIGINT?](./puppeteer.launchoptions.handlesigint.md) | boolean | <i>(Optional)</i> Close the browser process on <code>Ctrl+C</code>. |
 |  [handleSIGTERM?](./puppeteer.launchoptions.handlesigterm.md) | boolean | <i>(Optional)</i> Close the browser process on <code>SIGTERM</code>. |

--- a/website/versioned_docs/version-10.1.0/puppeteer.launchoptions.extraprefsfirefox.md
+++ b/website/versioned_docs/version-10.1.0/puppeteer.launchoptions.extraprefsfirefox.md
@@ -4,7 +4,7 @@
 
 ## LaunchOptions.extraPrefsFirefox property
 
-[Additional preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed when launching with Firefox.
+[Additional preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed when launching with Firefox.
 
 <b>Signature:</b>
 

--- a/website/versioned_docs/version-10.1.0/puppeteer.launchoptions.md
+++ b/website/versioned_docs/version-10.1.0/puppeteer.launchoptions.md
@@ -20,7 +20,7 @@ export interface LaunchOptions
 |  [dumpio?](./puppeteer.launchoptions.dumpio.md) | boolean | <i>(Optional)</i> If true, pipes the browser process stdout and stderr to <code>process.stdout</code> and <code>process.stderr</code>. |
 |  [env?](./puppeteer.launchoptions.env.md) | Record&lt;string, string \| undefined&gt; | <i>(Optional)</i> Specify environment variables that will be visible to the browser. |
 |  [executablePath?](./puppeteer.launchoptions.executablepath.md) | string | <i>(Optional)</i> Path to a browser executable to use instead of the bundled Chromium. Note that Puppeteer is only guaranteed to work with the bundled Chromium, so use this setting at your own risk. |
-|  [extraPrefsFirefox?](./puppeteer.launchoptions.extraprefsfirefox.md) | Record&lt;string, unknown&gt; | <i>(Optional)</i> [Additional preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed when launching with Firefox. |
+|  [extraPrefsFirefox?](./puppeteer.launchoptions.extraprefsfirefox.md) | Record&lt;string, unknown&gt; | <i>(Optional)</i> [Additional preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed when launching with Firefox. |
 |  [handleSIGHUP?](./puppeteer.launchoptions.handlesighup.md) | boolean | <i>(Optional)</i> Close the browser process on <code>SIGHUP</code>. |
 |  [handleSIGINT?](./puppeteer.launchoptions.handlesigint.md) | boolean | <i>(Optional)</i> Close the browser process on <code>Ctrl+C</code>. |
 |  [handleSIGTERM?](./puppeteer.launchoptions.handlesigterm.md) | boolean | <i>(Optional)</i> Close the browser process on <code>SIGTERM</code>. |

--- a/website/versioned_docs/version-9.1.1/puppeteer.launchoptions.extraprefsfirefox.md
+++ b/website/versioned_docs/version-9.1.1/puppeteer.launchoptions.extraprefsfirefox.md
@@ -4,7 +4,7 @@
 
 ## LaunchOptions.extraPrefsFirefox property
 
-[Additional preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed when launching with Firefox.
+[Additional preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed when launching with Firefox.
 
 <b>Signature:</b>
 

--- a/website/versioned_docs/version-9.1.1/puppeteer.launchoptions.md
+++ b/website/versioned_docs/version-9.1.1/puppeteer.launchoptions.md
@@ -20,7 +20,7 @@ export interface LaunchOptions
 |  [dumpio?](./puppeteer.launchoptions.dumpio.md) | boolean | <i>(Optional)</i> If true, pipes the browser process stdout and stderr to <code>process.stdout</code> and <code>process.stderr</code>. |
 |  [env?](./puppeteer.launchoptions.env.md) | Record&lt;string, string \| undefined&gt; | <i>(Optional)</i> Specify environment variables that will be visible to the browser. |
 |  [executablePath?](./puppeteer.launchoptions.executablepath.md) | string | <i>(Optional)</i> Path to a browser executable to use instead of the bundled Chromium. Note that Puppeteer is only guaranteed to work with the bundled Chromium, so use this setting at your own risk. |
-|  [extraPrefsFirefox?](./puppeteer.launchoptions.extraprefsfirefox.md) | Record&lt;string, unknown&gt; | <i>(Optional)</i> [Additional preferences](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference) that can be passed when launching with Firefox. |
+|  [extraPrefsFirefox?](./puppeteer.launchoptions.extraprefsfirefox.md) | Record&lt;string, unknown&gt; | <i>(Optional)</i> [Additional preferences](https://searchfox.org/mozilla-release/source/modules/libpref/init/all.js) that can be passed when launching with Firefox. |
 |  [handleSIGHUP?](./puppeteer.launchoptions.handlesighup.md) | boolean | <i>(Optional)</i> Close the browser process on <code>SIGHUP</code>. |
 |  [handleSIGINT?](./puppeteer.launchoptions.handlesigint.md) | boolean | <i>(Optional)</i> Close the browser process on <code>Ctrl+C</code>. |
 |  [handleSIGTERM?](./puppeteer.launchoptions.handlesigterm.md) | boolean | <i>(Optional)</i> Close the browser process on <code>SIGTERM</code>. |


### PR DESCRIPTION
The link used to document Firefox preferences no longer exists.  As no suitable alternative exists it's likely best just to link to the actual pref file that is used in Firefox by default.