### PR TITLE
fix: use win64 version of chromium when on arm64 windows

### DIFF
--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -237,9 +237,10 @@ export class BrowserFetcher {
           this.#platform = 'linux';
           break;
         case 'win32':
-          this.#platform = os.arch() === 'x64' || os.arch() === 'arm64'
-            ? 'win64'
-            : 'win32';
+          this.#platform = 
+            (os.arch() === 'x64' || os.arch() === 'arm64')
+              ? 'win64'
+              : 'win32';
           return;
         default:
           assert(false, 'Unsupported platform: ' + platform);

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -237,7 +237,9 @@ export class BrowserFetcher {
           this.#platform = 'linux';
           break;
         case 'win32':
-          this.#platform = os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
+          this.#platform = os.arch() === 'x64' || os.arch() === 'arm64'
+            ? 'win64'
+            : 'win32';
           return;
         default:
           assert(false, 'Unsupported platform: ' + platform);

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -237,7 +237,7 @@ export class BrowserFetcher {
           this.#platform = 'linux';
           break;
         case 'win32':
-          this.#platform = os.arch() === 'x64' ? 'win64' : 'win32';
+          this.#platform = os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
           return;
         default:
           assert(false, 'Unsupported platform: ' + platform);

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -238,9 +238,7 @@ export class BrowserFetcher {
           break;
         case 'win32':
           this.#platform = 
-            (os.arch() === 'x64' || os.arch() === 'arm64')
-              ? 'win64'
-              : 'win32';
+            os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
           return;
         default:
           assert(false, 'Unsupported platform: ' + platform);

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -237,7 +237,7 @@ export class BrowserFetcher {
           this.#platform = 'linux';
           break;
         case 'win32':
-          this.#platform = 
+          this.#platform =
             os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
           return;
         default:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
not relavant

**If relevant, did you update the documentation?**
not relavant

**Summary**
no Win_arm available on storage.googleapis.com yet, and it currently defaults to win32

**Does this PR introduce a breaking change?**
nope

**Other information**
