### PR TITLE
chore: use exit code 0 for doclint file gen

### DIFF
--- a/utils/doclint/Message.js
+++ b/utils/doclint/Message.js
@@ -39,6 +39,14 @@ class Message {
   static warning(text) {
     return new Message('warning', text);
   }
+
+  /**
+   * @param {string} text
+   * @returns {!Message}
+   */
+  static info(text) {
+    return new Message('info', text);
+  }
 }
 
 module.exports = Message;

--- a/utils/doclint/cli.js
+++ b/utils/doclint/cli.js
@@ -24,6 +24,7 @@ const PROJECT_DIR = path.join(__dirname, '..', '..');
 const VERSION = require(path.join(PROJECT_DIR, 'package.json')).version;
 
 const RED_COLOR = '\x1b[31m';
+const BLUE_COLOR = '\x1b[34m';
 const YELLOW_COLOR = '\x1b[33m';
 const RESET_COLOR = '\x1b[0m';
 
@@ -108,32 +109,40 @@ async function run() {
   if (errors.length) {
     console.log('DocLint Failures:');
     for (let i = 0; i < errors.length; ++i) {
-      let error = errors[i].text;
-      error = error.split('\n').join('\n      ');
-      console.log(`  ${i + 1}) ${RED_COLOR}${error}${RESET_COLOR}`);
+      const text = errors[i].text.split('\n').join('\n      ');
+      console.log(`  ${i + 1}) ${RED_COLOR}${text}${RESET_COLOR}`);
     }
   }
   const warnings = messages.filter((message) => message.type === 'warning');
   if (warnings.length) {
     console.log('DocLint Warnings:');
     for (let i = 0; i < warnings.length; ++i) {
-      let warning = warnings[i].text;
-      warning = warning.split('\n').join('\n      ');
-      console.log(`  ${i + 1}) ${YELLOW_COLOR}${warning}${RESET_COLOR}`);
+      const text = warnings[i].text.split('\n').join('\n      ');
+      console.log(`  ${i + 1}) ${YELLOW_COLOR}${text}${RESET_COLOR}`);
     }
   }
-  let clearExit = messages.length === 0;
-  if (changedFiles) {
-    if (clearExit)
-      console.log(`${YELLOW_COLOR}Some files were updated.${RESET_COLOR}`);
-    clearExit = false;
+  const info = messages.filter((message) => message.type === 'info');
+  if (info.length) {
+    console.log('DocLint Info:');
+    for (let i = 0; i < info.length; i++) {
+      const text = info[i].text.split('\n').join('\n      ');
+      console.log(`  ${i + 1}) ${BLUE_COLOR}${text}${RESET_COLOR}`);
+    }
   }
-  console.log(`${errors.length} failures, ${warnings.length} warnings.`);
+  if (changedFiles) {
+    console.log(`${BLUE_COLOR}Some files were updated.${RESET_COLOR}`);
+  }
 
-  if (!clearExit && !process.env.GITHUB_ACTIONS)
+  console.log(
+    `${info.length} info, ${errors.length} failures, ${warnings.length} warnings.`
+  );
+
+  const clearExit = errors.length + warnings.length === 0;
+  if (!clearExit && !process.env.GITHUB_ACTIONS) {
     console.log(
       '\nIs your lib/ directory up to date? You might need to `npm run tsc`.\n'
     );
+  }
 
   const runningTime = Date.now() - startTime;
   console.log(`DocLint Finished in ${runningTime / 1000} seconds`);

--- a/utils/doclint/preprocessor/index.js
+++ b/utils/doclint/preprocessor/index.js
@@ -31,7 +31,7 @@ module.exports.ensureReleasedAPILinks = function (sources, version) {
     const text = source.text();
     const newText = text.replace(apiLinkRegex, lastReleasedAPI);
     if (source.setText(newText))
-      messages.push(Message.warning(`GEN: updated ${source.projectPath()}`));
+      messages.push(Message.info(`GEN: updated ${source.projectPath()}`));
   }
   return messages;
 };
@@ -87,7 +87,7 @@ module.exports.runCommands = function (sources, version) {
     else if (applyCommand(command, newText)) changedSources.add(command.source);
   }
   for (const source of changedSources)
-    messages.push(Message.warning(`GEN: updated ${source.projectPath()}`));
+    messages.push(Message.info(`GEN: updated ${source.projectPath()}`));
   return messages;
 };
 


### PR DESCRIPTION
This PR converts some warnings from DocLint to info logs. In particular, it converts warnings about code generation that is intentionally performed (hence not needed to be warned about). In doing this, we can exit with code 0 since there are no warnings and errors.