### PR TITLE
chore: ignore stdout when dumpio isn't used

### DIFF
--- a/src/node/BrowserRunner.ts
+++ b/src/node/BrowserRunner.ts
@@ -64,10 +64,13 @@ export class BrowserRunner {
   start(options: LaunchOptions): void {
     const { handleSIGINT, handleSIGTERM, handleSIGHUP, dumpio, env, pipe } =
       options;
-    let stdio: Array<'ignore' | 'pipe'> = ['pipe', 'pipe', 'pipe'];
+    let stdio: Array<'ignore' | 'pipe'>;
     if (pipe) {
       if (dumpio) stdio = ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'];
       else stdio = ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'];
+    } else {
+      if (dumpio) stdio = ['pipe', 'pipe', 'pipe'];
+      else stdio = ['pipe', 'ignore', 'pipe'];
     }
     assert(!this.proc, 'This process has previously been started.');
     debugLauncher(


### PR DESCRIPTION
When the browser child process has logging enabled
and output on stdout isn't constantly processed,
the brower process is about to freeze.

To avoid such a situation at least the stdout
pipe shouldn't be set by default but only if
dumpio is enabled.
