### PR TITLE
chore: specify latest-release for puppeteer

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "last-release-sha": "2e3719cd7fbab551e99625bfb6198183aa23e7f5",
   "packages": {
     "packages/puppeteer": {
-      "component": "puppeteer"
+      "component": "puppeteer",
+      "last-release-sha": "30e5b1a58edb8b1d94acdff00d64c76e76cf02a3"
     },
     "packages/puppeteer-core": {
       "component": "puppeteer-core"


### PR DESCRIPTION
30e5b1a58edb8b1d94acdff00d64c76e76cf02a3 is for the 19.2.2 release which was the latest.