### PR TITLE
chore: remove environment variable that forces WebRender to be disabl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=14.1.0"
   },
   "scripts": {
-    "test": "cross-env MOZ_WEBRENDER=0 PUPPETEER_DEFERRED_PROMISE_DEBUG_TIMEOUT=20000 node utils/mochaRunner/lib/main.js",
+    "test": "cross-env PUPPETEER_DEFERRED_PROMISE_DEBUG_TIMEOUT=20000 node utils/mochaRunner/lib/main.js",
     "test:types": "tsd",
     "test:install": "scripts/test-install.sh",
     "test:firefox": "npm run test -- --test-suite firefox-headless",


### PR DESCRIPTION
This environment variable has been added a while ago because Firefox was crashing on Linux platforms where only Soft Rendering was available. As such we had to disable WebRender completely.

After some testing I cannot see that this is a problem anymore and as such lets try if we can finally remove it and run Firefox with its default configuration.