### PR TITLE
chore: fix third_party build

### DIFF
--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -39,11 +39,12 @@
     "build:types": "wireit",
     "build": "wireit",
     "check": "tsx tools/ensure-correct-devtools-protocol-package",
-    "clean": "tsc -b --clean && rimraf lib src/generated",
     "format:types": "wireit",
     "generate:package-json": "wireit",
     "generate:sources": "wireit",
-    "prepack": "wireit"
+    "prepack": "wireit",
+    "clean": "tsc -b --clean && rimraf lib src/generated",
+    "clean:third_party": "wireit"
   },
   "wireit": {
     "prepack": {
@@ -71,6 +72,9 @@
       "output": [
         "src/generated/**"
       ]
+    },
+    "clean:third_party": {
+      "command": "rimraf lib/esm/third_party lib/cjs/third_party"
     },
     "build:third_party": {
       "command": "rollup --config rollup.third_party.config.js",
@@ -129,6 +133,7 @@
       "command": "tsc -b",
       "clean": "if-file-deleted",
       "dependencies": [
+        "clean:third_party",
         "generate:sources"
       ],
       "files": [


### PR DESCRIPTION
The third_party folder is compiled with tsc and then rolled up in-place. This means that the next build might try to compile the file that has been rolled up leading to build errors. It seems the safest solution is to always rebuild third_party folder as the size is relatively small.