### PR TITLE
chore: use groupName in release-please manifest

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,7 @@
     {
       "type": "linked-versions",
       "group-name": "puppeteer",
+      "groupName": "puppeteer",
       "components": ["puppeteer", "puppeteer-core"]
     }
   ]


### PR DESCRIPTION
release-please does not handle `group-name` currently but very likely it will in the future.