### PR TITLE
revert: do not use loaderId for lifecycle events

### DIFF
--- a/src/common/LifecycleWatcher.ts
+++ b/src/common/LifecycleWatcher.ts
@@ -64,6 +64,7 @@ export class LifecycleWatcher {
   _timeout: number;
   _navigationRequest?: HTTPRequest;
   _eventListeners: PuppeteerEventListener[];
+  _initialLoaderId: string;
 
   _sameDocumentNavigationPromise: Promise<Error | null>;
   _sameDocumentNavigationCompleteCallback: (x?: Error) => void;
@@ -81,7 +82,6 @@ export class LifecycleWatcher {
 
   _maximumTimer?: NodeJS.Timeout;
   _hasSameDocumentNavigation?: boolean;
-  _newDocumentNavigation?: boolean;
   _swapped?: boolean;
 
   constructor(
@@ -100,6 +100,7 @@ export class LifecycleWatcher {
 
     this._frameManager = frameManager;
     this._frame = frame;
+    this._initialLoaderId = frame._loaderId;
     this._timeout = timeout;
     this._navigationRequest = null;
     this._eventListeners = [
@@ -120,11 +121,6 @@ export class LifecycleWatcher {
         this._frameManager,
         FrameManagerEmittedEvents.FrameNavigatedWithinDocument,
         this._navigatedWithinDocument.bind(this)
-      ),
-      helper.addEventListener(
-        this._frameManager,
-        FrameManagerEmittedEvents.FrameNavigated,
-        this._navigated.bind(this)
       ),
       helper.addEventListener(
         this._frameManager,
@@ -221,12 +217,6 @@ export class LifecycleWatcher {
     this._checkLifecycleComplete();
   }
 
-  _navigated(frame: Frame): void {
-    if (frame !== this._frame) return;
-    this._newDocumentNavigation = true;
-    this._checkLifecycleComplete();
-  }
-
   _frameSwapped(frame: Frame): void {
     if (frame !== this._frame) return;
     this._swapped = true;
@@ -237,9 +227,19 @@ export class LifecycleWatcher {
     // We expect navigation to commit.
     if (!checkLifecycle(this._frame, this._expectedLifecycle)) return;
     this._lifecycleCallback();
+    if (
+      this._frame._loaderId === this._initialLoaderId &&
+      !this._hasSameDocumentNavigation
+    ) {
+      if (this._swapped) {
+        this._swapped = false;
+        this._newDocumentNavigationCompleteCallback();
+      }
+      return;
+    }
     if (this._hasSameDocumentNavigation)
       this._sameDocumentNavigationCompleteCallback();
-    if (this._swapped || this._newDocumentNavigation)
+    if (this._frame._loaderId !== this._initialLoaderId)
       this._newDocumentNavigationCompleteCallback();
 
     /**


### PR DESCRIPTION
Reverts puppeteer/puppeteer#8353 as it breaks Firefox integration. 