### PR TITLE
chore: add strategy.fail-fast=false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
     name: ${{ matrix.spec.name }} tests on ${{ matrix.spec.machine }}(${{ matrix.spec.node }})
     runs-on: ${{ matrix.spec.machine }}
     strategy:
+      fail-fast: false
       matrix:
         spec:
           - name: chrome-headless


### PR DESCRIPTION
fail-fast=false ensures that we run all jobs even if some have failures happen, so that we receive test results from all configurations.

see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast