### PR TITLE
Fix NodeNext incompatibility in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "./cjs-entry.js",
   "exports": {
     ".": {
+      "types": "./lib/types.d.ts",
       "import": "./lib/esm/puppeteer/node.js",
       "require": "./cjs-entry.js"
     },


### PR DESCRIPTION
The spec for the "exports" field has it completely take over when present. Latest Typescript (4.7+), when using `moduleResolution` "NodeNext" follows the spec. It therefore looks for types in `package.json/exports/./types`. Puppeteer does not have that value, so Typescript gets confused and throws errors of various sorts on import statements.

Adding `package.json/exports/./types = "./lib/types.d.ts"` resolves this.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No. It's an extremely minor change that should not create backwards incompatibilities and brings the `package.json` to spec.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Resolves #8438

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**
