### PR TITLE
fix: specify Puppeteer version for Chromium 105.0.5173.0

### DIFF
--- a/docs/chromium-support.md
+++ b/docs/chromium-support.md
@@ -8,6 +8,7 @@ The following versions of Chromium are supported, mapped to Puppeteer version:
 
 <!-- version-start -->
 
+- Chromium 105.0.5173.0 - [Puppeteer v15.5.0](https://github.com/puppeteer/puppeteer/blob/v15.5.0/docs/api/index.md)
 - Chromium 104.0.5109.0 - Puppeteer v15.1.0
 - Chromium 103.0.5059.0 - [Puppeteer v14.2.0](https://github.com/puppeteer/puppeteer/blob/v14.2.0/docs/api.md)
 - Chromium 102.0.5002.0 - [Puppeteer v14.0.0](https://github.com/puppeteer/puppeteer/blob/v14.0.0/docs/api.md)

--- a/utils/generate_docs.ts
+++ b/utils/generate_docs.ts
@@ -19,6 +19,7 @@ import {join} from 'path';
 import {chdir} from 'process';
 import semver from 'semver';
 import {versionsPerRelease} from '../versions.js';
+import versionsArchived from '../website/versionsArchived.json';
 
 // eslint-disable-next-line import/extensions
 import {generateDocs} from './internal/custom_markdown_action';
@@ -58,7 +59,7 @@ chdir(join(__dirname, '..'));
  ---
  sidebar_position: 1
  ---
- 
+
  `;
   writeFileSync('docs/index.md', sectionContent + content);
 }
@@ -74,7 +75,11 @@ chdir(join(__dirname, '..'));
     if (puppeteerVersion === 'NEXT') {
       continue;
     }
-    if (semver.lt(puppeteerVersion, '15.0.0')) {
+    if (versionsArchived.includes(puppeteerVersion.substring(1))) {
+      buffer.push(
+        `  * Chromium ${chromiumVersion} - [Puppeteer ${puppeteerVersion}](https://github.com/puppeteer/puppeteer/blob/${puppeteerVersion}/docs/api/index.md)`
+      );
+    } else if (semver.lt(puppeteerVersion, '15.0.0')) {
       buffer.push(
         `  * Chromium ${chromiumVersion} - [Puppeteer ${puppeteerVersion}](https://github.com/puppeteer/puppeteer/blob/${puppeteerVersion}/docs/api.md)`
       );

--- a/versions.js
+++ b/versions.js
@@ -17,7 +17,7 @@
 const versionsPerRelease = new Map([
   // This is a mapping from Chromium version => Puppeteer version.
   // In Chromium roll patches, use 'NEXT' for the Puppeteer version.
-  ['105.0.5173.0', 'NEXT'],
+  ['105.0.5173.0', 'v15.5.0'],
   ['104.0.5109.0', 'v15.1.0'],
   ['103.0.5059.0', 'v14.2.0'],
   ['102.0.5002.0', 'v14.0.0'],


### PR DESCRIPTION
Filed https://github.com/puppeteer/puppeteer/issues/8764 to recover the functionality to automatically update this file.