### PR TITLE
docs: add gitlab-ci section to troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -359,6 +359,28 @@ USER pptruser
 ...
 ```
 
+## Running Puppeteer on GitlabCI
+
+This is very similar to some of the instructions above, but require a bit different configuration to finally achieve success.
+
+Usually the issue looks like this:
+```bash
+Error: Failed to launch chrome! spawn /usr/bin/chromium-browser ENOENT
+```
+
+You need to patch two places:
+1. Your `gitlab-ci.yml` config
+2. Arguments' list when launching pupepeteer
+
+In `gitlab-ci.yml` we need to install some packages to make it possible to launch headless Chrome in your docker env:
+```yml
+before_script:
+    - apt-get update
+    - apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libnss3 lsb-release xdg-utils wget
+```
+
+Next, you have to use `'--no-sandbox'` mode and also `'--disable-setuid-sandbox'` when launching Puppeteer. This can be done by passing them as an arguments to your `.launch()` call: `puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });`.
+
 #### Tips
 
 By default, Docker runs a container with a `/dev/shm` shared memory space 64MB.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Docs update for `troubleshooting.md`, related to GitlabCI

**Did you add tests for your changes?**
Not applicable

**If relevant, did you update the documentation?**
Yes. New section ## Running Puppeteer on GitlabCI

**Summary**
Adding explanatory section with detailed manual on how to launch puppeteer on GitlabCI. I was looking for any case or manual guide how to fix my issue, was looking through gh issues, stackoverflow and other places. I found lots of relevant info, but nothing concrete. Seems like troubleshooting document should include this section for one of the most usable CI. Let's save a couple of hours for those who want to use puppeteer on GitlabCI

**Does this PR introduce a breaking change?**
No breaking changes.

**Other information**
