### PR TITLE
feat(puppeteer-core): update Chrome launcher flags

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -157,38 +157,38 @@ export class ChromeLauncher extends ProductLauncher {
   }
 
   override defaultArgs(options: BrowserLaunchArgumentOptions = {}): string[] {
+    // See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
     const chromeArguments = [
       '--allow-pre-commit-input',
       '--disable-background-networking',
-      '--enable-features=NetworkServiceInProcess2',
       '--disable-background-timer-throttling',
       '--disable-backgrounding-occluded-windows',
       '--disable-breakpad',
       '--disable-client-side-phishing-detection',
       '--disable-component-extensions-with-background-pages',
+      '--disable-component-update',
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',
-      // TODO: remove AvoidUnnecessaryBeforeUnloadCheckSync below
-      // once crbug.com/1324138 is fixed and released.
       // AcceptCHFrame disabled because of crbug.com/1348106.
-      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,AvoidUnnecessaryBeforeUnloadCheckSync',
+      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints',
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',
       '--disable-prompt-on-repost',
       '--disable-renderer-backgrounding',
       '--disable-sync',
+      '--enable-automation',
+      // TODO(sadym): remove '--enable-blink-features=IdleDetection' once
+      // IdleDetection is turned on by default.
+      '--enable-blink-features=IdleDetection',
+      '--enable-features=NetworkServiceInProcess2',
+      '--export-tagged-pdf',
       '--force-color-profile=srgb',
       '--metrics-recording-only',
       '--no-first-run',
-      '--enable-automation',
       '--password-store=basic',
       '--use-mock-keychain',
-      // TODO(sadym): remove '--enable-blink-features=IdleDetection'
-      // once IdleDetection is turned on by default.
-      '--enable-blink-features=IdleDetection',
-      '--export-tagged-pdf',
     ];
     const {
       devtools = false,


### PR DESCRIPTION
This PR adds:
- `--disable-component-update`
- `--disable-features=MediaRouter`
- `--disable-features=OptimizationHints`

and removes `--disable-features=AvoidUnnecessaryBeforeUnloadCheckSync`.

See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md