### PR TITLE
chore: add CNAME

### DIFF
--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+pptr.dev


### PR DESCRIPTION
`CNAME` is written to the `gh-pages` branch for custom domains, however it gets deleted upon deployment of new docs. This PR ensures `CNAME` isn't erased by adding it to the static assets.