### PR TITLE
fix: restore WaitTask terminate  condition

### DIFF
--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -177,10 +177,11 @@ export class WaitTask<T = unknown> {
   async terminate(error?: unknown): Promise<void> {
     this.#world.taskManager.delete(this);
 
+    if (this.#timeout) {
+      clearTimeout(this.#timeout);
+    }
+
     if (error && !this.#result.finished()) {
-      if (this.#timeout) {
-        clearTimeout(this.#timeout);
-      }
       this.#result.reject(error);
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes a regression caused by [fix: mimic rejection for PuppeteerUtil on early call](https://github.com/puppeteer/puppeteer/commit/1980de91a161523c7098a79919b20e6d8d2e5d81) and closes #9610.

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

No

**Summary**

See #9610. A recent change causes `page.waitForSelector` to keep the Node process from exiting. This fix reverts to the old behavior.

**Does this PR introduce a breaking change?**

No.

**Other information**
