### PR TITLE
fix: disable bfcache in the launcher

### DIFF
--- a/src/node/Launcher.ts
+++ b/src/node/Launcher.ts
@@ -213,7 +213,7 @@ class ChromeLauncher implements ProductLauncher {
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',
-      '--disable-features=Translate',
+      '--disable-features=Translate,BackForwardCache',
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',


### PR DESCRIPTION
Puppeteer has problems handling navigations to pages that
are restored from the back-forward cache. Let's disable it
until we have the support and test coverage.

Issues: #8182, #8197