### PR TITLE
fix: make `waitForSelector` generic

### DIFF
--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -391,14 +391,14 @@ export class ElementHandle<
    * (30 seconds). Pass `0` to disable timeout. The default value can be changed
    * by using the {@link Page.setDefaultTimeout} method.
    */
-  async waitForSelector(
+  async waitForSelector<T extends boolean = false>(
     selector: string,
     options: {
       visible?: boolean;
-      hidden?: boolean;
+      hidden?: T;
       timeout?: number;
     } = {}
-  ): Promise<ElementHandle | null> {
+  ): Promise<T extends true ? null : ElementHandle> {
     const frame = this._context.frame();
     const secondaryContext = await frame._secondaryWorld.executionContext();
     const adoptedRoot = await secondaryContext._adoptElementHandle(this);
@@ -407,11 +407,11 @@ export class ElementHandle<
       root: adoptedRoot,
     });
     await adoptedRoot.dispose();
-    if (!handle) return null;
+    if (!handle) return null as T extends true ? null : ElementHandle;
     const mainExecutionContext = await frame._mainWorld.executionContext();
     const result = await mainExecutionContext._adoptElementHandle(handle);
     await handle.dispose();
-    return result;
+    return result as T extends true ? null : ElementHandle;
   }
 
   asElement(): ElementHandle<ElementType> | null {

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -3199,15 +3199,16 @@ export class Page extends EventEmitter {
    * (30 seconds). Pass `0` to disable timeout. The default value can be changed
    * by using the {@link Page.setDefaultTimeout} method.
    */
-  waitForSelector(
+  waitForSelector<T extends boolean = false>(
     selector: string,
     options: {
       visible?: boolean;
-      hidden?: boolean;
+      hidden?: T;
       timeout?: number;
     } = {}
-  ): Promise<ElementHandle | null> {
-    return this.mainFrame().waitForSelector(selector, options);
+  ): Promise<T extends true ? null : ElementHandle> {
+    const result = this.mainFrame().waitForSelector(selector, options);
+    return result as Promise<T extends true ? null : ElementHandle>;
   }
 
   /**

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -1055,6 +1055,13 @@ function compareDocumentations(actual, expected) {
           expectedName: 'T',
         },
       ],
+      [
+        'Method ElementHandle.waitForSelector() options.hidden',
+        {
+          actualName: 'boolean',
+          expectedName: 'T',
+        },
+      ],
     ]);
 
     const expectedForSource = expectedNamingMismatches.get(source);

--- a/utils/doclint/check_public_api/index.js
+++ b/utils/doclint/check_public_api/index.js
@@ -1048,6 +1048,13 @@ function compareDocumentations(actual, expected) {
           expectedName: 'JSHandle<unknown>',
         },
       ],
+      [
+        'Method Page.waitForSelector() options.hidden',
+        {
+          actualName: 'boolean',
+          expectedName: 'T',
+        },
+      ],
     ]);
 
     const expectedForSource = expectedNamingMismatches.get(source);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixes types only

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

No

**Summary**

```ts
const imgEl = await page.waitForSelector('img');
img; // ElementHandle<Element> (used to be ElementHandle<Element> | null)
```
whereas before this change:
```ts
const imgEl = await page.waitForSelector('img');
img; // ElementHandle<Element> | null
if (!img) throw new Error()
img; // ElementHandle<Element>
```
The extra check for `null` is now no longer necessary.

**Does this PR introduce a breaking change?**

No runtime changes for sure. Though users that were doing `null` checks as described above are now unnecessarily doing this. I'm not aware of any TypeScript configurations that would cause a compile error when a check like this is performed. In my brief testing I couldn't find any such situation.

**Other information**

Fixes #7295

I see `JSHandle` could benefit from the same same change. I'll try to add this as well.