### PR TITLE
refactoring: NetworkManager cleanup & refactor

### DIFF
--- a/src/common/NetworkEventManager.ts
+++ b/src/common/NetworkEventManager.ts
@@ -1,0 +1,83 @@
+import { Protocol } from 'devtools-protocol';
+import { HTTPRequest } from './HTTPRequest.js';
+
+type QueuedEvents = {
+  responseReceived: Protocol.Network.ResponseReceivedEvent;
+  promise: Promise<void>;
+  resolver: () => void;
+  loadingFinished?: Protocol.Network.LoadingFinishedEvent;
+  loadingFailed?: Protocol.Network.LoadingFailedEvent;
+};
+type RedirectInfoMap = Array<{
+  event: Protocol.Network.RequestWillBeSentEvent;
+  interceptionId?: string;
+}>;
+/**
+ * @internal
+ *
+ * Helper class to track network events by request ID
+ */
+export class NetworkEventManager {
+  /*
+   * There are four possible orders of events:
+   *  A. `_onRequestWillBeSent`
+   *  B. `_onRequestWillBeSent`, `_onRequestPaused`
+   *  C. `_onRequestPaused`, `_onRequestWillBeSent`
+   *  D. `_onRequestPaused`, `_onRequestWillBeSent`, `_onRequestPaused`,
+   *     `_onRequestWillBeSent`, `_onRequestPaused`, `_onRequestPaused`
+   *     (see crbug.com/1196004)
+   *
+   * For `_onRequest` we need the event from `_onRequestWillBeSent` and
+   * optionally the `interceptionId` from `_onRequestPaused`.
+   *
+   * If request interception is disabled, call `_onRequest` once per call to
+   * `_onRequestWillBeSent`.
+   * If request interception is enabled, call `_onRequest` once per call to
+   * `_onRequestPaused` (once per `interceptionId`).
+   *
+   * Events are stored to allow for subsequent events to call `_onRequest`.
+   *
+   * Note that (chains of) redirect requests have the same `requestId` (!) as
+   * the original request. We have to anticipate series of events like these:
+   *  A. `_onRequestWillBeSent`,
+   *     `_onRequestWillBeSent`, ...
+   *  B. `_onRequestWillBeSent`, `_onRequestPaused`,
+   *     `_onRequestWillBeSent`, `_onRequestPaused`, ...
+   *  C. `_onRequestWillBeSent`, `_onRequestPaused`,
+   *     `_onRequestPaused`, `_onRequestWillBeSent`, ...
+   *  D. `_onRequestPaused`, `_onRequestWillBeSent`,
+   *     `_onRequestPaused`, `_onRequestWillBeSent`, `_onRequestPaused`,
+   *     `_onRequestWillBeSent`, `_onRequestPaused`, `_onRequestPaused`, ...
+   *     (see crbug.com/1196004)
+   */
+  requestWillBeSent = new Map<
+    string,
+    Protocol.Network.RequestWillBeSentEvent
+  >();
+  requestPaused = new Map<string, Protocol.Fetch.RequestPausedEvent>();
+  httpRequest = new Map<string, HTTPRequest>();
+
+  /*
+   * The below maps are used to reconcile Network.responseReceivedExtraInfo
+   * events with their corresponding request. Each response and redirect
+   * response gets an ExtraInfo event, and we don't know which will come first.
+   * This means that we have to store a Response or an ExtraInfo for each
+   * response, and emit the event when we get both of them. In addition, to
+   * handle redirects, we have to make them Arrays to represent the chain of
+   * events.
+   */
+  responseReceivedExtraInfo = new Map<
+    string,
+    Protocol.Network.ResponseReceivedExtraInfoEvent[]
+  >();
+  queuedRedirectInfoMap = new Map<string, RedirectInfoMap>();
+  queuedEvents = new Map<string, QueuedEvents>();
+
+  forget(requestId: string): void {
+    this.requestWillBeSent.delete(requestId);
+    this.requestPaused.delete(requestId);
+    this.queuedEvents.delete(requestId);
+    this.queuedRedirectInfoMap.delete(requestId);
+    this.responseReceivedExtraInfo.delete(requestId);
+  }
+}

--- a/src/common/NetworkEventManager.ts
+++ b/src/common/NetworkEventManager.ts
@@ -9,9 +9,12 @@ export type QueuedEvents = {
   loadingFailed?: Protocol.Network.LoadingFailedEvent;
 };
 
+export type FetchRequestId = string;
+export type NetworkRequestId = string;
+
 export type RedirectInfoMap = Array<{
   event: Protocol.Network.RequestWillBeSentEvent;
-  fetchRequestId?: string;
+  fetchRequestId?: FetchRequestId;
 }>;
 
 /**
@@ -53,11 +56,14 @@ export class NetworkEventManager {
    *     (see crbug.com/1196004)
    */
   requestWillBeSent = new Map<
-    string,
+    NetworkRequestId,
     Protocol.Network.RequestWillBeSentEvent
   >();
-  requestPaused = new Map<string, Protocol.Fetch.RequestPausedEvent>();
-  httpRequest = new Map<string, HTTPRequest>();
+  requestPaused = new Map<
+    NetworkRequestId,
+    Protocol.Fetch.RequestPausedEvent
+  >();
+  httpRequest = new Map<NetworkRequestId, HTTPRequest>();
 
   /*
    * The below maps are used to reconcile Network.responseReceivedExtraInfo
@@ -69,33 +75,33 @@ export class NetworkEventManager {
    * events.
    */
   private _responseReceivedExtraInfo = new Map<
-    string,
+    NetworkRequestId,
     Protocol.Network.ResponseReceivedExtraInfoEvent[]
   >();
-  private _queuedRedirectInfoMap = new Map<string, RedirectInfoMap>();
-  queuedEvents = new Map<string, QueuedEvents>();
+  private _queuedRedirectInfoMap = new Map<NetworkRequestId, RedirectInfoMap>();
+  queuedEvents = new Map<NetworkRequestId, QueuedEvents>();
 
-  forget(requestId: string): void {
-    this.requestWillBeSent.delete(requestId);
-    this.requestPaused.delete(requestId);
-    this.queuedEvents.delete(requestId);
-    this._queuedRedirectInfoMap.delete(requestId);
-    this._responseReceivedExtraInfo.delete(requestId);
+  forget(networkRequestId: NetworkRequestId): void {
+    this.requestWillBeSent.delete(networkRequestId);
+    this.requestPaused.delete(networkRequestId);
+    this.queuedEvents.delete(networkRequestId);
+    this._queuedRedirectInfoMap.delete(networkRequestId);
+    this._responseReceivedExtraInfo.delete(networkRequestId);
   }
 
   responseExtraInfo(
-    requestId: string
+    networkRequestId: NetworkRequestId
   ): Protocol.Network.ResponseReceivedExtraInfoEvent[] {
-    if (!this._responseReceivedExtraInfo.has(requestId)) {
-      this._responseReceivedExtraInfo.set(requestId, []);
+    if (!this._responseReceivedExtraInfo.has(networkRequestId)) {
+      this._responseReceivedExtraInfo.set(networkRequestId, []);
     }
-    return this._responseReceivedExtraInfo.get(requestId);
+    return this._responseReceivedExtraInfo.get(networkRequestId);
   }
 
-  queuedRedirectInfo(requestId: string): RedirectInfoMap {
-    if (!this._queuedRedirectInfoMap.has(requestId)) {
-      this._queuedRedirectInfoMap.set(requestId, []);
+  queuedRedirectInfo(fetchRequestId: FetchRequestId): RedirectInfoMap {
+    if (!this._queuedRedirectInfoMap.has(fetchRequestId)) {
+      this._queuedRedirectInfoMap.set(fetchRequestId, []);
     }
-    return this._queuedRedirectInfoMap.get(requestId);
+    return this._queuedRedirectInfoMap.get(fetchRequestId);
   }
 }

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -87,7 +87,8 @@ export class NetworkManager extends EventEmitter {
    *  A. `_onRequestWillBeSent`
    *  B. `_onRequestWillBeSent`, `_onRequestPaused`
    *  C. `_onRequestPaused`, `_onRequestWillBeSent`
-   *  D. `_onRequestPaused`, `_onRequestWillBeSent`, `_onRequestPaused`
+   *  D. `_onRequestPaused`, `_onRequestWillBeSent`, `_onRequestPaused`,
+   *     `_onRequestWillBeSent`, `_onRequestPaused`, `_onRequestPaused`
    *     (see crbug.com/1196004)
    *
    * For `_onRequest` we need the event from `_onRequestWillBeSent` and
@@ -109,7 +110,8 @@ export class NetworkManager extends EventEmitter {
    *  C. `_onRequestWillBeSent`, `_onRequestPaused`,
    *     `_onRequestPaused`, `_onRequestWillBeSent`, ...
    *  D. `_onRequestPaused`, `_onRequestWillBeSent`,
-   *     `_onRequestPaused`, `_onRequestWillBeSent`, `_onRequestPaused`, ...
+   *     `_onRequestPaused`, `_onRequestWillBeSent`, `_onRequestPaused`,
+   *     `_onRequestWillBeSent`, `_onRequestPaused`, `_onRequestPaused`, ...
    *     (see crbug.com/1196004)
    */
   _networkRequestIdToRequestWillBeSentEvent = new Map<

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -308,6 +308,15 @@ export class NetworkManager extends EventEmitter {
       .catch(debugError);
   }
 
+  /**
+   * CDP may send a Fetch.requestPaused without or before a
+   * Network.requestWillBeSent
+   *
+   * CDP may send multiple Fetch.requestPaused
+   * for the same Network.requestWillBeSent.
+   *
+   *
+   */
   _onRequestPaused(event: Protocol.Fetch.RequestPausedEvent): void {
     if (
       !this._userRequestInterceptionEnabled &&
@@ -326,15 +335,6 @@ export class NetworkManager extends EventEmitter {
       return;
     }
 
-    /**
-     * CDP may send a Fetch.requestPaused without or before a
-     * Network.requestWillBeSent
-     *
-     * CDP may send multiple Fetch.requestPaused
-     * for the same Network.requestWillBeSent.
-     *
-     *
-     */
     const requestWillBeSentEvent = (() => {
       const requestWillBeSentEvent =
         this._networkRequestIdEventMap.requestWillBeSent.get(networkRequestId);

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -369,17 +369,6 @@ export class NetworkManager extends EventEmitter {
   }
 
   _onRequestPaused(event: Protocol.Fetch.RequestPausedEvent): void {
-    if (
-      !this._userRequestInterceptionEnabled &&
-      this._protocolRequestInterceptionEnabled
-    ) {
-      this._client
-        .send('Fetch.continueRequest', {
-          requestId: event.requestId,
-        })
-        .catch(debugError);
-    }
-
     const requestId = event.networkId;
     const interceptionId = event.requestId;
 

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -377,6 +377,17 @@ export class NetworkManager extends EventEmitter {
 
   _onRequestPaused(event: Protocol.Fetch.RequestPausedEvent): void {
     // console.log(`Fetch.requestPaused`, { event });
+    if (
+      !this._userRequestInterceptionEnabled &&
+      this._protocolRequestInterceptionEnabled
+    ) {
+      this._client
+        .send('Fetch.continueRequest', {
+          requestId: event.requestId,
+        })
+        .catch(debugError);
+    }
+
     const { networkId: networkRequestId, requestId: fetchRequestId } = event;
 
     if (!networkRequestId) {

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -22,7 +22,11 @@ import { helper, debugError } from './helper.js';
 import { Protocol } from 'devtools-protocol';
 import { HTTPRequest } from './HTTPRequest.js';
 import { HTTPResponse } from './HTTPResponse.js';
-import { NetworkEventManager } from './NetworkEventManager.js';
+import {
+  FetchRequestId,
+  NetworkEventManager,
+  NetworkRequestId,
+} from './NetworkEventManager.js';
 
 /**
  * @public
@@ -362,7 +366,7 @@ export class NetworkManager extends EventEmitter {
 
   _onRequest(
     event: Protocol.Network.RequestWillBeSentEvent,
-    fetchRequestId?: string
+    fetchRequestId?: FetchRequestId
   ): void {
     let redirectChain = [];
     if (event.redirectResponse) {
@@ -506,9 +510,11 @@ export class NetworkManager extends EventEmitter {
     this._emitResponseEvent(event, extraInfo);
   }
 
-  responseWaitingForExtraInfoPromise(requestId: string): Promise<void> {
+  responseWaitingForExtraInfoPromise(
+    networkRequestId: NetworkRequestId
+  ): Promise<void> {
     const responseReceived =
-      this._networkRequestIdEventMap.queuedEvents.get(requestId);
+      this._networkRequestIdEventMap.queuedEvents.get(networkRequestId);
     if (!responseReceived) return Promise.resolve();
     return responseReceived.promise;
   }

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -74,14 +74,25 @@ interface FrameManager {
   frame(frameId: string): Frame | null;
 }
 
+type QueuedEvents = {
+  responseReceived: Protocol.Network.ResponseReceivedEvent;
+  promise: Promise<void>;
+  resolver: () => void;
+  loadingFinished?: Protocol.Network.LoadingFinishedEvent;
+  loadingFailed?: Protocol.Network.LoadingFailedEvent;
+};
+
+type RedirectInfoMap = Array<{
+  event: Protocol.Network.RequestWillBeSentEvent;
+  interceptionId?: string;
+}>;
+
 /**
  * @internal
+ *
+ * Helper class to track network events by request ID
  */
-export class NetworkManager extends EventEmitter {
-  _client: CDPSession;
-  _ignoreHTTPSErrors: boolean;
-  _frameManager: FrameManager;
-
+class NetworkEventManager {
   /*
    * There are four possible orders of events:
    *  A. `_onRequestWillBeSent`
@@ -114,15 +125,12 @@ export class NetworkManager extends EventEmitter {
    *     `_onRequestWillBeSent`, `_onRequestPaused`, `_onRequestPaused`, ...
    *     (see crbug.com/1196004)
    */
-  _networkRequestIdToRequestWillBeSentEvent = new Map<
+  requestWillBeSent = new Map<
     string,
     Protocol.Network.RequestWillBeSentEvent
   >();
-  _networkRequestIdToRequestPausedEvent = new Map<
-    string,
-    Protocol.Fetch.RequestPausedEvent
-  >();
-  _requestIdToRequest = new Map<string, HTTPRequest>();
+  requestPaused = new Map<string, Protocol.Fetch.RequestPausedEvent>();
+  httpRequest = new Map<string, HTTPRequest>();
 
   /*
    * The below maps are used to reconcile Network.responseReceivedExtraInfo
@@ -133,27 +141,31 @@ export class NetworkManager extends EventEmitter {
    * handle redirects, we have to make them Arrays to represent the chain of
    * events.
    */
-  _networkRequestIdToResponseReceivedExtraInfo = new Map<
+  responseReceivedExtraInfo = new Map<
     string,
     Protocol.Network.ResponseReceivedExtraInfoEvent[]
   >();
-  _networkRequestIdToQueuedRedirectInfoMap = new Map<
-    string,
-    Array<{
-      event: Protocol.Network.RequestWillBeSentEvent;
-      interceptionId?: string;
-    }>
-  >();
-  _networkRequestIdToQueuedEvents = new Map<
-    string,
-    {
-      responseReceived: Protocol.Network.ResponseReceivedEvent;
-      promise: Promise<void>;
-      resolver: () => void;
-      loadingFinished?: Protocol.Network.LoadingFinishedEvent;
-      loadingFailed?: Protocol.Network.LoadingFailedEvent;
-    }
-  >();
+  queuedRedirectInfoMap = new Map<string, RedirectInfoMap>();
+  queuedEvents = new Map<string, QueuedEvents>();
+
+  forget(requestId: string) {
+    this.requestWillBeSent.delete(requestId);
+    this.requestPaused.delete(requestId);
+    this.queuedEvents.delete(requestId);
+    this.queuedRedirectInfoMap.delete(requestId);
+    this.responseReceivedExtraInfo.delete(requestId);
+  }
+}
+
+/**
+ * @internal
+ */
+export class NetworkManager extends EventEmitter {
+  _client: CDPSession;
+  _ignoreHTTPSErrors: boolean;
+  _frameManager: FrameManager;
+
+  _networkEventMap = new NetworkEventManager();
 
   _extraHTTPHeaders: Record<string, string> = {};
   _credentials?: Credentials = null;
@@ -238,7 +250,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   numRequestsInProgress(): number {
-    return [...this._requestIdToRequest].filter(([, request]) => {
+    return [...this._networkEventMap.httpRequest].filter(([, request]) => {
       return !request.response();
     }).length;
   }
@@ -332,20 +344,17 @@ export class NetworkManager extends EventEmitter {
     ) {
       const { requestId: networkRequestId } = event;
 
-      this._networkRequestIdToRequestWillBeSentEvent.set(
-        networkRequestId,
-        event
-      );
+      this._networkEventMap.requestWillBeSent.set(networkRequestId, event);
 
       /**
        * CDP may have sent a Fetch.requestPaused event already. Check for it.
        */
       const requestPausedEvent =
-        this._networkRequestIdToRequestPausedEvent.get(networkRequestId);
+        this._networkEventMap.requestPaused.get(networkRequestId);
       if (requestPausedEvent) {
         const { requestId: fetchRequestId } = requestPausedEvent;
         this._onRequest(event, fetchRequestId);
-        this._networkRequestIdToRequestPausedEvent.delete(networkRequestId);
+        this._networkEventMap.requestPaused.delete(networkRequestId);
       }
 
       return;
@@ -407,7 +416,7 @@ export class NetworkManager extends EventEmitter {
      */
     const requestWillBeSentEvent = (() => {
       const requestWillBeSentEvent =
-        this._networkRequestIdToRequestWillBeSentEvent.get(networkRequestId);
+        this._networkEventMap.requestWillBeSent.get(networkRequestId);
 
       // redirect requests have the same `requestId`,
       if (
@@ -415,7 +424,7 @@ export class NetworkManager extends EventEmitter {
         (requestWillBeSentEvent.request.url !== event.request.url ||
           requestWillBeSentEvent.request.method !== event.request.method)
       ) {
-        this._networkRequestIdToRequestWillBeSentEvent.delete(networkRequestId);
+        this._networkEventMap.requestWillBeSent.delete(networkRequestId);
         return;
       }
       return requestWillBeSentEvent;
@@ -424,7 +433,7 @@ export class NetworkManager extends EventEmitter {
     if (requestWillBeSentEvent) {
       this._onRequest(requestWillBeSentEvent, fetchRequestId);
     } else {
-      this._networkRequestIdToRequestPausedEvent.set(networkRequestId, event);
+      this._networkEventMap.requestPaused.set(networkRequestId, event);
     }
   }
 
@@ -432,19 +441,19 @@ export class NetworkManager extends EventEmitter {
     event: Protocol.Network.RequestWillBeSentEvent;
     interceptionId?: string;
   }> {
-    if (!this._networkRequestIdToQueuedRedirectInfoMap.has(requestId)) {
-      this._networkRequestIdToQueuedRedirectInfoMap.set(requestId, []);
+    if (!this._networkEventMap.queuedRedirectInfoMap.has(requestId)) {
+      this._networkEventMap.queuedRedirectInfoMap.set(requestId, []);
     }
-    return this._networkRequestIdToQueuedRedirectInfoMap.get(requestId);
+    return this._networkEventMap.queuedRedirectInfoMap.get(requestId);
   }
 
   _networkRequestIdToResponseExtraInfo(
     requestId: string
   ): Protocol.Network.ResponseReceivedExtraInfoEvent[] {
-    if (!this._networkRequestIdToResponseReceivedExtraInfo.has(requestId)) {
-      this._networkRequestIdToResponseReceivedExtraInfo.set(requestId, []);
+    if (!this._networkEventMap.responseReceivedExtraInfo.has(requestId)) {
+      this._networkEventMap.responseReceivedExtraInfo.set(requestId, []);
     }
-    return this._networkRequestIdToResponseReceivedExtraInfo.get(requestId);
+    return this._networkEventMap.responseReceivedExtraInfo.get(requestId);
   }
 
   _onRequest(
@@ -474,7 +483,7 @@ export class NetworkManager extends EventEmitter {
         }
       }
 
-      const request = this._requestIdToRequest.get(event.requestId);
+      const request = this._networkEventMap.httpRequest.get(event.requestId);
       // If we connect late to the target, we could have missed the
       // requestWillBeSent event.
       if (request) {
@@ -497,7 +506,7 @@ export class NetworkManager extends EventEmitter {
       event,
       redirectChain
     );
-    this._requestIdToRequest.set(event.requestId, request);
+    this._networkEventMap.httpRequest.set(event.requestId, request);
     this.emit(NetworkManagerEmittedEvents.Request, request);
     request.finalizeInterceptions();
   }
@@ -505,7 +514,7 @@ export class NetworkManager extends EventEmitter {
   _onRequestServedFromCache(
     event: Protocol.Network.RequestServedFromCacheEvent
   ): void {
-    const request = this._requestIdToRequest.get(event.requestId);
+    const request = this._networkEventMap.httpRequest.get(event.requestId);
     if (request) request._fromMemoryCache = true;
     this.emit(NetworkManagerEmittedEvents.RequestServedFromCache, request);
   }
@@ -535,7 +544,9 @@ export class NetworkManager extends EventEmitter {
     responseReceived: Protocol.Network.ResponseReceivedEvent,
     extraInfo: Protocol.Network.ResponseReceivedExtraInfoEvent
   ): void {
-    const request = this._requestIdToRequest.get(responseReceived.requestId);
+    const request = this._networkEventMap.httpRequest.get(
+      responseReceived.requestId
+    );
     // FileUpload sends a response without a matching request.
     if (!request) return;
 
@@ -559,7 +570,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   _onResponseReceived(event: Protocol.Network.ResponseReceivedEvent): void {
-    const request = this._requestIdToRequest.get(event.requestId);
+    const request = this._networkEventMap.httpRequest.get(event.requestId);
     let extraInfo = null;
     if (request && !request._fromMemoryCache && event.hasExtraInfo) {
       extraInfo = this._networkRequestIdToResponseExtraInfo(
@@ -569,7 +580,7 @@ export class NetworkManager extends EventEmitter {
         // Wait until we get the corresponding ExtraInfo event.
         let resolver = null;
         const promise = new Promise<void>((resolve) => (resolver = resolve));
-        this._networkRequestIdToQueuedEvents.set(event.requestId, {
+        this._networkEventMap.queuedEvents.set(event.requestId, {
           responseReceived: event,
           promise,
           resolver,
@@ -581,8 +592,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   responseWaitingForExtraInfoPromise(requestId: string): Promise<void> {
-    const responseReceived =
-      this._networkRequestIdToQueuedEvents.get(requestId);
+    const responseReceived = this._networkEventMap.queuedEvents.get(requestId);
     if (!responseReceived) return Promise.resolve();
     return responseReceived.promise;
   }
@@ -604,7 +614,7 @@ export class NetworkManager extends EventEmitter {
 
     // We may have skipped response and loading events because we didn't have
     // this ExtraInfo event yet. If so, emit those events now.
-    const queuedEvents = this._networkRequestIdToQueuedEvents.get(
+    const queuedEvents = this._networkEventMap.queuedEvents.get(
       event.requestId
     );
     if (queuedEvents) {
@@ -627,22 +637,18 @@ export class NetworkManager extends EventEmitter {
     const requestId = request._requestId;
     const interceptionId = request._interceptionId;
 
-    this._requestIdToRequest.delete(requestId);
+    this._networkEventMap.httpRequest.delete(requestId);
     this._attemptedAuthentications.delete(interceptionId);
 
     if (events) {
-      this._networkRequestIdToRequestWillBeSentEvent.delete(requestId);
-      this._networkRequestIdToRequestPausedEvent.delete(requestId);
-      this._networkRequestIdToQueuedEvents.delete(requestId);
-      this._networkRequestIdToQueuedRedirectInfoMap.delete(requestId);
-      this._networkRequestIdToResponseReceivedExtraInfo.delete(requestId);
+      this._networkEventMap.forget(requestId);
     }
   }
 
   _onLoadingFinished(event: Protocol.Network.LoadingFinishedEvent): void {
     // If the response event for this request is still waiting on a
     // corresponding ExtraInfo event, then wait to emit this event too.
-    const queuedEvents = this._networkRequestIdToQueuedEvents.get(
+    const queuedEvents = this._networkEventMap.queuedEvents.get(
       event.requestId
     );
     if (queuedEvents) {
@@ -653,7 +659,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   _emitLoadingFinished(event: Protocol.Network.LoadingFinishedEvent): void {
-    const request = this._requestIdToRequest.get(event.requestId);
+    const request = this._networkEventMap.httpRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
     // @see https://crbug.com/750469
     if (!request) return;
@@ -668,7 +674,7 @@ export class NetworkManager extends EventEmitter {
   _onLoadingFailed(event: Protocol.Network.LoadingFailedEvent): void {
     // If the response event for this request is still waiting on a
     // corresponding ExtraInfo event, then wait to emit this event too.
-    const queuedEvents = this._networkRequestIdToQueuedEvents.get(
+    const queuedEvents = this._networkEventMap.queuedEvents.get(
       event.requestId
     );
     if (queuedEvents) {
@@ -679,7 +685,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   _emitLoadingFailed(event: Protocol.Network.LoadingFailedEvent): void {
-    const request = this._requestIdToRequest.get(event.requestId);
+    const request = this._networkEventMap.httpRequest.get(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
     // @see https://crbug.com/750469
     if (!request) return;

--- a/test/NetworkManager.spec.ts
+++ b/test/NetworkManager.spec.ts
@@ -16,16 +16,21 @@
 
 import { describeChromeOnly } from './mocha-utils'; // eslint-disable-line import/extensions
 
-import { NetworkManager } from '../lib/cjs/puppeteer/common/NetworkManager.js';
+import expect from 'expect';
+import {
+  NetworkManager,
+  NetworkManagerEmittedEvents,
+} from '../lib/cjs/puppeteer/common/NetworkManager.js';
+import { HTTPRequest } from '../lib/cjs/puppeteer/common/HTTPRequest.js';
 import { EventEmitter } from '../lib/cjs/puppeteer/common/EventEmitter.js';
 import { Frame } from '../lib/cjs/puppeteer/common/FrameManager.js';
 
+class MockCDPSession extends EventEmitter {
+  async send(): Promise<any> {}
+}
+
 describeChromeOnly('NetworkManager', () => {
   it('should process extra info on multiple redirects', async () => {
-    class MockCDPSession extends EventEmitter {
-      send(): any {}
-    }
-
     const mockCDPSession = new MockCDPSession();
     new NetworkManager(mockCDPSession, true, {
       frame(): Frame | null {
@@ -455,5 +460,87 @@ describeChromeOnly('NetworkManager', () => {
       hasExtraInfo: true,
       frameId: '099A5216AF03AAFEC988F214B024DF08',
     });
+  });
+  it(`should handle multiple Fetch.requestPaused events for the same Network.requestWillBeSent event`, async () => {
+    const mockCDPSession = new MockCDPSession();
+    const manager = new NetworkManager(mockCDPSession, true, {
+      frame(): Frame | null {
+        return null;
+      },
+    });
+    manager.setRequestInterception(true);
+
+    const requests: HTTPRequest[] = [];
+    manager.on(NetworkManagerEmittedEvents.Request, (request: HTTPRequest) => {
+      request.continue();
+      requests.push(request);
+    });
+
+    /**
+     * This sequence was taken from an actual CDP session produced by the following
+     * test script:
+     *
+     * const browser = await puppeteer.launch({ headless: false });
+     * const page = await browser.newPage();
+     * await page.setCacheEnabled(false);
+     *
+     * await page.setRequestInterception(true)
+     * page.on('request', (interceptedRequest) => {
+     *   interceptedRequest.continue();
+     * });
+     *
+     * await page.goto('https://www.google.com');
+     * await browser.close();
+     *
+     */
+    mockCDPSession.emit('Network.requestWillBeSent', {
+      requestId: '11ACE9783588040D644B905E8B55285B',
+      loaderId: '11ACE9783588040D644B905E8B55285B',
+      documentURL: 'https://www.google.com/',
+      request: {
+        url: 'https://www.google.com/',
+        method: 'GET',
+        headers: [Object],
+        mixedContentType: 'none',
+        initialPriority: 'VeryHigh',
+        referrerPolicy: 'strict-origin-when-cross-origin',
+        isSameSite: true,
+      },
+      timestamp: 224604.980827,
+      wallTime: 1637955746.786191,
+      initiator: { type: 'other' },
+      redirectHasExtraInfo: false,
+      type: 'Document',
+      frameId: '84AC261A351B86932B775B76D1DD79F8',
+      hasUserGesture: false,
+    });
+    mockCDPSession.emit('Fetch.requestPaused', {
+      requestId: 'interception-job-1.0',
+      request: {
+        url: 'https://www.google.com/',
+        method: 'GET',
+        headers: [Object],
+        initialPriority: 'VeryHigh',
+        referrerPolicy: 'strict-origin-when-cross-origin',
+      },
+      frameId: '84AC261A351B86932B775B76D1DD79F8',
+      resourceType: 'Document',
+      networkId: '11ACE9783588040D644B905E8B55285B',
+    });
+    mockCDPSession.emit('Fetch.requestPaused', {
+      requestId: 'interception-job-2.0',
+      request: {
+        url: 'https://www.google.com/',
+        method: 'GET',
+        headers: [Object],
+        initialPriority: 'VeryHigh',
+        referrerPolicy: 'strict-origin-when-cross-origin',
+      },
+      frameId: '84AC261A351B86932B775B76D1DD79F8',
+      resourceType: 'Document',
+      networkId: '11ACE9783588040D644B905E8B55285B',
+    });
+
+    expect(requests.length).toBe(2);
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

refactoring

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

The distinction between a CDP's [Network.requestId](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-RequestId) and [Fetch.requestId](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#type-RequestId) was becoming ambiguous and verbose. This is an attempt to consolidate it into a new class and add clarity.

**Does this PR introduce a breaking change?**

No

**Other information**

Tagging @josepharhar who originated a lot of this and @jschfflr who reviewed @josepharhar's work.

#7764
#7760
Stacked on #7802 