### PR TITLE
fix: avoid `instanceof Object` check in `isErrorLike`

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -407,7 +407,9 @@ interface ErrorLike extends Error {
 }
 
 export function isErrorLike(obj: unknown): obj is ErrorLike {
-  return obj instanceof Object && 'name' in obj && 'message' in obj;
+  return (
+    typeof obj === 'object' && obj !== null && 'name' in obj && 'message' in obj
+  );
 }
 
 export function isErrnoException(obj: unknown): obj is NodeJS.ErrnoException {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Bug fix.

**Did you add tests for your changes?**

Did not.

**If relevant, did you update the documentation?**

N/A

**Summary**

#8497 does not seem to have been fully resolved for me with 14.4.0 (#8504), likely because the `instanceof` check being changed in this PR also causes issues in Jest due to facebook/jest#2549. I was able to confirm that this change avoids the error I've been seeing in CI by testing this change via `patch-package`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

None