### PR TITLE
feat: support node-like environments

### DIFF
--- a/src/common/BrowserConnector.ts
+++ b/src/common/BrowserConnector.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import { ConnectionTransport } from './ConnectionTransport.js';
+import { debugError } from '../common/helper.js';
+import { isNode } from '../environment.js';
+import { assert } from './assert.js';
 import {
   Browser,
-  TargetFilterCallback,
   IsPageTargetCallback,
+  TargetFilterCallback,
 } from './Browser.js';
-import { assert } from './assert.js';
-import { debugError } from '../common/helper.js';
 import { Connection } from './Connection.js';
-import { Viewport } from './PuppeteerViewport.js';
-import { isNode } from '../environment.js';
+import { ConnectionTransport } from './ConnectionTransport.js';
 import { getFetch } from './fetch.js';
+import { Viewport } from './PuppeteerViewport.js';
 
 /**
  * Generic browser options that can be passed when launching any browser or when

--- a/src/common/JSHandle.ts
+++ b/src/common/JSHandle.ts
@@ -14,25 +14,24 @@
  * limitations under the License.
  */
 
-import { assert } from './assert.js';
-import { helper, debugError } from './helper.js';
-import { ExecutionContext } from './ExecutionContext.js';
-import { Page, ScreenshotOptions } from './Page.js';
-import { CDPSession } from './Connection.js';
-import { KeyInput } from './USKeyboardLayout.js';
-import { FrameManager, Frame } from './FrameManager.js';
-import { getQueryHandlerAndSelector } from './QueryHandler.js';
 import { Protocol } from 'devtools-protocol';
+import { assert } from './assert.js';
+import { CDPSession } from './Connection.js';
 import {
   EvaluateFn,
-  SerializableOrJSHandle,
   EvaluateFnReturnType,
   EvaluateHandleFn,
-  WrapElementHandle,
+  SerializableOrJSHandle,
   UnwrapPromiseLike,
+  WrapElementHandle,
 } from './EvalTypes.js';
-import { isNode } from '../environment.js';
+import { ExecutionContext } from './ExecutionContext.js';
+import { Frame, FrameManager } from './FrameManager.js';
+import { debugError, helper } from './helper.js';
 import { MouseButton } from './Input.js';
+import { Page, ScreenshotOptions } from './Page.js';
+import { getQueryHandlerAndSelector } from './QueryHandler.js';
+import { KeyInput } from './USKeyboardLayout.js';
 
 /**
  * @public
@@ -822,17 +821,18 @@ export class ElementHandle<
       'Multiple file uploads only work with <input type=file multiple>'
     );
 
-    if (!isNode) {
-      throw new Error(
-        `JSHandle#uploadFile can only be used in Node environments.`
-      );
-    }
-    /*
-     This import is only needed for `uploadFile`, so keep it scoped here to
-     avoid paying the cost unnecessarily.
-    */
-    const path = await import('path');
     // Locate all files and confirm that they exist.
+    let path: typeof import('path');
+    try {
+      path = await import('path');
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new Error(
+          `JSHandle#uploadFile can only be used in Node-like environments.`
+        );
+      }
+      throw error;
+    }
     const files = filePaths.map((filePath) => {
       if (path.isAbsolute(filePath)) {
         return filePath;

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { isNode } from '../environment.js';
-
 /* Use the global version if we're in the browser, else load the node-fetch module. */
 export const getFetch = async (): Promise<typeof fetch> => {
-  return isNode ? (await import('cross-fetch')).fetch : globalThis.fetch;
+  return globalThis.fetch || (await import('cross-fetch')).fetch;
 };

--- a/src/node-puppeteer-core.ts
+++ b/src/node-puppeteer-core.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { initializePuppeteerNode } from './initialize-node.js';
 import { isNode } from './environment.js';
+import { initializePuppeteerNode } from './initialize-node.js';
 
 if (!isNode) {
   throw new Error('Cannot run puppeteer-core outside of Node.js');

--- a/src/node.ts
+++ b/src/node.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { initializePuppeteerNode } from './initialize-node.js';
 import { isNode } from './environment.js';
+import { initializePuppeteerNode } from './initialize-node.js';
 
 if (!isNode) {
   throw new Error('Trying to run Puppeteer-Node in a web environment.');
 }
-export default initializePuppeteerNode('puppeteer');
+
+const puppeteer = initializePuppeteerNode('puppeteer');
+export default puppeteer;

--- a/src/web.ts
+++ b/src/web.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { initializePuppeteerWeb } from './initialize-web.js';
 import { isNode } from './environment.js';
+import { initializePuppeteerWeb } from './initialize-web.js';
 
 if (isNode) {
   throw new Error('Trying to run Puppeteer-Web in a Node environment');
 }
 
-export default initializePuppeteerWeb('puppeteer');
+const puppeteer = initializePuppeteerWeb('puppeteer');
+export default puppeteer;


### PR DESCRIPTION
This PR removes some node environment checks in favor of import-existence checks. This generalizes puppeteer capabilities to Node-like environments (environments that have the minimal imports needed for functionality; i.e. polyfills).