### PR TITLE
fix: ignore favicon requests in page.spec event handler tests

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -127,14 +127,20 @@ describe('Page', function () {
       const { page, server } = getTestState();
 
       const handler = sinon.spy();
-      page.on('response', handler);
+      const onResponse = (response) => {
+        // Ignore default favicon requests.
+        if (!response.url().endsWith('favicon.ico')) {
+          handler();
+        }
+      };
+      page.on('response', onResponse);
       await page.goto(server.EMPTY_PAGE);
       expect(handler.callCount).toBe(1);
-      page.off('response', handler);
+      page.off('response', onResponse);
       await page.goto(server.EMPTY_PAGE);
       // Still one because we removed the handler.
       expect(handler.callCount).toBe(1);
-      page.on('response', handler);
+      page.on('response', onResponse);
       await page.goto(server.EMPTY_PAGE);
       // Two now because we added the handler back.
       expect(handler.callCount).toBe(2);
@@ -144,14 +150,21 @@ describe('Page', function () {
       const { page, server } = getTestState();
 
       const handler = sinon.spy();
-      page.on('request', handler);
+      const onResponse = (response) => {
+        // Ignore default favicon requests.
+        if (!response.url().endsWith('favicon.ico')) {
+          handler();
+        }
+      };
+
+      page.on('request', onResponse);
       await page.goto(server.EMPTY_PAGE);
       expect(handler.callCount).toBe(1);
-      page.off('request', handler);
+      page.off('request', onResponse);
       await page.goto(server.EMPTY_PAGE);
       // Still one because we removed the handler.
       expect(handler.callCount).toBe(1);
-      page.on('request', handler);
+      page.on('request', onResponse);
       await page.goto(server.EMPTY_PAGE);
       // Two now because we added the handler back.
       expect(handler.callCount).toBe(2);


### PR DESCRIPTION
Fixes #6020 

Favicon requests are automatically triggered when loading empty.html (except on chrome headless) and make the tests fail intermittently.

In this patch, I define a custom response handler which ignores specifically the favicon requests. I prefer this rather than "only consider requests to empty.html" because it feels more conservative, and should not hide potential future regressions.

Alternatively, we could use a different test page than empty.html, eg called `no-favicon.html` which would simply contain
```html
<link rel="icon" href="data:,">
```

Let me know which approach you prefer.