### PR TITLE
chore: allow parallel testing

### DIFF
--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -51,7 +51,6 @@ describe('Cookie specs', () => {
           httpOnly: false,
           secure: false,
           session: true,
-          sourcePort: 8907,
           sourceScheme: 'NonSecure',
         },
       ]);
@@ -112,7 +111,6 @@ describe('Cookie specs', () => {
           httpOnly: false,
           secure: false,
           session: true,
-          sourcePort: 8907,
           sourceScheme: 'NonSecure',
         },
         {
@@ -126,7 +124,6 @@ describe('Cookie specs', () => {
           httpOnly: false,
           secure: false,
           session: true,
-          sourcePort: 8907,
           sourceScheme: 'NonSecure',
         },
       ]);

--- a/test/src/coverage.spec.ts
+++ b/test/src/coverage.spec.ts
@@ -128,7 +128,7 @@ describe('Coverage specs', function () {
       await page.goto(server.PREFIX + '/jscoverage/involved.html');
       const coverage = await page.coverage.stopJSCoverage();
       expect(
-        JSON.stringify(coverage, null, 2).replace(/:\d{4}\//g, ':<PORT>/')
+        JSON.stringify(coverage, null, 2).replace(/:\d{4,5}\//g, ':<PORT>/')
       ).toBeGolden('jscoverage-involved.txt');
     });
     // @see https://crbug.com/990945
@@ -267,7 +267,7 @@ describe('Coverage specs', function () {
       await page.goto(server.PREFIX + '/csscoverage/involved.html');
       const coverage = await page.coverage.stopCSSCoverage();
       expect(
-        JSON.stringify(coverage, null, 2).replace(/:\d{4}\//g, ':<PORT>/')
+        JSON.stringify(coverage, null, 2).replace(/:\d{4,5}\//g, ':<PORT>/')
       ).toBeGolden('csscoverage-involved.txt');
     });
     it('should work with empty stylesheets', async () => {

--- a/test/src/defaultbrowsercontext.spec.ts
+++ b/test/src/defaultbrowsercontext.spec.ts
@@ -44,7 +44,6 @@ describe('DefaultBrowserContext', function () {
         httpOnly: false,
         secure: false,
         session: true,
-        sourcePort: 8907,
         sourceScheme: 'NonSecure',
       },
     ]);

--- a/test/src/golden-utils.ts
+++ b/test/src/golden-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import assert from 'assert';
-import diff from 'diff';
+import {diffLines} from 'diff';
 import fs from 'fs';
 import jpeg from 'jpeg-js';
 import mime from 'mime';
@@ -90,7 +90,7 @@ const compareText = (
   if (expected === actual) {
     return;
   }
-  const result = diff.diffLines(expected, actual);
+  const result = diffLines(expected, actual);
   const html = result.reduce((text, change) => {
     text += change.added
       ? `<span class='ins'>${change.value}</span>`

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -116,7 +116,7 @@ export const dumpFrames = (
   indentation?: string
 ): Array<string> => {
   indentation = indentation || '';
-  let description = frame.url().replace(/:\d{4}\//, ':<PORT>/');
+  let description = frame.url().replace(/:\d{4,5}\//, ':<PORT>/');
   if (frame.name()) {
     description += ' (' + frame.name() + ')';
   }


### PR DESCRIPTION
This PR amends the tests to allow for `--parallel` testing.