### PR TITLE
fix: remove viewport conditions in `waitForSelector`

### DIFF
--- a/packages/puppeteer-core/src/injected/util.ts
+++ b/packages/puppeteer-core/src/injected/util.ts
@@ -64,12 +64,5 @@ export const checkVisibility = (
 
 function isBoundingBoxVisible(element: Element): boolean {
   const rect = element.getBoundingClientRect();
-  return (
-    rect.width > 0 &&
-    rect.height > 0 &&
-    rect.right > 0 &&
-    rect.bottom > 0 &&
-    rect.left < self.innerWidth &&
-    rect.top < self.innerHeight
-  );
+  return rect.width > 0 && rect.height > 0 && rect.right > 0 && rect.bottom > 0;
 }

--- a/test/src/waittask.spec.ts
+++ b/test/src/waittask.spec.ts
@@ -537,37 +537,7 @@ describe('waittask specs', function () {
         Promise.race([promise, createTimeout(40)])
       ).resolves.toBeFalsy();
       await element.evaluate(e => {
-        e.style.setProperty('position', 'absolute');
-        e.style.setProperty('right', '100vw');
         e.style.removeProperty('height');
-      });
-      await expect(
-        Promise.race([promise, createTimeout(40)])
-      ).resolves.toBeFalsy();
-      await element.evaluate(e => {
-        e.style.setProperty('left', '100vw');
-        e.style.removeProperty('right');
-      });
-      await expect(
-        Promise.race([promise, createTimeout(40)])
-      ).resolves.toBeFalsy();
-      await element.evaluate(e => {
-        e.style.setProperty('top', '100vh');
-        e.style.removeProperty('left');
-      });
-      await expect(
-        Promise.race([promise, createTimeout(40)])
-      ).resolves.toBeFalsy();
-      await element.evaluate(e => {
-        e.style.setProperty('bottom', '100vh');
-        e.style.removeProperty('top');
-      });
-      await expect(
-        Promise.race([promise, createTimeout(40)])
-      ).resolves.toBeFalsy();
-      await element.evaluate(e => {
-        // Just peeking
-        e.style.setProperty('bottom', '99vh');
       });
       await expect(promise).resolves.toBeTruthy();
     });


### PR DESCRIPTION
This PR removes the viewport conditions in `waitForSelector`.

See discussion: https://github.com/puppeteer/puppeteer/pull/8954#issuecomment-1272338883