### PR TITLE
fix: Kill browser process when 'taskkill' fails on Windows

### DIFF
--- a/src/node/BrowserRunner.ts
+++ b/src/node/BrowserRunner.ts
@@ -186,7 +186,14 @@ export class BrowserRunner {
     if (this.proc && this.proc.pid && pidExists(this.proc.pid)) {
       try {
         if (process.platform === 'win32') {
-          childProcess.exec(`taskkill /pid ${this.proc.pid} /T /F`, () => {});
+          childProcess.exec(`taskkill /pid ${this.proc.pid} /T /F`, (error) => {
+            if (error) {
+              // taskkill can fail to kill the process e.g. due to missing permissions.
+              // Let's kill the process via Node API. This delays killing of all child
+              // proccesses of `this.proc` until the main Node.js process dies.
+              this.proc.kill();
+            }
+          });
         } else {
           // on linux the process group can be killed with the group id prefixed with
           // a minus sign. The process group id is the group leader's pid.


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No, this PR affects windows only and affects how we shut down the browser process.

**Summary**

On windows, we use `taskkill` to kill the browser process. The reason is that we want to shutdown the whole process group, i.e. also kill all child processes spawned by the browser process. Calling `taskkill` can fail though, if its called by a user with not enough privileges, in that case we should fall back to using `subprocess.kill`.

As per Node.js documentation we also cleanup all the processes of a process group as long as we do not start the browser process in detached mode (which we do not do) once the main Node.js process dies.

**Does this PR introduce a breaking change?**

No

**Other information**

This might also fix issue #7922.