### PR TITLE
chore: allow to skip the installation of Husky in the prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "assert-unit-coverage": "cross-env COVERAGE=1 mocha --config mocha-config/coverage-tests.js",
     "funit": "cross-env PUPPETEER_PRODUCT=firefox npm run unit",
     "test": "npm run tsc && npm run lint --silent && npm run unit-with-coverage && npm run test-browser",
-    "prepare": "node typescript-if-required.js && husky install",
+    "prepare": "node typescript-if-required.js && ([[ $HUSKY = 0 ]] || husky install)",
     "prepublishOnly": "npm run build",
     "dev-install": "npm run tsc && node install.js",
     "install": "node install.js",


### PR DESCRIPTION
By setting the `HUSKY=0` environment variable it should be possible to stop the installation of Husky during the npm prepare step.

@OrKoN could you please review? Thanks!