### PR TITLE
docs: update examples' `README`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,3 +39,4 @@ More complex and use case driven examples can be found at [github.com/GoogleChro
 ## Services
 
 - [Checkly](https://checklyhq.com) - Monitoring SaaS that uses Puppeteer to check availability and correctness of web pages and apps.
+- [Doppio](https://doppio.sh) - SaaS API to create screenshots or PDFs from HTML/CSS/JS


### PR DESCRIPTION
Update exemples/README.md file to add Doppio.sh in the services list