### PR TITLE
fix: ignore not found contexts for console messages

### DIFF
--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -174,10 +174,16 @@ export class FrameManager extends EventEmitter {
     contextId: number,
     session: CDPSession = this.#client
   ): ExecutionContext {
-    const key = `${session.id()}:${contextId}`;
-    const context = this.#contextIdToContext.get(key);
+    const context = this.getExecutionContextById(contextId, session);
     assert(context, 'INTERNAL ERROR: missing context with id = ' + contextId);
     return context;
+  }
+
+  getExecutionContextById(
+    contextId: number,
+    session: CDPSession = this.#client
+  ): ExecutionContext | undefined {
+    return this.#contextIdToContext.get(`${session.id()}:${contextId}`);
   }
 
   page(): Page {

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -747,10 +747,20 @@ export class CDPPage extends Page {
       // @see https://github.com/puppeteer/puppeteer/issues/3865
       return;
     }
-    const context = this.#frameManager.executionContextById(
+    const context = this.#frameManager.getExecutionContextById(
       event.executionContextId,
       this.#client
     );
+    if (!context) {
+      debugError(
+        new Error(
+          `ExecutionContext not found for a console message: ${JSON.stringify(
+            event
+          )}`
+        )
+      );
+      return;
+    }
     const values = event.args.map(arg => {
       return createJSHandle(context, arg);
     });


### PR DESCRIPTION
I think it is possible that there is no context for a console message. I am not sure we should try to await for a context potentially arriving later. Since the reports say it happens in practice, let's turn the assertion into a debug log.

See https://github.com/puppeteer/puppeteer/issues/9514#issuecomment-1405571870