### PR TITLE
chore: Update comment after confirming issue

### DIFF
--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -121,6 +121,22 @@ jobs:
               repo: context.repo.repo,
               labels: ["confirmed"]
             })
+      - name: Find Comment Id
+        uses: peter-evans/find-comment@v2
+        id: find-comment-id
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: 'github-actions[bot]'
+      - name: Upsert comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.find-comment-id.outputs.comment-id }}
+          issue-number: ${{ github.event.issue.number }}
+          edit-mode: replace
+          body: |
+            You bug has been successfully **confirmed** :rocket:.
+
+            A Puppeteer maintainer will take a closer look and assist you with you problem!
 
   label-invalid-issue:
     needs: [analyze-issue]

--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -134,9 +134,8 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           edit-mode: replace
           body: |
-            You bug has been successfully **confirmed** :rocket:.
-
-            A Puppeteer maintainer will take a closer look and assist you with you problem!
+            The issue has been labeled as **confirmed** by the automatic analyser.
+            Someone from the Puppeteer team will take a look soon!
 
   label-invalid-issue:
     needs: [analyze-issue]


### PR DESCRIPTION
Update the Issue Analyzer comment after successfully confirming the issue.

Currently the Issue Analyzer just leaves the problem message when confirming an bug. 
This does not look good in my opinion. 