### PR TITLE
docs(troubleshooting.md): fix alpine install adduser command

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -367,7 +367,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
 RUN yarn add puppeteer@10.0.0
 
 # Add user so we don't need --no-sandbox.
-RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+RUN addgroup -S pptruser && adduser -S -G pptruser pptruser \
     && mkdir -p /home/pptruser/Downloads /app \
     && chown -R pptruser:pptruser /home/pptruser \
     && chown -R pptruser:pptruser /app


### PR DESCRIPTION
**What kind of change does this PR introduce?**

changes of documentation only

**Did you add tests for your changes?**

yes

**Summary**

in the example of installation in alpine, the `adduser` command is executed with the option `-g`, which is the `-g GECOS`, a GECOS field instead assigning the user to the group we created. The correct option should be `-G GRP`

**Does this PR introduce a breaking change?**

no

**Other information**
![image](https://user-images.githubusercontent.com/11881669/155689014-4ed1bc3f-2bad-4293-a343-2a447aa445c2.png)
