### PR TITLE
chore: fix deprecate command

### DIFF
--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -25,7 +25,7 @@ jobs:
           npm publish
           DEPRECATED_RANGE=$(node utils/get_deprecated_version_range.js)
           echo "Deprecating old puppeteer versions: $DEPRECATED_RANGE"
-          npm deprecate puppeteer@\"$DEPRECATED_RANGE\" "Version no longer supported. Upgrade to @latest"
+          npm deprecate puppeteer@$DEPRECATED_RANGE "Version no longer supported. Upgrade to @latest"
       - name: Publish puppeteer-core
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER_CORE}}

--- a/utils/get_deprecated_version_range.js
+++ b/utils/get_deprecated_version_range.js
@@ -18,10 +18,13 @@ const {
   versionsPerRelease,
   lastMaintainedChromiumVersion,
 } = require('../versions.js');
-const version = versionsPerRelease.get(lastMaintainedChromiumVersion);
+let version = versionsPerRelease.get(lastMaintainedChromiumVersion);
 if (version.toLowerCase() === 'next') {
   console.error('Unexpected NEXT Puppeteer version in versions.js');
   process.exit(1);
 }
-console.log('< ' + version);
+if (version.startsWith('v')) {
+  version = version.substring(1);
+}
+console.log('<' + version);
 process.exit(0);


### PR DESCRIPTION
Another speculative attempt at fixing the deprecate command. https://github.com/puppeteer/puppeteer/runs/5142799557?check_suite_focus=true confirmed that it is the deprecate command that is failing although the escape double quotes were not needed. This PR makes sure there is no space in the version and, thus, double quotes should not be needed and makes sure that `v` is stripped from the version. 