### PR TITLE
chore: remove commit lint from pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,11 @@ jobs:
           npm run ensure-correct-devtools-protocol-revision
           npm run test-types-file
 
+      - name: Run commit lint
+        run: |
+          npm run commitlint
+        if: github.event_name != 'pull_request'
+
       - name: Run unit tests
         uses: nick-invision/retry@v2
         env:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "commitlint": "commitlint --from=HEAD~1",
     "markdownlint": "prettier --check **/README.md docs/troubleshooting.md",
     "markdownlint-fix": "prettier --write **/README.md docs/troubleshooting.md",
-    "lint": "npm run eslint && npm run build && npm run doc && npm run commitlint && npm run markdownlint",
+    "lint": "npm run eslint && npm run build && npm run doc && npm run markdownlint",
     "doc": "node utils/doclint/cli.js",
     "clean-lib": "rimraf lib",
     "build": "npm run tsc && npm run generate-d-ts",


### PR DESCRIPTION
The commit log is still checked post-merge. Before the merge the commit message is checked using a git hooks and conventionalcommits.org check on the PR using Github Actions.