### PR TITLE
chore: disable yarn tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,6 @@ jobs:
           - 18
         pkg_manager:
           - npm
-          - yarn
     steps:
       - name: Download installation test
         uses: actions/download-artifact@v3


### PR DESCRIPTION
The number of jobs we run is already high.
Yarn does not work well in our test setup on release PRs. Therefore, I suggest we disable explicit tests for it and let's assume it's compatible enough with npm.