### PR TITLE
chore: try linked versions for release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,13 @@
   },
   "plugins": [
     {
-      "type": "node-workspace"
+      "type": "node-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "group-name": "puppeteer",
+      "components": ["puppeteer", "puppeteer-core"]
     }
   ]
 }


### PR DESCRIPTION
Let's give this plugin a try? with dependency pinning it seems useful to make sure these packages get released together. 