### PR TITLE
chore: add id-token permissions to scorecard-action

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -20,6 +20,8 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      # Needed to access OIDC token.
+      id-token: write
 
     steps:
       - name: 'Checkout code'


### PR DESCRIPTION
See ossf/scorecard-action#900

Example failure with scorecard-action@2 https://github.com/puppeteer/puppeteer/actions/runs/3066712334/jobs/4952194627
