### PR TITLE
fix: allow multiple navigations to happen in LifecycleWatcher

### DIFF
--- a/src/common/LifecycleWatcher.ts
+++ b/src/common/LifecycleWatcher.ts
@@ -179,9 +179,10 @@ export class LifecycleWatcher {
       return;
     }
     this.#navigationRequest = request;
-    this.#navigationResponseReceived?.reject(
-      new Error('New navigation request was received')
-    );
+    // Resolve previous navigation response in case there are multiple
+    // navigation requests reported by the backend. This generally should not
+    // happen by it looks like it's possible.
+    this.#navigationResponseReceived?.resolve();
     this.#navigationResponseReceived = createDeferredPromise();
     if (request.response() !== null) {
       this.#navigationResponseReceived?.resolve();


### PR DESCRIPTION
There is no repro but it looks like sometimes the backend reports
two navigation requests. This PR changes the logic to allow that
instead of failing as it seems that failing is a bigger issue
than handling multiple navigation requests.

Closes #8811
