### PR TITLE
fix(typo): fix typo in Page.waitForSelector() method

### DIFF
--- a/docs/api/puppeteer.page.waitforselector.md
+++ b/docs/api/puppeteer.page.waitforselector.md
@@ -58,6 +58,6 @@ The optional Parameter in Arguments `options` are :
 
 - `Visible`: A boolean wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 
-- `hidden`: ait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+- `hidden`: wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 
 - `timeout`: maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.


### PR DESCRIPTION
fix typo from ait to wait in Remarks - hidden option