### PR TITLE
docs: correct comment about anonymous script coverage urls

### DIFF
--- a/docs/api/puppeteer.coverage.startjscoverage.md
+++ b/docs/api/puppeteer.coverage.startjscoverage.md
@@ -26,4 +26,4 @@ Promise that resolves when coverage is started.
 
 ## Remarks
 
-Anonymous scripts are ones that don't have an associated url. These are scripts that are dynamically created on the page using `eval` or `new Function`. If `reportAnonymousScripts` is set to `true`, anonymous scripts will have `pptr://__puppeteer_evaluation_script__` as their URL.
+Anonymous scripts are ones that don't have an associated url. These are scripts that are dynamically created on the page using `eval` or `new Function`. If `reportAnonymousScripts` is set to `true`, anonymous scripts URL will start with `debugger://VM` (unless a magic //\# sourceURL comment is present, in which case that will the be URL).

--- a/src/common/Coverage.ts
+++ b/src/common/Coverage.ts
@@ -142,7 +142,8 @@ export class Coverage {
    * Anonymous scripts are ones that don't have an associated url. These are
    * scripts that are dynamically created on the page using `eval` or
    * `new Function`. If `reportAnonymousScripts` is set to `true`, anonymous
-   * scripts will have `pptr://__puppeteer_evaluation_script__` as their URL.
+   * scripts URL will start with `debugger://VM` (unless a magic //# sourceURL
+   * comment is present, in which case that will the be URL).
    */
   async startJSCoverage(options: JSCoverageOptions = {}): Promise<void> {
     return await this.#jsCoverage.start(options);


### PR DESCRIPTION
Example:

```js
import puppeteer from 'puppeteer';

const b = await puppeteer.launch();
const p = await b.newPage();

await p.coverage.startJSCoverage({reportAnonymousScripts: true});
await p.goto('http://localhost:10503/index.html');

const r = await p.coverage.stopJSCoverage();

console.log(r);

await b.close();
```

```html
<script>
  eval("var a = 1 + 100;\n");
  eval("var a = 2 + 100;\n//# sourceURL=/some-custom-url.js");
</script>
```

prints:

```js
[
  {
    url: 'http://localhost:10503/byte-efficiency/tester.html',
    ranges: [ [Object] ],
    text: '\n' +
      '  eval("var a = 1 + 100;\\n");\n' +
      '  eval("var a = 2 + 100;\\n//# sourceURL=/some-custom-url.js");\n'
  },
  {
    url: 'debugger://VM5',
    ranges: [ [Object] ],
    text: 'var a = 1 + 100;\n'
  },
  {
    url: '/some-custom-url.js',
    ranges: [ [Object] ],
    text: 'var a = 2 + 100;\n//# sourceURL=/some-custom-url.js'
  }
]
```

