### PR TITLE
test: move async predicate to waitForResponse describe

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -763,21 +763,6 @@ describe('Page', function () {
         .catch((error_) => (error = error_));
       expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
     });
-    it('should work with async predicate', async () => {
-      const { page, server } = getTestState();
-      await page.goto(server.EMPTY_PAGE);
-      const [response] = await Promise.all([
-        page.waitForResponse(async (response) => {
-          return response.url() === server.PREFIX + '/digits/2.png';
-        }),
-        page.evaluate(() => {
-          fetch('/digits/1.png');
-          fetch('/digits/2.png');
-          fetch('/digits/3.png');
-        }),
-      ]);
-      expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
-    });
     it('should work with no timeout', async () => {
       const { page, server } = getTestState();
 
@@ -838,6 +823,21 @@ describe('Page', function () {
         page.waitForResponse(
           (response) => response.url() === server.PREFIX + '/digits/2.png'
         ),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }),
+      ]);
+      expect(response.url()).toBe(server.PREFIX + '/digits/2.png');
+    });
+    it('should work with async predicate', async () => {
+      const { page, server } = getTestState();
+      await page.goto(server.EMPTY_PAGE);
+      const [response] = await Promise.all([
+        page.waitForResponse(async (response) => {
+          return response.url() === server.PREFIX + '/digits/2.png';
+        }),
         page.evaluate(() => {
           fetch('/digits/1.png');
           fetch('/digits/2.png');


### PR DESCRIPTION
**Summary**

Although `should work with async predicate` tests all the `waitForEvent`s, this test is using `waitForResponse` so it should go in the `waitForResponse` `describe`.