### PR TITLE
fix: use content box for OOPIF offset calculations

### DIFF
--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -489,14 +489,14 @@ export class ElementHandle<
       const { backendNodeId } = await parent._client.send('DOM.getFrameOwner', {
         frameId: frame._id,
       });
-      const { quads } = await parent._client.send('DOM.getContentQuads', {
+      const result = await parent._client.send('DOM.getBoxModel', {
         backendNodeId: backendNodeId,
       });
-      if (!quads || !quads.length) {
+      if (!result) {
         break;
       }
-      const protocolQuads = quads.map((quad) => this._fromProtocolQuad(quad));
-      const topLeftCorner = protocolQuads[0][0];
+      const contentBoxQuad = result.model.content;
+      const topLeftCorner = this._fromProtocolQuad(contentBoxQuad)[0];
       offsetX += topLeftCorner.x;
       offsetY += topLeftCorner.y;
       frame = parent;


### PR DESCRIPTION
If an iframe has a border, it has to be added to the offsets
too. We can work around it by using the content box coordinates
for the offsets. That should also prevent discrepancies if the
iframe has a padding set.

Issues: #7849
