### PR TITLE
docs: prevent truncating of long messages with DEBUG_MAX_STRING_LENGTH=null

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -130,6 +130,9 @@ variable before running your script. This will log internal traffic via
 # Basic verbose logging
 env DEBUG="puppeteer:*" node script.js
 
+# Prevent truncating of long messages
+env DEBUG="puppeteer:*" env DEBUG_MAX_STRING_LENGTH=null node script.js
+
 # Protocol traffic can be rather noisy. This example filters out all Network domain messages
 env DEBUG="puppeteer:*" env DEBUG_COLORS=true node script.js 2>&1 | grep -v '"Network'
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

It changes the docs.

**Did you add tests for your changes?**

No.

**If relevant, did you update the documentation?**

Yes.

**Summary**

When logging the DevTools protocol traffic, the default value of `maxStringLength` is 10000. Messages longer than that will be truncated. This change adds an example to show how to remove the limitation with `DEBUG_MAX_STRING_LENGTH=null`.

See https://nodejs.org/api/util.html#util_util_inspect_object_options.

**Does this PR introduce a breaking change?**

No.

**Other information**

None.