### PR TITLE
fix: get extra headers from Fetch.requestPaused event

### DIFF
--- a/src/common/NetworkManager.ts
+++ b/src/common/NetworkManager.ts
@@ -268,6 +268,7 @@ export class NetworkManager extends EventEmitter {
         this._networkEventManager.getRequestPaused(networkRequestId);
       if (requestPausedEvent) {
         const { requestId: fetchRequestId } = requestPausedEvent;
+        this._patchRequestEventHeaders(event, requestPausedEvent);
         this._onRequest(event, fetchRequestId);
         this._networkEventManager.forgetRequestPaused(networkRequestId);
       }
@@ -345,10 +346,22 @@ export class NetworkManager extends EventEmitter {
     })();
 
     if (requestWillBeSentEvent) {
+      this._patchRequestEventHeaders(requestWillBeSentEvent, event);
       this._onRequest(requestWillBeSentEvent, fetchRequestId);
     } else {
       this._networkEventManager.storeRequestPaused(networkRequestId, event);
     }
+  }
+
+  _patchRequestEventHeaders(
+    requestWillBeSentEvent: Protocol.Network.RequestWillBeSentEvent,
+    requestPausedEvent: Protocol.Fetch.RequestPausedEvent
+  ): void {
+    requestWillBeSentEvent.request.headers = {
+      ...requestWillBeSentEvent.request.headers,
+      // includes extra headers, like: Accept, Origin
+      ...requestPausedEvent.request.headers,
+    };
   }
 
   _onRequest(

--- a/test/requestinterception.spec.ts
+++ b/test/requestinterception.spec.ts
@@ -40,6 +40,7 @@ describe('request interception', function () {
         }
         expect(request.url()).toContain('empty.html');
         expect(request.headers()['user-agent']).toBeTruthy();
+        expect(request.headers()['accept']).toBeTruthy();
         expect(request.method()).toBe('GET');
         expect(request.postData()).toBe(undefined);
         expect(request.isNavigationRequest()).toBe(true);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- merge request headers between Fetch.requestPaused and Network.requestWillBeSent

**Did you add tests for your changes?**

- Yes

**Summary**

extra headers from Fetch.requestPaused

<img width="889" alt="image" src="https://user-images.githubusercontent.com/17005098/159868837-22f17d2f-26f5-43ad-8c6a-f73624864605.png">

**Does this PR introduce a breaking change?**

- Yes, `httpRequest.headers()` return more headers.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

A base case with CORS error.

```javascript
const puppeteer = require('puppeteer');

(async () => {
  const browser = await puppeteer.launch({
    headless: false,
    devtools: true,
    defaultViewport: null,
  });
  const page = (await browser.pages())[0] || await browser.newPage();

  await page.setRequestInterception(true);

  page.on('request', (request) => {
    const headers = request.headers();

    request.continue({
      headers,
    });
  });

  await page.goto('https://www.tiktok.com/?lang=en');
})();
```

A patch to fix it.

```javascript
const puppeteer = require('puppeteer');

(async () => {
  const browser = await puppeteer.launch({
    headless: false,
    devtools: true,
    defaultViewport: null,
  });
  const page = (await browser.pages())[0] || await browser.newPage();
  const pausedRequestMap = new Map();

  await page.setRequestInterception(true);

  page._client.on('Fetch.requestPaused', (event) => {
    const { networkId } = event;

    pausedRequestMap.set(networkId, event);
  });

  page.on('request', (request) => {
    const headers = request.headers();
    const pausedRequest = pausedRequestMap.get(request._requestId);

    if (pausedRequest) {
      Object.assign(headers, pausedRequest.request.headers);
    }
  
    request.continue({
      headers,
    });
  });

  await page.goto('https://www.tiktok.com/?lang=en');
})();
```
