### PR TITLE
chore: disable docs website build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,9 @@ jobs:
         run: |
           npm run ensure-pinned-deps
           npm run lint
-          npm run generate-docs
+          # Skipping as it's flakey and we are not currently using the new documentation site in the wild yet.
+          # See https://github.com/puppeteer/puppeteer/issues/7710 for more info
+          # npm run generate-docs
           npm run ensure-correct-devtools-protocol-revision
           npm run test-types-file
 


### PR DESCRIPTION
It is flakey on the bots and we're not actively using it yet, so let's
disable it for now. We will work on extracting this into its own repo
and that work is tracked in
https://github.com/puppeteer/puppeteer/issues/7710.
