### PR TITLE
docs: use a number of documented versions for indexing

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,9 +8,9 @@
       "name": "website",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-client-redirects": "2.1.0",
-        "@docusaurus/preset-classic": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-client-redirects": "2.2.0",
+        "@docusaurus/preset-classic": "2.2.0",
         "@mdx-js/react": "1.6.22",
         "clsx": "1.2.1",
         "prism-react-renderer": "1.3.5",
@@ -18,34 +18,34 @@
         "react-dom": "17.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
         "swc-loader": "0.2.3"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       },
       "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.14.2",
@@ -1962,18 +1962,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.2.tgz",
-      "integrity": "sha512-VB0Evx4ikS1ZlW1YVUw+vI9b3H/UXMCo4W/ZWy+n56Sho4KOqyCHcINVays91TJt7HTV/CKO3FCbm2VJg5Wipw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.2.tgz",
-      "integrity": "sha512-1Hn2SNQUFVPrzqvaj+vxXZfsfn3rnW8CoyGAJ1LqXMY9py8GbxK8VfmJ5Z6z4LwG9849tGru/N6dp0cQO6r9Ag==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.2",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -1994,9 +1994,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2008,13 +2008,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
+      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2108,14 +2108,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2139,12 +2139,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
+      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2158,15 +2158,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.1.0.tgz",
-      "integrity": "sha512-3PhzwHSyZWqBAFPJuLJE3dZVuKWQEj9ReQP85Z3/2hpnQoVNBgAqc+64FIko0FvvK1iluLeasO7NWGyuATngvw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.2.0.tgz",
+      "integrity": "sha512-psBoWi+cbc2I+VPkKJlcZ12tRN3xiv22tnZfNKyMo18iSY8gr4B6Q0G2KZXGPgNGJ/6gq7ATfgDK6p9h9XRxMQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "eta": "^1.12.3",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
@@ -2181,17 +2181,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
+      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2211,17 +2211,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
+      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2241,15 +2241,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
+      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2263,13 +2263,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
+      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2283,13 +2283,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
+      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2301,13 +2301,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
+      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2319,16 +2319,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2342,22 +2342,22 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
+      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/plugin-debug": "2.2.0",
+        "@docusaurus/plugin-google-analytics": "2.2.0",
+        "@docusaurus/plugin-google-gtag": "2.2.0",
+        "@docusaurus/plugin-sitemap": "2.2.0",
+        "@docusaurus/theme-classic": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-search-algolia": "2.2.0",
+        "@docusaurus/types": "2.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2380,22 +2380,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
+      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2419,16 +2419,16 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
+      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2447,18 +2447,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
+      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2477,9 +2477,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
+      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2489,9 +2489,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2508,11 +2508,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -2541,9 +2541,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2560,12 +2560,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -4102,9 +4102,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.12",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
-      "integrity": "sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4117,7 +4117,7 @@
       ],
       "dependencies": {
         "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001407",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -4537,9 +4537,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5355,12 +5355,12 @@
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
+      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
       "dependencies": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.13",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -5374,24 +5374,24 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+      "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
       "dependencies": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.3",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -5399,11 +5399,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.1",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -6569,9 +6569,9 @@
       }
     },
     "node_modules/github-slugger": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
-      "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -8601,9 +8601,9 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -8823,11 +8823,11 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "dependencies": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -8932,12 +8932,12 @@
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -8947,11 +8947,11 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+      "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
@@ -8994,11 +8994,11 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -9160,11 +9160,11 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -9233,11 +9233,11 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+      "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
@@ -9835,9 +9835,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.3.0",
@@ -11124,11 +11124,11 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       },
       "engines": {
@@ -12701,25 +12701,25 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
     },
     "@algolia/cache-browser-local-storage": {
       "version": "4.14.2",
@@ -14058,25 +14058,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.2.tgz",
-      "integrity": "sha512-VB0Evx4ikS1ZlW1YVUw+vI9b3H/UXMCo4W/ZWy+n56Sho4KOqyCHcINVays91TJt7HTV/CKO3FCbm2VJg5Wipw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "@docsearch/react": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.2.tgz",
-      "integrity": "sha512-1Hn2SNQUFVPrzqvaj+vxXZfsfn3rnW8CoyGAJ1LqXMY9py8GbxK8VfmJ5Z6z4LwG9849tGru/N6dp0cQO6r9Ag==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.2",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -14088,13 +14088,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -14152,9 +14152,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
+      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -14163,23 +14163,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -14196,12 +14196,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
+      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14211,15 +14211,15 @@
       }
     },
     "@docusaurus/plugin-client-redirects": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.1.0.tgz",
-      "integrity": "sha512-3PhzwHSyZWqBAFPJuLJE3dZVuKWQEj9ReQP85Z3/2hpnQoVNBgAqc+64FIko0FvvK1iluLeasO7NWGyuATngvw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.2.0.tgz",
+      "integrity": "sha512-psBoWi+cbc2I+VPkKJlcZ12tRN3xiv22tnZfNKyMo18iSY8gr4B6Q0G2KZXGPgNGJ/6gq7ATfgDK6p9h9XRxMQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "eta": "^1.12.3",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
@@ -14227,17 +14227,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
+      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -14250,17 +14250,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
+      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -14273,88 +14273,88 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
+      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
+      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
+      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
+      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
+      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/plugin-debug": "2.2.0",
+        "@docusaurus/plugin-google-analytics": "2.2.0",
+        "@docusaurus/plugin-google-gtag": "2.2.0",
+        "@docusaurus/plugin-sitemap": "2.2.0",
+        "@docusaurus/theme-classic": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-search-algolia": "2.2.0",
+        "@docusaurus/types": "2.2.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14367,22 +14367,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
+      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -14399,16 +14399,16 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
+      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14420,18 +14420,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
+      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -14443,18 +14443,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
+      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14467,11 +14467,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -14489,20 +14489,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -15664,12 +15664,12 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.12",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
-      "integrity": "sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "requires": {
         "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001407",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -15985,9 +15985,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ=="
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -16536,12 +16536,12 @@
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
+      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
       "requires": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.13",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -16549,24 +16549,24 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+      "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
       "requires": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.3",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -16574,11 +16574,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.1",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -17425,9 +17425,9 @@
       }
     },
     "github-slugger": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
-      "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -18876,9 +18876,9 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
         "entities": "^4.4.0"
       }
@@ -19033,11 +19033,11 @@
       }
     },
     "postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "requires": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -19093,20 +19093,20 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       }
     },
     "postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+      "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
@@ -19131,11 +19131,11 @@
       }
     },
     "postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       }
@@ -19227,11 +19227,11 @@
       }
     },
     "postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -19270,11 +19270,11 @@
       }
     },
     "postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+      "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       }
     },
@@ -19715,9 +19715,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.3.0",
@@ -20698,11 +20698,11 @@
       }
     },
     "stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -15,9 +15,9 @@
     "archive": "node archive.js"
   },
   "dependencies": {
-    "@docusaurus/core": "2.1.0",
-    "@docusaurus/plugin-client-redirects": "2.1.0",
-    "@docusaurus/preset-classic": "2.1.0",
+    "@docusaurus/core": "2.2.0",
+    "@docusaurus/plugin-client-redirects": "2.2.0",
+    "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "1.6.22",
     "clsx": "1.2.1",
     "prism-react-renderer": "1.3.5",
@@ -25,7 +25,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.1.0",
+    "@docusaurus/module-type-aliases": "2.2.0",
     "swc-loader": "0.2.3"
   },
   "browserslist": {

--- a/website/src/theme/SearchMetadata/index.js
+++ b/website/src/theme/SearchMetadata/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+
+// Tracks the global package version as a local, monotonic counter. This
+// prevents Algolia from deleting based on differing package versions and
+// instead delete based on the number of versions we intend to keep documented.
+let globalCounter = -1;
+const versionToCounter = new Map();
+
+export default function SearchMetadata({locale, version}) {
+  const language = locale;
+  let counter;
+  if (version) {
+    counter = versionToCounter.get(version);
+    if (!counter) {
+      counter = ++globalCounter;
+      versionToCounter.set(version, counter);
+    }
+  }
+  return (
+    <Head>
+      {language && <meta name="docsearch:language" content={language} />}
+      {counter && <meta name="docsearch:counter" content={counter} />}
+    </Head>
+  );
+}


### PR DESCRIPTION
This PR allows Algolia to index on the number of documented versions rather than on the global version of packages.

Fixed: #9329