### PR TITLE
chore: enable followRedirects for NodeWebSocket

### DIFF
--- a/src/node/NodeWebSocketTransport.ts
+++ b/src/node/NodeWebSocketTransport.ts
@@ -20,6 +20,7 @@ export class NodeWebSocketTransport implements ConnectionTransport {
   static create(url: string): Promise<NodeWebSocketTransport> {
     return new Promise((resolve, reject) => {
       const ws = new NodeWebSocket(url, [], {
+        followRedirects: true,
         perMessageDeflate: false,
         maxPayload: 256 * 1024 * 1024, // 256Mb
       });


### PR DESCRIPTION
I'm building a cluster of Chromium browsers that is load balanced using redirects.
Since `puppeteer.connect` uses the [`ws`](https://github.com/websockets/ws) library under the hood, it'd be nice if we followed redirects.
`ws` has supported following redirects this for a while now: https://github.com/websockets/ws/pull/1490

This PR simply enables the `followRedirects` option when constructing the `WebSocket` in `.connect`.