### PR TITLE
chore: rerun tasks after the util handle has been evaluated

### DIFF
--- a/src/common/IsolatedWorld.ts
+++ b/src/common/IsolatedWorld.ts
@@ -159,7 +159,6 @@ export class IsolatedWorld {
     this.#injectPuppeteerUtil(context);
     this.#ctxBindings.clear();
     this.#context.resolve(context);
-    this.#taskManager.rerunAll();
   }
 
   async #injectPuppeteerUtil(context: ExecutionContext): Promise<void> {
@@ -173,6 +172,7 @@ export class IsolatedWorld {
             })()`
         )) as JSHandle<PuppeteerUtil>
       );
+      this.#taskManager.rerunAll();
     } catch (error: unknown) {
       debugError(error);
     }


### PR DESCRIPTION
That is at least one of the sources of flakiness: the current code might evaluate the handle from the previous execution context.