### PR TITLE
chore: enable anchor navigation tests for Firefox

### DIFF
--- a/test/frame.spec.ts
+++ b/test/frame.spec.ts
@@ -134,19 +134,16 @@ describe('Frame specs', function () {
         expect(detachedFrames[0].isDetached()).toBe(true);
       }
     );
-    itFailsFirefox(
-      'should send "framenavigated" when navigating on anchor URLs',
-      async () => {
-        const { page, server } = getTestState();
+    it('should send "framenavigated" when navigating on anchor URLs', async () => {
+      const { page, server } = getTestState();
 
-        await page.goto(server.EMPTY_PAGE);
-        await Promise.all([
-          page.goto(server.EMPTY_PAGE + '#foo'),
-          utils.waitEvent(page, 'framenavigated'),
-        ]);
-        expect(page.url()).toBe(server.EMPTY_PAGE + '#foo');
-      }
-    );
+      await page.goto(server.EMPTY_PAGE);
+      await Promise.all([
+        page.goto(server.EMPTY_PAGE + '#foo'),
+        utils.waitEvent(page, 'framenavigated'),
+      ]);
+      expect(page.url()).toBe(server.EMPTY_PAGE + '#foo');
+    });
     it('should persist mainFrame on cross-process navigation', async () => {
       const { page, server } = getTestState();
 
@@ -164,7 +161,7 @@ describe('Frame specs', function () {
       await page.goto(server.EMPTY_PAGE);
       expect(hasEvents).toBe(false);
     });
-    itFailsFirefox('should detach child frames on navigation', async () => {
+    it('should detach child frames on navigation', async () => {
       const { page, server } = getTestState();
 
       let attachedFrames = [];
@@ -186,7 +183,7 @@ describe('Frame specs', function () {
       expect(detachedFrames.length).toBe(4);
       expect(navigatedFrames.length).toBe(1);
     });
-    itFailsFirefox('should support framesets', async () => {
+    it('should support framesets', async () => {
       const { page, server } = getTestState();
 
       let attachedFrames = [];

--- a/test/navigation.spec.ts
+++ b/test/navigation.spec.ts
@@ -35,7 +35,7 @@ describe('navigation', function () {
       await page.goto(server.EMPTY_PAGE);
       expect(page.url()).toBe(server.EMPTY_PAGE);
     });
-    itFailsFirefox('should work with anchor navigation', async () => {
+    it('should work with anchor navigation', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.EMPTY_PAGE);
@@ -488,7 +488,7 @@ describe('navigation', function () {
   });
 
   describe('Page.waitForNavigation', function () {
-    itFailsFirefox('should work', async () => {
+    it('should work', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.EMPTY_PAGE);
@@ -526,7 +526,7 @@ describe('navigation', function () {
       await bothFiredPromise;
       await navigationPromise;
     });
-    itFailsFirefox('should work with clicking on anchor links', async () => {
+    it('should work with clicking on anchor links', async () => {
       const { page, server } = getTestState();
 
       await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
New puppeteer tests started passing on mozilla-central's CI after landing https://bugzilla.mozilla.org/show_bug.cgi?id=1636453 which should now be included in the latest Nightly.

It would be great to have them enabled in puppeteer's CI as well, assuming they work on all platforms there (mozilla-central only runs puppeteer tests on linux)

Related to #8361