### PR TITLE
fix: allow getting a frame from an elementhandle

### DIFF
--- a/docs/api/puppeteer.elementhandle.frame.md
+++ b/docs/api/puppeteer.elementhandle.frame.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: ElementHandle.frame
+---
+
+# ElementHandle.frame property
+
+**Signature:**
+
+```typescript
+class ElementHandle {
+  get frame(): Frame;
+}
+```

--- a/docs/api/puppeteer.elementhandle.md
+++ b/docs/api/puppeteer.elementhandle.md
@@ -39,6 +39,12 @@ If you're using TypeScript, ElementHandle takes a generic argument that denotes 
 
 The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `ElementHandle` class.
 
+## Properties
+
+| Property                                    | Modifiers             | Type                          | Description |
+| ------------------------------------------- | --------------------- | ----------------------------- | ----------- |
+| [frame](./puppeteer.elementhandle.frame.md) | <code>readonly</code> | [Frame](./puppeteer.frame.md) |             |
+
 ## Methods
 
 | Method                                                                                       | Modifiers | Description                                                                                                                                                                                                                                                                                                                   |

--- a/src/common/ElementHandle.ts
+++ b/src/common/ElementHandle.ts
@@ -88,9 +88,6 @@ export class ElementHandle<
     return this.#frame.page();
   }
 
-  /**
-   * @internal
-   */
   get frame(): Frame {
     return this.#frame;
   }


### PR DESCRIPTION
Libraries like pptr-testing-library and expect-puppeteer seem to rely on it.