### PR TITLE
chore: set yarn version to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,9 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Set up ${{ matrix.pkg_manager }}
         run: npm install -g ${{ matrix.pkg_manager }}@latest
+      - name: Set yarn version
+        if: ${{ matrix.pkg_manager == 'yarn' }}
+        run: yarn set version stable
       - name: Install dependencies
         run: ${{ matrix.pkg_manager }} install
       - name: Test


### PR DESCRIPTION
This PR sets the `yarn` version to `stable` in CI. This is necessary since yarn manages their versions independently of `npm`