### PR TITLE
test: run Frame.evaluate tests on Firefox

### DIFF
--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -2824,7 +2824,7 @@ export class Page extends EventEmitter {
   }
 
   /**
-   * Generatees a PDF of the page with the `print` CSS media type.
+   * Generates a PDF of the page with the `print` CSS media type.
    * @remarks
    *
    * NOTE: PDF generation is only supported in Chrome headless mode.

--- a/test/evaluation.spec.ts
+++ b/test/evaluation.spec.ts
@@ -436,7 +436,7 @@ describe('Evaluation specs', function () {
   });
 
   describe('Frame.evaluate', function () {
-    itFailsFirefox('should have different execution contexts', async () => {
+    it('should have different execution contexts', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.EMPTY_PAGE);
@@ -447,7 +447,7 @@ describe('Evaluation specs', function () {
       expect(await page.frames()[0].evaluate(() => globalThis.FOO)).toBe('foo');
       expect(await page.frames()[1].evaluate(() => globalThis.FOO)).toBe('bar');
     });
-    itFailsFirefox('should have correct execution contexts', async () => {
+    it('should have correct execution contexts', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.PREFIX + '/frames/one-frame.html');


### PR DESCRIPTION
I think there is no reason to ignore those tests on Firefox. Let's see if the CI proves me right.