### PR TITLE
fix: ignore *.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 lib/
 
 # Generated files
-tsconfig.tsbuildinfo
+**/*.tsbuildinfo
 puppeteer.api.json
 puppeteer*.tgz
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "files": [
     "lib",
     "install.js",
-    "typescript-if-required.js"
+    "typescript-if-required.js",
+    "!**/*.tsbuildinfo"
   ],
   "author": "The Chromium Authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR ignores `*. tsbuildinfo` during publishing.

Fixes #8621.