### PR TITLE
chore: remove increase swap action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,6 @@ jobs:
       - name: Install dependencies
         working-directory: ./website
         run: npm ci
-      - name: Increase swap space
-        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
-        with:
-          swap-size-gb: 10
       - name: Build website
         working-directory: ./website
         env:


### PR DESCRIPTION
Now that we generate only a single version and use swc we should not need increased swap space.