### PR TITLE
fix: increase commit header length limit

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -19,5 +19,6 @@ module.exports = {
     'body-max-line-length': [0, 'always', 100],
     'footer-max-line-length': [0, 'always', 100],
     'subject-case': [0, 'never'],
+    'header-max-length': [0, 'always', 120],
   },
 };


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/commit/04f7659f9adae7415bfea3f538a446c624d852e8 hit the limit but I don't see a reason why we need to be so strict. Increasing the limit to 120 chars. 