### PR TITLE
feat(page): expose page.client()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,6 +133,7 @@
   * [page.browser()](#pagebrowser)
   * [page.browserContext()](#pagebrowsercontext)
   * [page.click(selector[, options])](#pageclickselector-options)
+  * [page.client()](#pageclient)
   * [page.close([options])](#pagecloseoptions)
   * [page.content()](#pagecontent)
   * [page.cookies([...urls])](#pagecookiesurls)
@@ -1464,6 +1465,12 @@ const [response] = await Promise.all([
 ```
 
 Shortcut for [page.mainFrame().click(selector[, options])](#frameclickselector-options).
+
+#### page.client()
+
+- returns: <[CDPSession]>
+
+Get the CDP session client the page belongs to.
 
 #### page.close([options])
 

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -730,6 +730,13 @@ export class Page extends EventEmitter {
   }
 
   /**
+   * Get the CDP session client the page belongs to.
+   */
+  client(): CDPSession {
+    return this._client;
+  }
+
+  /**
    * Get the browser the page belongs to.
    */
   browser(): Browser {

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -27,6 +27,7 @@ import {
   describeFailsFirefox,
 } from './mocha-utils'; // eslint-disable-line import/extensions
 import { Page, Metrics } from '../lib/cjs/puppeteer/common/Page.js';
+import { CDPSession } from '../lib/cjs/puppeteer/common/Connection.js';
 import { JSHandle } from '../lib/cjs/puppeteer/common/JSHandle.js';
 
 describe('Page', function () {
@@ -1900,6 +1901,13 @@ describe('Page', function () {
       const { page, context } = getTestState();
 
       expect(page.browserContext()).toBe(context);
+    });
+  });
+
+  describe('Page.client', function () {
+    it('should return the client instance', async () => {
+      const { page } = getTestState();
+      expect(page.client()).toBeInstanceOf(CDPSession);
     });
   });
 });


### PR DESCRIPTION
Puppeteer already allows creating a new CDP session
via target.createCDPSession but there is no way
to get access to any existing session to send
some additional commands.