### PR TITLE
fix: use different test names for browser specific default arguments tests in launcher.spec.ts

### DIFF
--- a/test/launcher.spec.ts
+++ b/test/launcher.spec.ts
@@ -404,44 +404,49 @@ describe('Launcher specs', function () {
         await page.close();
         await browser.close();
       });
-      itChromeOnly('should filter out ignored default arguments', async () => {
-        const { defaultBrowserOptions, puppeteer } = getTestState();
-        // Make sure we launch with `--enable-automation` by default.
-        const defaultArgs = puppeteer.defaultArgs();
-        const browser = await puppeteer.launch(
-          Object.assign({}, defaultBrowserOptions, {
-            // Ignore first and third default argument.
-            ignoreDefaultArgs: [defaultArgs[0], defaultArgs[2]],
-          })
-        );
-        const spawnargs = browser.process().spawnargs;
-        if (!spawnargs) {
-          throw new Error('spawnargs not present');
+      itChromeOnly(
+        'should filter out ignored default arguments in Chrome',
+        async () => {
+          const { defaultBrowserOptions, puppeteer } = getTestState();
+          // Make sure we launch with `--enable-automation` by default.
+          const defaultArgs = puppeteer.defaultArgs();
+          const browser = await puppeteer.launch(
+            Object.assign({}, defaultBrowserOptions, {
+              // Ignore first and third default argument.
+              ignoreDefaultArgs: [defaultArgs[0], defaultArgs[2]],
+            })
+          );
+          const spawnargs = browser.process().spawnargs;
+          if (!spawnargs) {
+            throw new Error('spawnargs not present');
+          }
+          expect(spawnargs.indexOf(defaultArgs[0])).toBe(-1);
+          expect(spawnargs.indexOf(defaultArgs[1])).not.toBe(-1);
+          expect(spawnargs.indexOf(defaultArgs[2])).toBe(-1);
+          await browser.close();
         }
-        expect(spawnargs.indexOf(defaultArgs[0])).toBe(-1);
-        expect(spawnargs.indexOf(defaultArgs[1])).not.toBe(-1);
-        expect(spawnargs.indexOf(defaultArgs[2])).toBe(-1);
-        await browser.close();
-      });
-      itFirefoxOnly('should filter out ignored default arguments', async () => {
-        const { defaultBrowserOptions, puppeteer } = getTestState();
+      );
+      itFirefoxOnly(
+        'should filter out ignored default argument in Firefox',
+        async () => {
+          const { defaultBrowserOptions, puppeteer } = getTestState();
 
-        const defaultArgs = puppeteer.defaultArgs();
-        const browser = await puppeteer.launch(
-          Object.assign({}, defaultBrowserOptions, {
-            // Only the first argument is fixed, others are optional.
-            ignoreDefaultArgs: [defaultArgs[0]],
-          })
-        );
-        const spawnargs = browser.process().spawnargs;
-        if (!spawnargs) {
-          throw new Error('spawnargs not present');
+          const defaultArgs = puppeteer.defaultArgs();
+          const browser = await puppeteer.launch(
+            Object.assign({}, defaultBrowserOptions, {
+              // Only the first argument is fixed, others are optional.
+              ignoreDefaultArgs: [defaultArgs[0]],
+            })
+          );
+          const spawnargs = browser.process().spawnargs;
+          if (!spawnargs) {
+            throw new Error('spawnargs not present');
+          }
+          expect(spawnargs.indexOf(defaultArgs[0])).toBe(-1);
+          expect(spawnargs.indexOf(defaultArgs[1])).not.toBe(-1);
+          await browser.close();
         }
-        expect(spawnargs.indexOf(defaultArgs[0])).toBe(-1);
-        expect(spawnargs.indexOf(defaultArgs[1])).not.toBe(-1);
-        await browser.close();
-      });
-
+      );
       it('should have default URL when launching browser', async function () {
         const { defaultBrowserOptions, puppeteer } = getTestState();
         const browser = await puppeteer.launch(defaultBrowserOptions);


### PR DESCRIPTION
The changes as pushed on RP #8233 caused duplicated test names which makes it hard for our downstream sync of Puppeteer to maintain an expected results list in JSON by having test names as key. 

As such I would suggest that we rename both tests and explicitly add the browser name in the test name.