### PR TITLE
feat!: deprecate `createBrowserFetcher` in favor of `BrowserFetcher`

### DIFF
--- a/docs/api/puppeteer.browserfetcher._constructor_.md
+++ b/docs/api/puppeteer.browserfetcher._constructor_.md
@@ -1,0 +1,21 @@
+---
+sidebar_label: BrowserFetcher.(constructor)
+---
+
+# BrowserFetcher.(constructor)
+
+Constructs a browser fetcher for the given options.
+
+**Signature:**
+
+```typescript
+class BrowserFetcher {
+  constructor(options?: BrowserFetcherOptions);
+}
+```
+
+## Parameters
+
+| Parameter | Type                                                          | Description       |
+| --------- | ------------------------------------------------------------- | ----------------- |
+| options   | [BrowserFetcherOptions](./puppeteer.browserfetcheroptions.md) | <i>(Optional)</i> |

--- a/docs/api/puppeteer.browserfetcher.md
+++ b/docs/api/puppeteer.browserfetcher.md
@@ -14,23 +14,25 @@ export declare class BrowserFetcher
 
 ## Remarks
 
-BrowserFetcher operates on revision strings that specify a precise version of Chromium, e.g. `"533271"`. Revision strings can be obtained from [omahaproxy.appspot.com](http://omahaproxy.appspot.com/). In the Firefox case, BrowserFetcher downloads Firefox Nightly and operates on version numbers such as `"75"`.
-
-The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `BrowserFetcher` class.
+BrowserFetcher is not designed to work concurrently with other instances of BrowserFetcher that share the same downloads directory.
 
 ## Example
 
 An example of using BrowserFetcher to download a specific version of Chromium and running Puppeteer against it:
 
 ```ts
-const browserFetcher = puppeteer.createBrowserFetcher();
+const browserFetcher = new BrowserFetcher();
 const revisionInfo = await browserFetcher.download('533271');
 const browser = await puppeteer.launch({
   executablePath: revisionInfo.executablePath,
 });
 ```
 
-**NOTE** BrowserFetcher is not designed to work concurrently with other instances of BrowserFetcher that share the same downloads directory.
+## Constructors
+
+| Constructor                                                           | Modifiers | Description                                         |
+| --------------------------------------------------------------------- | --------- | --------------------------------------------------- |
+| [(constructor)(options)](./puppeteer.browserfetcher._constructor_.md) |           | Constructs a browser fetcher for the given options. |
 
 ## Methods
 

--- a/docs/api/puppeteer.browserfetcheroptions.host.md
+++ b/docs/api/puppeteer.browserfetcheroptions.host.md
@@ -4,6 +4,8 @@ sidebar_label: BrowserFetcherOptions.host
 
 # BrowserFetcherOptions.host property
 
+Determines the host that will be used for downloading.
+
 **Signature:**
 
 ```typescript

--- a/docs/api/puppeteer.browserfetcheroptions.md
+++ b/docs/api/puppeteer.browserfetcheroptions.md
@@ -12,9 +12,9 @@ export interface BrowserFetcherOptions
 
 ## Properties
 
-| Property                                                   | Modifiers | Type                                | Description       |
-| ---------------------------------------------------------- | --------- | ----------------------------------- | ----------------- |
-| [host?](./puppeteer.browserfetcheroptions.host.md)         |           | string                              | <i>(Optional)</i> |
-| [path?](./puppeteer.browserfetcheroptions.path.md)         |           | string                              | <i>(Optional)</i> |
-| [platform?](./puppeteer.browserfetcheroptions.platform.md) |           | [Platform](./puppeteer.platform.md) | <i>(Optional)</i> |
-| [product?](./puppeteer.browserfetcheroptions.product.md)   |           | string                              | <i>(Optional)</i> |
+| Property                                                   | Modifiers | Type                                | Description                                                                                            |
+| ---------------------------------------------------------- | --------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [host?](./puppeteer.browserfetcheroptions.host.md)         |           | string                              | <i>(Optional)</i> Determines the host that will be used for downloading.                               |
+| [path?](./puppeteer.browserfetcheroptions.path.md)         |           | string                              | <i>(Optional)</i> Determines the path to download browsers to.                                         |
+| [platform?](./puppeteer.browserfetcheroptions.platform.md) |           | [Platform](./puppeteer.platform.md) | <i>(Optional)</i> Determines which platform the browser will be suited for.                            |
+| [product?](./puppeteer.browserfetcheroptions.product.md)   |           | 'chrome' \| 'firefox'               | <i>(Optional)</i> Determines which product the [BrowserFetcher](./puppeteer.browserfetcher.md) is for. |

--- a/docs/api/puppeteer.browserfetcheroptions.path.md
+++ b/docs/api/puppeteer.browserfetcheroptions.path.md
@@ -4,6 +4,8 @@ sidebar_label: BrowserFetcherOptions.path
 
 # BrowserFetcherOptions.path property
 
+Determines the path to download browsers to.
+
 **Signature:**
 
 ```typescript

--- a/docs/api/puppeteer.browserfetcheroptions.platform.md
+++ b/docs/api/puppeteer.browserfetcheroptions.platform.md
@@ -4,6 +4,8 @@ sidebar_label: BrowserFetcherOptions.platform
 
 # BrowserFetcherOptions.platform property
 
+Determines which platform the browser will be suited for.
+
 **Signature:**
 
 ```typescript

--- a/docs/api/puppeteer.browserfetcheroptions.product.md
+++ b/docs/api/puppeteer.browserfetcheroptions.product.md
@@ -4,10 +4,12 @@ sidebar_label: BrowserFetcherOptions.product
 
 # BrowserFetcherOptions.product property
 
+Determines which product the [BrowserFetcher](./puppeteer.browserfetcher.md) is for.
+
 **Signature:**
 
 ```typescript
 interface BrowserFetcherOptions {
-  product?: string;
+  product?: 'chrome' | 'firefox';
 }
 ```

--- a/docs/api/puppeteer.createbrowserfetcher.md
+++ b/docs/api/puppeteer.createbrowserfetcher.md
@@ -4,6 +4,10 @@ sidebar_label: createBrowserFetcher
 
 # createBrowserFetcher variable
 
+> Warning: This API is now obsolete.
+>
+> Import [BrowserFetcher](./puppeteer.browserfetcher.md) directly and use the constructor.
+
 **Signature:**
 
 ```typescript

--- a/docs/api/puppeteer.puppeteernode.createbrowserfetcher.md
+++ b/docs/api/puppeteer.puppeteernode.createbrowserfetcher.md
@@ -4,6 +4,10 @@ sidebar_label: PuppeteerNode.createBrowserFetcher
 
 # PuppeteerNode.createBrowserFetcher() method
 
+> Warning: This API is now obsolete.
+>
+> Import [BrowserFetcher](./puppeteer.browserfetcher.md) directly and use the constructor.
+
 **Signature:**
 
 ```typescript

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -221,7 +221,8 @@ export class FirefoxLauncher implements ProductLauncher {
           '_projectRoot is undefined. Unable to create a BrowserFetcher.'
         );
       }
-      const browserFetcher = new BrowserFetcher(this._projectRoot, {
+      const browserFetcher = new BrowserFetcher({
+        projectRoot: this._projectRoot,
         product: this.product,
       });
       const localRevisions = await browserFetcher.localRevisions();

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -160,7 +160,8 @@ export function resolveExecutablePath(
       '_projectRoot is undefined. Unable to create a BrowserFetcher.'
     );
   }
-  const browserFetcher = new BrowserFetcher(_projectRoot, {
+  const browserFetcher = new BrowserFetcher({
+    projectRoot: _projectRoot,
     product: product,
     path: downloadPath,
   });

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -234,16 +234,13 @@ export class PuppeteerNode extends Puppeteer {
   }
 
   /**
+   * @deprecated Import {@link BrowserFetcher} directly and use the constructor.
+   *
    * @param options - Set of configurable options to specify the settings of the
    * BrowserFetcher.
    * @returns A new BrowserFetcher instance.
    */
   createBrowserFetcher(options: BrowserFetcherOptions): BrowserFetcher {
-    if (!this.#projectRoot) {
-      throw new Error(
-        '_projectRoot is undefined. Unable to create a BrowserFetcher.'
-      );
-    }
-    return new BrowserFetcher(this.#projectRoot, options);
+    return new BrowserFetcher({...options, projectRoot: this.#projectRoot});
   }
 }

--- a/packages/puppeteer-core/src/puppeteer-core.ts
+++ b/packages/puppeteer-core/src/puppeteer-core.ts
@@ -19,6 +19,7 @@ export * from './common/Device.js';
 export * from './common/Errors.js';
 export * from './common/PredefinedNetworkConditions.js';
 export * from './common/Puppeteer.js';
+export * from './node/BrowserFetcher.js';
 
 /**
  * @deprecated Use the query handler API defined on {@link Puppeteer}
@@ -39,6 +40,7 @@ const puppeteer = new PuppeteerNode({
 
 export const {
   connect,
+  /** @deprecated Import {@link BrowserFetcher} directly and use the constructor. */
   createBrowserFetcher,
   defaultArgs,
   executablePath,

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -59,7 +59,7 @@ export async function downloadBrowser(): Promise<void> {
     process.env['PUPPETEER_DOWNLOAD_PATH'] ||
     process.env['npm_config_puppeteer_download_path'] ||
     process.env['npm_package_config_puppeteer_download_path'];
-  const browserFetcher = (puppeteer as PuppeteerNode).createBrowserFetcher({
+  const browserFetcher = puppeteer.createBrowserFetcher({
     product,
     host: downloadHost,
     path: downloadPath,

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -19,11 +19,11 @@ export * from 'puppeteer-core/internal/common/Device.js';
 export * from 'puppeteer-core/internal/common/Errors.js';
 export * from 'puppeteer-core/internal/common/PredefinedNetworkConditions.js';
 export * from 'puppeteer-core/internal/common/Puppeteer.js';
+export * from 'puppeteer-core/internal/node/BrowserFetcher.js';
 /**
  * @deprecated Use the query handler API defined on {@link Puppeteer}
  */
 export * from 'puppeteer-core/internal/common/QueryHandler.js';
-export {BrowserFetcher} from 'puppeteer-core/internal/node/BrowserFetcher.js';
 export {LaunchOptions} from 'puppeteer-core/internal/node/LaunchOptions.js';
 
 import {Product} from 'puppeteer-core';
@@ -57,6 +57,7 @@ const puppeteer = new PuppeteerNode({
 
 export const {
   connect,
+  /** @deprecated Import {@link BrowserFetcher} directly and use the constructor. */
   createBrowserFetcher,
   defaultArgs,
   executablePath,


### PR DESCRIPTION
This PR deprecates the `createBrowserFetcher` API and requests users to import the `BrowserFetcher` directly.

Fixed: #8999