### PR TITLE
fix: suppress init errors if the target is closed

### DIFF
--- a/src/common/BrowserConnector.ts
+++ b/src/common/BrowserConnector.ts
@@ -131,7 +131,6 @@ export async function _connectToBrowser(
     targetFilter,
     isPageTarget
   );
-  await browser.pages();
   return browser;
 }
 

--- a/src/common/Connection.ts
+++ b/src/common/Connection.ts
@@ -445,3 +445,13 @@ function rewriteError(
   error.originalMessage = originalMessage ?? error.originalMessage;
   return error;
 }
+
+/**
+ * @internal
+ */
+export function isTargetClosedError(err: Error): boolean {
+  return (
+    err.message.includes('Target closed') ||
+    err.message.includes('Session closed')
+  );
+}

--- a/src/common/FrameManager.ts
+++ b/src/common/FrameManager.ts
@@ -19,7 +19,7 @@ import {assert} from '../util/assert.js';
 import {createDebuggableDeferredPromise} from '../util/DebuggableDeferredPromise.js';
 import {DeferredPromise} from '../util/DeferredPromise.js';
 import {isErrorLike} from '../util/ErrorLike.js';
-import {CDPSession} from './Connection.js';
+import {CDPSession, isTargetClosedError} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {EVALUATION_SCRIPT_URL, ExecutionContext} from './ExecutionContext.js';
 import {Frame} from './Frame.js';
@@ -172,11 +172,7 @@ export class FrameManager extends EventEmitter {
       ]);
     } catch (error) {
       // The target might have been closed before the initialization finished.
-      if (
-        isErrorLike(error) &&
-        (error.message.includes('Target closed') ||
-          error.message.includes('Session closed'))
-      ) {
+      if (isErrorLike(error) && isTargetClosedError(error)) {
         return;
       }
 


### PR DESCRIPTION
With #8520 Puppeteer is now aware of all targets it connects to. In order to have a not flaky init, Puppeteer waits for all existing targets to be configured during the connection process. This does not work well in case of concurrent connections because while one connection might initialising a target the other one might be closed it. In general, that is expected because we can only be eventually consistent about the target state but we also should not crash the init if some targets have been closed. This PR implements checks to see if the errors are caused by the target or session closures and suppresses them if it's the case.

Also we don't need to call browser.pages() in BrowserConnector as it appears to be redundant for the current TargetManager implementation and forces connection to all existing pages.

Closes #8944