### PR TITLE
fix: use targetFilter in puppeteer.launch

### DIFF
--- a/src/common/Target.ts
+++ b/src/common/Target.ts
@@ -138,6 +138,13 @@ export class Target {
   /**
    * @internal
    */
+  get [Symbol.toStringTag](): string {
+    return JSON.stringify(this.#targetInfo, null, 2);
+  }
+
+  /**
+   * @internal
+   */
   _targetManager(): TargetManager {
     return this.#targetManager;
   }

--- a/src/node/ChromeLauncher.ts
+++ b/src/node/ChromeLauncher.ts
@@ -161,7 +161,8 @@ export class ChromeLauncher implements ProductLauncher {
         ignoreHTTPSErrors,
         defaultViewport,
         runner.proc,
-        runner.close.bind(runner)
+        runner.close.bind(runner),
+        options.targetFilter
       );
     } catch (error) {
       runner.kill();

--- a/src/node/FirefoxLauncher.ts
+++ b/src/node/FirefoxLauncher.ts
@@ -158,7 +158,8 @@ export class FirefoxLauncher implements ProductLauncher {
         ignoreHTTPSErrors,
         defaultViewport,
         runner.proc,
-        runner.close.bind(runner)
+        runner.close.bind(runner),
+        options.targetFilter
       );
     } catch (error) {
       runner.kill();

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -753,6 +753,29 @@ describe('Launcher specs', function () {
         await page.close();
         await browser.close();
       });
+
+      it('should support targetFilter option in puppeteer.launch', async () => {
+        const {puppeteer, defaultBrowserOptions} = getTestState();
+        const browser = await puppeteer.launch({
+          ...defaultBrowserOptions,
+          targetFilter: target => {
+            return target.type !== 'page';
+          },
+          waitForInitialPage: false,
+        });
+        try {
+          const targets = browser.targets();
+          expect(targets.length).toEqual(1);
+          expect(
+            targets.find(target => {
+              return target.type() === 'page';
+            })
+          ).toBeUndefined();
+        } finally {
+          await browser.close();
+        }
+      });
+
       // @see https://github.com/puppeteer/puppeteer/issues/4197
       itFailsFirefox('should support targetFilter option', async () => {
         const {server, puppeteer, defaultBrowserOptions} = getTestState();


### PR DESCRIPTION
Drive-by: adds Symbol.toStringTag to Target to simplify
debugging.

Closes #8772