### PR TITLE
chore: drop Node 12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # Include all major maintenance + active LTS + current Node.js versions.
         # https://github.com/nodejs/Release#release-schedule
-        node: [12, 14, 16]
+        node: [14, 16]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
         with:
           # Test only the oldest maintenance LTS Node.js version.
           # https://github.com/nodejs/Release#release-schedule
-          node-version: 12
+          node-version: 14
 
       - name: Install dependencies
         run: |
@@ -152,7 +152,7 @@ jobs:
         with:
           # Test only the oldest maintenance LTS Node.js version.
           # https://github.com/nodejs/Release#release-schedule
-          node-version: 12
+          node-version: 14
 
       - name: Install dependencies
         run: |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -156,7 +156,7 @@ If you get an error that looks like this when trying to launch Chromium:
 spawn /Users/.../node_modules/puppeteer/.local-chromium/mac-756035/chrome-mac/Chromium.app/Contents/MacOS/Chromium ENOENT
 ```
 
-This means that the browser was downloaded but failed to be extracted correctly. The most common cause is a bug in Node.js v14.0.0 which broke `extract-zip`, the module Puppeteer uses to extract browser downloads into the right place. The bug was fixed in Node.js v14.1.0, so please make sure you're running that version or higher. Alternatively, if you cannot upgrade, you could downgrade to Node.js v12, but we recommend upgrading when possible.
+This means that the browser was downloaded but failed to be extracted correctly. The most common cause is a bug in Node.js v14.0.0 which broke `extract-zip`, the module Puppeteer uses to extract browser downloads into the right place. The bug was fixed in Node.js v14.1.0, so please make sure you're running that version or higher.
 
 ## Setting Up Chrome Linux Sandbox
 
@@ -242,7 +242,7 @@ Running Puppeteer smoothly on CircleCI requires the following steps:
    like so:
    ```yaml
    docker:
-     - image: circleci/node:12 # Use your desired version
+     - image: circleci/node:14 # Use your desired version
        environment:
          NODE_ENV: development # Only needed if puppeteer is in `devDependencies`
    ```
@@ -277,7 +277,7 @@ To fix, you'll need to install the missing dependencies and the
 latest Chromium package in your Dockerfile:
 
 ```Dockerfile
-FROM node:12-slim
+FROM node:14-slim
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "types": "lib/types.d.ts",
   "repository": "github:puppeteer/puppeteer",
   "engines": {
-    "node": ">=10.18.1"
+    "node": ">=14.1.0"
   },
   "scripts": {
     "test-browser": "wtr",


### PR DESCRIPTION
This patches removes support for Node 12.

BREAKING CHANGE: Node 12 is no longer supported.