### PR TITLE
fix: make sure there is a check for targets when timeout=0

### DIFF
--- a/src/common/Browser.ts
+++ b/src/common/Browser.ts
@@ -649,10 +649,10 @@ export class Browser extends EventEmitter {
     this.on(BrowserEmittedEvents.TargetCreated, check);
     this.on(BrowserEmittedEvents.TargetChanged, check);
     try {
+      this.targets().forEach(check);
       if (!timeout) {
         return await targetPromise;
       }
-      this.targets().forEach(check);
       return await waitWithTimeout(targetPromise, 'target', timeout);
     } finally {
       this.off(BrowserEmittedEvents.TargetCreated, check);

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -543,6 +543,14 @@ describe('Launcher specs', function () {
         });
         expect(error).toBeInstanceOf(puppeteer.errors.TimeoutError);
       });
+      it('should work with timeout = 0', async () => {
+        const {puppeteer, defaultBrowserOptions} = getTestState();
+        const options = Object.assign({}, defaultBrowserOptions, {
+          timeout: 0,
+        });
+        const browser = await puppeteer.launch(options);
+        await browser.close();
+      });
       it('should set the default viewport', async () => {
         const {puppeteer, defaultBrowserOptions} = getTestState();
         const options = Object.assign({}, defaultBrowserOptions, {


### PR DESCRIPTION
Previously, if timeout is falsy, the targets would only
be checked if a browser-level event fires which lead to
a race: if the events arrived before waiting for a target,
the promise would never resolve.

Fixes #8763