### PR TITLE
fix: atomically get Puppeteer utilities

### DIFF
--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -34,6 +34,7 @@ import {Page} from '../api/Page.js';
 import {getQueryHandlerAndSelector} from './QueryHandler.js';
 import {EvaluateFunc, HandleFor, NodeFor} from './types.js';
 import {importFS} from './util.js';
+import {LazyArg} from './LazyArg.js';
 
 /**
  * @public
@@ -839,7 +840,9 @@ export class Frame {
           await promise;
           return script;
         },
-        await this.worlds[PUPPETEER_WORLD].puppeteerUtil,
+        LazyArg.create(context => {
+          return context.puppeteerUtil;
+        }),
         {...options, type, content}
       )
     );
@@ -923,7 +926,9 @@ export class Frame {
           await promise;
           return element;
         },
-        await this.worlds[PUPPETEER_WORLD].puppeteerUtil,
+        LazyArg.create(context => {
+          return context.puppeteerUtil;
+        }),
         options
       )
     );

--- a/packages/puppeteer-core/src/common/LazyArg.ts
+++ b/packages/puppeteer-core/src/common/LazyArg.ts
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
+import {ExecutionContext} from './ExecutionContext.js';
+
 /**
  * @internal
  */
 export class LazyArg<T> {
-  #get: () => Promise<T>;
-  constructor(get: () => Promise<T>) {
+  static create = <T>(
+    get: (context: ExecutionContext) => Promise<T> | T
+  ): T => {
+    // We don't want to introduce LazyArg to the type system, otherwise we would
+    // have to make it public.
+    return new LazyArg(get) as unknown as T;
+  };
+
+  #get: (context: ExecutionContext) => Promise<T> | T;
+  private constructor(get: (context: ExecutionContext) => Promise<T> | T) {
     this.#get = get;
   }
 
-  get(): Promise<T> {
-    return this.#get();
+  async get(context: ExecutionContext): Promise<T> {
+    return this.#get(context);
   }
 }

--- a/packages/puppeteer-core/src/common/QueryHandler.ts
+++ b/packages/puppeteer-core/src/common/QueryHandler.ts
@@ -21,6 +21,7 @@ import {ElementHandle} from './ElementHandle.js';
 import {Frame} from './Frame.js';
 import {WaitForSelectorOptions} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
+import {LazyArg} from './LazyArg.js';
 
 /**
  * @public
@@ -105,7 +106,9 @@ function createPuppeteerQueryHandler(
       const jsHandle = await element.evaluateHandle(
         queryOne,
         selector,
-        await world.puppeteerUtil
+        LazyArg.create(context => {
+          return context.puppeteerUtil;
+        })
       );
       const elementHandle = jsHandle.asElement();
       if (elementHandle) {
@@ -153,7 +156,9 @@ function createPuppeteerQueryHandler(
       const jsHandle = await element.evaluateHandle(
         queryAll,
         selector,
-        await element.executionContext()._world!.puppeteerUtil
+        LazyArg.create(context => {
+          return context.puppeteerUtil;
+        })
       );
       const properties = await jsHandle.getProperties();
       await jsHandle.dispose();

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -20,6 +20,7 @@ import {ElementHandle} from './ElementHandle.js';
 import {TimeoutError} from './Errors.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {JSHandle} from './JSHandle.js';
+import {LazyArg} from './LazyArg.js';
 import {HandleFor} from './types.js';
 
 /**
@@ -114,7 +115,9 @@ export class WaitTask<T = unknown> {
                 return fun(...args) as Promise<T>;
               });
             },
-            await this.#world.puppeteerUtil,
+            LazyArg.create(context => {
+              return context.puppeteerUtil;
+            }),
             this.#fn,
             ...this.#args
           );
@@ -127,7 +130,9 @@ export class WaitTask<T = unknown> {
                 return fun(...args) as Promise<T>;
               }, root || document);
             },
-            await this.#world.puppeteerUtil,
+            LazyArg.create(context => {
+              return context.puppeteerUtil;
+            }),
             this.#root,
             this.#fn,
             ...this.#args
@@ -141,7 +146,9 @@ export class WaitTask<T = unknown> {
                 return fun(...args) as Promise<T>;
               }, ms);
             },
-            await this.#world.puppeteerUtil,
+            LazyArg.create(context => {
+              return context.puppeteerUtil;
+            }),
             this.#polling,
             this.#fn,
             ...this.#args

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3013,7 +3013,7 @@
   },
   {
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should work with removed MutationObserver",
-    "platforms": ["darwin", "win32"],
+    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"]
   },

--- a/test/src/injected.spec.ts
+++ b/test/src/injected.spec.ts
@@ -16,6 +16,7 @@
 
 import expect from 'expect';
 import {PUPPETEER_WORLD} from 'puppeteer-core/internal/common/IsolatedWorlds.js';
+import {LazyArg} from 'puppeteer-core/internal/common/LazyArg.js';
 import {
   getTestState,
   setupTestBrowserHooks,
@@ -30,9 +31,14 @@ describe('PuppeteerUtil tests', function () {
     const {page} = getTestState();
 
     const world = page.mainFrame().worlds[PUPPETEER_WORLD];
-    const value = await world.evaluate(PuppeteerUtil => {
-      return typeof PuppeteerUtil === 'object';
-    }, world.puppeteerUtil);
+    const value = await world.evaluate(
+      PuppeteerUtil => {
+        return typeof PuppeteerUtil === 'object';
+      },
+      LazyArg.create(context => {
+        return context.puppeteerUtil;
+      })
+    );
     expect(value).toBeTruthy();
   });
 
@@ -45,7 +51,9 @@ describe('PuppeteerUtil tests', function () {
         ({createFunction}, fnString) => {
           return createFunction(fnString)(4);
         },
-        await world.puppeteerUtil,
+        LazyArg.create(context => {
+          return context.puppeteerUtil;
+        }),
         (() => {
           return 4;
         }).toString()


### PR DESCRIPTION
This PR implements atomic retrieval of the PuppeteerUtil class. It also refactors the ExecutionContext code such that the PuppeteerUtil is always evaluated before the context is available for general consumption.