### PR TITLE
fix: update node-fetch package

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "devtools-protocol": "0.0.948846",
     "extract-zip": "2.0.1",
     "https-proxy-agent": "5.0.0",
-    "node-fetch": "2.6.5",
+    "node-fetch": "2.6.7",
     "pkg-dir": "4.2.0",
     "progress": "2.0.3",
     "proxy-from-env": "1.1.0",


### PR DESCRIPTION
Update node-fetch to version 2.6.7 to avoid a high vulnerability

Issue: #7921

https://github.com/advisories/GHSA-r683-j2x4-v87g
