### PR TITLE
feat(page): mark page.client() as internal

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,6 @@
   * [page.browser()](#pagebrowser)
   * [page.browserContext()](#pagebrowsercontext)
   * [page.click(selector[, options])](#pageclickselector-options)
-  * [page.client()](#pageclient)
   * [page.close([options])](#pagecloseoptions)
   * [page.content()](#pagecontent)
   * [page.cookies([...urls])](#pagecookiesurls)
@@ -1465,12 +1464,6 @@ const [response] = await Promise.all([
 ```
 
 Shortcut for [page.mainFrame().click(selector[, options])](#frameclickselector-options).
-
-#### page.client()
-
-- returns: <[CDPSession]>
-
-Get the CDP session client the page belongs to.
 
 #### page.close([options])
 

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -731,6 +731,7 @@ export class Page extends EventEmitter {
 
   /**
    * Get the CDP session client the page belongs to.
+   * @internal
    */
   client(): CDPSession {
     return this._client;

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -25,6 +25,7 @@ const {
 const EXCLUDE_PROPERTIES = new Set([
   'Browser.create',
   'Headers.fromPayload',
+  'Page.client',
   'Page.create',
   'JSHandle.toString',
   'TimeoutError.name',


### PR DESCRIPTION
This PR marks the .client() method as internal since
we don't encourage our users to use it.