### PR TITLE
chore: use `tsx` for utils and scripts

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm install
       - name: Build
         run: |
-          ts-node utils/generate_sources.ts
+          npm run generate:sources
           npm run docs
       - name: Version docs
         working-directory: ./website

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "commonmark": "0.30.0",
         "cross-env": "7.0.3",
         "diff": "5.1.0",
-        "esbuild": "^0.15.5",
+        "esbuild": "0.15.5",
         "eslint": "8.21.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-formatter-codeframe": "7.32.1",
@@ -78,6 +78,7 @@
         "source-map-support": "0.5.21",
         "text-diff": "1.0.1",
         "tsd": "0.22.0",
+        "tsx": "3.8.2",
         "typescript": "4.7.4"
       },
       "engines": {
@@ -466,6 +467,36 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/cjs-loader": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.3.3.tgz",
+      "integrity": "sha512-Rt4O1mXlPEDVxvjsHLgbtHVdUXYK9C1/6ThpQnt7FaXIjUOsI6qhHYMgALhNnlIMZffag44lXd6Dqgx3xALbpQ==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^2.1.0",
+        "get-tsconfig": "^4.1.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-2.2.0.tgz",
+      "integrity": "sha512-RsVE6OT7yINJ27+daxemksMJFR+jdTEATivyomEXUxMsRmQMD1e99ogf1hifxVmdrnyLmvmfR4iAhXw/HMbRvQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.15.4",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.4.2.tgz",
+      "integrity": "sha512-N9dPKAj8WOx6djVnStgILWXip4fjDcBk9L7azO0/uQDpu8Ee0eaL78mkN4Acid9BzvNAKWwdYXFJZnsVahNEew==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^2.1.0",
+        "get-tsconfig": "^4.1.0"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
@@ -4029,6 +4060,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.2.0.tgz",
+      "integrity": "sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/git-raw-commits": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
@@ -7331,6 +7371,23 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tsx": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.8.2.tgz",
+      "integrity": "sha512-Jf9izq3Youry5aEarspf6Gm+v/IE2A2xP7YVhtNH1VSCpM0jjACg7C3oD5rIoLBfXWGJSZj4KKC2bwE0TgLb2Q==",
+      "dev": true,
+      "dependencies": {
+        "@esbuild-kit/cjs-loader": "^2.3.3",
+        "@esbuild-kit/core-utils": "^2.1.0",
+        "@esbuild-kit/esm-loader": "^2.4.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8019,6 +8076,36 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@esbuild-kit/cjs-loader": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/cjs-loader/-/cjs-loader-2.3.3.tgz",
+      "integrity": "sha512-Rt4O1mXlPEDVxvjsHLgbtHVdUXYK9C1/6ThpQnt7FaXIjUOsI6qhHYMgALhNnlIMZffag44lXd6Dqgx3xALbpQ==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^2.1.0",
+        "get-tsconfig": "^4.1.0"
+      }
+    },
+    "@esbuild-kit/core-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-2.2.0.tgz",
+      "integrity": "sha512-RsVE6OT7yINJ27+daxemksMJFR+jdTEATivyomEXUxMsRmQMD1e99ogf1hifxVmdrnyLmvmfR4iAhXw/HMbRvQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.15.4",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "@esbuild-kit/esm-loader": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.4.2.tgz",
+      "integrity": "sha512-N9dPKAj8WOx6djVnStgILWXip4fjDcBk9L7azO0/uQDpu8Ee0eaL78mkN4Acid9BzvNAKWwdYXFJZnsVahNEew==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/core-utils": "^2.1.0",
+        "get-tsconfig": "^4.1.0"
       }
     },
     "@esbuild/linux-loong64": {
@@ -10615,6 +10702,12 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "get-tsconfig": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.2.0.tgz",
+      "integrity": "sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==",
+      "dev": true
+    },
     "git-raw-commits": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
@@ -13040,6 +13133,18 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "tsx": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.8.2.tgz",
+      "integrity": "sha512-Jf9izq3Youry5aEarspf6Gm+v/IE2A2xP7YVhtNH1VSCpM0jjACg7C3oD5rIoLBfXWGJSZj4KKC2bwE0TgLb2Q==",
+      "dev": true,
+      "requires": {
+        "@esbuild-kit/cjs-loader": "^2.3.3",
+        "@esbuild-kit/core-utils": "^2.1.0",
+        "@esbuild-kit/esm-loader": "^2.4.2",
+        "fsevents": "~2.3.2"
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "lint:prettier": "prettier --check .",
     "lint:eslint": "([ \"$CI\" = true ] && eslint --ext js --ext ts --quiet -f codeframe . || eslint --ext js --ext ts .)",
     "install": "node install.js",
-    "generate:sources": "ts-node utils/generate_sources.ts",
+    "generate:sources": "tsx utils/generate_sources.ts",
     "generate:types": "node utils/export_all.js && api-extractor run --local --verbose && eslint --ext ts --no-ignore --no-eslintrc -c .eslintrc.types.cjs --fix lib/types.d.ts",
-    "generate:markdown": "ts-node utils/generate_docs.ts && prettier --ignore-path none --write docs",
+    "generate:markdown": "tsx utils/generate_docs.ts && prettier --ignore-path none --write docs",
     "generate:esm-package-json": "echo '{\"type\": \"module\"}' > lib/esm/package.json",
     "format": "run-s format:*",
     "format:prettier": "prettier --write .",
@@ -53,8 +53,8 @@
     "commitlint": "commitlint --from=HEAD~1",
     "clean": "rimraf lib && rimraf test/build",
     "check": "run-p check:*",
-    "check:protocol-revision": "ts-node -s scripts/ensure-correct-devtools-protocol-package",
-    "check:pinned-deps": "ts-node -s scripts/ensure-pinned-deps",
+    "check:protocol-revision": "tsx scripts/ensure-correct-devtools-protocol-package",
+    "check:pinned-deps": "tsx scripts/ensure-pinned-deps",
     "build": "run-s generate:sources build:tsc generate:types generate:esm-package-json",
     "build:tsc": "tsc --version && run-p build:tsc:*",
     "build:tsc:esm": "tsc -b src/tsconfig.esm.json",
@@ -138,6 +138,7 @@
     "source-map-support": "0.5.21",
     "text-diff": "1.0.1",
     "tsd": "0.22.0",
+    "tsx": "3.8.2",
     "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
This PR switches from `ts-node` to `tsx` which increases the speed of on-demand compile time of scripts by 70%.