### PR TITLE
fix: enable page.spec event handler test for firefox

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -118,11 +118,7 @@ describe('Page', function () {
     });
   });
 
-  // This test fails on Firefox on CI consistently but cannot be replicated
-  // locally. Skipping for now to unblock the Mitt release and given FF support
-  // isn't fully done yet but raising an issue to ask the FF folks to have a
-  // look at this.
-  describeFailsFirefox('removing and adding event handlers', () => {
+  describe('removing and adding event handlers', () => {
     it('should correctly fire event handlers as they are added and then removed', async () => {
       const { page, server } = getTestState();
 


### PR DESCRIPTION
Follow-up to #8208 

We should actually be able to turn on those tests for Firefox now, presumably this was the only reason they were failing in CI here.