### PR TITLE
docs: add warning about version of try-puppeteer.appspot.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 - Test Chrome Extensions.
 <!-- [END usecases] -->
 
-Give it a spin: [https://try-puppeteer.appspot.com/](https://try-puppeteer.appspot.com/)
+Give it a spin: [https://try-puppeteer.appspot.com/](https://try-puppeteer.appspot.com/) (please note that it runs an older version (v1.4.0) of Puppeteer).
 
 <!-- [START getstarted] -->
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Clarifies an external source in docs (README.md).

**Did you add tests for your changes?**

not applicable

**If relevant, did you update the documentation?**

not applicable

**Summary**

The URL https://try-puppeteer.appspot.com/ is mentioned around the top of `README.md` even if it is running a very outdated version (v1.4.0). I suggest either (1) remove it from the docs or (2) putting a warning that it is a bit outdated.  
I made a suggestion for the latter in this PR.

**Does this PR introduce a breaking change?**

no

**Other information**

There has been a [question](https://stackoverflow.com/questions/69363761/are-google-devs-just-wrong-with-their-puppeteer-code-custom-event-js) about a try-puppeteer issue on SO that I partially try to address with this warning text. Some might think that it is maintained and upgraded in parallel with Puppeteer.