### PR TITLE
chore: fix failing test for the chrome headless

### DIFF
--- a/test/browser.spec.ts
+++ b/test/browser.spec.ts
@@ -22,11 +22,13 @@ describe('Browser specs', function () {
 
   describe('Browser.version', function () {
     it('should return whether we are in headless', async () => {
-      const { browser, isHeadless } = getTestState();
+      const { browser, isHeadless, headless } = getTestState();
 
       const version = await browser.version();
       expect(version.length).toBeGreaterThan(0);
-      expect(version.startsWith('Headless')).toBe(isHeadless);
+      expect(version.startsWith('Headless')).toBe(
+        isHeadless && headless !== 'chrome'
+      );
     });
   });
 

--- a/test/mocha-utils.ts
+++ b/test/mocha-utils.ts
@@ -137,6 +137,7 @@ interface PuppeteerTestState {
   isFirefox: boolean;
   isChrome: boolean;
   isHeadless: boolean;
+  headless: string;
   puppeteerPath: string;
 }
 const state: Partial<PuppeteerTestState> = {};
@@ -270,6 +271,7 @@ export const mochaHooks = {
       state.isFirefox = isFirefox;
       state.isChrome = isChrome;
       state.isHeadless = isHeadless;
+      state.headless = headless;
       state.puppeteerPath = path.resolve(path.join(__dirname, '..'));
     },
     coverageHooks.beforeAll,


### PR DESCRIPTION
Just a small test fix for the new headless mode that does not report a different user agent. 