### PR TITLE
fix(types): enable type errors w. $x() empty array

### DIFF
--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -1103,7 +1103,7 @@ export class ElementHandle<
    * If there are no such elements, the method will resolve to an empty array.
    * @param expression - Expression to {@link https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate | evaluate}
    */
-  async $x(expression: string): Promise<ElementHandle[]> {
+  async $x(expression: string): Promise<(ElementHandle | undefined)[]> {
     const arrayHandle = await this.evaluateHandle(
       (element: Document, expression: string) => {
         const document = element.ownerDocument || element;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

First of all, thanks for all of your continued effort on Puppeteer, really amazing project!

**What kind of change does this PR introduce?**

Bugfix - if `page.$x` returns an empty array, throw type error when runtime error possible.

For example, the runtime error below would also become a type error:

```js
// Non-existent button selected below, causing runtime error but no type error
const [button] = await page.$x("//button[text()='non-existent']");
button.click(); // 💥 TypeError: Cannot read properties of undefined (reading 'click')
```

It would require code to guard against `undefined`:

```typescript
const [button] = await page.$x("//button[text()='non-existent']");
if (button) {
  button.click(); // ✅
}
```

**Did you add tests for your changes?**

No, but I can update tests if necessary

**If relevant, did you update the documentation?**

I'm hoping the documentation is auto-generated from the TS types, but if necessary I can update the docs manually.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Motivation is described above.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Yes, this is a breaking change for the types.

**Other information**

**Alternatives considered**

A workaround that we've explored for now (although not as nice as the destructuring in the original post above):

```ts
const buttons = await page.$x("//button[text()='non-existent']");
if (buttons.length > 0) {
  buttons[0].click(); // ✅
}
```

The reason why the destructuring + simple guard at the top of this post doesn't work for us is because of [`@typescript-eslint/no-unnecessary-condition`](https://typescript-eslint.io/rules/no-unnecessary-condition/), which recognizes this as an unnecessary condition:

<img width="591" alt="Screen Shot 2022-01-18 at 12 08 20" src="https://user-images.githubusercontent.com/1935696/149926221-0fab1838-b7d7-4dd4-b2ec-538cfc40b276.png">

This is because TypeScript will return the type of `ElementHandle<Element>` for the first destructured element, which will always be truthy.