### PR TITLE
Ensure all tests honour the BINARY envvar.

### DIFF
--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -708,9 +708,9 @@ describe('Launcher specs', function () {
       itFailsFirefox(
         'should be able to connect to the same page simultaneously',
         async () => {
-          const { puppeteer } = getTestState();
+          const { puppeteer, defaultBrowserOptions } = getTestState();
 
-          const browserOne = await puppeteer.launch();
+          const browserOne = await puppeteer.launch(defaultBrowserOptions);
           const browserTwo = await puppeteer.connect({
             browserWSEndpoint: browserOne.wsEndpoint(),
           });
@@ -726,8 +726,8 @@ describe('Launcher specs', function () {
         }
       );
       it('should be able to reconnect', async () => {
-        const { puppeteer, server } = getTestState();
-        const browserOne = await puppeteer.launch();
+        const { puppeteer, server, defaultBrowserOptions } = getTestState();
+        const browserOne = await puppeteer.launch(defaultBrowserOptions);
         const browserWSEndpoint = browserOne.wsEndpoint();
         const pageOne = await browserOne.newPage();
         await pageOne.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
Without this patch, two tests ignore the BINARY envvar, and fail when not using the embedded chromium, unless the chromium executable path is defined via PUPPETEER_EXECUTABLE_PATH, which should not be considered according to the docs.