### PR TITLE
fix: Update example to align with the website (7789)

### DIFF
--- a/examples/cross-browser.js
+++ b/examples/cross-browser.js
@@ -34,7 +34,7 @@ const firefoxOptions = {
   await page.goto('https://news.ycombinator.com/');
 
   // Extract articles from the page.
-  const resultsSelector = '.storylink';
+  const resultsSelector = '.titlelink';
   const links = await page.evaluate((resultsSelector) => {
     const anchors = Array.from(document.querySelectorAll(resultsSelector));
     return anchors.map((anchor) => {


### PR DESCRIPTION
Issues: #7789
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix: example `examples/cross-browser.js` doesn't work, as it uses a wrong class selector `. storylink` instead of the proper `. titlelink`. This PR change the selector to the proper one.

**Did you add tests for your changes?**

Run `NODE_PATH=../ node examples/cross-browser.js`

Before: only browser version.

After: browser version + articles.

**If relevant, did you update the documentation?**

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Update example to align with the website. `news.ycombinator.com` uses class `.titlelink`.