### PR TITLE
fix: update `BrowserFetcher` deprecation message

### DIFF
--- a/docs/api/puppeteer.createbrowserfetcher.md
+++ b/docs/api/puppeteer.createbrowserfetcher.md
@@ -4,10 +4,6 @@ sidebar_label: createBrowserFetcher
 
 # createBrowserFetcher variable
 
-> Warning: This API is now obsolete.
->
-> Import [BrowserFetcher](./puppeteer.browserfetcher.md) directly and use the constructor.
-
 **Signature:**
 
 ```typescript

--- a/docs/api/puppeteer.puppeteernode.createbrowserfetcher.md
+++ b/docs/api/puppeteer.puppeteernode.createbrowserfetcher.md
@@ -6,7 +6,7 @@ sidebar_label: PuppeteerNode.createBrowserFetcher
 
 > Warning: This API is now obsolete.
 >
-> Import [BrowserFetcher](./puppeteer.browserfetcher.md) directly and use the constructor.
+> If you are using `puppeteer-core`, do not use this method. Just construct [BrowserFetcher](./puppeteer.browserfetcher.md) manually.
 
 **Signature:**
 

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -229,10 +229,12 @@ export class PuppeteerNode extends Puppeteer {
   }
 
   /**
-   * @deprecated Import {@link BrowserFetcher} directly and use the constructor.
+   * @deprecated If you are using `puppeteer-core`, do not use this method. Just
+   * construct {@link BrowserFetcher} manually.
    *
    * @param options - Set of configurable options to specify the settings of the
    * BrowserFetcher.
+   *
    * @returns A new BrowserFetcher instance.
    */
   createBrowserFetcher(options: BrowserFetcherOptions): BrowserFetcher {

--- a/packages/puppeteer-core/src/puppeteer-core.ts
+++ b/packages/puppeteer-core/src/puppeteer-core.ts
@@ -36,7 +36,9 @@ const puppeteer = new PuppeteerNode({
 
 export const {
   connect,
-  /** @deprecated Import {@link BrowserFetcher} directly and use the constructor. */
+  /**
+   * @deprecated Construct {@link BrowserFetcher} manually.
+   */
   createBrowserFetcher,
   defaultArgs,
   executablePath,

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -54,7 +54,6 @@ const puppeteer = new PuppeteerNode({
 
 export const {
   connect,
-  /** @deprecated Import {@link BrowserFetcher} directly and use the constructor. */
   createBrowserFetcher,
   defaultArgs,
   executablePath,


### PR DESCRIPTION
This PR updates the deprecation message for `BrowserFetcher`. In the future, we will be implementing defaults through this method only for `puppeteer`.