### PR TITLE
fix(types): ensure compiler directives are at top

### DIFF
--- a/inject-global-type-stubs.js
+++ b/inject-global-type-stubs.js
@@ -23,7 +23,7 @@ async function injctGlobalTypeStubs() {
   const globalsPath = join(__dirname, 'lib', 'cjs', 'puppeteer', 'global.d.ts');
   const types = await fs.readFile(typesPath, 'utf-8');
   const globals = await fs.readFile(globalsPath, 'utf-8');
-  await fs.writeFile(typesPath, `${globals}\n${types}`);
+  await fs.writeFile(typesPath, `${types}\n${globals}`);
 }
 
 injctGlobalTypeStubs();


### PR DESCRIPTION
The workaround to make Puppeteers types work without DOM types
unfortunately breaks tsc's module resolution, since it put a declaration
before a [triple-slash compiler directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html). This makes the directive
invalid and it is therefore ignored by the typescript compiler when
resolving modules.

This fix instead appends the `global.d.ts` declarations at the end of
the generated `types.d.ts` file, ensuring that any directives stays at
the top of the file.