### PR TITLE
chore: disable failing permission test

### DIFF
--- a/test/page.spec.ts
+++ b/test/page.spec.ts
@@ -306,7 +306,10 @@ describe('Page', function () {
       expect(await getPermission(page, 'geolocation')).toBe('prompt');
     });
     itFailsFirefox('should trigger permission onchange', async () => {
-      const { page, server, context } = getTestState();
+      const { page, server, context, isHeadless } = getTestState();
+
+      // TODO: re-enable this test in headful once crbug.com/1324480 rolls out.
+      if (!isHeadless) return;
 
       await page.goto(server.EMPTY_PAGE);
       await page.evaluate(() => {


### PR DESCRIPTION
The test depends on the upstream fix that will be rolled out in M103.