### PR TITLE
chore: check if rimraf package is installed before running the cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build --workspaces --if-present",
     "check:pinned-deps": "tsx tools/ensure-pinned-deps",
     "check": "npm run check --workspaces --if-present && run-p check:*",
-    "clean": "npm run clean --workspaces --if-present && rimraf **/.wireit",
+    "clean": "npm list rimraf && npm run clean --workspaces --if-present && rimraf **/.wireit",
     "commitlint": "commitlint --from=HEAD~1",
     "debug": "mocha --inspect-brk",
     "docs": "run-s build generate:markdown",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

A change to the npm cleanup script.

**Summary**

When working with puppeteer in mozilla repo we regularly update puppeteer versions, which leads to the situation when developers could have outdated build folders, to avoid this we would like to add `npm clean` command as a part of puppeteer setup process and running test. But we use the same command on the ci, where we don't have dependencies set up yet, also developers might have a fresh checkout without dependencies set up. To avoid the errors in this case, the idea would be to check first if `rimraf` package is installed.

**Does this PR introduce a breaking change?**

no
