### PR TITLE
fix(ariaqueryhandler): allow single quotes in aria attribute selector

### DIFF
--- a/src/common/AriaQueryHandler.ts
+++ b/src/common/AriaQueryHandler.ts
@@ -41,7 +41,7 @@ const normalizeValue = (value: string): string =>
   value.replace(/ +/g, ' ').trim();
 const knownAttributes = new Set(['name', 'role']);
 const attributeRegexp =
-  /\[\s*(?<attribute>\w+)\s*=\s*"(?<value>\\.|[^"\\]*)"\s*\]/g;
+  /\[\s*(?<attribute>\w+)\s*=\s*(?<quote>"|')(?<value>\\.|.*?(?=\k<quote>))\k<quote>\s*\]/g;
 
 /*
  * The selectors consist of an accessible name to query for and optionally
@@ -58,7 +58,7 @@ function parseAriaSelector(selector: string): ariaQueryOption {
   const queryOptions: ariaQueryOption = {};
   const defaultName = selector.replace(
     attributeRegexp,
-    (_, attribute: string, value: string) => {
+    (_, attribute: string, quote: string, value: string) => {
       attribute = attribute.trim();
       if (!knownAttributes.has(attribute))
         throw new Error(`Unknown aria attribute "${attribute}" in selector`);

--- a/test/ariaqueryhandler.spec.ts
+++ b/test/ariaqueryhandler.spec.ts
@@ -47,6 +47,10 @@ describeChromeOnly('AriaQueryHandler', () => {
       );
       await expectFound(button);
       button = await page.$(
+        "aria/Submit button and some spaces[role='button']"
+      );
+      await expectFound(button);
+      button = await page.$(
         'aria/  Submit button and some spaces[role="button"]'
       );
       await expectFound(button);
@@ -68,6 +72,10 @@ describeChromeOnly('AriaQueryHandler', () => {
       await expectFound(button);
       button = await page.$(
         'aria/[name="  Submit  button and some  spaces"][role="button"]'
+      );
+      await expectFound(button);
+      button = await page.$(
+        "aria/[name='  Submit  button and some  spaces'][role='button']"
       );
       await expectFound(button);
       button = await page.$(


### PR DESCRIPTION
This updates the regular expression used to parse aria attribute
selectors so that single quotes may be used as an alternative to double
quotes, e.g. `aria/Single button[role='button']`.

Issues: #7721