### PR TITLE
feat: add support for async waitForTarget

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -983,7 +983,7 @@ the method will return an array with all the targets in all browser contexts.
 
 #### browser.waitForTarget(predicate[, options])
 
-- `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
+- `predicate` <[function]\([Target]\):[boolean]|[Promise<boolean>]> A function to be run for every target
 - `options` <[Object]>
   - `timeout` <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
 - returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.
@@ -1135,7 +1135,7 @@ An array of all active targets inside the browser context.
 
 #### browserContext.waitForTarget(predicate[, options])
 
-- `predicate` <[function]\([Target]\):[boolean]> A function to be run for every target
+- `predicate` <[function]\([Target]\):[boolean]|[Promise<boolean>]> A function to be run for every target
 - `options` <[Object]>
   - `timeout` <[number]> Maximum wait time in milliseconds. Pass `0` to disable the timeout. Defaults to 30 seconds.
 - returns: <[Promise]<[Target]>> Promise which resolves to the first target found that matches the `predicate` function.

--- a/experimental/puppeteer-firefox/lib/Browser.js
+++ b/experimental/puppeteer-firefox/lib/Browser.js
@@ -122,23 +122,34 @@ class Browser extends EventEmitter {
     const {
       timeout = 30000
     } = options;
-    let existingTarget;
-    for (const target of this.targets()) {
-      if (await predicate(target)) {
-        existingTarget = target;
-        break;
-      }
-    }
-    if (existingTarget)
-      return existingTarget;
+    let remainingTimeout = timeout;
+    const existingTarget = await helper.waitWithTimeout(
+      (async () => {
+        const startTime = Date.now();
+        let existingTarget;
+        for (const target of this.targets()) {
+          if (await predicate(target)) {
+            existingTarget = target;
+            break;
+          }
+        }
+        if (timeout) {
+          remainingTimeout = Math.max(timeout - (Date.now() - startTime), 1);
+        }
+        if (existingTarget) return existingTarget;
+      })(),
+      'predicate',
+      timeout
+    );
+    if (existingTarget) return existingTarget;
     let resolve;
     const targetPromise = new Promise(x => resolve = x);
     this.on(Events.Browser.TargetCreated, check);
     this.on('targetchanged', check);
     try {
-      if (!timeout)
+      if (!remainingTimeout)
         return await targetPromise;
-      return await helper.waitWithTimeout(targetPromise, 'target', timeout);
+      return await helper.waitWithTimeout(targetPromise, 'target', remainingTimeout);
     } finally {
       this.removeListener(Events.Browser.TargetCreated, check);
       this.removeListener('targetchanged', check);

--- a/experimental/puppeteer-firefox/lib/Browser.js
+++ b/experimental/puppeteer-firefox/lib/Browser.js
@@ -114,7 +114,7 @@ class Browser extends EventEmitter {
   }
 
   /**
-   * @param {function(!Target):boolean} predicate
+   * @param {function(!Target):boolean|Promise<boolean>} predicate
    * @param {{timeout?: number}=} options
    * @return {!Promise<!Target>}
    */
@@ -122,7 +122,13 @@ class Browser extends EventEmitter {
     const {
       timeout = 30000
     } = options;
-    const existingTarget = this.targets().find(predicate);
+    let existingTarget;
+    for (const target of this.targets()) {
+      if (await predicate(target)) {
+        existingTarget = target;
+        break;
+      }
+    }
     if (existingTarget)
       return existingTarget;
     let resolve;
@@ -141,8 +147,8 @@ class Browser extends EventEmitter {
     /**
      * @param {!Target} target
      */
-    function check(target) {
-      if (predicate(target))
+    async function check(target) {
+      if (await predicate(target))
         resolve(target);
     }
   }
@@ -334,7 +340,7 @@ class BrowserContext extends EventEmitter {
   }
 
   /**
-   * @param {function(Target):boolean} predicate
+   * @param {function(Target):boolean|Promise<boolean>} predicate
    * @param {{timeout?: number}=} options
    * @return {!Promise<Target>}
    */

--- a/test/target.spec.ts
+++ b/test/target.spec.ts
@@ -86,7 +86,10 @@ describe('Target', function () {
         server.CROSS_PROCESS_PREFIX + '/empty.html'
       ),
     ]);
-    expect(otherPage.url()).toContain(server.CROSS_PROCESS_PREFIX);
+    expect(otherPage.url()).toEqual(
+      server.CROSS_PROCESS_PREFIX + '/empty.html'
+    );
+    expect(page).not.toEqual(otherPage);
   });
   itFailsFirefox(
     'should report when a new page is created and closed',

--- a/test/target.spec.ts
+++ b/test/target.spec.ts
@@ -67,6 +67,27 @@ describe('Target', function () {
     ).toBe('Hello world');
     expect(await originalPage.$('body')).toBeTruthy();
   });
+  itFailsFirefox('should be able to use async waitForTarget', async () => {
+    const { page, server, context } = getTestState();
+
+    const [otherPage] = await Promise.all([
+      context
+        .waitForTarget((target) =>
+          target
+            .page()
+            .then(
+              (page) =>
+                page.url() === server.CROSS_PROCESS_PREFIX + '/empty.html'
+            )
+        )
+        .then((target) => target.page()),
+      page.evaluate(
+        (url: string) => window.open(url),
+        server.CROSS_PROCESS_PREFIX + '/empty.html'
+      ),
+    ]);
+    expect(otherPage.url()).toContain(server.CROSS_PROCESS_PREFIX);
+  });
   itFailsFirefox(
     'should report when a new page is created and closed',
     async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature

**Did you add tests for your changes?**
yes
**If relevant, did you update the documentation?**
yes
**Summary**
sometimes we need to call `waitForTarget` in async:
```javascript
const target = await browser.waitForTarget((target) =>
  target
    .page()
    .then((page) => page.title())
    .then((title) => title === 'expected')
);
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
