### PR TITLE
Update puppeteer.page.waitfornetworkidle.md

### DIFF
--- a/docs/api/puppeteer.page.waitfornetworkidle.md
+++ b/docs/api/puppeteer.page.waitfornetworkidle.md
@@ -17,12 +17,14 @@ class Page {
 
 ## Parameters
 
-| Parameter | Type                                     | Description                                   |
-| --------- | ---------------------------------------- | --------------------------------------------- |
-| options   | { idleTime?: number; timeout?: number; } | <i>(Optional)</i> Optional waiting parameters |
+| Parameter        | Type                                     | Description                                                        |
+| ---------------- | ---------------------------------------- | ------------------------------------------------------------------ |
+| options          | { idleTime?: number; timeout?: number; } | <i>(Optional)</i> Optional waiting parameters                      |
+| options.idleTime | number                                   | The duration of network idling in milliseconds in order to resolve |
+| options.timeout  | number                                   | Maximum waiting time in milliseconds                               |
 
 **Returns:**
 
 Promise&lt;void&gt;
 
-Promise which resolves when network is idle
+Promise which resolves when the network remains idle. When the `timeout` is reached and the network has not reached idle, the promise is rejected.


### PR DESCRIPTION
**Summary**
Documentation update for `page.waitForNetworkIdle()`. The original documentation did not mention anything about a failing promise, and if/how that would ever happen.

**Other information**
There appear to be many more spots where proper documentation is missing. For instance the default values for this function's `idleTime` + `timeout` options are not documented.

- I am assuming that the default `timeout` is set using `page.setDefaultTimeout()` (I don't know which property this sets; it would be nice if you could call `page.defaultTimeout` to get the default timeout setting.) Nevertheless it should be nice if it was referenced in each function.
- I guess `idleTime` defaults to `0`? Which would mean that the instant that the network is idle the promise resolves?