### PR TITLE
fix: firefox revision resolution should not update chrome revision

### DIFF
--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -194,7 +194,7 @@ export class FirefoxLauncher extends ProductLauncher {
       });
       const localRevisions = browserFetcher.localRevisions();
       if (localRevisions[0]) {
-        this.puppeteer.configuration.browserRevision = localRevisions[0];
+        this.actualBrowserRevision = localRevisions[0];
       }
     }
     return this.resolveExecutablePath();

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -41,6 +41,11 @@ export class ProductLauncher {
   /**
    * @internal
    */
+  protected actualBrowserRevision?: string;
+
+  /**
+   * @internal
+   */
   constructor(puppeteer: PuppeteerNode, product: Product) {
     this.puppeteer = puppeteer;
     this.#product = product;
@@ -63,6 +68,15 @@ export class ProductLauncher {
   defaultArgs(object: BrowserLaunchArgumentOptions): string[];
   defaultArgs(): string[] {
     throw new Error('Not implemented');
+  }
+
+  /**
+   * Set only for Firefox, after the launcher resolves the `latest` revision to
+   * the actual revision.
+   * @internal
+   */
+  getActualBrowserRevision(): string | undefined {
+    return this.actualBrowserRevision;
   }
 
   /**

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -217,7 +217,11 @@ export class PuppeteerNode extends Puppeteer {
    * @internal
    */
   get browserRevision(): string {
-    return this.configuration.browserRevision ?? this.defaultBrowserRevision!;
+    return (
+      this.#_launcher?.getActualBrowserRevision() ??
+      this.configuration.browserRevision ??
+      this.defaultBrowserRevision!
+    );
   }
 
   /**
@@ -292,19 +296,22 @@ export class PuppeteerNode extends Puppeteer {
     options: Partial<BrowserFetcherOptions> = {}
   ): BrowserFetcher {
     const downloadPath = this.defaultDownloadPath;
-    if (downloadPath) {
+    if (!options.path && downloadPath) {
       options.path = downloadPath;
     }
     if (!options.path) {
       throw new Error('A `path` must be specified for `puppeteer-core`.');
     }
-    if (this.configuration.experiments?.macArmChromiumEnabled) {
+    if (
+      !('useMacOSARMBinary' in options) &&
+      this.configuration.experiments?.macArmChromiumEnabled
+    ) {
       options.useMacOSARMBinary = true;
     }
-    if (this.configuration.downloadHost) {
+    if (!('host' in options) && this.configuration.downloadHost) {
       options.host = this.configuration.downloadHost;
     }
-    if (this.configuration.defaultProduct) {
+    if (!('product' in options) && this.configuration.defaultProduct) {
       options.product = this.configuration.defaultProduct;
     }
     return new BrowserFetcher(options as BrowserFetcherOptions);


### PR DESCRIPTION
Drive-by: don't override options in PuppeteerNode if they are provided.

Closes #9461