### PR TITLE
fix: don't clean up previous browser versions

### DIFF
--- a/packages/puppeteer-core/src/node/BrowserFetcher.ts
+++ b/packages/puppeteer-core/src/node/BrowserFetcher.ts
@@ -504,6 +504,13 @@ export class BrowserFetcher {
   #getFolderPath(revision: string): string {
     return path.resolve(this.#downloadPath, `${this.#platform}-${revision}`);
   }
+
+  /**
+   * @internal
+   */
+  getDownloadPath(): string {
+    return this.#downloadPath;
+  }
 }
 
 function parseFolderPath(

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -94,13 +94,18 @@ export async function downloadBrowser(): Promise<void> {
       logPolitely(
         `${supportedProducts[product]} (${revisionInfo.revision}) downloaded to ${revisionInfo.folderPath}`
       );
-      localRevisions = localRevisions.filter(revision => {
+      const otherRevisions = localRevisions.filter(revision => {
         return revision !== revisionInfo.revision;
       });
-      const cleanupOldVersions = localRevisions.map(revision => {
-        return browserFetcher.remove(revision);
-      });
-      Promise.all([...cleanupOldVersions]);
+      if (otherRevisions.length) {
+        logPolitely(
+          `Other installed ${
+            supportedProducts[product]
+          } browsers in ${browserFetcher.getDownloadPath()} include: ${otherRevisions.join(
+            ', '
+          )}. Remove old revisions from ${browserFetcher.getDownloadPath()} if you don't need them.`
+        );
+      }
     }
 
     function onError(error: Error) {


### PR DESCRIPTION
Since we moved to the central binaries cache it does not make sense to clean up old binaries automatically because multiple installations can use different versions. We expect the users to clean the cache from time to time until we offer a CLI for managing the browsers.

Closes #9533