### PR TITLE
fix: Clean up tmp profile dirs when browser is closed

### DIFF
--- a/src/node/ChromeLauncher.ts
+++ b/src/node/ChromeLauncher.ts
@@ -92,7 +92,7 @@ export class ChromeLauncher implements ProductLauncher {
       }
     }
 
-    let isTempUserDataDir = true;
+    let isTempUserDataDir = false;
 
     // Check for the user data dir argument, which will always be set even
     // with a custom directory specified via the userDataDir option.
@@ -100,6 +100,7 @@ export class ChromeLauncher implements ProductLauncher {
       return arg.startsWith('--user-data-dir');
     });
     if (userDataDirIndex < 0) {
+      isTempUserDataDir = true;
       chromeArguments.push(
         `--user-data-dir=${await fs.promises.mkdtemp(
           path.join(tmpdir(), 'puppeteer_dev_chrome_profile-')
@@ -110,8 +111,6 @@ export class ChromeLauncher implements ProductLauncher {
 
     const userDataDir = chromeArguments[userDataDirIndex]!.split('=', 2)[1];
     assert(typeof userDataDir === 'string', '`--user-data-dir` is malformed');
-
-    isTempUserDataDir = false;
 
     let chromeExecutable = executablePath;
     if (channel) {

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -251,7 +251,7 @@ describe('Launcher specs', function () {
         // This might throw. See https://github.com/puppeteer/puppeteer/issues/2778
         await rmAsync(userDataDir).catch(() => {});
       });
-      it('tmp profile should be deleted without userDataDir option', async () => {
+      itChromeOnly('tmp profile should be cleaned up', async () => {
         const {defaultBrowserOptions, puppeteer} = getTestState();
 
         // Set a custom test tmp dir so that we can validate that


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: Puppeteer is not deleting tmp profiles after browser is closed.

**Did you add tests for your changes?**

Yes, I actually first created the test to verify that it was actually broken the way I thought.

**If relevant, did you update the documentation?**

No, this is a small bugfix, but let me know if I should update anything. 

**Summary**

Puppeteer has a feature in which if you don't specify a user data dir (`--user-data-dir`) it automatically creates one in a tmp folder, and then it's deleted when the browser is closed. 
It seems that this feature [got broken here](https://github.com/puppeteer/puppeteer/commit/b4e751f29cb6fd4c3cc41fe702de83721f0eb6dc?diff=split#diff-d09eb6dc12121ed413d2820db7fa8ba1dff9260a2ad2486a6220c861a8e5e673R134), as it is now setting `isTempUserDataDir` to false in any case. 

In my particular case, I instantiate Puppeteer multiple times, leading to an infinite number of dirs in the /tmp folder which were only deleted when I restarted the node.
```
ls -l /tmp/puppeteer_dev_chrome_profile-*  | wc -l
344
```

**Does this PR introduce a breaking change?**

No. (unless for any reason somebody is expecting for tmp profiles to be kept)

