### PR TITLE
chore: Rename chrome-headless to new-headless

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-install": "npm run test --workspace @puppeteer-test/installation",
     "test-types": "tsd -t packages/puppeteer",
     "test:chrome:headful": "npm test -- --test-suite chrome-headful",
-    "test:chrome:headless-chrome": "npm test -- --test-suite chrome-new-headless",
+    "test:chrome:new-headless": "npm test -- --test-suite chrome-new-headless",
     "test:chrome:headless": "npm test -- --test-suite chrome-headless",
     "test:chrome:bidi": "npm test -- --test-suite chrome-bidi",
     "test:chrome": "run-s test:chrome:*",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -488,7 +488,7 @@
   {
     "testIdPattern": "[fixtures.spec] Fixtures dumpio option should work with pipe option",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "chrome-headless"],
+    "parameters": ["chrome", "new-headless"],
     "expectations": ["PASS", "FAIL"]
   },
   {
@@ -2864,7 +2864,7 @@
   {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should work in \"fromSurface: false\" mode",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "chrome-headless"],
+    "parameters": ["chrome", "new-headless"],
     "expectations": ["SKIP"]
   },
   {
@@ -3104,13 +3104,13 @@
   {
     "testIdPattern": "[network.spec] network \"after each\" hook for \"Same-origin set-cookie subresource\"",
     "platforms": ["win32"],
-    "parameters": ["chrome", "chrome-headless"],
+    "parameters": ["chrome", "new-headless"],
     "expectations": ["PASS", "FAIL"]
   },
   {
     "testIdPattern": "[network.spec] network \"after each\" hook for \"Same-origin set-cookie subresource\"",
     "platforms": ["win32"],
-    "parameters": ["chrome", "chrome-headless"],
+    "parameters": ["chrome", "new-headless"],
     "expectations": ["PASS", "FAIL"]
   },
   {
@@ -3122,7 +3122,7 @@
   {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should return base64",
     "platforms": ["linux"],
-    "parameters": ["chrome", "chrome-headless"],
+    "parameters": ["chrome", "new-headless"],
     "expectations": ["PASS", "FAIL"]
   },
   {
@@ -3146,7 +3146,7 @@
   {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should work",
     "platforms": ["linux"],
-    "parameters": ["chrome", "chrome-headless"],
+    "parameters": ["chrome", "new-headless"],
     "expectations": ["PASS", "FAIL"]
   },
   {

--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -15,7 +15,7 @@
     {
       "id": "chrome-new-headless",
       "platforms": ["linux"],
-      "parameters": ["chrome", "chrome-headless"],
+      "parameters": ["chrome", "new-headless"],
       "expectedLineCoverage": 93
     },
     {
@@ -56,7 +56,7 @@
     "headful": {
       "HEADLESS": "false"
     },
-    "chrome-headless": {
+    "new-headless": {
       "HEADLESS": "new"
     },
     "webDriverBiDi": {


### PR DESCRIPTION
Back in #9364 we updated `chrome-headless` to `new-headless` which was required rename.
We never propagated the change to the `TestExpectaion.json` and `TestSuit.json` fully this PR aligns both places and the script in `package.json`. 
