### PR TITLE
fix(initialize-node): __dirname in some envrioments

### DIFF
--- a/src/initialize-node.ts
+++ b/src/initialize-node.ts
@@ -20,7 +20,8 @@ import pkgDir from 'pkg-dir';
 import { Product } from './common/Product.js';
 
 export const initializePuppeteerNode = (packageName: string): PuppeteerNode => {
-  const puppeteerRootDirectory = pkgDir.sync(__dirname);
+  const puppeteerRootDirectory =
+    pkgDir.sync(__dirname) || pkgDir.sync(process.cwd());
 
   let preferredRevision = PUPPETEER_REVISIONS.chromium;
   const isPuppeteerCore = packageName === 'puppeteer-core';


### PR DESCRIPTION
This patch fixes __dirname pointing to / in some envrioments by
trying process.cwd() if __dirname returne undefined.

Issues: #7085 #7932

**What kind of change does this PR introduce?**

Fixes #7932 where certain node environments with webpack don't place nicely to __dirname.

**Did you add tests for your changes?**

No. This is very difficult to reproduce in simple environments. This change only affects those where __dirname returns undefined on initialization. 

**If relevant, did you update the documentation?**

No relevant documentation updates needed.

**Summary**

When __dirname points to / it falls back to process.cwd to get the projectRoot on initialization. 

**Does this PR introduce a breaking change?**

No. 