### PR TITLE
docs(faq): update paths to revisions.ts

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -117,7 +117,7 @@ npm install puppeteer-core@chrome-71
 Find the version using one of the following ways:
 
 - Look for the `chromium` entry in
-  [revisions.ts](https://github.com/puppeteer/puppeteer/blob/main/src/revisions.ts).
+  [revisions.ts](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/revisions.ts).
   To find the corresponding Chromium commit and version number, search for the
   revision prefixed by an `r` in [OmahaProxy](https://omahaproxy.appspot.com/)'s
   "Find Releases" section.
@@ -132,7 +132,7 @@ Since Firefox support is experimental, Puppeteer downloads the latest
 [Firefox Nightly](https://wiki.mozilla.org/Nightly) when the `PUPPETEER_PRODUCT`
 environment variable is set to `firefox`. That's also why the value of `firefox`
 in
-[revisions.ts](https://github.com/puppeteer/puppeteer/blob/main/src/revisions.ts)
+[revisions.ts](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/revisions.ts)
 is `latest` -- Puppeteer isn't tied to a particular Firefox version.
 
 To fetch Firefox Nightly as part of Puppeteer installation:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

it updates currently broken paths to [`revisions.ts`](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/revisions.ts) file on the FAQ page.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

not applicable

**If relevant, did you update the documentation?**

yes :)

**Summary**

when the separation of puppeteer and puppeteer-core happened in https://github.com/puppeteer/puppeteer/pull/9023 the references were not updated in the FAQ to the new path: `src/revisions.ts` -> `packages/puppeteer-core/src/revisions.ts`. this PR addresses it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

I am not familiar with the docusaurus process yet, but I believe the links will be fixed on the https://pptr.dev/faq URL only after it was merged and released. let me know if I need to generate/lint anything additional.