### PR TITLE
chore: adjusted screenshots to CDP changes

### DIFF
--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -2600,7 +2600,7 @@ export class CDPPage extends Page {
       targetId: this.#target._targetId,
     });
     let clip = options.clip ? processClip(options.clip) : undefined;
-    const captureBeyondViewport =
+    let captureBeyondViewport =
       typeof options.captureBeyondViewport === 'boolean'
         ? options.captureBeyondViewport
         : true;
@@ -2614,8 +2614,8 @@ export class CDPPage extends Page {
       // Fallback to `contentSize` in case of using Firefox.
       const {width, height} = metrics.cssContentSize || metrics.contentSize;
 
-      // Overwrite clip for full page.
-      clip = {x: 0, y: 0, width, height, scale: 1};
+      // Overwrite clip for full page and full screen.
+      clip = undefined;
 
       if (!captureBeyondViewport) {
         const {
@@ -2635,6 +2635,9 @@ export class CDPPage extends Page {
           screenOrientation,
         });
       }
+    } else if (!clip) {
+      // Override captureBeyondViewport for full screen mode.
+      captureBeyondViewport = false;
     }
     const shouldSetDefaultBackground =
       options.omitBackground && (format === 'png' || format === 'webp');

--- a/test/src/emulation.spec.ts
+++ b/test/src/emulation.spec.ts
@@ -426,49 +426,50 @@ describe('Emulation', () => {
   describe('Page.emulateVisionDeficiency', function () {
     it('should work', async () => {
       const {page, server} = getTestState();
+      const full_page_options = {captureBeyondViewport: false};
 
       await page.setViewport({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
 
       {
         await page.emulateVisionDeficiency('none');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('screenshot-sanity.png');
       }
 
       {
         await page.emulateVisionDeficiency('achromatopsia');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('vision-deficiency-achromatopsia.png');
       }
 
       {
         await page.emulateVisionDeficiency('blurredVision');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('vision-deficiency-blurredVision.png');
       }
 
       {
         await page.emulateVisionDeficiency('deuteranopia');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('vision-deficiency-deuteranopia.png');
       }
 
       {
         await page.emulateVisionDeficiency('protanopia');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('vision-deficiency-protanopia.png');
       }
 
       {
         await page.emulateVisionDeficiency('tritanopia');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('vision-deficiency-tritanopia.png');
       }
 
       {
         await page.emulateVisionDeficiency('none');
-        const screenshot = await page.screenshot();
+        const screenshot = await page.screenshot(full_page_options);
         expect(screenshot).toBeGolden('screenshot-sanity.png');
       }
     });

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -31,7 +31,9 @@ describe('Screenshots', function () {
 
       await page.setViewport({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
-      const screenshot = await page.screenshot();
+      const screenshot = await page.screenshot({
+        captureBeyondViewport: false,
+      });
       expect(screenshot).toBeGolden('screenshot-sanity.png');
     });
     it('should clip rect', async () => {
@@ -191,6 +193,7 @@ describe('Screenshots', function () {
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot({
         encoding: 'base64',
+        captureBeyondViewport: false,
       });
       // TODO (@jackfranklin): improve the screenshot types.
       // - if we pass encoding: 'base64', it returns a string


### PR DESCRIPTION
This PR adjusts to the changes in CDP screenshots.

CDP captureScreenshots don't need a full page clip for the full page screenshot mode anymore. Therefore, without a clip specified, CDP will default to full page screenshot (when captureBeyondViewport enabled) or to viewport screenshots (when captureBeyondViewport false).
