### PR TITLE
chore: re-enable tests for Firefox related to fixed Input.dispatchMouseEvent issues

### DIFF
--- a/test/click.spec.ts
+++ b/test/click.spec.ts
@@ -238,8 +238,7 @@ describe('Page.click', function () {
       )
     ).toBe('clicked');
   });
-  // See https://github.com/puppeteer/puppeteer/issues/7175
-  itFailsFirefox('should double click the button', async () => {
+  it('should double click the button', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/button.html');
@@ -292,7 +291,7 @@ describe('Page.click', function () {
     // This await should not hang.
     await page.click('a');
   });
-  itFailsFirefox('should click the button inside an iframe', async () => {
+  it('should click the button inside an iframe', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.EMPTY_PAGE);
@@ -328,25 +327,20 @@ describe('Page.click', function () {
     await frame.click('button');
     expect(await frame.evaluate(() => globalThis.result)).toBe('Clicked');
   });
-  itFailsFirefox(
-    'should click the button with deviceScaleFactor set',
-    async () => {
-      const { page, server } = getTestState();
+  it('should click the button with deviceScaleFactor set', async () => {
+    const { page, server } = getTestState();
 
-      await page.setViewport({ width: 400, height: 400, deviceScaleFactor: 5 });
-      expect(await page.evaluate(() => window.devicePixelRatio)).toBe(5);
-      await page.setContent(
-        '<div style="width:100px;height:100px">spacer</div>'
-      );
-      await utils.attachFrame(
-        page,
-        'button-test',
-        server.PREFIX + '/input/button.html'
-      );
-      const frame = page.frames()[1];
-      const button = await frame.$('button');
-      await button.click();
-      expect(await frame.evaluate(() => globalThis.result)).toBe('Clicked');
-    }
-  );
+    await page.setViewport({ width: 400, height: 400, deviceScaleFactor: 5 });
+    expect(await page.evaluate(() => window.devicePixelRatio)).toBe(5);
+    await page.setContent('<div style="width:100px;height:100px">spacer</div>');
+    await utils.attachFrame(
+      page,
+      'button-test',
+      server.PREFIX + '/input/button.html'
+    );
+    const frame = page.frames()[1];
+    const button = await frame.$('button');
+    await button.click();
+    expect(await frame.evaluate(() => globalThis.result)).toBe('Clicked');
+  });
 });

--- a/test/elementhandle.spec.ts
+++ b/test/elementhandle.spec.ts
@@ -258,7 +258,7 @@ describe('ElementHandle specs', function () {
   });
 
   describe('ElementHandle.hover', function () {
-    itFailsFirefox('should work', async () => {
+    it('should work', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.PREFIX + '/input/scrollable.html');

--- a/test/mouse.spec.ts
+++ b/test/mouse.spec.ts
@@ -71,7 +71,7 @@ describe('Mouse', function () {
     expect(event.isTrusted).toBe(true);
     expect(event.button).toBe(0);
   });
-  itFailsFirefox('should resize the textarea', async () => {
+  it('should resize the textarea', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/textarea.html');
@@ -87,7 +87,7 @@ describe('Mouse', function () {
     expect(newDimensions.width).toBe(Math.round(width + 104));
     expect(newDimensions.height).toBe(Math.round(height + 104));
   });
-  itFailsFirefox('should select the text with mouse', async () => {
+  it('should select the text with mouse', async () => {
     const { page, server } = getTestState();
 
     await page.goto(server.PREFIX + '/input/textarea.html');
@@ -220,23 +220,20 @@ describe('Mouse', function () {
     ]);
   });
   // @see https://crbug.com/929806
-  itFailsFirefox(
-    'should work with mobile viewports and cross process navigations',
-    async () => {
-      const { page, server } = getTestState();
+  it('should work with mobile viewports and cross process navigations', async () => {
+    const { page, server } = getTestState();
 
-      await page.goto(server.EMPTY_PAGE);
-      await page.setViewport({ width: 360, height: 640, isMobile: true });
-      await page.goto(server.CROSS_PROCESS_PREFIX + '/mobile.html');
-      await page.evaluate(() => {
-        document.addEventListener('click', (event) => {
-          globalThis.result = { x: event.clientX, y: event.clientY };
-        });
+    await page.goto(server.EMPTY_PAGE);
+    await page.setViewport({ width: 360, height: 640, isMobile: true });
+    await page.goto(server.CROSS_PROCESS_PREFIX + '/mobile.html');
+    await page.evaluate(() => {
+      document.addEventListener('click', (event) => {
+        globalThis.result = { x: event.clientX, y: event.clientY };
       });
+    });
 
-      await page.mouse.click(30, 40);
+    await page.mouse.click(30, 40);
 
-      expect(await page.evaluate('result')).toEqual({ x: 30, y: 40 });
-    }
-  );
+    expect(await page.evaluate('result')).toEqual({ x: 30, y: 40 });
+  });
 });


### PR DESCRIPTION
Fixes issue #7175. With the patch on https://bugzilla.mozilla.org/show_bug.cgi?id=1740798 landed in Firefox Nightly the related tests are no longer failing.