### PR TITLE
chore(docs): Fix extensions guide

### DIFF
--- a/docs/guides/chrome-extensions.md
+++ b/docs/guides/chrome-extensions.md
@@ -20,7 +20,7 @@ import path from 'path';
 (async () => {
   const pathToExtension = path.join(process.cwd(), 'my-extension');
   const browser = await puppeteer.launch({
-    headless: 'chrome',
+    headless: 'new',
     args: [
       `--disable-extensions-except=${pathToExtension}`,
       `--load-extension=${pathToExtension}`,


### PR DESCRIPTION
Closes #9653

Update to Chromium 109.0.5412.0 (#9364) changed parameters from `--headless=chrome` to `--headless=new`.
This change updates the reference in docs. 