### PR TITLE
fix: typos in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4644,9 +4644,9 @@ This method returns boxes of the element, or `null` if the element is not visibl
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[number]> defaults to 1. See [UIEvent.detail].
   - `delay` <[number]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
-  - `offset` <[Object]> Offset in pixels relative to the top-left corder of the border box of the element.
-    - `x` <number> x-offset in pixels relative to the top-left corder of the border box of the element.
-    - `y` <number> y-offset in pixels relative to the top-left corder of the border box of the element.
+  - `offset` <[Object]> Offset in pixels relative to the top-left corner of the border box of the element.
+    - `x` <number> x-offset in pixels relative to the top-left corner of the border box of the element.
+    - `y` <number> y-offset in pixels relative to the top-left corner of the border box of the element.
 - returns: <[Promise]> Promise which resolves when the element is successfully clicked. Promise gets rejected if the element is detached from DOM.
 
 This method scrolls element into view if needed, and then uses [page.mouse](#pagemouse) to click in the center of the element.
@@ -4655,8 +4655,8 @@ If the element is detached from DOM, the method throws an error.
 #### elementHandle.clickablePoint([offset])
 
 - `offset` <[Object]>
-  - `x` <number> x-offset in pixels relative to the top-left corder of the border box of the element.
-  - `y` <number> y-offset in pixels relative to the top-left corder of the border box of the element.
+  - `x` <number> x-offset in pixels relative to the top-left corner of the border box of the element.
+  - `y` <number> y-offset in pixels relative to the top-left corner of the border box of the element.
 - returns: <[Promise<[Point]>]> Resolves to the x, y point that describes the element's position.
 
 #### elementHandle.contentFrame()

--- a/examples/oopif.js
+++ b/examples/oopif.js
@@ -39,7 +39,7 @@ async function attachFrame(frameId, url) {
   await page.evaluateHandle(attachFrame, 'frame1', 'https://example.com/');
 
   // At this point there should be a message in the output:
-  // puppeteer:frame The frame '...' moved to another session. Out-of-proccess
+  // puppeteer:frame The frame '...' moved to another session. Out-of-process
   // iframes (OOPIF) are not supported by Puppeteer yet.
   // https://github.com/puppeteer/puppeteer/issues/2548
 

--- a/experimental/puppeteer-firefox/lib/BrowserFetcher.js
+++ b/experimental/puppeteer-firefox/lib/BrowserFetcher.js
@@ -102,7 +102,7 @@ class BrowserFetcher {
    */
   constructor(projectRoot, options = {}) {
     this._product = (options.product || 'chromium').toLowerCase();
-    assert(this._product === 'chromium' || this._product === 'firefox', `Unkown product: "${options.product}"`);
+    assert(this._product === 'chromium' || this._product === 'firefox', `Unknown product: "${options.product}"`);
     this._downloadsFolder = options.path || path.join(projectRoot, '.local-browser');
     this._downloadHost = options.host || downloadURLs[this._product].host;
     this._platform = options.platform || '';

--- a/src/common/Puppeteer.ts
+++ b/src/common/Puppeteer.ts
@@ -32,7 +32,7 @@ import {
 } from './NetworkConditions.js';
 
 /**
- * Settings that are common to the Puppeteer class, regardless of enviroment.
+ * Settings that are common to the Puppeteer class, regardless of environment.
  * @internal
  */
 export interface CommonPuppeteerSettings {


### PR DESCRIPTION
Typo fixes from the following PRs:

https://github.com/puppeteer/puppeteer/pull/7962
https://github.com/puppeteer/puppeteer/pull/7956

The original PRs require rebasing to be merged. 