### PR TITLE
fix: forget request will be sent from the _requestWillBeSentMap list.

### DIFF
--- a/src/common/NetworkEventManager.ts
+++ b/src/common/NetworkEventManager.ts
@@ -140,7 +140,7 @@ export class NetworkEventManager {
   }
 
   forgetRequestWillBeSent(networkRequestId: NetworkRequestId): void {
-    this._requestPausedMap.delete(networkRequestId);
+    this._requestWillBeSentMap.delete(networkRequestId);
   }
 
   getRequestPaused(


### PR DESCRIPTION
That `forget` looked wrong to me. Let me know if this change is correct.
