### PR TITLE
docs: remove try-puppeteer.appspot.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 - Test Chrome Extensions.
 <!-- [END usecases] -->
 
-Give it a spin: [https://try-puppeteer.appspot.com/](https://try-puppeteer.appspot.com/) (please note that it runs an older version (v1.4.0) of Puppeteer).
-
 <!-- [START getstarted] -->
 
 ## Getting Started


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

removing a broken link from `README.md`

**Did you add tests for your changes?**

not applicable

**If relevant, did you update the documentation?**

not applicable

**Summary**

a few days ago I proposed a change on this part of the README https://github.com/puppeteer/puppeteer/pull/7639 to add a note about try-puppeteer's outdated version, it seems it BUMP-ed the topic, and **since that the site was taken down (now it gives HTTP 404).**  
now this link is totally obsolete, I suggest removing it.

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

if there will be any new try-puppeteer project which will be maintained by the Puppeteer community: I'd be glad to contribute to 👍