### PR TITLE
fix: change injected.ts imports

### DIFF
--- a/src/injected/injected.ts
+++ b/src/injected/injected.ts
@@ -15,23 +15,35 @@
  */
 
 import {createDeferredPromise} from '../util/DeferredPromise.js';
-import * as Poller from './Poller.js';
-import * as TextContent from './TextContent.js';
+import {RAFPoller, MutationPoller, IntervalPoller} from './Poller.js';
+import {
+  isSuitableNodeForTextMatching,
+  createTextContent,
+} from './TextContent.js';
 import * as TextQuerySelector from './TextQuerySelector.js';
 import * as XPathQuerySelector from './XPathQuerySelector.js';
 import * as PierceQuerySelector from './PierceQuerySelector.js';
 import * as util from './util.js';
 
+/**
+ * @internal
+ */
 const PuppeteerUtil = Object.freeze({
   ...util,
-  ...Poller,
-  ...TextContent,
   ...TextQuerySelector,
   ...XPathQuerySelector,
   ...PierceQuerySelector,
   createDeferredPromise,
+  createTextContent,
+  IntervalPoller,
+  isSuitableNodeForTextMatching,
+  MutationPoller,
+  RAFPoller,
 });
 
+/**
+ * @internal
+ */
 type PuppeteerUtil = typeof PuppeteerUtil;
 
 /**

--- a/test-d/puppeteer.test-d.ts
+++ b/test-d/puppeteer.test-d.ts
@@ -6,7 +6,7 @@ import {
   executablePath,
   launch,
   default as puppeteer,
-} from '../lib/esm/puppeteer/puppeteer.js';
+} from '..';
 
 expectType<typeof launch>(puppeteer.launch);
 expectType<typeof connect>(puppeteer.connect);


### PR DESCRIPTION
it looks like local type aliases have to be marked as `@internal` too or they leak into types.d.ts. Also, not sure why api-extractor generates broken .d.ts files if the star import is used for Poller and TextContext.

Drive-by: updated tsd tests to use the generated types.d.ts instead of only using esm/types.d.ts

Closes #8986 