### PR TITLE
chore: use named import for devtools-protocol module

### DIFF
--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import {Protocol} from 'devtools-protocol';
 import {assert} from '../util/assert.js';
 import {CDPSession, Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import {Protocol} from 'devtools-protocol';
 import {assert} from '../util/assert.js';
 import {CDPSession, Connection} from './Connection.js';
 import {Target} from './Target.js';

--- a/packages/puppeteer-core/src/common/TargetManager.ts
+++ b/packages/puppeteer-core/src/common/TargetManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import {Protocol} from 'devtools-protocol';
 import {CDPSession} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {Target} from './Target.js';

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Protocol from 'devtools-protocol';
+import {Protocol} from 'devtools-protocol';
 import expect from 'expect';
 import fs from 'fs';
 import os from 'os';

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import {Protocol} from 'devtools-protocol';
 import expect from 'expect';
 import * as fs from 'fs';
 import * as path from 'path';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
types fix

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
Not relevant

**Summary**
I am updating `import`s of `devtools-protocol` to always use named import instead of the default.
For some reason, typescript doesn't understand when it is imported as default. 

```
node_modules/puppeteer-core/lib/esm/puppeteer/common/TargetManager.d.ts:23:59 - error TS2694: Namespace '"/Users/kyrylo/pacakge/node_modules/puppeteer-core/node_modules/devtools-protocol/types/protocol"' has no exported member 'Target'.

23 export declare type TargetFactory = (targetInfo: Protocol.Target.TargetInfo, session?: CDPSession) => Target;
                                                             ~~~~~~


Found 1 error in node_modules/puppeteer-core/lib/esm/puppeteer/common/TargetManager.d.ts:23
```

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I am updating `import`s of `devtools-protocol` to always use named import instead of the default.
