### PR TITLE
docs: update screenshot type formats

### DIFF
--- a/docs/api/puppeteer.page.screenshot.md
+++ b/docs/api/puppeteer.page.screenshot.md
@@ -34,7 +34,7 @@ Options object which might have the following properties:
 
 - `path` : The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the image won't be saved to the disk.
 
-- `type` : Specify screenshot type, can be either `jpeg` or `png`. Defaults to 'png'.
+- `type` : Specify screenshot type, can be either `jpeg`, `png` or `webp`. Defaults to 'png'.
 
 - `quality` : The quality of the image, between 0-100. Not applicable to `png` images.
 


### PR DESCRIPTION
Puppeteer supports `webp` format:
https://github.com/puppeteer/puppeteer/blob/b8ea891ab86cb5d21c173ed9cc72f6dd2a6e28d6/packages/puppeteer-core/src/api/Page.ts#L152