### PR TITLE
fix: waitForRequest works with async predicate

### DIFF
--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -1668,12 +1668,12 @@ export class CDPPage extends Page {
     return waitForEvent(
       this.#frameManager.networkManager,
       NetworkManagerEmittedEvents.Request,
-      request => {
+      async request => {
         if (isString(urlOrPredicate)) {
           return urlOrPredicate === request.url();
         }
         if (typeof urlOrPredicate === 'function') {
-          return !!urlOrPredicate(request);
+          return !!(await urlOrPredicate(request));
         }
         return false;
       },

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -907,6 +907,22 @@ describe('Page', function () {
       ]);
       expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
     });
+    it('should work with async predicate', async () => {
+      const {page, server} = getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      const [request] = await Promise.all([
+        page.waitForRequest(async request => {
+          return request.url() === server.PREFIX + '/digits/2.png';
+        }),
+        page.evaluate(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }),
+      ]);
+      expect(request.url()).toBe(server.PREFIX + '/digits/2.png');
+    });
     it('should respect timeout', async () => {
       const {page, puppeteer} = getTestState();
 


### PR DESCRIPTION

```Page.waitForRequest``` don't support async cb. 
The problem is in this line:
```javascript
return !!urlOrPredicate(request);
```
It always returns true since `!!{}` is always true.
So I checked `Page.waitForResponse` code and applied alike changes.
P.S: before doing any changes I'd run tests and 3 of them failed. So it's not my fault if you're asking)
