### PR TITLE
Add types to the exports field of package.json to support typescript nodenext module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "./cjs-entry.js",
   "exports": {
     ".": {
+      "types": "./lib/types.d.ts",
       "import": "./lib/esm/puppeteer/node.js",
       "require": "./cjs-entry.js"
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

package.json export field

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

No

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Typescript uses `./lib/esm/puppeteer/node-puppeteer-core.d.ts` as the export type of puppeteer-core in nodenext module type,
which causes the following import report type error:
`import { type Browser } from 'puppeteer-core'`

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
