### PR TITLE
refactor: custom query handlers and global bindings

### DIFF
--- a/packages/puppeteer-core/src/common/Binding.ts
+++ b/packages/puppeteer-core/src/common/Binding.ts
@@ -6,16 +6,19 @@ import {debugError} from './util.js';
 /**
  * @internal
  */
-export class Binding {
+export class Binding<Params extends unknown[] = any[]> {
   #name: string;
-  #fn: (...args: unknown[]) => unknown;
-  constructor(name: string, fn: (...args: unknown[]) => unknown) {
+  #fn: (...args: Params) => unknown;
+  constructor(name: string, fn: (...args: Params) => unknown) {
     this.#name = name;
     this.#fn = fn;
   }
 
+  get name(): string {
+    return this.#name;
+  }
+
   /**
-   *
    * @param context - Context to run the binding in; the context should have
    * the binding added to it beforehand.
    * @param id - ID of the call. This should come from the CDP
@@ -25,7 +28,7 @@ export class Binding {
   async run(
     context: ExecutionContext,
     id: number,
-    args: unknown[],
+    args: Params,
     isTrivial: boolean
   ): Promise<void> {
     const garbage = [];

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -176,9 +176,9 @@ export class CDPElementHandle<
   override async $<Selector extends string>(
     selector: Selector
   ): Promise<CDPElementHandle<NodeFor<Selector>> | null> {
-    const {updatedSelector, queryHandler} =
+    const {updatedSelector, QueryHandler} =
       getQueryHandlerAndSelector(selector);
-    return (await queryHandler.queryOne(
+    return (await QueryHandler.queryOne(
       this,
       updatedSelector
     )) as CDPElementHandle<NodeFor<Selector>> | null;
@@ -187,10 +187,10 @@ export class CDPElementHandle<
   override async $$<Selector extends string>(
     selector: Selector
   ): Promise<Array<CDPElementHandle<NodeFor<Selector>>>> {
-    const {updatedSelector, queryHandler} =
+    const {updatedSelector, QueryHandler} =
       getQueryHandlerAndSelector(selector);
     return IterableUtil.collect(
-      queryHandler.queryAll(this, updatedSelector)
+      QueryHandler.queryAll(this, updatedSelector)
     ) as Promise<Array<CDPElementHandle<NodeFor<Selector>>>>;
   }
 
@@ -256,9 +256,9 @@ export class CDPElementHandle<
     selector: Selector,
     options: WaitForSelectorOptions = {}
   ): Promise<CDPElementHandle<NodeFor<Selector>> | null> {
-    const {updatedSelector, queryHandler} =
+    const {updatedSelector, QueryHandler} =
       getQueryHandlerAndSelector(selector);
-    return (await queryHandler.waitFor(
+    return (await QueryHandler.waitFor(
       this,
       updatedSelector,
       options

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -617,9 +617,9 @@ export class Frame {
     selector: Selector,
     options: WaitForSelectorOptions = {}
   ): Promise<ElementHandle<NodeFor<Selector>> | null> {
-    const {updatedSelector, queryHandler} =
+    const {updatedSelector, QueryHandler} =
       getQueryHandlerAndSelector(selector);
-    return (await queryHandler.waitFor(
+    return (await QueryHandler.waitFor(
       this,
       updatedSelector,
       options

--- a/packages/puppeteer-core/src/common/GetQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/GetQueryHandler.ts
@@ -48,21 +48,23 @@ export function getQueryHandlerByName(
  */
 export function getQueryHandlerAndSelector(selector: string): {
   updatedSelector: string;
-  queryHandler: typeof QueryHandler;
+  QueryHandler: typeof QueryHandler;
 } {
   for (const handlerMap of [
-    customQueryHandlers,
+    customQueryHandlers.names().map(name => {
+      return [name, customQueryHandlers.get(name)!] as const;
+    }),
     Object.entries(BUILTIN_QUERY_HANDLERS),
   ]) {
-    for (const [name, queryHandler] of handlerMap) {
+    for (const [name, QueryHandler] of handlerMap) {
       for (const separator of QUERY_SEPARATORS) {
         const prefix = `${name}${separator}`;
         if (selector.startsWith(prefix)) {
           selector = selector.slice(prefix.length);
-          return {updatedSelector: selector, queryHandler};
+          return {updatedSelector: selector, QueryHandler};
         }
       }
     }
   }
-  return {updatedSelector: selector, queryHandler: CSSQueryHandler};
+  return {updatedSelector: selector, QueryHandler: CSSQueryHandler};
 }

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -41,6 +41,7 @@ import {TaskManager, WaitTask} from './WaitTask.js';
 import type {ElementHandle} from '../api/ElementHandle.js';
 import {Binding} from './Binding.js';
 import {LazyArg} from './LazyArg.js';
+import {stringifyFunction} from '../util/Function.js';
 
 /**
  * @public
@@ -455,7 +456,7 @@ export class IsolatedWorld {
         LazyArg.create(context => {
           return context.puppeteerUtil;
         }),
-        queryOne.toString(),
+        stringifyFunction(queryOne as (...args: unknown[]) => unknown),
         selector,
         root,
         waitForVisible ? true : waitForHidden ? false : undefined

--- a/packages/puppeteer-core/src/common/Puppeteer.ts
+++ b/packages/puppeteer-core/src/common/Puppeteer.ts
@@ -20,13 +20,7 @@ import {
   _connectToCDPBrowser,
 } from './BrowserConnector.js';
 import {ConnectionTransport} from './ConnectionTransport.js';
-import {
-  clearCustomQueryHandlers,
-  CustomQueryHandler,
-  customQueryHandlerNames,
-  registerCustomQueryHandler,
-  unregisterCustomQueryHandler,
-} from './CustomQueryHandler.js';
+import {CustomQueryHandler, customQueryHandlers} from './CustomQueryHandler.js';
 
 /**
  * Settings that are common to the Puppeteer class, regardless of environment.
@@ -58,9 +52,18 @@ export interface ConnectOptions extends BrowserConnectOptions {
  * instance of {@link PuppeteerNode} when you import or require `puppeteer`.
  * That class extends `Puppeteer`, so has all the methods documented below as
  * well as all that are defined on {@link PuppeteerNode}.
+ *
  * @public
  */
 export class Puppeteer {
+  /**
+   * Operations for {@link CustomQueryHandler | custom query handlers}. See
+   * {@link CustomQueryHandlerRegistry}.
+   *
+   * @internal
+   */
+  static customQueryHandlers = customQueryHandlers;
+
   /**
    * Registers a {@link CustomQueryHandler | custom query handler}.
    *
@@ -87,28 +90,28 @@ export class Puppeteer {
     name: string,
     queryHandler: CustomQueryHandler
   ): void {
-    return registerCustomQueryHandler(name, queryHandler);
+    return this.customQueryHandlers.register(name, queryHandler);
   }
 
   /**
    * Unregisters a custom query handler for a given name.
    */
   static unregisterCustomQueryHandler(name: string): void {
-    return unregisterCustomQueryHandler(name);
+    return this.customQueryHandlers.unregister(name);
   }
 
   /**
    * Gets the names of all custom query handlers.
    */
   static customQueryHandlerNames(): string[] {
-    return customQueryHandlerNames();
+    return this.customQueryHandlers.names();
   }
 
   /**
    * Unregisters all custom query handlers.
    */
   static clearCustomQueryHandlers(): void {
-    return clearCustomQueryHandlers();
+    return this.customQueryHandlers.clear();
   }
 
   /**

--- a/packages/puppeteer-core/src/common/ScriptInjector.ts
+++ b/packages/puppeteer-core/src/common/ScriptInjector.ts
@@ -1,0 +1,49 @@
+import {source as injectedSource} from '../generated/injected.js';
+
+class ScriptInjector {
+  #updated = false;
+  #amendments = new Set<string>();
+
+  // Appends a statement of the form `(PuppeteerUtil) => {...}`.
+  append(statement: string): void {
+    this.#update(() => {
+      this.#amendments.add(statement);
+    });
+  }
+
+  pop(statement: string): void {
+    this.#update(() => {
+      this.#amendments.delete(statement);
+    });
+  }
+
+  inject(inject: (script: string) => void, force = false) {
+    if (this.#updated || force) {
+      inject(this.#get());
+    }
+    this.#updated = false;
+  }
+
+  #update(callback: () => void): void {
+    callback();
+    this.#updated = true;
+  }
+
+  #get(): string {
+    return `(() => {
+      const module = {};
+      ${injectedSource}
+      ${[...this.#amendments]
+        .map(statement => {
+          return `(${statement})(module.exports.default);`;
+        })
+        .join('')}
+      return module.exports.default;
+    })()`;
+  }
+}
+
+/**
+ * @internal
+ */
+export const scriptInjector = new ScriptInjector();

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -18,6 +18,7 @@ import {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 import type {Poller} from '../injected/Poller.js';
 import {createDeferredPromise} from '../util/DeferredPromise.js';
+import {stringifyFunction} from '../util/Function.js';
 import {Binding} from './Binding.js';
 import {TimeoutError} from './Errors.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
@@ -68,7 +69,7 @@ export class WaitTask<T = unknown> {
         this.#fn = `() => {return (${fn});}`;
         break;
       default:
-        this.#fn = fn.toString();
+        this.#fn = stringifyFunction(fn);
         break;
     }
     this.#args = args;

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -17,10 +17,11 @@
 import {Page as PageBase} from '../../api/Page.js';
 import {Connection} from './Connection.js';
 import type {EvaluateFunc, HandleFor} from '../types.js';
-import {isString, stringifyFunction} from '../util.js';
+import {isString} from '../util.js';
 import {BidiSerializer} from './Serializer.js';
 import {JSHandle} from './JSHandle.js';
 import {Reference} from './types.js';
+import {stringifyFunction} from '../../util/Function.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -438,29 +438,3 @@ export async function getReadableFromProtocolStream(
     },
   });
 }
-
-/**
- * @internal
- */
-export function stringifyFunction(expression: Function): string {
-  let functionText = expression.toString();
-  try {
-    new Function('(' + functionText + ')');
-  } catch (error) {
-    // This means we might have a function shorthand. Try another
-    // time prefixing 'function '.
-    if (functionText.startsWith('async ')) {
-      functionText =
-        'async function ' + functionText.substring('async '.length);
-    } else {
-      functionText = 'function ' + functionText;
-    }
-    try {
-      new Function('(' + functionText + ')');
-    } catch (error) {
-      // We tried hard to serialize, but there's a weird beast here.
-      throw new Error('Passed function is not well-serializable!');
-    }
-  }
-  return functionText;
-}

--- a/packages/puppeteer-core/src/injected/ARIAQuerySelector.ts
+++ b/packages/puppeteer-core/src/injected/ARIAQuerySelector.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  interface Window {
+    /**
+     * @internal
+     */
+    __ariaQuerySelector(root: Node, selector: string): Promise<Element | null>;
+  }
+}
+
+export const ariaQuerySelector = (
+  root: Node,
+  selector: string
+): Promise<Element | null> => {
+  return window.__ariaQuerySelector(root, selector);
+};

--- a/packages/puppeteer-core/src/injected/CustomQuerySelector.ts
+++ b/packages/puppeteer-core/src/injected/CustomQuerySelector.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {CustomQueryHandler} from '../common/CustomQueryHandler.js';
+
+export interface CustomQuerySelector {
+  querySelector(root: Node, selector: string): Node | null;
+  querySelectorAll(root: Node, selector: string): Iterable<Node>;
+}
+
+/**
+ * This class mimics the injected {@link CustomQuerySelectorRegistry}.
+ */
+class CustomQuerySelectorRegistry {
+  #selectors = new Map<string, CustomQuerySelector>();
+
+  register(name: string, handler: CustomQueryHandler): void {
+    if (!handler.queryOne && handler.queryAll) {
+      const querySelectorAll = handler.queryAll;
+      handler.queryOne = (node, selector) => {
+        for (const result of querySelectorAll(node, selector)) {
+          return result;
+        }
+        return null;
+      };
+    } else if (handler.queryOne && !handler.queryAll) {
+      const querySelector = handler.queryOne;
+      handler.queryAll = (node, selector) => {
+        const result = querySelector(node, selector);
+        return result ? [result] : [];
+      };
+    } else if (!handler.queryOne || !handler.queryAll) {
+      throw new Error('At least one query method must be defined.');
+    }
+
+    this.#selectors.set(name, {
+      querySelector: handler.queryOne,
+      querySelectorAll: handler.queryAll!,
+    });
+  }
+
+  unregister(name: string): void {
+    this.#selectors.delete(name);
+  }
+
+  get(name: string): CustomQuerySelector | undefined {
+    return this.#selectors.get(name);
+  }
+
+  clear() {
+    this.#selectors.clear();
+  }
+}
+
+export const customQuerySelectors = new CustomQuerySelectorRegistry();

--- a/packages/puppeteer-core/src/injected/injected.ts
+++ b/packages/puppeteer-core/src/injected/injected.ts
@@ -16,26 +16,30 @@
 
 import {createDeferredPromise} from '../util/DeferredPromise.js';
 import {createFunction} from '../util/Function.js';
-import {RAFPoller, MutationPoller, IntervalPoller} from './Poller.js';
+import * as ARIAQuerySelector from './ARIAQuerySelector.js';
+import * as CustomQuerySelectors from './CustomQuerySelector.js';
+import * as PierceQuerySelector from './PierceQuerySelector.js';
+import {IntervalPoller, MutationPoller, RAFPoller} from './Poller.js';
 import {
-  isSuitableNodeForTextMatching,
   createTextContent,
+  isSuitableNodeForTextMatching,
 } from './TextContent.js';
 import * as TextQuerySelector from './TextQuerySelector.js';
-import * as XPathQuerySelector from './XPathQuerySelector.js';
-import * as PierceQuerySelector from './PierceQuerySelector.js';
 import * as util from './util.js';
+import * as XPathQuerySelector from './XPathQuerySelector.js';
 
 /**
  * @internal
  */
 const PuppeteerUtil = Object.freeze({
-  ...util,
-  ...TextQuerySelector,
-  ...XPathQuerySelector,
+  ...ARIAQuerySelector,
+  ...CustomQuerySelectors,
   ...PierceQuerySelector,
-  createFunction,
+  ...TextQuerySelector,
+  ...util,
+  ...XPathQuerySelector,
   createDeferredPromise,
+  createFunction,
   createTextContent,
   IntervalPoller,
   isSuitableNodeForTextMatching,

--- a/packages/puppeteer-core/src/util/Function.ts
+++ b/packages/puppeteer-core/src/util/Function.ts
@@ -33,3 +33,66 @@ export const createFunction = (
   createdFunctions.set(functionValue, fn);
   return fn;
 };
+
+/**
+ * @internal
+ */
+export function stringifyFunction(fn: (...args: never) => unknown): string {
+  let value = fn.toString();
+  try {
+    new Function(`(${value})`);
+  } catch {
+    // This means we might have a function shorthand (e.g. `test(){}`). Let's
+    // try prefixing.
+    let prefix = 'function ';
+    if (value.startsWith('async ')) {
+      prefix = `async ${prefix}`;
+      value = value.substring('async '.length);
+    }
+    value = `${prefix}${value}`;
+    try {
+      new Function(`(${value})`);
+    } catch {
+      // We tried hard to serialize, but there's a weird beast here.
+      throw new Error('Passed function cannot be serialized!');
+    }
+  }
+  return value;
+}
+
+/**
+ * Replaces `PLACEHOLDER`s with the given replacements.
+ *
+ * All replacements must be valid JS code.
+ *
+ * @example
+ *
+ * ```ts
+ * interpolateFunction(() => PLACEHOLDER('test'), {test: 'void 0'});
+ * // Equivalent to () => void 0
+ * ```
+ *
+ * @internal
+ */
+export const interpolateFunction = <T extends (...args: never[]) => unknown>(
+  fn: T,
+  replacements: Record<string, string>
+): T => {
+  let value = stringifyFunction(fn);
+  for (const [name, jsValue] of Object.entries(replacements)) {
+    value = value.replace(
+      new RegExp(`PLACEHOLDER\\(\\s*(?:'${name}'|"${name}")\\s*\\)`, 'g'),
+      jsValue
+    );
+  }
+  return createFunction(value) as unknown as T;
+};
+
+declare global {
+  /**
+   * Used for interpolation with {@link interpolateFunction}.
+   *
+   * @internal
+   */
+  function PLACEHOLDER<T>(name: string): T;
+}

--- a/test/src/elementhandle.spec.ts
+++ b/test/src/elementhandle.spec.ts
@@ -702,6 +702,27 @@ describe('ElementHandle specs', function () {
       });
       expect(txtContents).toBe('textcontent');
     });
+
+    it('should work with function shorthands', async () => {
+      const {page} = getTestState();
+      await page.setContent('<div id="not-foo"></div><div id="foo"></div>');
+
+      Puppeteer.registerCustomQueryHandler('getById', {
+        // This is a function shorthand
+        queryOne(_element, selector) {
+          return document.querySelector(`[id="${selector}"]`);
+        },
+      });
+
+      const element = (await page.$(
+        'getById/foo'
+      )) as ElementHandle<HTMLDivElement>;
+      expect(
+        await page.evaluate(element => {
+          return element.id;
+        }, element)
+      ).toBe('foo');
+    });
   });
 
   describe('Element.toElement', () => {


### PR DESCRIPTION
This PR refactors the custom query handling API and the global bindings API.

## Background

While implementing `P` queries (https://github.com/puppeteer/puppeteer/pull/9639) on the client-side, there were two problems:

 1. ARIA selector bindings must always be installed.
 2. Custom query selectors must somehow be available within the page.

## What's changed?

In order to facilitate (1), we will install the ARIA selector binding whenever the PuppeteerUtil is used. This is safe since the binding will only exist within Puppeteer's isolated world. This also obsoletes a lot of code (not removed in this PR for brevity) related to `WaitTask` bindings that will require refactoring after this PR.

For (2), this PR now allows restricted modifications of the Puppeteer utilities script at runtime through the `ScriptInjector`. This lets us install custom query selectors into the page through the `PuppeteerUtil.customQuerySelectors` registry.