### PR TITLE
chore: continue on error for Firefox tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Run unit tests on Firefox
         uses: nick-invision/retry@v2
+        continue-on-error: true
         env:
           FIREFOX: true
           MOZ_WEBRENDER: 0
@@ -133,6 +134,7 @@ jobs:
 
       - name: Run unit tests on Firefox
         uses: nick-invision/retry@v2
+        continue-on-error: true
         with:
           max_attempts: 3
           timeout_minutes: 10


### PR DESCRIPTION
Temporarily continue on test failures in Firefox until https://github.com/puppeteer/puppeteer/issues/8361 is fixed