### PR TITLE
chore: remove special handling for shared_worker

### DIFF
--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -231,13 +231,6 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
       const target = this.#targetFactory(event.targetInfo, undefined);
       this.#attachedTargetsByTargetId.set(event.targetInfo.targetId, target);
     }
-
-    if (event.targetInfo.type === 'shared_worker') {
-      // Special case (https://crbug.com/1338156): currently, shared_workers
-      // don't get auto-attached. This should be removed once the auto-attach
-      // works.
-      await this.#connection._createSession(event.targetInfo, true);
-    }
   };
 
   #onTargetDestroyed = (event: Protocol.Target.TargetDestroyedEvent) => {


### PR DESCRIPTION
With Chromium M107+ this should not be required anymore.
