### PR TITLE
chore: use a modern disable-popup-blocking flag version

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -220,7 +220,7 @@ class ChromeLauncher implements ProductLauncher {
       '--disable-features=Translate',
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
-      '--disable-popup-blocking',
+      '--block-new-web-contents',
       '--disable-prompt-on-repost',
       '--disable-renderer-backgrounding',
       '--disable-sync',


### PR DESCRIPTION
According to https://github.com/GoogleChrome/chrome-launcher/blob/master/docs/chrome-flags-for-tools.md#performance--web-platform-behavior

> `--block-new-web-contents` is the strict version of `--disable-popup-blocking`.

Non related but `--disable-features=ScriptStreaming` is missing and chrome-launcher recommends it as optimization. Should I add it?