### PR TITLE
chore: include component in puppeteer tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,21 +21,14 @@ jobs:
         run: npm run build
       - name: Set npm registry
         run: npm config set registry 'https://wombat-dressing-room.appspot.com/'
-      - name: Publish Puppeteer
-        if: ${{ startsWith(github.ref_name, 'v') }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER}}
-        run: |
-          npm config set '//wombat-dressing-room.appspot.com/:_authToken' $NODE_AUTH_TOKEN
-          npm publish --workspace packages/puppeteer
       - name: Publish packages
-        if: ${{ !startsWith(github.ref_name, 'v') }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_RELEASE}}
         run: |
           npm config set '//wombat-dressing-room.appspot.com/:_authToken' $NODE_AUTH_TOKEN
           npm publish --workspace packages/${GITHUB_REF_NAME%-v*}
       - name: Deprecate old versions
+        if: ${{ startsWith(github.ref_name, 'puppeteer-v') }}
         run: |
           version_range=$(node tools/get_deprecated_version_range.js)
           npm deprecate puppeteer@"$version_range" "$version_range is no longer supported"
@@ -43,7 +36,7 @@ jobs:
   docker-publish:
     name: Publish Docker image
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref_name, 'v') }}
+    if: ${{ startsWith(github.ref_name, 'puppeteer-v') }}
     permissions:
       contents: read
       packages: write
@@ -73,7 +66,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             latest
-            type=semver,pattern={{version}}
+            type=match,pattern=puppeteer-v(\d+\.\d+\.\d+),group=1
       - name: Build and push the Docker image
         uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94
         with:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "last-release-sha": "2e3719cd7fbab551e99625bfb6198183aa23e7f5",
   "packages": {
     "packages/puppeteer": {
-      "include-component-in-tag": false,
       "component": "puppeteer"
     },
     "packages/puppeteer-core": {


### PR DESCRIPTION
Removes `include-component-in-tag` from the release please config which means that Puppeteer package releases will now be following the format `puppeteer-vX.X.X`. Also, this PR updates the docker publishing action to correctly parse such a tag to extract the `X.X.X` part, that is to be used as the docker image label.  