### PR TITLE
docs: fix simple typo, consided -> considered

### DIFF
--- a/docs/api/puppeteer.frame.waitfornavigation.md
+++ b/docs/api/puppeteer.frame.waitfornavigation.md
@@ -23,7 +23,7 @@ class Frame {
 
 | Parameter | Type                                                                                                                                                                          | Description                                                                      |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| options   | { timeout?: number; waitUntil?: [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md) \| [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md)\[\]; } | <i>(Optional)</i> options to configure when the navigation is consided finished. |
+| options   | { timeout?: number; waitUntil?: [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md) \| [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md)\[\]; } | <i>(Optional)</i> options to configure when the navigation is considered finished. |
 
 **Returns:**
 

--- a/website/versioned_docs/version-19.3.0/api/puppeteer.frame.waitfornavigation.md
+++ b/website/versioned_docs/version-19.3.0/api/puppeteer.frame.waitfornavigation.md
@@ -23,7 +23,7 @@ class Frame {
 
 | Parameter | Type                                                                                                                                                                          | Description                                                                      |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| options   | { timeout?: number; waitUntil?: [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md) \| [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md)\[\]; } | <i>(Optional)</i> options to configure when the navigation is consided finished. |
+| options   | { timeout?: number; waitUntil?: [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md) \| [PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md)\[\]; } | <i>(Optional)</i> options to configure when the navigation is considered finished. |
 
 **Returns:**
 


### PR DESCRIPTION
There is a small typo in docs/api/puppeteer.frame.waitfornavigation.md, website/versioned_docs/version-19.3.0/api/puppeteer.frame.waitfornavigation.md.

Should read `considered` rather than `consided`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md