### PR TITLE
fix: Inherit browser-level proxy settings from incognito context

### DIFF
--- a/src/common/Browser.ts
+++ b/src/common/Browser.ts
@@ -319,7 +319,7 @@ export class Browser extends EventEmitter {
   async createIncognitoBrowserContext(
     options: BrowserContextOptions = {}
   ): Promise<BrowserContext> {
-    const { proxyServer = '', proxyBypassList = [] } = options;
+    const { proxyServer, proxyBypassList } = options;
 
     const { browserContextId } = await this._connection.send(
       'Target.createBrowserContext',

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -17,7 +17,11 @@
 import expect from 'expect';
 import http from 'http';
 import os from 'os';
-import { getTestState, describeFailsFirefox } from './mocha-utils'; // eslint-disable-line import/extensions
+import {
+  getTestState,
+  describeFailsFirefox,
+  itFailsWindows,
+} from './mocha-utils'; // eslint-disable-line import/extensions
 import type { Server, IncomingMessage, ServerResponse } from 'http';
 import type { Browser } from '../lib/cjs/puppeteer/common/Browser.js';
 import type { AddressInfo } from 'net';
@@ -167,22 +171,28 @@ describeFailsFirefox('request proxy', () => {
       expect(proxiedRequestUrls).toEqual([]);
     });
 
-    it('should proxy requests when configured at context level', async () => {
-      const { puppeteer, defaultBrowserOptions, server } = getTestState();
-      const emptyPageUrl = getEmptyPageUrl(server);
+    /**
+     * See issues #7873, #7719, and #7698.
+     */
+    itFailsWindows(
+      'should proxy requests when configured at context level',
+      async () => {
+        const { puppeteer, defaultBrowserOptions, server } = getTestState();
+        const emptyPageUrl = getEmptyPageUrl(server);
 
-      browser = await puppeteer.launch(defaultBrowserOptions);
+        browser = await puppeteer.launch(defaultBrowserOptions);
 
-      const context = await browser.createIncognitoBrowserContext({
-        proxyServer: proxyServerUrl,
-      });
-      const page = await context.newPage();
-      const response = await page.goto(emptyPageUrl);
+        const context = await browser.createIncognitoBrowserContext({
+          proxyServer: proxyServerUrl,
+        });
+        const page = await context.newPage();
+        const response = await page.goto(emptyPageUrl);
 
-      expect(response.ok()).toBe(true);
+        expect(response.ok()).toBe(true);
 
-      expect(proxiedRequestUrls).toEqual([emptyPageUrl]);
-    });
+        expect(proxiedRequestUrls).toEqual([emptyPageUrl]);
+      }
+    );
 
     it('should respect proxy bypass list when configured at context level', async () => {
       const { puppeteer, defaultBrowserOptions, server } = getTestState();

--- a/test/proxy.spec.ts
+++ b/test/proxy.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2021 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+import http from 'http';
+import os from 'os';
+import { getTestState, describeFailsFirefox } from './mocha-utils'; // eslint-disable-line import/extensions
+import type { Server, IncomingMessage, ServerResponse } from 'http';
+import type { Browser } from '../lib/cjs/puppeteer/common/Browser.js';
+import type { AddressInfo } from 'net';
+
+const HOSTNAME = os.hostname().toLowerCase();
+
+/**
+ * Requests to localhost do not get proxied by default. Create a URL using the hostname
+ * instead.
+ */
+function getEmptyPageUrl(server: { PORT: number; EMPTY_PAGE: string }): string {
+  const emptyPagePath = new URL(server.EMPTY_PAGE).pathname;
+
+  return `http://${HOSTNAME}:${server.PORT}${emptyPagePath}`;
+}
+
+describeFailsFirefox('request proxy', () => {
+  let browser: Browser;
+  let proxiedRequestUrls: string[];
+  let proxyServer: Server;
+  let proxyServerUrl: string;
+
+  beforeEach(() => {
+    proxiedRequestUrls = [];
+
+    proxyServer = http
+      .createServer(
+        (
+          originalRequest: IncomingMessage,
+          originalResponse: ServerResponse
+        ) => {
+          proxiedRequestUrls.push(originalRequest.url as string);
+
+          const proxyRequest = http.request(
+            originalRequest.url as string,
+            {
+              method: originalRequest.method,
+              headers: originalRequest.headers,
+            },
+            (proxyResponse) => {
+              originalResponse.writeHead(
+                proxyResponse.statusCode as number,
+                proxyResponse.headers
+              );
+              proxyResponse.pipe(originalResponse, { end: true });
+            }
+          );
+
+          originalRequest.pipe(proxyRequest, { end: true });
+        }
+      )
+      .listen();
+
+    proxyServerUrl = `http://${HOSTNAME}:${
+      (proxyServer.address() as AddressInfo).port
+    }`;
+  });
+
+  afterEach(async () => {
+    await browser.close();
+
+    await new Promise((resolve, reject) => {
+      proxyServer.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(undefined);
+        }
+      });
+    });
+  });
+
+  it('should proxy requests when configured', async () => {
+    const { puppeteer, defaultBrowserOptions, server } = getTestState();
+    const emptyPageUrl = getEmptyPageUrl(server);
+
+    browser = await puppeteer.launch({
+      ...defaultBrowserOptions,
+      args: [`--proxy-server=${proxyServerUrl}`],
+    });
+
+    const page = await browser.newPage();
+    const response = await page.goto(emptyPageUrl);
+
+    expect(response.ok()).toBe(true);
+
+    expect(proxiedRequestUrls).toEqual([emptyPageUrl]);
+  });
+
+  it('should respect proxy bypass list', async () => {
+    const { puppeteer, defaultBrowserOptions, server } = getTestState();
+    const emptyPageUrl = getEmptyPageUrl(server);
+
+    browser = await puppeteer.launch({
+      ...defaultBrowserOptions,
+      args: [
+        `--proxy-server=${proxyServerUrl}`,
+        `--proxy-bypass-list=${new URL(emptyPageUrl).host}`,
+      ],
+    });
+
+    const page = await browser.newPage();
+    const response = await page.goto(emptyPageUrl);
+
+    expect(response.ok()).toBe(true);
+
+    expect(proxiedRequestUrls).toEqual([]);
+  });
+
+  describe('in incognito browser context', () => {
+    it('should proxy requests when configured at browser level', async () => {
+      const { puppeteer, defaultBrowserOptions, server } = getTestState();
+      const emptyPageUrl = getEmptyPageUrl(server);
+
+      browser = await puppeteer.launch({
+        ...defaultBrowserOptions,
+        args: [`--proxy-server=${proxyServerUrl}`],
+      });
+
+      const context = await browser.createIncognitoBrowserContext();
+      const page = await context.newPage();
+      const response = await page.goto(emptyPageUrl);
+
+      expect(response.ok()).toBe(true);
+
+      expect(proxiedRequestUrls).toEqual([emptyPageUrl]);
+    });
+
+    it('should respect proxy bypass list when configured at browser level', async () => {
+      const { puppeteer, defaultBrowserOptions, server } = getTestState();
+      const emptyPageUrl = getEmptyPageUrl(server);
+
+      browser = await puppeteer.launch({
+        ...defaultBrowserOptions,
+        args: [
+          `--proxy-server=${proxyServerUrl}`,
+          `--proxy-bypass-list=${new URL(emptyPageUrl).host}`,
+        ],
+      });
+
+      const context = await browser.createIncognitoBrowserContext();
+      const page = await context.newPage();
+      const response = await page.goto(emptyPageUrl);
+
+      expect(response.ok()).toBe(true);
+
+      expect(proxiedRequestUrls).toEqual([]);
+    });
+
+    it('should proxy requests when configured at context level', async () => {
+      const { puppeteer, defaultBrowserOptions, server } = getTestState();
+      const emptyPageUrl = getEmptyPageUrl(server);
+
+      browser = await puppeteer.launch(defaultBrowserOptions);
+
+      const context = await browser.createIncognitoBrowserContext({
+        proxyServer: proxyServerUrl,
+      });
+      const page = await context.newPage();
+      const response = await page.goto(emptyPageUrl);
+
+      expect(response.ok()).toBe(true);
+
+      expect(proxiedRequestUrls).toEqual([emptyPageUrl]);
+    });
+
+    it('should respect proxy bypass list when configured at context level', async () => {
+      const { puppeteer, defaultBrowserOptions, server } = getTestState();
+      const emptyPageUrl = getEmptyPageUrl(server);
+
+      browser = await puppeteer.launch(defaultBrowserOptions);
+
+      const context = await browser.createIncognitoBrowserContext({
+        proxyServer: proxyServerUrl,
+        proxyBypassList: [new URL(emptyPageUrl).host],
+      });
+      const page = await context.newPage();
+      const response = await page.goto(emptyPageUrl);
+
+      expect(response.ok()).toBe(true);
+
+      expect(proxiedRequestUrls).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This fixes #7589 which was a regression caused by #7516 and released in 10.4.0. It closes #7677 which fixed part of the issue but did not cover the proxy bypass list and also did not include tests.

**Did you add tests for your changes?**

Yes.

**If relevant, did you update the documentation?**

N/A

**Summary**

Browser-level proxy settings are now once again respected when creating new incognito browser contexts. Browser-level settings can be overridden at the context level. Tests were added for request proxy behavior in general.

**Does this PR introduce a breaking change?**

Nope.

**Other information**

N/A