### PR TITLE
chore: add custom reporter

### DIFF
--- a/utils/mochaRunner/src/main.ts
+++ b/utils/mochaRunner/src/main.ts
@@ -121,8 +121,9 @@ async function main() {
         [
           '-u',
           path.join(__dirname, 'interface.js'),
-          '--reporter=json',
-          '--reporter-option',
+          '-R',
+          path.join(__dirname, 'reporter.js'),
+          '-O',
           'output=' + tmpFilename,
         ],
         {
@@ -143,16 +144,6 @@ async function main() {
       console.log('Finished', JSON.stringify(parameters));
       try {
         const results = readJSON(tmpFilename) as MochaResults;
-        console.log('Results from mocha');
-        console.log('Stats', JSON.stringify(results.stats));
-        results.pending.length > 0 && console.log('# Pending tests');
-        for (const test of results.pending) {
-          console.log(`\t? ${test.fullTitle} ${test.file}`);
-        }
-        results.failures.length > 0 && console.log('# Failed tests');
-        for (const test of results.failures) {
-          console.log(`\tF ${test.fullTitle} ${test.file}`, test.err);
-        }
         const recommendation = getExpectationUpdates(
           results,
           applicableExpectations,

--- a/utils/mochaRunner/src/reporter.ts
+++ b/utils/mochaRunner/src/reporter.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Mocha from 'mocha';
+
+class SpecJSONReporter extends Mocha.reporters.Spec {
+  constructor(runner: Mocha.Runner, options?: Mocha.MochaOptions) {
+    super(runner, options);
+    Mocha.reporters.JSON.call(this, runner, options);
+  }
+}
+
+module.exports = SpecJSONReporter;


### PR DESCRIPTION
This PR adds a custom mocha reporter that is a combination of the Spec + JSON reporters. This way our test runner can remove custom printing logic for test runs and only output expectations.