### PR TITLE
Fix documentation typo in Page.waitForSelector optional `visible` parameter

### DIFF
--- a/docs/api/puppeteer.page.waitforselector.md
+++ b/docs/api/puppeteer.page.waitforselector.md
@@ -54,9 +54,9 @@ Promise which resolves when element specified by selector string is added to DOM
 
 ## Remarks
 
-The optional Parameter in Arguments `options` are :
+The optional Parameter in Arguments `options` are:
 
-- `Visible`: A boolean wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+- `visible`: A boolean wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 
 - `hidden`: Wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2398,9 +2398,9 @@ export class Page extends EventEmitter {
    * is added to DOM. Resolves to `null` if waiting for hidden: `true` and
    * selector is not found in DOM.
    * @remarks
-   * The optional Parameter in Arguments `options` are :
+   * The optional Parameter in Arguments `options` are:
    *
-   * - `Visible`: A boolean wait for element to be present in DOM and to be
+   * - `visible`: A boolean wait for element to be present in DOM and to be
    *   visible, i.e. to not have `display: none` or `visibility: hidden` CSS
    *   properties. Defaults to `false`.
    *

--- a/website/versioned_docs/version-19.4.0/api/puppeteer.page.waitforselector.md
+++ b/website/versioned_docs/version-19.4.0/api/puppeteer.page.waitforselector.md
@@ -54,9 +54,9 @@ Promise which resolves when element specified by selector string is added to DOM
 
 ## Remarks
 
-The optional Parameter in Arguments `options` are :
+The optional Parameter in Arguments `options` are:
 
-- `Visible`: A boolean wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
+- `visible`: A boolean wait for element to be present in DOM and to be visible, i.e. to not have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 
 - `hidden`: Wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Typo fix in the documentation

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

N/A

**Summary**

I spotted the `Visible` parameter had an uppercase `V` in the [Remarks section of  the Page.waitForSelector API documentation](https://pptr.dev/api/puppeteer.page.waitforselector#remarks). Updated this to the lowercase `v` in the relevant places (source, documentation, versioned version of the doc page). 

While doing this, I also spotted there was an extra space in `are :` in the sentence above – so changed that as well.

**Does this PR introduce a breaking change?**

No

**Other information**

I’ve confirmed the parameter is spelled correctly on https://pptr.dev/api/puppeteer.waitforselectoroptions. I’m not sure why the documentation for those properties is in two places with slightly different wording – but to me it felt useful to see this directly on the method’s API docs.