### PR TITLE
refactor: remove unused QueuedEventGroup.promise

### DIFF
--- a/src/common/NetworkEventManager.ts
+++ b/src/common/NetworkEventManager.ts
@@ -3,8 +3,6 @@ import { HTTPRequest } from './HTTPRequest.js';
 
 export type QueuedEventGroup = {
   responseReceivedEvent: Protocol.Network.ResponseReceivedEvent;
-  promise: Promise<void>;
-  resolver: () => void;
   loadingFinishedEvent?: Protocol.Network.LoadingFinishedEvent;
   loadingFailedEvent?: Protocol.Network.LoadingFailedEvent;
 };

--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -22,11 +22,7 @@ import { helper, debugError } from './helper.js';
 import { Protocol } from 'devtools-protocol';
 import { HTTPRequest } from './HTTPRequest.js';
 import { HTTPResponse } from './HTTPResponse.js';
-import {
-  FetchRequestId,
-  NetworkEventManager,
-  NetworkRequestId,
-} from './NetworkEventManager.js';
+import { FetchRequestId, NetworkEventManager } from './NetworkEventManager.js';
 
 /**
  * @public
@@ -480,26 +476,13 @@ export class NetworkManager extends EventEmitter {
         .shift();
       if (!extraInfo) {
         // Wait until we get the corresponding ExtraInfo event.
-        let resolver = null;
-        const promise = new Promise<void>((resolve) => (resolver = resolve));
         this._networkEventManager.queueEventGroup(event.requestId, {
           responseReceivedEvent: event,
-          promise,
-          resolver,
         });
         return;
       }
     }
     this._emitResponseEvent(event, extraInfo);
-  }
-
-  responseWaitingForExtraInfoPromise(
-    networkRequestId: NetworkRequestId
-  ): Promise<void> {
-    const responseReceived =
-      this._networkEventManager.getQueuedEventGroup(networkRequestId);
-    if (!responseReceived) return Promise.resolve();
-    return responseReceived.promise;
   }
 
   _onResponseReceivedExtraInfo(
@@ -530,7 +513,6 @@ export class NetworkManager extends EventEmitter {
       if (queuedEvents.loadingFailedEvent) {
         this._emitLoadingFailed(queuedEvents.loadingFailedEvent);
       }
-      queuedEvents.resolver();
       return;
     }
 


### PR DESCRIPTION
**Did you add tests for your changes?**

N/A

**Summary**

Referring back to discussion on https://github.com/puppeteer/puppeteer/pull/7826/files#diff-bc1ce23addce6e88bde0b9802379569654d1f1aa5ce76aa8883068604181ec31L7, I believe it is safe to remove all this. `NetworkManager.responseWaitingForExtraInfoPromise`, while public, is not referenced in any code or docs.

**Does this PR introduce a breaking change?**

Not sure. What is Puppeteer's policy on unpublished API changes? `NetworkManager.responseWaitingForExtraInfoPromise` is public but it is [relatively new](https://github.com/puppeteer/puppeteer/commit/ac162c561ee43dd69eff38e1b354a41bb42c9eba#diff-3280fbae5b6189c9b87a76ea21a5da3e10140467e29532e0b7b72608036f5070R561) and I suspect was just a refactoring oversight. I see no purpose for it. 
