### PR TITLE
fix: always use ENV executable path when present

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -146,15 +146,9 @@ class ChromeLauncher implements ProductLauncher {
 
       chromeExecutable = executablePathForChannel(channel);
     } else if (!executablePath) {
-      // Use Intel x86 builds on Apple M1 until native macOS arm64
-      // Chromium builds are available.
-      if (os.platform() !== 'darwin' && os.arch() === 'arm64') {
-        chromeExecutable = '/usr/bin/chromium-browser';
-      } else {
-        const { missingText, executablePath } = resolveExecutablePath(this);
-        if (missingText) throw new Error(missingText);
-        chromeExecutable = executablePath;
-      }
+      const { missingText, executablePath } = resolveExecutablePath(this);
+      if (missingText) throw new Error(missingText);
+      chromeExecutable = executablePath;
     }
 
     if (!chromeExecutable) {
@@ -799,9 +793,11 @@ function resolveExecutablePath(launcher: ChromeLauncher | FirefoxLauncher): {
   executablePath: string;
   missingText?: string;
 } {
+  const { product, _isPuppeteerCore, _projectRoot, _preferredRevision } =
+    launcher;
   let downloadPath: string | undefined;
   // puppeteer-core doesn't take into account PUPPETEER_* env variables.
-  if (!launcher._isPuppeteerCore) {
+  if (!_isPuppeteerCore) {
     const executablePath =
       process.env.PUPPETEER_EXECUTABLE_PATH ||
       process.env.npm_config_puppeteer_executable_path ||
@@ -813,22 +809,31 @@ function resolveExecutablePath(launcher: ChromeLauncher | FirefoxLauncher): {
         : undefined;
       return { executablePath, missingText };
     }
+    const ubuntuChromiumPath = '/usr/bin/chromium-browser';
+    if (
+      product === 'chrome' &&
+      os.platform() !== 'darwin' &&
+      os.arch() === 'arm64' &&
+      fs.existsSync(ubuntuChromiumPath)
+    ) {
+      return { executablePath: ubuntuChromiumPath, missingText: undefined };
+    }
     downloadPath =
       process.env.PUPPETEER_DOWNLOAD_PATH ||
       process.env.npm_config_puppeteer_download_path ||
       process.env.npm_package_config_puppeteer_download_path;
   }
-  if (!launcher._projectRoot) {
+  if (!_projectRoot) {
     throw new Error(
       '_projectRoot is undefined. Unable to create a BrowserFetcher.'
     );
   }
-  const browserFetcher = new BrowserFetcher(launcher._projectRoot, {
-    product: launcher.product,
+  const browserFetcher = new BrowserFetcher(_projectRoot, {
+    product: product,
     path: downloadPath,
   });
 
-  if (!launcher._isPuppeteerCore && launcher.product === 'chrome') {
+  if (!_isPuppeteerCore && product === 'chrome') {
     const revision = process.env['PUPPETEER_CHROMIUM_REVISION'];
     if (revision) {
       const revisionInfo = browserFetcher.revisionInfo(revision);
@@ -839,13 +844,13 @@ function resolveExecutablePath(launcher: ChromeLauncher | FirefoxLauncher): {
       return { executablePath: revisionInfo.executablePath, missingText };
     }
   }
-  const revisionInfo = browserFetcher.revisionInfo(launcher._preferredRevision);
+  const revisionInfo = browserFetcher.revisionInfo(_preferredRevision);
 
   const firefoxHelp = `Run \`PUPPETEER_PRODUCT=firefox npm install\` to download a supported Firefox browser binary.`;
   const chromeHelp = `Run \`npm install\` to download the correct Chromium revision (${launcher._preferredRevision}).`;
   const missingText = !revisionInfo.local
-    ? `Could not find expected browser (${launcher.product}) locally. ${
-        launcher.product === 'chrome' ? chromeHelp : firefoxHelp
+    ? `Could not find expected browser (${product}) locally. ${
+        product === 'chrome' ? chromeHelp : firefoxHelp
       }`
     : undefined;
   return { executablePath: revisionInfo.executablePath, missingText };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes #7981 

These changes:

1. Allow the ENV variable to always be used when defined and not specified in LaunchOptions (and when not puppeteer-core)
2. Retain the existing behavior of assuming /usr/bin/chromium-browser on platforms like Ubuntu, Alpine (exact if-conditions preserved to avoid any breaking changes + an added check for file.exists?)
3. Add some tests for this particular portion of the code.

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

No. I could add a note about precedence if desired.

**Summary**

#7981

On linux/arm64, puppeteer always assumes /usr/bin/chromium-browser exists. It ignores `PUPPETEER_EXECUTABLE_PATH` and fails when /usr/bin/chromium-browser doesn't exist. Not all linux distros install to /usr/bin/chromium-browser, so it would be better to allow PUPPETEER_EXECUTABLE_PATH` to have precedence. Debian for instance installs to /usr/bin/chromium. I can't launch chromium unless I explicitly pass an executable path in `LaunchOptions`.

Some recent changes to allow arm64 environments (including M1 macs) to launch a chromium installation successfully before arm-compatible builds were downloadable prevented the usage of PUPPETEER_EXECUTABLE_PATH in some environments. Currently, when the platform is not darwin and the arch is arm64, an executable cannot be specified using the environment variable.

Generally speaking, environment variables have highest precedence for options such as this since they depend on system configuration.

**Does this PR introduce a breaking change?**

No. An executablePath provided via LaunchOptions always gets used. If empty, the ENV var is used. The assumed default executable of `/usr/bin/chromium-browser` **is retained** in case its being relied on (though, if PUPPETEER_EXECUTABLE_PATH is _also_ set, it would start working differently). The assumed scope of `if not darwin and arm64` was too broad, so this narrows it. `/usr/bin/chromium-browser` would be present if the OS was Ubuntu, but not Debian. I presume Ubuntu is more common so it was used.

