### PR TITLE
fix: ensure dom binding is not called after detach

### DIFF
--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -139,7 +139,7 @@ export class DOMWorld {
   }
 
   _hasContext(): boolean {
-    return !this._contextResolveCallback;
+    return !this._contextResolveCallback && !this._detached;
   }
 
   _detach(): void {

--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -139,11 +139,12 @@ export class DOMWorld {
   }
 
   _hasContext(): boolean {
-    return !this._contextResolveCallback && !this._detached;
+    return !this._contextResolveCallback;
   }
 
   _detach(): void {
     this._detached = true;
+    this._client.removeAllListeners('Runtime.bindingCalled');
     for (const waitTask of this._waitTasks)
       waitTask.terminate(
         new Error('waitForFunction failed: frame got detached.')

--- a/src/common/DOMWorld.ts
+++ b/src/common/DOMWorld.ts
@@ -111,9 +111,8 @@ export class DOMWorld {
     this._frame = frame;
     this._timeoutSettings = timeoutSettings;
     this._setContext(null);
-    this._client.on('Runtime.bindingCalled', (event) =>
-      this._onBindingCalled(event)
-    );
+    this._onBindingCalled = this._onBindingCalled.bind(this);
+    this._client.on('Runtime.bindingCalled', this._onBindingCalled);
   }
 
   frame(): Frame {
@@ -144,7 +143,7 @@ export class DOMWorld {
 
   _detach(): void {
     this._detached = true;
-    this._client.removeAllListeners('Runtime.bindingCalled');
+    this._client.off('Runtime.bindingCalled', this._onBindingCalled);
     for (const waitTask of this._waitTasks)
       waitTask.terminate(
         new Error('waitForFunction failed: frame got detached.')

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -1035,6 +1035,26 @@ describe('Page', function () {
       });
       expect(result).toBe(15);
     });
+    it('should not throw when frames detach', async () => {
+      const { page, server } = getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+      await page.exposeFunction('compute', function (a, b) {
+        return Promise.resolve(a * b);
+      });
+      await utils.detachFrame(page, 'frame1');
+
+      let result = undefined;
+      expect(
+        (async () => {
+          result = await page.evaluate(async function () {
+            return await globalThis.compute(3, 5);
+          });
+        })()
+      ).not.toThrow();
+      expect(result).toBe(15);
+    });
     it('should work with complex objects', async () => {
       const { page } = getTestState();
 

--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -1045,15 +1045,11 @@ describe('Page', function () {
       });
       await utils.detachFrame(page, 'frame1');
 
-      let result = undefined;
-      expect(
-        (async () => {
-          result = await page.evaluate(async function () {
-            return await globalThis.compute(3, 5);
-          });
-        })()
-      ).not.toThrow();
-      expect(result).toBe(15);
+      await expect(
+        page.evaluate(async function () {
+          return await globalThis.compute(3, 5);
+        })
+      ).resolves.toEqual(15);
     });
     it('should work with complex objects', async () => {
       const { page } = getTestState();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bug fix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

~No, but can add if deemed necessary~

**If relevant, did you update the documentation?**

No

**Summary**

Fixes #7814

Functions exposed via `page.exposeFunction` are not unbind when a frame is detached, which in turn causes the error regarding missing execution context being raised.

https://github.com/puppeteer/puppeteer/blob/1d6c82b254d97861e67f44f659c8bfa12baa596d/src/common/DOMWorld.ts#L153-L159

This PR adds `_detached` as a criterion to `_hasContext`, indicating there is no context available, causing `_onBindCalled` to exit early. An alternative solution could be to remove all `Runtime.bindingCalled` listeners on the client when detaching, which will stop events from firing completely.

https://github.com/puppeteer/puppeteer/blob/1d6c82b254d97861e67f44f659c8bfa12baa596d/src/common/DOMWorld.ts#L114-L116

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

First started happening in `11.0.0`, still reproducible in the latest release.
Tested on Node.js 14.x and 16.x.