### PR TITLE
fix: mimic rejection for PuppeteerUtil on early call

### DIFF
--- a/packages/puppeteer-core/src/common/QueryHandler.ts
+++ b/packages/puppeteer-core/src/common/QueryHandler.ts
@@ -15,6 +15,7 @@
  */
 
 import PuppeteerUtil from '../injected/injected.js';
+import {assert} from '../util/assert.js';
 import {ariaHandler} from './AriaQueryHandler.js';
 import {ElementHandle} from './ElementHandle.js';
 import {Frame} from './Frame.js';
@@ -99,10 +100,12 @@ function createPuppeteerQueryHandler(
   if (handler.queryOne) {
     const queryOne = handler.queryOne;
     internalHandler.queryOne = async (element, selector) => {
+      const world = element.executionContext()._world;
+      assert(world);
       const jsHandle = await element.evaluateHandle(
         queryOne,
         selector,
-        await element.executionContext()._world!.puppeteerUtil
+        await world.puppeteerUtil
       );
       const elementHandle = jsHandle.asElement();
       if (elementHandle) {
@@ -145,6 +148,8 @@ function createPuppeteerQueryHandler(
   if (handler.queryAll) {
     const queryAll = handler.queryAll;
     internalHandler.queryAll = async (element, selector) => {
+      const world = element.executionContext()._world;
+      assert(world);
       const jsHandle = await element.evaluateHandle(
         queryAll,
         selector,

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -170,11 +170,10 @@ export class WaitTask<T = unknown> {
   async terminate(error?: unknown): Promise<void> {
     this.#world.taskManager.delete(this);
 
-    if (this.#timeout) {
-      clearTimeout(this.#timeout);
-    }
-
     if (error && !this.#result.finished()) {
+      if (this.#timeout) {
+        clearTimeout(this.#timeout);
+      }
       this.#result.reject(error);
     }
 


### PR DESCRIPTION
This PR rejects the PuppeteerUtil promise to mimic the behavior of when PuppeteerUtil cannot be evaluated due to navigation.

This also fixes a problem where the timeout would clear on navigation.