### PR TITLE
fix: dead lock when execution contexts are created in a different order

### DIFF
--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -389,4 +389,11 @@ export class ExecutionContext {
     });
     return this._adoptBackendNodeId(nodeInfo.node.backendNodeId);
   }
+
+  /**
+   * @internal
+   */
+  _setWorld(world: DOMWorld): void {
+    this._world = world;
+  }
 }


### PR DESCRIPTION
Sometimes it's possible that the ExecutionContextCreated message
for a frame arrives before the frame has been registered by
Puppeteer. In this case, the DOM world for the frame will never
have the execution context set resulting in a indefinite await
for the result of DOMWorld::executionContext().
