### PR TITLE
fix: use win64 version of chromium when on arm64 windows

### DIFF
--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -21,7 +21,6 @@ import * as util from 'util';
 import * as childProcess from 'child_process';
 import * as https from 'https';
 import * as http from 'http';
-import * as semver from 'semver';
 
 import {Product} from '../common/Product.js';
 import extractZip from 'extract-zip';
@@ -241,7 +240,7 @@ export class BrowserFetcher {
           this.#platform =
             os.arch() === 'x64' ||
             // Windows 11 for ARM supports x64 emulation
-            (os.arch() === 'arm64' && semver.gte(os.release(), '10.0.22000'))
+            (os.arch() === 'arm64' && _isWindows11(os.release()))
               ? 'win64'
               : 'win32';
           return;
@@ -501,6 +500,25 @@ function parseFolderPath(
     return;
   }
   return {product, platform, revision};
+}
+
+/**
+ * Windows 11 is identified by 10.0.22000 or greater
+ * @internal
+ */
+function _isWindows11(version: string): boolean {
+  const parts = version.split('.');
+  if (parts.length > 2) {
+    const major = parseInt(parts[0] as string, 10);
+    const minor = parseInt(parts[1] as string, 10);
+    const patch = parseInt(parts[2] as string, 10);
+    return (
+      major > 10 ||
+      (major === 10 && minor > 0) ||
+      (major === 10 && minor === 0 && patch >= 22000)
+    );
+  }
+  return false;
 }
 
 /**

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -21,6 +21,7 @@ import * as util from 'util';
 import * as childProcess from 'child_process';
 import * as https from 'https';
 import * as http from 'http';
+import * as semver from 'semver';
 
 import {Product} from '../common/Product.js';
 import extractZip from 'extract-zip';
@@ -238,7 +239,11 @@ export class BrowserFetcher {
           break;
         case 'win32':
           this.#platform =
-            os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
+            os.arch() === 'x64' ||
+            // Windows 11 for ARM supports x64 emulation
+            (os.arch() === 'arm64' && semver.gte(os.release(), '10.0.22000'))
+              ? 'win64'
+              : 'win32';
           return;
         default:
           assert(false, 'Unsupported platform: ' + platform);

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -237,7 +237,8 @@ export class BrowserFetcher {
           this.#platform = 'linux';
           break;
         case 'win32':
-          this.#platform = os.arch() === 'x64' ? 'win64' : 'win32';
+          this.#platform = 
+            os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
           return;
         default:
           assert(false, 'Unsupported platform: ' + platform);

--- a/src/node/BrowserFetcher.ts
+++ b/src/node/BrowserFetcher.ts
@@ -237,7 +237,7 @@ export class BrowserFetcher {
           this.#platform = 'linux';
           break;
         case 'win32':
-          this.#platform = 
+          this.#platform =
             os.arch() === 'x64' || os.arch() === 'arm64' ? 'win64' : 'win32';
           return;
         default:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
not relavant

**If relevant, did you update the documentation?**
not relavant

**Summary**
no Win_arm available on storage.googleapis.com yet, and it currently defaults to win32

**Does this PR introduce a breaking change?**
nope

**Other information**
