### PR TITLE
fix: resolve navigation requests when request fails

### DIFF
--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -168,6 +168,11 @@ export class LifecycleWatcher {
         NetworkManagerEmittedEvents.Response,
         this.#onResponse.bind(this)
       ),
+      addEventListener(
+        this.#frameManager.networkManager,
+        NetworkManagerEmittedEvents.RequestFailed,
+        this.#onRequestFailed.bind(this)
+      ),
     ];
 
     this.#timeoutPromise = this.#createTimeoutPromise();
@@ -187,6 +192,13 @@ export class LifecycleWatcher {
     if (request.response() !== null) {
       this.#navigationResponseReceived?.resolve();
     }
+  }
+
+  #onRequestFailed(request: HTTPRequest): void {
+    if (this.#navigationRequest?._requestId !== request._requestId) {
+      return;
+    }
+    this.#navigationResponseReceived?.resolve();
   }
 
   #onResponse(response: HTTPResponse): void {


### PR DESCRIPTION
#8768 fixes flakiness in handling navigations but it didn't account for the fact that subsequent navigation requests could be aborted via the request interception. In that case, the navigationResponseReceived promise would never be resolved. This PR adds a listener for the failed network requests and resolves the promise if the network request has failed. Adding test coverage for this seems tricky, as the reproduction depends on timing of the second navigation request.

Closes #9175