### PR TITLE
chore: add headful mode tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,3 +184,41 @@ jobs:
           max_attempts: 3
           timeout_minutes: 10
           command: npm run funit
+
+  linux-headful-checks:
+    # https://github.com/actions/virtual-environments#available-environments
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [16]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3.1.1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install xvfb
+          npm install
+          ls .local-chromium
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Run unit tests in headful mode
+        uses: nick-invision/retry@v2
+        continue-on-error: true
+        env:
+          CHROMIUM: true
+          HEADLESS: false
+        with:
+          max_attempts: 1
+          command: xvfb-run --auto-servernum npm run unit
+          timeout_minutes: 10


### PR DESCRIPTION
This PR adds a new workflow to run unit tests against a headful browser instance. It's currently allowed to fail since there are differences between the headless and headful modes. We can use this CI to fix the failing tests and make it required after that. The workflow is run only on a single OS and a single Node version to avoid increasing the overall CI runtime.