### PR TITLE
chore: fix race in test Frame.waitForFunction should work when context is destroyed

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2124,13 +2124,19 @@
     "expectations": ["PASS", "FAIL"]
   },
   {
-    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should survive cross-process navigation",
+    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should survive cross-process navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["PASS", "FAIL"]
   },
   {
-    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should survive cross-process navigation",
+    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should work when resolved right before execution context disposal",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"]
+  },
+  {
+    "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should survive cross-process navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["PASS", "FAIL"]

--- a/test/src/waittask.spec.ts
+++ b/test/src/waittask.spec.ts
@@ -48,6 +48,7 @@ describe('waittask specs', function () {
       await page.waitForFunction(() => {
         if (!(globalThis as any).__RELOADED) {
           window.location.reload();
+          return false;
         }
         return true;
       });


### PR DESCRIPTION
Fixes the race condition which causes intermittent failures in Firefox because we haven't implemented bootstrap scripts to run on document creation. 