### PR TITLE
Fix: linux arm64 check on windows arm

### DIFF
--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -336,7 +336,7 @@ export class BrowserFetcher {
     }
 
     // Use system Chromium builds on Linux ARM devices
-    if (os.platform() !== 'darwin' && os.arch() === 'arm64') {
+    if (os.platform() === 'linux' && os.arch() === 'arm64') {
       handleArm64();
       return;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

not relavant

**If relevant, did you update the documentation?**

not relavant

**Summary**

Unable to use puppeteer > 3.3.0 on Windows 11 for ARM

https://github.com/puppeteer/puppeteer/issues/8915

**Does this PR introduce a breaking change?**

Nope

**Other information**
