### PR TITLE
docs: fix typo in docs visible on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ import puppeteer from 'puppeteer';
   await page.waitForSelector(searchResultSelector);
   await page.click(searchResultSelector);
 
-  // Localte the full title with a unique string
+  // Locate the full title with a unique string
   const textSelector = await page.waitForSelector(
     'text/Customize and automate'
   );

--- a/docs/index.md
+++ b/docs/index.md
@@ -149,7 +149,7 @@ import puppeteer from 'puppeteer';
   await page.waitForSelector(searchResultSelector);
   await page.click(searchResultSelector);
 
-  // Localte the full title with a unique string
+  // Locate the full title with a unique string
   const textSelector = await page.waitForSelector(
     'text/Customize and automate'
   );


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Docs typo fix.

PR replaces https://github.com/puppeteer/puppeteer/pull/9604 which was automatically closed by GitHub.

**Did you add tests for your changes?**

n/a

**If relevant, did you update the documentation?**

Yes

**Summary**

Fix typo visible on main page of site.

**Does this PR introduce a breaking change?**

No

**Other information**

n/a