### PR TITLE
chore: Add Node testing option in ng-schematics

### DIFF
--- a/packages/ng-schematics/src/schematics/ng-add/files/base/e2e/tests/app.e2e.ts.template
+++ b/packages/ng-schematics/src/schematics/ng-add/files/base/e2e/tests/app.e2e.ts.template
@@ -1,5 +1,14 @@
 import * as puppeteer from 'puppeteer';
-<% if(testingFramework == 'mocha') { %>
+<% if(testingFramework == 'node') { %>
+import {
+  describe,
+  it,
+  before,
+  beforeEach,
+  after,
+  afterEach,
+} from 'node:test';
+<% } %><% if(testingFramework == 'mocha' || testingFramework == 'node') { %>
 import * as assert from 'assert';
 <% } %>
 
@@ -11,7 +20,7 @@ describe('App test', function () {
   beforeAll(async () => {
     browser = await puppeteer.launch();
   });
-<% } %><% if(testingFramework == 'mocha') { %>
+<% } %><% if(testingFramework == 'mocha' || testingFramework == 'node') { %>
   before(async () => {
     browser = await puppeteer.launch();
   });
@@ -26,11 +35,11 @@ describe('App test', function () {
     await page.close();
   });
 
-<% if(testingFramework == 'jest') { %>
+<% if(testingFramework == 'jasmine' || testingFramework == 'jest') { %>
   afterAll(async () => {
     await browser.close();
   });
-<% } %><% if(testingFramework == 'mocha') { %>
+<% } %><% if(testingFramework == 'mocha' || testingFramework == 'node') { %>
   after(async () => {
     await browser.close();
   });
@@ -43,7 +52,7 @@ describe('App test', function () {
 
 <% if(testingFramework == 'jasmine' || testingFramework == 'jest') { %>
     expect(element).not.toBeNull();
-<% } %><% if(testingFramework == 'mocha') { %>
+<% } %><% if(testingFramework == 'mocha' || testingFramework == 'node') { %>
     assert.ok(element);
 <% } %>
   });

--- a/packages/ng-schematics/src/schematics/ng-add/files/base/e2e/tsconfig.json.template
+++ b/packages/ng-schematics/src/schematics/ng-add/files/base/e2e/tsconfig.json.template
@@ -2,9 +2,13 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    <% if(testingFramework == 'jest') { %>
+<% if(testingFramework == 'jest') { %>
     "esModuleInterop": true,
-    <% } %>
+<% } %><% if(testingFramework == 'node') { %>
+    "module": "CommonJS",
+    "rootDir": "tests/",
+    "outDir": "out-tsc/",
+<% } %>
     "types": ["<%= testingFramework %>"]
   },
   "include": ["tests/**/*.e2e.ts"]

--- a/packages/ng-schematics/src/schematics/ng-add/files/node/e2e/.gitignore.template
+++ b/packages/ng-schematics/src/schematics/ng-add/files/node/e2e/.gitignore.template
@@ -1,0 +1,3 @@
+# Compiled e2e tests output
+
+/out-tsc

--- a/packages/ng-schematics/src/schematics/ng-add/schema.json
+++ b/packages/ng-schematics/src/schematics/ng-add/schema.json
@@ -13,7 +13,7 @@
     "testingFramework": {
       "description": "",
       "type": "string",
-      "enum": ["jasmine", "jest", "mocha"],
+      "enum": ["jasmine", "jest", "mocha", "node"],
       "default": "jasmine",
       "x-prompt": {
         "message": "With what Testing Library do you wish to integrate?",
@@ -30,6 +30,10 @@
           {
             "value": "mocha",
             "label": "Use Mocha [https://mochajs.org/]"
+          },
+          {
+            "value": "node",
+            "label": "Use Node Test Runner (Experimental: Node v18) [https://nodejs.org/api/test.html]"
           }
         ]
       }

--- a/packages/ng-schematics/src/schematics/utils/files.ts
+++ b/packages/ng-schematics/src/schematics/utils/files.ts
@@ -129,6 +129,8 @@ export function getScriptFromOptions(options: SchematicsOptions): string {
       return 'jest -c e2e/jest.config.js';
     case TestingFramework.Mocha:
       return 'mocha --config=./e2e/.mocharc.js';
+    case TestingFramework.Node:
+      return 'tsc -p e2e/tsconfig.json && node --test e2e/out-tsc/**.js';
     default:
       throw new SchematicsException('Testing framework not supported.');
   }

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -125,6 +125,9 @@ export function getDependenciesFromOptions(
     case TestingFramework.Mocha:
       dependencies.push('mocha', '@types/mocha', ...babelPackages);
       break;
+    case TestingFramework.Node:
+      dependencies.push('@types/node');
+      break;
     default:
       throw new SchematicsException(`Testing framework not supported.`);
   }

--- a/packages/ng-schematics/test/src/index.spec.ts
+++ b/packages/ng-schematics/test/src/index.spec.ts
@@ -153,4 +153,16 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
     expect(devDependencies).toContain('@babel/register');
     expect(devDependencies).toContain('@babel/preset-typescript');
   });
+
+  it('should create Node files"', async () => {
+    const tree = await buildTestingTree({
+      testingFramework: 'node',
+    });
+    const {scripts} = getPackageJson(tree);
+
+    expect(tree.files).toContain(getProjectFile('e2e/.gitignore'));
+    expect(scripts['e2e']).toBe(
+      'tsc -p e2e/tsconfig.json && node --test e2e/out-tsc/**.js'
+    );
+  });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It lets Users create an schematic for Puppeteer in Angular project using Node's new test runner.

**Did you add tests for your changes?**

Yes. Unit test for module.

**If relevant, did you update the documentation?**

No

**Summary**

**Does this PR introduce a breaking change?**

No

**Other information**
