### PR TITLE
chore: disable certain Fission features for Firefox

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -513,8 +513,11 @@ class FirefoxLauncher implements ProductLauncher {
       // Make sure opening about:addons will not hit the network
       'extensions.webservice.discoverURL': `http://${server}/dummy/discoveryURL`,
 
-      // Force disable Fission until the Remote Agent is compatible
-      'fission.autostart': false,
+      // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
+      'fission.bfcacheInParent': false,
+
+      // Force all web content to use a single content process
+      'fission.webContentIsolationStrategy': 0,
 
       // Allow the application to have focus even it runs in the background
       'focusmanager.testmode': true,


### PR DESCRIPTION
Enable basic Fission support for Firefox' CDP implementation. Some other Fission specific features have to be kept disabled for now.

