### PR TITLE
chore: Add BiDi serialization for RegExp and Date

### DIFF
--- a/packages/puppeteer-core/src/common/bidi/Serializer.ts
+++ b/packages/puppeteer-core/src/common/bidi/Serializer.ts
@@ -1,5 +1,5 @@
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import {debugError, isPlainObject} from '../util.js';
+import {debugError, isDate, isPlainObject, isRegExp} from '../util.js';
 
 /**
  * @internal
@@ -57,6 +57,19 @@ export class BidiSerializer {
       return {
         type: 'object',
         value: parsedObject,
+      };
+    } else if (isRegExp(arg)) {
+      return {
+        type: 'regexp',
+        value: {
+          pattern: arg.source,
+          flags: arg.flags,
+        },
+      };
+    } else if (isDate(arg)) {
+      return {
+        type: 'date',
+        value: arg.toISOString(),
       };
     }
 
@@ -152,6 +165,11 @@ export class BidiSerializer {
         }, new Map());
       case 'promise':
         return {};
+      case 'regexp':
+        return new RegExp(result.value.pattern, result.value.flags);
+      case 'date':
+        return new Date(result.value);
+
       case 'undefined':
         return undefined;
       case 'null':

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -169,6 +169,20 @@ export const isPlainObject = (obj: unknown): obj is Record<any, unknown> => {
 /**
  * @internal
  */
+export const isRegExp = (obj: unknown): obj is RegExp => {
+  return typeof obj === 'object' && obj?.constructor === RegExp;
+};
+
+/**
+ * @internal
+ */
+export const isDate = (obj: unknown): obj is Date => {
+  return typeof obj === 'object' && obj?.constructor === Date;
+};
+
+/**
+ * @internal
+ */
 export async function waitForEvent<T>(
   emitter: CommonEventEmitter,
   eventName: string | symbol,


### PR DESCRIPTION
These types are able to be parsed to and from BiDi, so added them so users can benefit. 
I do not think at this time that CDP supports them so omitted adding new test for them.