### PR TITLE
Bump node-fetch from 2.6.1 to 2.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "devtools-protocol": "0.0.901419",
     "extract-zip": "2.0.1",
     "https-proxy-agent": "5.0.0",
-    "node-fetch": "2.6.1",
+    "node-fetch": "2.6.5",
     "pkg-dir": "4.2.0",
     "progress": "2.0.1",
     "proxy-from-env": "1.1.0",


### PR DESCRIPTION
This is the last release before 3.0.0.

This is a mitigation for the issue described in https://github.com/puppeteer/puppeteer/issues/7239#issuecomment-932044494.