### PR TITLE
docs: fix a couple of typos in docker guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,7 +213,7 @@ docker pull ghcr.io/puppeteer/puppeteer:latest # pulls the latest
 docker pull ghcr.io/puppeteer/puppeteer:16.1.0 # pulls the image that contains Puppeteer v16.1.0
 ```
 
-The image is meant for running the browser in the sandobx mode and therefore, running the image requires the `SYS_ADMIN` capability. For example,
+The image is meant for running the browser in the sandbox mode and therefore, running the image requires the `SYS_ADMIN` capability. For example,
 
 ```sh
 docker run -i --init --cap-add=SYS_ADMIN --rm ghcr.io/puppeteer/puppeteer:latest node -e "`cat docker/test/smoke-test.js`"
@@ -222,7 +222,7 @@ docker run -i --init --cap-add=SYS_ADMIN --rm ghcr.io/puppeteer/puppeteer:latest
 Replace the path to [`smoke-test.js`](https://raw.githubusercontent.com/puppeteer/puppeteer/main/docker/test/smoke-test.js) with a path to your script.
 The script can import or require the `puppeteer` module because it's pre-installed inside the image.
 
-Currently, the image includes the LTS version of Node.js. If you need to built an image based on a different base image, you can use our [`Dockerfile`](https://github.com/puppeteer/puppeteer/blob/main/docker/Dockerfile) as the starting point.
+Currently, the image includes the LTS version of Node.js. If you need to build an image based on a different base image, you can use our [`Dockerfile`](https://github.com/puppeteer/puppeteer/blob/main/docker/Dockerfile) as the starting point.
 
 ### Working with Chrome Extensions
 


### PR DESCRIPTION
This just fixes two minor typos I noticed that were introduced in the recent docs update for the docker container.