### PR TITLE
Expose #client via `_client()` on HTTPRequest

### DIFF
--- a/src/common/HTTPRequest.ts
+++ b/src/common/HTTPRequest.ts
@@ -196,11 +196,10 @@ export class HTTPRequest {
     return this.#url;
   }
   
-
   /**
    * @returns the respective client of the request
    */
-  client(): string {
+  _client(): string {
     return this.#client;
   }
 

--- a/src/common/HTTPRequest.ts
+++ b/src/common/HTTPRequest.ts
@@ -195,6 +195,14 @@ export class HTTPRequest {
   url(): string {
     return this.#url;
   }
+  
+
+  /**
+   * @returns the respective client of the request
+   */
+  client(): string {
+    return this.#client;
+  }
 
   /**
    * @returns the `ContinueRequestOverrides` that will be used


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

A small change that will allow the puppeteer-page-proxy project a path to working again with the latest versions of puppeteer

**Did you add tests for your changes?**

`_client()` is not documented on `Page` yet still exists so I guess it's not required.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Completely eliminating access to the HTTPRequest._client property will break `puppeteer-page-proxy` and in turn negatively affect my users. Forcing my project to use older puppeteer version will also negatively affect my users. I am making this PR so I can eventually make a PR/fork on `puppeteer-page-proxy`

https://github.com/open-wa/wa-automate-nodejs/issues/2755
https://github.com/Cuadrix/puppeteer-page-proxy/issues/78

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
