### PR TITLE
Add iPhone 12 mini to the list of devices

### DIFF
--- a/src/common/DeviceDescriptors.ts
+++ b/src/common/DeviceDescriptors.ts
@@ -708,6 +708,32 @@ const devices: Device[] = [
     },
   },
   {
+    name: 'iPhone 12 mini',
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Mobile/15E148 Safari/604.1',
+    viewport: {
+      width: 375,
+      height: 812,
+      deviceScaleFactor: 3,
+      isMobile: true,
+      hasTouch: true,
+      isLandscape: false,
+    },
+  },
+  {
+    name: 'iPhone 12 mini landscape',
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 15_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Mobile/15E148 Safari/604.1',
+    viewport: {
+      width: 812,
+      height: 375,
+      deviceScaleFactor: 3,
+      isMobile: true,
+      hasTouch: true,
+      isLandscape: true,
+    },
+  },
+  {
     name: 'JioPhone 2',
     userAgent:
       'Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-15-130718-i;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This adds another device to the devices list.

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

I wanted to produce a screenshot that fit the dimensions of my iPhone 12 mini, but the iPhone 12 mini was not an option. 

**Does this PR introduce a breaking change?**

N/A

**Other information**

I did not add in the other iPhone 12 devices because I only own a 12 mini.