### PR TITLE
chore: fix website URLs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,6 +41,13 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  scripts: [
+    {
+      src: '/fix-location.js',
+      async: false,
+      defer: false,
+    },
+  ],
   webpack: {
     jsLoader: isServer => {
       return {

--- a/website/static/fix-location.js
+++ b/website/static/fix-location.js
@@ -1,0 +1,5 @@
+const url = new URL(window.location.href);
+if (url.pathname.endsWith('/') && url.pathname !== '/') {
+  url.pathname = url.pathname.substring(0, url.pathname.length - 1);
+  window.history.replaceState(null, undefined, url.toString());
+}


### PR DESCRIPTION
GitHub Pages appends trailing slashes which might break docusaurus links.