### PR TITLE
docs: fix typo in Viewport fields

### DIFF
--- a/docs/api/puppeteer.page.viewport.md
+++ b/docs/api/puppeteer.page.viewport.md
@@ -20,7 +20,7 @@ class Page {
 
 - `height`: page's height in pixels
 
-- `deviceScalarFactor`: Specify device scale factor (can be though of as dpr). Defaults to `1`.
+- `deviceScaleFactor`: Specify device scale factor (can be though of as dpr). Defaults to `1`.
 
 - `isMobile`: Whether the meta viewport tag is taken into account. Defaults to `false`.
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1948,7 +1948,7 @@ export class Page extends EventEmitter {
    *
    * - `height`: page's height in pixels
    *
-   * - `deviceScalarFactor`: Specify device scale factor (can be though of as
+   * - `deviceScaleFactor`: Specify device scale factor (can be though of as
    *   dpr). Defaults to `1`.
    *
    * - `isMobile`: Whether the meta viewport tag is taken into account. Defaults

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -2258,7 +2258,7 @@ export class CDPPage extends Page {
    *
    * - `height`: page's height in pixels
    *
-   * - `deviceScalarFactor`: Specify device scale factor (can be though of as
+   * - `deviceScaleFactor`: Specify device scale factor (can be though of as
    *   dpr). Defaults to `1`.
    *
    * - `isMobile`: Whether the meta viewport tag is taken into account. Defaults

--- a/website/versioned_docs/version-19.2.2/api/puppeteer.page.viewport.md
+++ b/website/versioned_docs/version-19.2.2/api/puppeteer.page.viewport.md
@@ -20,7 +20,7 @@ class Page {
 
 - `height`: page's height in pixels
 
-- `deviceScalarFactor`: Specify device scale factor (can be though of as dpr). Defaults to `1`.
+- `deviceScaleFactor`: Specify device scale factor (can be though of as dpr). Defaults to `1`.
 
 - `isMobile`: Whether the meta viewport tag is taken into account. Defaults to `false`.
 


### PR DESCRIPTION
The `deviceScalarFactor` field of `Viewport` is actually named `deviceScaleFactor`.