### PR TITLE
chore: update deprecation script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,12 +27,14 @@ jobs:
         run: |
           npm config set '//wombat-dressing-room.appspot.com/:_authToken' $NODE_AUTH_TOKEN
           npm publish --workspace packages/${GITHUB_REF_NAME%-v*}
-      - name: Deprecate old versions
+      - name: Deprecate old Puppeteer versions
         if: ${{ startsWith(github.ref_name, 'puppeteer-v') }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER}}
         run: |
+          npm config set '//wombat-dressing-room.appspot.com/:_authToken' $NODE_AUTH_TOKEN
           version_range=$(node tools/get_deprecated_version_range.js)
           npm deprecate puppeteer@"$version_range" "$version_range is no longer supported"
-          npm deprecate puppeteer-core@"$version_range" "$version_range is no longer supported"
   docker-publish:
     name: Publish Docker image
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed deprecation for puppeteer-core as we normally don't deprecate it since it does not download the browser binaries.