### PR TITLE
docs: fix cross-browser.js example

### DIFF
--- a/examples/cross-browser.js
+++ b/examples/cross-browser.js
@@ -34,7 +34,7 @@ const firefoxOptions = {
   await page.goto('https://news.ycombinator.com/');
 
   // Extract articles from the page.
-  const resultsSelector = '.titlelink';
+  const resultsSelector = '.titleline > a';
   const links = await page.evaluate(resultsSelector => {
     const anchors = Array.from(document.querySelectorAll(resultsSelector));
     return anchors.map(anchor => {


### PR DESCRIPTION
The previous selector is broken as of ~2 months ago, c.f. https://news.ycombinator.com/item?id=33027700

Changed from:

    <a class="titlelink"></a>

To:

    <span class="titleline">
    <a></a>
    </span>