### PR TITLE
feat(chromium): roll to Chromium 111.0.5556.0 (r1095492)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3037,9 +3037,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1082910",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww=="
+      "version": "0.0.1094867",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz",
+      "integrity": "sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ=="
     },
     "node_modules/diff": {
       "version": "5.1.0",
@@ -8751,7 +8751,7 @@
         "chromium-bidi": "0.4.3",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
+        "devtools-protocol": "0.0.1094867",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
@@ -11330,9 +11330,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.1082910",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww=="
+      "version": "0.0.1094867",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz",
+      "integrity": "sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ=="
     },
     "diff": {
       "version": "5.1.0",
@@ -14180,7 +14180,7 @@
         "chromium-bidi": "0.4.3",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
+        "devtools-protocol": "0.0.1094867",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -175,7 +175,7 @@
     "chromium-bidi": "0.4.3",
     "cross-fetch": "3.1.5",
     "debug": "4.3.4",
-    "devtools-protocol": "0.0.1082910",
+    "devtools-protocol": "0.0.1094867",
     "extract-zip": "2.0.1",
     "https-proxy-agent": "5.0.1",
     "proxy-from-env": "1.1.0",

--- a/packages/puppeteer-core/src/revisions.ts
+++ b/packages/puppeteer-core/src/revisions.ts
@@ -18,6 +18,6 @@
  * @internal
  */
 export const PUPPETEER_REVISIONS = Object.freeze({
-  chromium: '1083080',
+  chromium: '1095492',
   firefox: 'latest',
 });

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -6,10 +6,10 @@
     "expectations": ["SKIP"]
   },
   {
-    "testIdPattern": "[page.spec] Page BrowserContext.overridePermissions should trigger permission onchange",
+    "testIdPattern": "[navigation.spec] navigation Frame.goto should reject when frame detaches",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome"],
-    "expectations": ["FAIL"]
+    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[accessibility.spec]",

--- a/versions.js
+++ b/versions.js
@@ -17,6 +17,7 @@
 const versionsPerRelease = new Map([
   // This is a mapping from Chromium version => Puppeteer version.
   // In Chromium roll patches, use `NEXT` for the Puppeteer version.
+  ['111.0.5556.0', 'NEXT'],
   ['110.0.5479.0', 'v19.6.0'],
   ['109.0.5412.0', 'v19.4.0'],
   ['108.0.5351.0', 'v19.2.0'],
@@ -55,7 +56,7 @@ const versionsPerRelease = new Map([
 ]);
 
 // Should not be more than 2 major versions behind Chrome Stable (https://chromestatus.com/roadmap).
-const lastMaintainedChromiumVersion = '107.0.5296.0';
+const lastMaintainedChromiumVersion = '108.0.5351.0';
 
 if (!versionsPerRelease.has(lastMaintainedChromiumVersion)) {
   throw new Error(


### PR DESCRIPTION
New version fixes one bug related to permissions but brings in another issue: the error for navigating a detaching frame is now different. I think it should not block the roll though.