### PR TITLE
chore: try to fix the docusaurus build by giving Node more old mem space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
         run: npm ci
       - name: Build website
         working-directory: ./website
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Currently the site build is failing https://github.com/puppeteer/puppeteer/runs/7425413602?check_suite_focus=true

GitHub Actions runners should have at least 7GB RAM: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources