### PR TITLE
fix: issue with reading versions.js in doclint

### DIFF
--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -38,7 +38,7 @@ async function run() {
   let changedFiles = false;
 
   if (IS_RELEASE) {
-    const { versionsPerRelease: versions } = await Source.readFile(
+    const versions = await Source.readFile(
       path.join(PROJECT_DIR, 'versions.js')
     );
     versions.setText(


### PR DESCRIPTION
Partially reverts https://github.com/puppeteer/puppeteer/pull/7927 where the regression happened.
