### PR TITLE
fix: make projectRoot optional in Puppeteer and launchers

### DIFF
--- a/src/initialize-node.ts
+++ b/src/initialize-node.ts
@@ -34,10 +34,6 @@ export const initializePuppeteerNode = (packageName: string): PuppeteerNode => {
   if (!isPuppeteerCore && productName === 'firefox')
     preferredRevision = PUPPETEER_REVISIONS.firefox;
 
-  if (!puppeteerRootDirectory) {
-    throw new Error('puppeteerRootDirectory is not found.');
-  }
-
   return new PuppeteerNode({
     projectRoot: puppeteerRootDirectory,
     preferredRevision,

--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -52,12 +52,12 @@ export interface ProductLauncher {
  * @internal
  */
 class ChromeLauncher implements ProductLauncher {
-  _projectRoot: string;
+  _projectRoot: string | undefined;
   _preferredRevision: string;
   _isPuppeteerCore: boolean;
 
   constructor(
-    projectRoot: string,
+    projectRoot: string | undefined,
     preferredRevision: string,
     isPuppeteerCore: boolean
   ) {
@@ -276,12 +276,12 @@ class ChromeLauncher implements ProductLauncher {
  * @internal
  */
 class FirefoxLauncher implements ProductLauncher {
-  _projectRoot: string;
+  _projectRoot: string | undefined;
   _preferredRevision: string;
   _isPuppeteerCore: boolean;
 
   constructor(
-    projectRoot: string,
+    projectRoot: string | undefined,
     preferredRevision: string,
     isPuppeteerCore: boolean
   ) {
@@ -428,6 +428,11 @@ class FirefoxLauncher implements ProductLauncher {
   async _updateRevision(): Promise<void> {
     // replace 'latest' placeholder with actual downloaded revision
     if (this._preferredRevision === 'latest') {
+      if (!this._projectRoot) {
+        throw new Error(
+          '_projectRoot is undefined. Unable to create a BrowserFetcher.'
+        );
+      }
       const browserFetcher = new BrowserFetcher(this._projectRoot, {
         product: this.product,
       });
@@ -813,6 +818,11 @@ function resolveExecutablePath(launcher: ChromeLauncher | FirefoxLauncher): {
       process.env.npm_config_puppeteer_download_path ||
       process.env.npm_package_config_puppeteer_download_path;
   }
+  if (!launcher._projectRoot) {
+    throw new Error(
+      '_projectRoot is undefined. Unable to create a BrowserFetcher.'
+    );
+  }
   const browserFetcher = new BrowserFetcher(launcher._projectRoot, {
     product: launcher.product,
     path: downloadPath,
@@ -845,7 +855,7 @@ function resolveExecutablePath(launcher: ChromeLauncher | FirefoxLauncher): {
  * @internal
  */
 export default function Launcher(
-  projectRoot: string,
+  projectRoot: string | undefined,
   preferredRevision: string,
   isPuppeteerCore: boolean,
   product?: string

--- a/src/node/Puppeteer.ts
+++ b/src/node/Puppeteer.ts
@@ -67,7 +67,7 @@ import { Product } from '../common/Product.js';
  */
 export class PuppeteerNode extends Puppeteer {
   private _lazyLauncher?: ProductLauncher;
-  private _projectRoot: string;
+  private _projectRoot?: string;
   private __productName?: Product;
   /**
    * @internal
@@ -79,7 +79,7 @@ export class PuppeteerNode extends Puppeteer {
    */
   constructor(
     settings: {
-      projectRoot: string;
+      projectRoot?: string;
       preferredRevision: string;
       productName?: Product;
     } & CommonPuppeteerSettings
@@ -224,6 +224,11 @@ export class PuppeteerNode extends Puppeteer {
    * @returns A new BrowserFetcher instance.
    */
   createBrowserFetcher(options: BrowserFetcherOptions): BrowserFetcher {
+    if (!this._projectRoot) {
+      throw new Error(
+        '_projectRoot is undefined. Unable to create a BrowserFetcher.'
+      );
+    }
     return new BrowserFetcher(this._projectRoot, options);
   }
 }


### PR DESCRIPTION
It appears that the projectRoot might actually be undefined in some environments. I suspect that projectRoot is not needed at all in runtime and, therefore, we should make it optional until it reaches a BrowserFetcher instance.