### PR TITLE
fix: add missing code coverage ranges that span only a single character

### DIFF
--- a/src/common/Coverage.ts
+++ b/src/common/Coverage.ts
@@ -484,6 +484,6 @@ function convertToDisjointRanges(
   }
   // Filter out empty ranges.
   return results.filter(range => {
-    return range.end - range.start > 1;
+    return range.end - range.start > 0;
   });
 }

--- a/test/assets/jscoverage/involved.html
+++ b/test/assets/jscoverage/involved.html
@@ -6,6 +6,7 @@ function foo() {
     console.log(2);
   let x = 1 > 2 ? 'foo' : 'bar';
   let y = 1 < 2 ? 'foo' : 'bar';
+  let p = {a:1 > 2?function(){console.log('unused');}:function(){console.log('unused');}};
   let z = () => {};
   let q = () => {};
   q();

--- a/test/golden-chromium/jscoverage-involved.txt
+++ b/test/golden-chromium/jscoverage-involved.txt
@@ -16,13 +16,21 @@
       },
       {
         "start": 148,
-        "end": 160
+        "end": 168
       },
       {
-        "start": 168,
-        "end": 207
+        "start": 203,
+        "end": 204
+      },
+      {
+        "start": 238,
+        "end": 251
+      },
+      {
+        "start": 259,
+        "end": 298
       }
     ],
-    "text": "\nfunction foo() {\n  if (1 > 2)\n    console.log(1);\n  if (1 < 2)\n    console.log(2);\n  let x = 1 > 2 ? 'foo' : 'bar';\n  let y = 1 < 2 ? 'foo' : 'bar';\n  let z = () => {};\n  let q = () => {};\n  q();\n}\n\nfoo();\n"
+    "text": "\nfunction foo() {\n  if (1 > 2)\n    console.log(1);\n  if (1 < 2)\n    console.log(2);\n  let x = 1 > 2 ? 'foo' : 'bar';\n  let y = 1 < 2 ? 'foo' : 'bar';\n  let p = {a:1 > 2?function(){console.log('unused');}:function(){console.log('unused');}};\n  let z = () => {};\n  let q = () => {};\n  q();\n}\n\nfoo();\n"
   }
 ]

--- a/test/src/coverage.spec.ts
+++ b/test/src/coverage.spec.ts
@@ -104,9 +104,11 @@ describe('Coverage specs', function () {
       const coverage = await page.coverage.stopJSCoverage();
       expect(coverage.length).toBe(1);
       const entry = coverage[0]!;
-      expect(entry.ranges.length).toBe(1);
-      const range = entry.ranges[0]!;
-      expect(entry.text.substring(range.start, range.end)).toBe(
+      expect(entry.ranges.length).toBe(2);
+      const range1 = entry.ranges[0]!;
+      expect(entry.text.substring(range1.start, range1.end)).toBe('\n');
+      const range2 = entry.ranges[1]!;
+      expect(entry.text.substring(range2.start, range2.end)).toBe(
         `console.log('used!');`
       );
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

*Bugfix*

**Summary**

This change fixes an issue in the JavaScript code coverage collection algorithm that, under specific circumstances, can lead to incomplete coverage data. 

The existing algorithm filtered out code coverage range results that spanned a single character, perhaps in the assumption that such characters could only represent trivia tokens. This is safe when such tokens represented whitespace, or newline trivia, but unfortunately it also had the effect of filtering out valid semantic tokens as well, such as the ternary operators `?`/`:`.

Furthermore, this particular implementation meant that the resulting output of an otherwise repeatable code-coverage run would differ between manual collection via Chrome Dev Tools, and automated collection via Puppeteer, since the former would correctly include such single-character tokens, and the latter would not.

**Links/Issues**

While this fix was not introduced explicitly to solve for the following issue, a quick search yielded this existing report, and I believe that this may solve for the reported issue (or perhaps at least inform anybody following the issue for a thread to pull on):

- https://github.com/puppeteer/puppeteer/issues/7859

**Does this PR introduce a breaking change?**

This fix introduces a change in behavior to how we collect coverage ranges. Previously, coverage ranges of a single character length were elided entirely from the coverage output. With this change, those ranges are not ignored, and are included in the resulting coverage output.

From the perspective of consumers, anybody relying on consistent output of coverage ranges from this algorithm (ex. unit tests that rely upon cached or saved copies of coverage data) will need to update their expectations to match these changes accordingly - in essence, consumers should now expect that trivia tokens (like newlines), *or more importantly* single-token operators (like the ternary false operator `:`) will be included as part of the coverage output.  This aligns with the expected output of Chrome's code coverage tooling in Dev Tools.

**Other information**

Please feel free to reach out if there are any questions, and I'll be happy to provide further help or input as needed; I really appreciate all the hard work this team does in providing such an invaluable product!