### PR TITLE
feat: add Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,3 +181,35 @@ jobs:
         run: |
           # Note: this modifies package.json to test puppeteer-core, so we test this last.
           npm run test:install
+
+  docker-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [16]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Set up Node.js
+        uses: actions/setup-node@v3.1.1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: |
+          npm install
+          ls .local-chromium
+      - name: Build
+        run: |
+          npm run build
+          docker/pack.sh
+      - name: Build docker image
+        working-directory: ./docker
+        run: |
+          docker build -t puppeteer-test-image .
+      - name: Run smoke test
+        working-directory: ./docker
+        run: |
+          docker run -i --init --cap-add=SYS_ADMIN --rm puppeteer-test-image node -e "`cat test/smoke-test.js`"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:16
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/pptruser
+
+COPY puppeteer-latest.tgz /home/pptruser/puppeteer-latest.tgz
+
+# Install puppeteer into /home/pptruser/node_modules.
+RUN npm i ./puppeteer-latest.tgz \
+    && rm puppeteer-latest.tgz \
+    # Add user so we don't need --no-sandbox.
+    # same layer as npm install to keep re-chowned files from using up several hundred MBs more space
+    && groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && (node -e "require('child_process').execSync(require('puppeteer').executablePath() + ' --credits', {stdio: 'inherit'})" > THIRD_PARTY_NOTICES)
+
+USER pptruser
+
+CMD ["google-chrome-stable"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+# Dockerfile for Puppeteer
+
+This directory contains files needed to containerize Puppeteer. The major problem
+that this is solving is the problem of providing all dependencies required to run a
+browser instance.
+
+## Building the image
+
+```sh
+docker build -t puppeteer-chrome-linux . # `puppeteer-chrome-linux` is the name of the image.
+```
+
+## Running the image
+
+```sh
+docker run -i --init --rm --cap-add=SYS_ADMIN --name puppeteer-chrome puppeteer-chrome-linux node -e "`cat test.js`"
+```
+
+`--cap-add=SYS_ADMIN` capability is needed to enable Chromium sandbox that makes the browser more secure. Alternatively, it should be possible to start the browser binary with the `--no-sandbox` flag.

--- a/docker/pack.sh
+++ b/docker/pack.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Packs puppeteer using npm and moves the archive file to docker/puppeteer-latest.tgz.
+# Expected cwd: project root directory.
+
+set -e
+set +x
+
+FILENAME=$(npm pack)
+
+echo $FILENAME
+
+mv $FILENAME docker/puppeteer-latest.tgz

--- a/docker/test/smoke-test.js
+++ b/docker/test/smoke-test.js
@@ -1,0 +1,9 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
+  await browser.close();
+  console.log('done');
+})();


### PR DESCRIPTION
This PR adds an official Dockerfile for Puppeteer. The content of the Dockerfile is practically the same as documented in troubleshooting.md:

1) It installs chrome-stable and dependencies via apt-get.
2) it installs a local Puppeteer build into the docker user's home folder.
3) configures required permissions for the user.
4) outputs licenses into the THIRD_PARTY_NOTICES file.

The local Puppeteer build is created by `docker/pack.sh` which is meant to be used in CI. This PR also includes a GitHub action that would build a docker image and run a smote test inside of it.

The next step would be actually publishing the docker image from GitHub Actions to GitHub Registry.
