### PR TITLE
fix(page): fix page.#scrollIntoViewIfNeeded method

### DIFF
--- a/test/src/click.spec.ts
+++ b/test/src/click.spec.ts
@@ -164,7 +164,10 @@ describe('Page.click', function () {
     await page.goto(server.PREFIX + '/offscreenbuttons.html');
     const messages: any[] = [];
     page.on('console', msg => {
-      return messages.push(msg.text());
+      if (msg.type() === 'log') {
+        return messages.push(msg.text());
+      }
+      return;
     });
     for (let i = 0; i < 11; ++i) {
       // We might've scrolled to click a button - reset to (0, 0).

--- a/test/src/elementhandle.spec.ts
+++ b/test/src/elementhandle.spec.ts
@@ -203,7 +203,7 @@ describe('ElementHandle specs', function () {
         })
       ).toBe(true);
     });
-    it('should work for TextNodes', async () => {
+    it('should not work for TextNodes', async () => {
       const {page, server} = getTestState();
 
       await page.goto(server.PREFIX + '/input/button.html');


### PR DESCRIPTION
This patch fixes page.#scrollIntoViewIfNeededso that it works with devtools protocol.
Now it blocks the main thread and waits until the scrolling action finishes.

Issues: #8627, #1805

BREAKING CHANGE: page.#scrollIntoViewIfNeeded throws erros which come from the internal implementation.
 - `Protocol error (DOM.scrollIntoViewIfNeeded): Node is detached from document`
 - `Protocol error (DOM.scrollIntoViewIfNeeded): Node does not have a layout object`
Also now it does work with TextNode properly and does not throw an error.
