### PR TITLE
fix: waitForNavigation in OOPIFs

### DIFF
--- a/src/common/FrameManager.ts
+++ b/src/common/FrameManager.ts
@@ -53,6 +53,7 @@ export const FrameManagerEmittedEvents = {
   FrameAttached: Symbol('FrameManager.FrameAttached'),
   FrameNavigated: Symbol('FrameManager.FrameNavigated'),
   FrameDetached: Symbol('FrameManager.FrameDetached'),
+  FrameSwapped: Symbol('FrameManager.FrameSwapped'),
   LifecycleEvent: Symbol('FrameManager.LifecycleEvent'),
   FrameNavigatedWithinDocument: Symbol(
     'FrameManager.FrameNavigatedWithinDocument'
@@ -422,6 +423,8 @@ export class FrameManager extends EventEmitter {
       // an actual removement of the frame.
       // For frames that become OOP iframes, the reason would be 'swap'.
       if (frame) this._removeFramesRecursively(frame);
+    } else if (reason === 'swap') {
+      this.emit(FrameManagerEmittedEvents.FrameSwapped, frame);
     }
   }
 

--- a/test/oopif.spec.ts
+++ b/test/oopif.spec.ts
@@ -154,6 +154,30 @@ describeChromeOnly('OOPIF', function () {
     await utils.detachFrame(page, 'frame1');
     expect(page.frames()).toHaveLength(1);
   });
+
+  it('should support wait for navigation for transitions from local to OOPIF', async () => {
+    const { server } = getTestState();
+
+    await page.goto(server.EMPTY_PAGE);
+    const framePromise = page.waitForFrame((frame) => {
+      return page.frames().indexOf(frame) === 1;
+    });
+    await utils.attachFrame(page, 'frame1', server.EMPTY_PAGE);
+
+    const frame = await framePromise;
+    expect(frame.isOOPFrame()).toBe(false);
+    const nav = frame.waitForNavigation();
+    await utils.navigateFrame(
+      page,
+      'frame1',
+      server.CROSS_PROCESS_PREFIX + '/empty.html'
+    );
+    await nav;
+    expect(frame.isOOPFrame()).toBe(true);
+    await utils.detachFrame(page, 'frame1');
+    expect(page.frames()).toHaveLength(1);
+  });
+
   it('should keep track of a frames OOP state', async () => {
     const { server } = getTestState();
 


### PR DESCRIPTION
This PR fixes the issue with `frame.waitForNavigation` timing out when navigating a local iframe to a URL that turns the iframe into the out-of-process iframe.