### PR TITLE
replace if/else inside the test case by itChromeOnly and itFirefoxOnly

### DIFF
--- a/test/network.spec.ts
+++ b/test/network.spec.ts
@@ -24,6 +24,8 @@ import {
   setupTestPageAndContextHooks,
   itFailsFirefox,
   describeFailsFirefox,
+  itChromeOnly,
+  itFirefoxOnly,
 } from './mocha-utils'; // eslint-disable-line import/extensions
 import { HTTPResponse } from '../lib/cjs/puppeteer/api-docs-entry.js';
 
@@ -113,14 +115,17 @@ describe('network', function () {
   });
 
   describe('Request.headers', function () {
-    it('should work', async () => {
-      const { page, server, isChrome } = getTestState();
+    itChromeOnly('should define Chrome as user agent header', async () => {
+      const { page, server } = getTestState();
+      const response = await page.goto(server.EMPTY_PAGE);
+      expect(response.request().headers()['user-agent']).toContain('Chrome');
+    });
+
+    itFirefoxOnly('should define Firefox as user agent header', async () => {
+      const { page, server } = getTestState();
 
       const response = await page.goto(server.EMPTY_PAGE);
-      if (isChrome)
-        expect(response.request().headers()['user-agent']).toContain('Chrome');
-      else
-        expect(response.request().headers()['user-agent']).toContain('Firefox');
+      expect(response.request().headers()['user-agent']).toContain('Firefox');
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This is a refactor that aims to improve a bit how the test is structured? Instead of having a if/else inside the test case, I am using the utility function itChromeOnly and itFirefoxOnly

**Did you add tests for your changes?**

I ran the test suite in my local

**If relevant, did you update the documentation?**

Not sure if this requires doc update?

**Summary**

The motivation is just for the test structure in a sense? I saw that this utility function was added but is not used on this specific case. Maybe it is a good idea to use the helper. If it is, I can try to inspect the code and replace in other places.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
As far as I can see no

**Other information**
