### PR TITLE
Fix typings for ElementHandle.screenshot() options

### DIFF
--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -17,7 +17,7 @@
 import { assert } from './assert.js';
 import { helper, debugError } from './helper.js';
 import { ExecutionContext } from './ExecutionContext.js';
-import { Page } from './Page.js';
+import { Page, ScreenshotOptions } from './Page.js';
 import { CDPSession } from './Connection.js';
 import { KeyInput } from './USKeyboardLayout.js';
 import { FrameManager, Frame } from './FrameManager.js';
@@ -813,7 +813,7 @@ export class ElementHandle<
    * {@link Page.screenshot} to take a screenshot of the element.
    * If the element is detached from DOM, the method throws an error.
    */
-  async screenshot(options = {}): Promise<string | Buffer> {
+  async screenshot(options: ScreenshotOptions = {}): Promise<string | Buffer> {
     let needsViewportReset = false;
 
     let boundingBox = await this.boundingBox();

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -429,6 +429,13 @@ function compareDocumentations(actual, expected) {
         },
       ],
       [
+        'Method ElementHandle.screenshot() options',
+        {
+          actualName: 'Object',
+          expectedName: 'ScreenshotOptions',
+        },
+      ],
+      [
         'Method Keyboard.down() key',
         {
           actualName: 'string',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Typings fix.

**If relevant, did you update the documentation?**

This correction brings the typings for `ElementHandle.screenshot()` in line with [the existing documentation](https://pptr.dev/#?product=Puppeteer&version=v10.4.0&show=api-elementhandlescreenshotoptions).

**Summary**

This PR corrects the TypeScript typings for `ElementHandle.screenshot()`.

Fixes #7601.

**Does this PR introduce a breaking change?**

This isn't a breaking change, though if consumers were passing in excess or incorrect properties to the method they'll now receive a typechecking error.
