### PR TITLE
fix: remove main field

### DIFF
--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -9,7 +9,6 @@
     "automation"
   ],
   "type": "commonjs",
-  "main": "./lib/cjs/puppeteer/puppeteer.js",
   "types": "./lib/types.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Puppeteer requires export maps to import from puppeteer-core and, thus, the main field should not be needed because it won't work if imported via main anyway.

Closes #9535