### PR TITLE
fix: specify the target filter in setDiscoverTargets

### DIFF
--- a/src/common/ChromeTargetManager.ts
+++ b/src/common/ChromeTargetManager.ts
@@ -101,7 +101,12 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
     this.#connection.on('sessiondetached', this.#onSessionDetached);
     this.#setupAttachmentListeners(this.#connection);
 
-    this.#connection.send('Target.setDiscoverTargets', {discover: true});
+    // TODO: remove `as any` once the protocol definitions are updated with the
+    // next Chromium roll.
+    this.#connection.send('Target.setDiscoverTargets', {
+      discover: true,
+      filter: [{type: 'tab', exclude: true}, {}],
+    } as any);
   }
 
   async initialize(): Promise<void> {


### PR DESCRIPTION
To stay compatible with the next version of Chromium.
See https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-setDiscoverTargets