### PR TITLE
fix: fix BrowserFetcher._getFolderPath to support relative install paths

### DIFF
--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -419,9 +419,7 @@ export class BrowserFetcher {
    * @internal
    */
   _getFolderPath(revision: string): string {
-    return path.resolve(
-      path.join(this._downloadsFolder, `${this._platform}-${revision}`)
-    );
+    return path.resolve(this._downloadsFolder, `${this._platform}-${revision}`);
   }
 }
 

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -419,7 +419,9 @@ export class BrowserFetcher {
    * @internal
    */
   _getFolderPath(revision: string): string {
-    return path.join(this._downloadsFolder, `${this._platform}-${revision}`);
+    return path.resolve(
+      path.join(this._downloadsFolder, `${this._platform}-${revision}`)
+    );
   }
 }
 


### PR DESCRIPTION
This patch fixes the BrowserFetcher._getFolderPath method so that it supports relative download paths using PUPPETEER_DOWNLOAD_PATH or npm config

Issues: #7592
