### PR TITLE
fix: typos in various files

### DIFF
--- a/examples/oopif.js
+++ b/examples/oopif.js
@@ -39,7 +39,7 @@ async function attachFrame(frameId, url) {
   await page.evaluateHandle(attachFrame, 'frame1', 'https://example.com/');
 
   // At this point there should be a message in the output:
-  // puppeteer:frame The frame '...' moved to another session. Out-of-proccess
+  // puppeteer:frame The frame '...' moved to another session. Out-of-process
   // iframes (OOPIF) are not supported by Puppeteer yet.
   // https://github.com/puppeteer/puppeteer/issues/2548
 

--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -102,7 +102,7 @@ class BrowserFetcher {
    */
   constructor(projectRoot, options = {}) {
     this._product = (options.product || 'chromium').toLowerCase();
-    assert(this._product === 'chromium' || this._product === 'firefox', `Unkown product: "${options.product}"`);
+    assert(this._product === 'chromium' || this._product === 'firefox', `Unknown product: "${options.product}"`);
     this._downloadsFolder = options.path || path.join(projectRoot, '.local-browser');
     this._downloadHost = options.host || downloadURLs[this._product].host;
     this._platform = options.platform || '';

--- a/src/common/Puppeteer.ts
+++ b/src/common/Puppeteer.ts
@@ -32,7 +32,7 @@ import {
 } from './NetworkConditions.js';
 
 /**
- * Settings that are common to the Puppeteer class, regardless of enviroment.
+ * Settings that are common to the Puppeteer class, regardless of environment.
  * @internal
  */
 export interface CommonPuppeteerSettings {


### PR DESCRIPTION
- `examples/oopif.js`: proccess -> **process**
- `experimental/puppeteer-firefox/lib/BrowserFetcher.js`: Unkown -> **Unknown**
- `src/common/Puppeteer.ts`: enviroment -> **environment**