### PR TITLE
chore(ng-schematics): Use WireIt for builds and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ generated/
 /.cache/
 
 # IDE Artifacts
-.vscode
+.vscode/*
+!.vscode/extensions.json
 .devcontainer
 
 # Misc

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,7 +21,8 @@ generated/
 /.cache/
 
 # IDE Artifacts
-.vscode
+.vscode/*
+!.vscode/extensions.json
 .devcontainer
 
 # Misc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["google.wireit"]
+}

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -3,13 +3,53 @@
   "version": "0.1.0",
   "description": "Puppeteer Angular schematics",
   "scripts": {
-    "copy": "node copySchemaFiles.js",
-    "clean": "tsc -b --clean && rimraf lib",
-    "dev": "run-s clean copy && tsc -p tsconfig.json --watch",
-    "build": "run-s build:*",
-    "build:schematics": "npm run copy && tsc -p tsconfig.json",
-    "build:test": "tsc -p tsconfig.spec.json",
-    "test": "run-s clean build && mocha"
+    "dev": "npm run build --watch",
+    "dev:test": "npm run test --watch",
+    "copy": "wireit",
+    "build": "wireit",
+    "clean": "tsc --build --clean && rimraf lib",
+    "clean:test": "rimraf test/build",
+    "test": "wireit"
+  },
+  "wireit": {
+    "copy": {
+      "clean": "if-file-deleted",
+      "command": "node copySchemaFiles.js",
+      "files": [
+        "src/**/files/**",
+        "src/**/*.json"
+      ],
+      "output": [
+        "lib/**/files/**",
+        "lib/**/*.json"
+      ],
+      "dependencies": [
+        "clean"
+      ]
+    },
+    "build": {
+      "command": "tsc -b",
+      "files": [
+        "src/**/*.ts",
+        "!src/**/files",
+        "!src/**/*.json"
+      ],
+      "output": [
+        "lib/**",
+        "!lib/**/files",
+        "!lib/**/*.json"
+      ],
+      "dependencies": [
+        "copy"
+      ]
+    },
+    "test": {
+      "command": "mocha",
+      "dependencies": [
+        "clean:test",
+        "build"
+      ]
+    }
   },
   "keywords": [
     "angular",

--- a/packages/ng-schematics/tsconfig.json
+++ b/packages/ng-schematics/tsconfig.json
@@ -14,5 +14,6 @@
     "target": "ES6"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/files/**/*"]
+  "exclude": ["src/**/files/**/*"],
+  "references": [{"path": "./tsconfig.spec.json"}]
 }

--- a/packages/ng-schematics/tsconfig.spec.json
+++ b/packages/ng-schematics/tsconfig.spec.json
@@ -5,6 +5,6 @@
     "outDir": "test/build/",
     "types": ["node", "mocha"]
   },
-  "include": ["test/**/*"],
+  "include": ["test/src/**/*"],
   "exclude": ["test/build/**/*"]
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It moves all the `ng-schematics` commands to WireIt

**Did you add tests for your changes?**

N/A

**Summary**

We want all our packages to use the same processes to build and test.
This also allows us to have better build times and also watch mode 👀.

**Does this PR introduce a breaking change?**

No

**Other information**
