### PR TITLE
docs: fix typo for PUPPETEER_DOWNLOAD_PATH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ We have a [troubleshooting](https://github.com/puppeteer/puppeteer/blob/main/doc
 
 #### Q: Chromium gets downloaded on every `npm ci` run. How can I cache the download?
 
-The default download path is `node_modules/puppeteer/.local-chromium`. However, you can change that path with the `PUPPETTER_DOWNLOAD_PATH` environment variable.
+The default download path is `node_modules/puppeteer/.local-chromium`. However, you can change that path with the `PUPPETEER_DOWNLOAD_PATH` environment variable.
 
 Puppeteer uses that variable to resolve the Chromium executable location during launch, so you don’t need to specify `PUPPETEER_EXECUTABLE_PATH` as well.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR is a bugfix.

**Did you add tests for your changes?**

N/A

**Summary**

This PR fixes a typo seen in https://github.com/puppeteer/puppeteer/blob/main/README.md#q-chromium-gets-downloaded-on-every-npm-ci-run-how-can-i-cache-the-download:  `PUPPETTER_DOWNLOAD_PATH` should be `PUPPETEER_DOWNLOAD_PATH`

**Does this PR introduce a breaking change?**

No.

**Other information**

N/A