### PR TITLE
chore: configure docker image tags

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -35,6 +35,10 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            latest
+            type=semver,pattern={{version}}
+
       - name: Pack Puppeteer for docker
         run: docker/pack.sh
       - name: Build and push the Docker image


### PR DESCRIPTION
This configuration is supposed to mark every built image as latest and using the version from the tag name