### PR TITLE
chore: remove unused return type

### DIFF
--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -344,7 +344,7 @@ export class Frame {
       referrer: string | undefined,
       referrerPolicy: Protocol.Page.ReferrerPolicy | undefined,
       frameId: string
-    ): Promise<Error | null> {
+    ): Promise<void> {
       try {
         const response = await client.send('Page.navigate', {
           url,
@@ -353,14 +353,11 @@ export class Frame {
           referrerPolicy,
         });
         ensureNewDocumentNavigation = !!response.loaderId;
-        return response.errorText
-          ? new Error(`${response.errorText} at ${url}`)
-          : null;
+        return;
       } catch (error) {
-        if (isErrorLike(error)) {
-          return error;
+        if (!isErrorLike(error)) {
+          throw error;
         }
-        throw error;
       }
     }
   }


### PR DESCRIPTION
# Description

I don't know if something got lost when this code was moved from the frame manager to the frame. But the output of the `navigate` function is not being used.