### PR TITLE
chore: add ES lint rule `import/order`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,6 +110,14 @@ module.exports = {
     ],
     'import/extensions': ['error', 'ignorePackages'],
 
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: {order: 'asc', caseInsensitive: true},
+      },
+    ],
+
     'no-restricted-syntax': [
       'error',
       // Don't allow underscored declarations on camelCased variables/properties.

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import yargs from 'yargs';
 import ProgressBar from 'progress';
+import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
+
 import {Browser, BrowserPlatform} from './browsers/types.js';
 import {fetch} from './fetch.js';
 

--- a/packages/browsers/src/CacheStructure.ts
+++ b/packages/browsers/src/CacheStructure.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {Browser, BrowserPlatform} from './browsers/types.js';
 import path from 'path';
+
+import {Browser, BrowserPlatform} from './browsers/types.js';
 
 /**
  * The cache used by Puppeteer relies on the following structure:

--- a/packages/browsers/src/browsers/chrome.ts
+++ b/packages/browsers/src/browsers/chrome.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {BrowserPlatform} from './types.js';
 import path from 'path';
+
+import {BrowserPlatform} from './types.js';
 
 function archive(platform: BrowserPlatform, revision: string): string {
   switch (platform) {

--- a/packages/browsers/src/browsers/firefox.ts
+++ b/packages/browsers/src/browsers/firefox.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {BrowserPlatform} from './types.js';
 import path from 'path';
+
+import {BrowserPlatform} from './types.js';
 
 function archive(platform: BrowserPlatform, revision: string): string {
   switch (platform) {

--- a/packages/browsers/src/detectPlatform.ts
+++ b/packages/browsers/src/detectPlatform.ts
@@ -15,6 +15,7 @@
  */
 
 import os from 'os';
+
 import {BrowserPlatform} from './browsers/browsers.js';
 
 export function detectBrowserPlatform(): BrowserPlatform | undefined {

--- a/packages/browsers/src/fetch.ts
+++ b/packages/browsers/src/fetch.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
+import assert from 'assert';
 import {existsSync} from 'fs';
 import {mkdir, unlink} from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
-import {debug} from './debug.js';
 import {Browser, BrowserPlatform, downloadUrls} from './browsers/browsers.js';
-import {downloadFile, headHttpRequest} from './httpUtil.js';
-import assert from 'assert';
-import {unpackArchive} from './fileUtil.js';
-import {detectBrowserPlatform} from './detectPlatform.js';
 import {CacheStructure} from './CacheStructure.js';
+import {debug} from './debug.js';
+import {detectBrowserPlatform} from './detectPlatform.js';
+import {unpackArchive} from './fileUtil.js';
+import {downloadFile, headHttpRequest} from './httpUtil.js';
 
 const debugFetch = debug('puppeteer:browsers:fetcher');
 

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import * as path from 'path';
 import {exec as execChildProcess} from 'child_process';
-import extractZip from 'extract-zip';
 import {createReadStream} from 'fs';
 import {mkdir, readdir} from 'fs/promises';
+import * as path from 'path';
+import {promisify} from 'util';
+
+import extractZip from 'extract-zip';
 import tar from 'tar-fs';
 import bzip from 'unbzip2-stream';
-import {promisify} from 'util';
 
 const exec = promisify(execChildProcess);
 

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import {createWriteStream} from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 import {URL} from 'url';
+
 import createHttpsProxyAgent from 'https-proxy-agent';
 import {getProxyForUrl} from 'proxy-from-env';
-import {createWriteStream} from 'fs';
 
 export function headHttpRequest(url: URL): Promise<boolean> {
   return new Promise(resolve => {

--- a/packages/browsers/src/launcher.ts
+++ b/packages/browsers/src/launcher.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
+import os from 'os';
+import path from 'path';
+
 import {
   Browser,
   BrowserPlatform,
   executablePathByBrowser,
 } from './browsers/browsers.js';
-import {detectBrowserPlatform} from './detectPlatform.js';
-import os from 'os';
-import path from 'path';
 import {CacheStructure} from './CacheStructure.js';
+import {detectBrowserPlatform} from './detectPlatform.js';
 
 /**
  * @public

--- a/packages/browsers/test/src/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome-data.spec.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import assert from 'assert';
+import path from 'path';
+
+import {BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
 import {
   resolveDownloadUrl,
   relativeExecutablePath,
 } from '../../lib/cjs/browsers/chrome.js';
-import {BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
-import assert from 'assert';
-import path from 'path';
 
 describe('Chrome', () => {
   it('should resolve download URLs', () => {

--- a/packages/browsers/test/src/cli.spec.ts
+++ b/packages/browsers/test/src/cli.spec.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import {CLI} from '../../lib/cjs/CLI.js';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
 import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {CLI} from '../../lib/cjs/CLI.js';
 
 describe('CLI', function () {
   this.timeout(60000);

--- a/packages/browsers/test/src/fetch.spec.ts
+++ b/packages/browsers/test/src/fetch.spec.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {fetch, canFetch} from '../../lib/cjs/fetch.js';
-import {Browser, BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
-
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
 import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {Browser, BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
+import {fetch, canFetch} from '../../lib/cjs/fetch.js';
 
 /**
  * Tests in this spec use real download URLs and unpack live browser archives

--- a/packages/browsers/test/src/firefox-data.spec.ts
+++ b/packages/browsers/test/src/firefox-data.spec.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import assert from 'assert';
+import path from 'path';
+
+import {BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
 import {
   relativeExecutablePath,
   resolveDownloadUrl,
 } from '../../lib/cjs/browsers/firefox.js';
-import {BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
-import assert from 'assert';
-import path from 'path';
 
 describe('Firefox', () => {
   it('should resolve download URLs', () => {

--- a/packages/browsers/test/src/launcher.spec.ts
+++ b/packages/browsers/test/src/launcher.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {computeExecutablePath} from '../../lib/cjs/launcher.js';
-import {Browser, BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
-
 import assert from 'assert';
 import path from 'path';
+
+import {Browser, BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
+import {computeExecutablePath} from '../../lib/cjs/launcher.js';
 
 describe('launcher', () => {
   it('should compute executable path for Chrome', () => {

--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -1,3 +1,5 @@
+import {spawn} from 'child_process';
+
 import {
   createBuilder,
   BuilderContext,
@@ -6,7 +8,6 @@ import {
   BuilderRun,
 } from '@angular-devkit/architect';
 import {JsonObject} from '@angular-devkit/core';
-import {spawn} from 'child_process';
 
 import {PuppeteerBuilderOptions} from './types.js';
 

--- a/packages/ng-schematics/src/schematics/ng-add/index.ts
+++ b/packages/ng-schematics/src/schematics/ng-add/index.ts
@@ -16,14 +16,15 @@
 
 import {chain, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
-
-import {concatMap, map, scan} from 'rxjs/operators';
 import {of} from 'rxjs';
+import {concatMap, map, scan} from 'rxjs/operators';
+
 import {
   addBaseFiles,
   addFrameworkFiles,
   getNgCommandName,
 } from '../utils/files.js';
+import {getAngularConfig} from '../utils/json.js';
 import {
   addPackageJsonDependencies,
   addPackageJsonScripts,
@@ -33,9 +34,7 @@ import {
   type NodePackage,
   updateAngularJsonScripts,
 } from '../utils/packages.js';
-
 import {type SchematicsOptions} from '../utils/types.js';
-import {getAngularConfig} from '../utils/json.js';
 
 // You don't have to export the function as default. You can also have more than one rule
 // factory per file.

--- a/packages/ng-schematics/src/schematics/utils/files.ts
+++ b/packages/ng-schematics/src/schematics/utils/files.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {relative, resolve} from 'path';
+
 import {getSystemPath, normalize, strings} from '@angular-devkit/core';
 import {
   SchematicContext,
@@ -26,7 +28,7 @@ import {
   move,
   url,
 } from '@angular-devkit/schematics';
-import {relative, resolve} from 'path';
+
 import {SchematicsOptions, TestingFramework} from './types.js';
 
 export interface FilesOptions {

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import {Tree} from '@angular-devkit/schematics';
 import {get} from 'https';
-import {SchematicsOptions, TestingFramework} from './types.js';
+
+import {Tree} from '@angular-devkit/schematics';
+
+import {getNgCommandName, getScriptFromOptions} from './files.js';
 import {
   getAngularConfig,
   getJsonFileAsObject,
   getObjectAsJson,
 } from './json.js';
-import {getNgCommandName, getScriptFromOptions} from './files.js';
+import {SchematicsOptions, TestingFramework} from './types.js';
 export interface NodePackage {
   name: string;
   version: string;

--- a/packages/ng-schematics/test/src/index.spec.ts
+++ b/packages/ng-schematics/test/src/index.spec.ts
@@ -1,12 +1,13 @@
-import expect from 'expect';
-import sinon from 'sinon';
 import https from 'https';
 import {join} from 'path';
+
+import {JsonObject} from '@angular-devkit/core';
 import {
   SchematicTestRunner,
   UnitTestTree,
 } from '@angular-devkit/schematics/testing/schematic-test-runner';
-import {JsonObject} from '@angular-devkit/core';
+import expect from 'expect';
+import sinon from 'sinon';
 
 const WORKSPACE_OPTIONS = {
   name: 'workspace',

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -17,11 +17,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import {ChildProcess} from 'child_process';
+
 import {Protocol} from 'devtools-protocol';
+
 import {EventEmitter} from '../common/EventEmitter.js';
-import type {Page} from './Page.js'; // TODO: move to ./api
 import type {Target} from '../common/Target.js'; // TODO: move to ./api
+
 import type {BrowserContext} from './BrowserContext.js';
+import type {Page} from './Page.js'; // TODO: move to ./api
 
 /**
  * BrowserContext options.

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -15,9 +15,10 @@
  */
 
 import {EventEmitter} from '../common/EventEmitter.js';
-import {Page} from './Page.js';
 import {Target} from '../common/Target.js';
+
 import type {Permission, Browser} from './Browser.js';
+import {Page} from './Page.js';
 
 /**
  * BrowserContexts provide a way to operate multiple independent browser

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -15,6 +15,7 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {CDPSession} from '../common/Connection.js';
 import {ExecutionContext} from '../common/ExecutionContext.js';
 import {Frame} from '../common/Frame.js';
@@ -27,6 +28,7 @@ import {
   NodeFor,
 } from '../common/types.js';
 import {KeyInput} from '../common/USKeyboardLayout.js';
+
 import {JSHandle} from './JSHandle.js';
 import {ScreenshotOptions} from './Page.js';
 

--- a/packages/puppeteer-core/src/api/JSHandle.ts
+++ b/packages/puppeteer-core/src/api/JSHandle.ts
@@ -15,9 +15,11 @@
  */
 
 import Protocol from 'devtools-protocol';
+
 import {CDPSession} from '../common/Connection.js';
 import {ExecutionContext} from '../common/ExecutionContext.js';
 import {EvaluateFuncWith, HandleFor, HandleOr} from '../common/types.js';
+
 import {ElementHandle} from './ElementHandle.js';
 
 declare const __JSHandleSymbol: unique symbol;

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
 import type {Readable} from 'stream';
+
+import {Protocol} from 'devtools-protocol';
+
 import type {Accessibility} from '../common/Accessibility.js';
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
 import type {Coverage} from '../common/Coverage.js';
@@ -51,6 +53,7 @@ import type {
   NodeFor,
 } from '../common/types.js';
 import type {WebWorker} from '../common/WebWorker.js';
+
 import type {Browser} from './Browser.js';
 import type {BrowserContext} from './BrowserContext.js';
 import type {ElementHandle} from './ElementHandle.js';

--- a/packages/puppeteer-core/src/common/Accessibility.ts
+++ b/packages/puppeteer-core/src/common/Accessibility.ts
@@ -15,8 +15,10 @@
  */
 
 import {Protocol} from 'devtools-protocol';
-import {CDPSession} from './Connection.js';
+
 import {ElementHandle} from '../api/ElementHandle.js';
+
+import {CDPSession} from './Connection.js';
 
 /**
  * Represents a Node and the properties of it that are relevant to Accessibility.

--- a/packages/puppeteer-core/src/common/AriaQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/AriaQueryHandler.ts
@@ -19,6 +19,7 @@ import {Protocol} from 'devtools-protocol';
 import {ElementHandle} from '../api/ElementHandle.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
+
 import {CDPSession} from './Connection.js';
 import {QueryHandler, QuerySelector} from './QueryHandler.js';
 import {AwaitableIterable} from './types.js';

--- a/packages/puppeteer-core/src/common/Binding.ts
+++ b/packages/puppeteer-core/src/common/Binding.ts
@@ -1,5 +1,6 @@
 import {JSHandle} from '../api/JSHandle.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import {ExecutionContext} from './ExecutionContext.js';
 import {debugError} from './util.js';
 

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -15,17 +15,9 @@
  */
 
 import {ChildProcess} from 'child_process';
+
 import {Protocol} from 'devtools-protocol';
-import {assert} from '../util/assert.js';
-import {CDPSession, Connection, ConnectionEmittedEvents} from './Connection.js';
-import {waitWithTimeout} from './util.js';
-import {Page} from '../api/Page.js';
-import {Viewport} from './PuppeteerViewport.js';
-import {Target} from './Target.js';
-import {TaskQueue} from './TaskQueue.js';
-import {TargetManager, TargetManagerEmittedEvents} from './TargetManager.js';
-import {ChromeTargetManager} from './ChromeTargetManager.js';
-import {FirefoxTargetManager} from './FirefoxTargetManager.js';
+
 import {
   Browser as BrowserBase,
   BrowserCloseCallback,
@@ -39,6 +31,17 @@ import {
   Permission,
 } from '../api/Browser.js';
 import {BrowserContext} from '../api/BrowserContext.js';
+import {Page} from '../api/Page.js';
+import {assert} from '../util/assert.js';
+
+import {ChromeTargetManager} from './ChromeTargetManager.js';
+import {CDPSession, Connection, ConnectionEmittedEvents} from './Connection.js';
+import {FirefoxTargetManager} from './FirefoxTargetManager.js';
+import {Viewport} from './PuppeteerViewport.js';
+import {Target} from './Target.js';
+import {TargetManager, TargetManagerEmittedEvents} from './TargetManager.js';
+import {TaskQueue} from './TaskQueue.js';
+import {waitWithTimeout} from './util.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import {debugError} from './util.js';
-import {isErrorLike} from '../util/ErrorLike.js';
+import {IsPageTargetCallback, TargetFilterCallback} from '../api/Browser.js';
 import {isNode} from '../environment.js';
 import {assert} from '../util/assert.js';
-import {IsPageTargetCallback, TargetFilterCallback} from '../api/Browser.js';
+import {isErrorLike} from '../util/ErrorLike.js';
+
 import {CDPBrowser} from './Browser.js';
 import {Connection} from './Connection.js';
 import {ConnectionTransport} from './ConnectionTransport.js';
 import {getFetch} from './fetch.js';
-import {Viewport} from './PuppeteerViewport.js';
-
 import type {ConnectOptions} from './Puppeteer.js';
+import {Viewport} from './PuppeteerViewport.js';
+import {debugError} from './util.js';
 /**
  * Generic browser options that can be passed when launching any browser or when
  * connecting to an existing browser instance.

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -15,18 +15,20 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
+import {TargetFilterCallback} from '../api/Browser.js';
 import {assert} from '../util/assert.js';
+
 import {CDPSession, Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {Target} from './Target.js';
-import {debugError} from './util.js';
-import {TargetFilterCallback} from '../api/Browser.js';
 import {
   TargetInterceptor,
   TargetFactory,
   TargetManager,
   TargetManagerEmittedEvents,
 } from './TargetManager.js';
+import {debugError} from './util.js';
 
 /**
  * ChromeTargetManager uses the CDP's auto-attach mechanism to intercept

--- a/packages/puppeteer-core/src/common/Connection.ts
+++ b/packages/puppeteer-core/src/common/Connection.ts
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/* eslint-disable import/order */
 import {assert} from '../util/assert.js';
+
 import {debug} from './Debug.js';
 const debugProtocolSend = debug('puppeteer:protocol:SEND ►');
 const debugProtocolReceive = debug('puppeteer:protocol:RECV ◀');
 
 import {Protocol} from 'devtools-protocol';
 import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+
 import {ConnectionTransport} from './ConnectionTransport.js';
-import {EventEmitter} from './EventEmitter.js';
 import {ProtocolError} from './Errors.js';
+import {EventEmitter} from './EventEmitter.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/Coverage.ts
+++ b/packages/puppeteer-core/src/common/Coverage.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import {assert} from '../util/assert.js';
-import {addEventListener, debugError, PuppeteerEventListener} from './util.js';
 import {Protocol} from 'devtools-protocol';
-import {CDPSession} from './Connection.js';
 
+import {assert} from '../util/assert.js';
+
+import {CDPSession} from './Connection.js';
 import {EVALUATION_SCRIPT_URL} from './ExecutionContext.js';
+import {addEventListener, debugError, PuppeteerEventListener} from './util.js';
 import {removeEventListeners} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/CustomQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/CustomQueryHandler.ts
@@ -17,6 +17,7 @@
 import type PuppeteerUtil from '../injected/injected.js';
 import {assert} from '../util/assert.js';
 import {interpolateFunction, stringifyFunction} from '../util/Function.js';
+
 import {QueryHandler, QuerySelector, QuerySelectorAll} from './QueryHandler.js';
 import {scriptInjector} from './ScriptInjector.js';
 

--- a/packages/puppeteer-core/src/common/Dialog.ts
+++ b/packages/puppeteer-core/src/common/Dialog.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import {assert} from '../util/assert.js';
-import {CDPSession} from './Connection.js';
 import {Protocol} from 'devtools-protocol';
+
+import {assert} from '../util/assert.js';
+
+import {CDPSession} from './Connection.js';
 
 /**
  * Dialog instances are dispatched by the {@link Page} via the `dialog` event.

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -15,6 +15,7 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {
   BoundingBox,
   BoxModel,
@@ -27,13 +28,15 @@ import {
 import {JSHandle} from '../api/JSHandle.js';
 import {Page, ScreenshotOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
+import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
+
 import {CDPSession} from './Connection.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {Frame} from './Frame.js';
 import {FrameManager} from './FrameManager.js';
 import {getQueryHandlerAndSelector} from './GetQueryHandler.js';
 import {WaitForSelectorOptions} from './IsolatedWorld.js';
-import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
+import {CDPJSHandle} from './JSHandle.js';
 import {CDPPage} from './Page.js';
 import {
   ElementFor,
@@ -44,7 +47,6 @@ import {
 } from './types.js';
 import {KeyInput} from './USKeyboardLayout.js';
 import {debugError, isString} from './util.js';
-import {CDPJSHandle} from './JSHandle.js';
 
 const applyOffsetsToQuad = (
   quad: Point[],

--- a/packages/puppeteer-core/src/common/EmulationManager.ts
+++ b/packages/puppeteer-core/src/common/EmulationManager.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Protocol} from 'devtools-protocol';
+
 import {CDPSession} from './Connection.js';
 import {Viewport} from './PuppeteerViewport.js';
-import {Protocol} from 'devtools-protocol';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/common/ExecutionContext.ts
@@ -15,15 +15,19 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import type {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 import type PuppeteerUtil from '../injected/injected.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {stringifyFunction} from '../util/Function.js';
+
 import {ARIAQueryHandler} from './AriaQueryHandler.js';
 import {Binding} from './Binding.js';
 import {CDPSession} from './Connection.js';
+import {CDPElementHandle} from './ElementHandle.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
+import {CDPJSHandle} from './JSHandle.js';
 import {LazyArg} from './LazyArg.js';
 import {scriptInjector} from './ScriptInjector.js';
 import {EvaluateFunc, HandleFor} from './types.js';
@@ -33,8 +37,6 @@ import {
   isString,
   valueFromRemoteObject,
 } from './util.js';
-import {CDPJSHandle} from './JSHandle.js';
-import {CDPElementHandle} from './ElementHandle.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/FileChooser.ts
+++ b/packages/puppeteer-core/src/common/FileChooser.ts
@@ -15,8 +15,9 @@
  */
 
 import {Protocol} from 'devtools-protocol';
-import {assert} from '../util/assert.js';
+
 import {ElementHandle} from '../api/ElementHandle.js';
+import {assert} from '../util/assert.js';
 
 /**
  * File choosers let you react to the page requesting for a file.

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -15,17 +15,19 @@
  */
 
 import {Protocol} from 'devtools-protocol';
-import {assert} from '../util/assert.js';
-import {CDPSession, Connection} from './Connection.js';
-import {Target} from './Target.js';
+
 import {TargetFilterCallback} from '../api/Browser.js';
+import {assert} from '../util/assert.js';
+
+import {CDPSession, Connection} from './Connection.js';
+import {EventEmitter} from './EventEmitter.js';
+import {Target} from './Target.js';
 import {
   TargetFactory,
   TargetInterceptor,
   TargetManagerEmittedEvents,
   TargetManager,
 } from './TargetManager.js';
-import {EventEmitter} from './EventEmitter.js';
 
 /**
  * FirefoxTargetManager implements target management using

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -15,9 +15,11 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {ElementHandle} from '../api/ElementHandle.js';
 import {Page} from '../api/Page.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import {CDPSession} from './Connection.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {FrameManager} from './FrameManager.js';

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -15,8 +15,11 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
+import {Page} from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import {CDPSession, isTargetClosedError} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {EVALUATION_SCRIPT_URL, ExecutionContext} from './ExecutionContext.js';
@@ -25,7 +28,6 @@ import {FrameTree} from './FrameTree.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import {NetworkManager} from './NetworkManager.js';
-import {Page} from '../api/Page.js';
 import {Target} from './Target.js';
 import {TimeoutSettings} from './TimeoutSettings.js';
 import {debugError} from './util.js';

--- a/packages/puppeteer-core/src/common/FrameTree.ts
+++ b/packages/puppeteer-core/src/common/FrameTree.ts
@@ -18,6 +18,7 @@ import {
   createDeferredPromise,
   DeferredPromise,
 } from '../util/DeferredPromise.js';
+
 import type {Frame} from './Frame.js';
 
 /**

--- a/packages/puppeteer-core/src/common/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/common/HTTPRequest.ts
@@ -15,12 +15,14 @@
  */
 import {Protocol} from 'devtools-protocol';
 import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+
 import {assert} from '../util/assert.js';
+
 import {ProtocolError} from './Errors.js';
 import {EventEmitter} from './EventEmitter.js';
 import {Frame} from './Frame.js';
-import {debugError, isString} from './util.js';
 import {HTTPResponse} from './HTTPResponse.js';
+import {debugError, isString} from './util.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/common/HTTPResponse.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Protocol} from 'devtools-protocol';
 import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
+import {ProtocolError} from './Errors.js';
 import {EventEmitter} from './EventEmitter.js';
 import {Frame} from './Frame.js';
 import {HTTPRequest} from './HTTPRequest.js';
 import {SecurityDetails} from './SecurityDetails.js';
-import {Protocol} from 'devtools-protocol';
-import {ProtocolError} from './Errors.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/HandleIterator.ts
+++ b/packages/puppeteer-core/src/common/HandleIterator.ts
@@ -15,6 +15,7 @@
  */
 
 import {JSHandle} from '../api/JSHandle.js';
+
 import {AwaitableIterable, HandleFor} from './types.js';
 
 const DEFAULT_BATCH_SIZE = 20;

--- a/packages/puppeteer-core/src/common/Input.ts
+++ b/packages/puppeteer-core/src/common/Input.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import {Protocol} from 'devtools-protocol';
+
+import {Point} from '../api/ElementHandle.js';
 import {assert} from '../util/assert.js';
+
 import {CDPSession} from './Connection.js';
 import {_keyDefinitions, KeyDefinition, KeyInput} from './USKeyboardLayout.js';
-import {Protocol} from 'devtools-protocol';
-import {Point} from '../api/ElementHandle.js';
 
 type KeyDescription = Required<
   Pick<KeyDefinition, 'keyCode' | 'key' | 'text' | 'code' | 'location'>

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -15,9 +15,13 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
+import type {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 import {assert} from '../util/assert.js';
 import {createDeferredPromise} from '../util/DeferredPromise.js';
+
+import {Binding} from './Binding.js';
 import {CDPSession} from './Connection.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {Frame} from './Frame.js';
@@ -36,9 +40,6 @@ import {
 } from './types.js';
 import {addPageBinding, createJSHandle, debugError} from './util.js';
 import {TaskManager, WaitTask} from './WaitTask.js';
-
-import type {ElementHandle} from '../api/ElementHandle.js';
-import {Binding} from './Binding.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/JSHandle.ts
+++ b/packages/puppeteer-core/src/common/JSHandle.ts
@@ -15,8 +15,10 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {JSHandle} from '../api/JSHandle.js';
 import {assert} from '../util/assert.js';
+
 import {CDPSession} from './Connection.js';
 import type {CDPElementHandle} from './ElementHandle.js';
 import {ExecutionContext} from './ExecutionContext.js';

--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -16,21 +16,22 @@
 
 import {assert} from '../util/assert.js';
 import {
+  DeferredPromise,
+  createDeferredPromise,
+} from '../util/DeferredPromise.js';
+
+import {CDPSessionEmittedEvents} from './Connection.js';
+import {TimeoutError} from './Errors.js';
+import {Frame} from './Frame.js';
+import {FrameManager, FrameManagerEmittedEvents} from './FrameManager.js';
+import {HTTPRequest} from './HTTPRequest.js';
+import {HTTPResponse} from './HTTPResponse.js';
+import {NetworkManagerEmittedEvents} from './NetworkManager.js';
+import {
   addEventListener,
   PuppeteerEventListener,
   removeEventListeners,
 } from './util.js';
-import {
-  DeferredPromise,
-  createDeferredPromise,
-} from '../util/DeferredPromise.js';
-import {TimeoutError} from './Errors.js';
-import {FrameManager, FrameManagerEmittedEvents} from './FrameManager.js';
-import {Frame} from './Frame.js';
-import {HTTPRequest} from './HTTPRequest.js';
-import {HTTPResponse} from './HTTPResponse.js';
-import {NetworkManagerEmittedEvents} from './NetworkManager.js';
-import {CDPSessionEmittedEvents} from './Connection.js';
 /**
  * @public
  */

--- a/packages/puppeteer-core/src/common/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkEventManager.ts
@@ -15,6 +15,7 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {HTTPRequest} from './HTTPRequest.js';
 
 /**

--- a/packages/puppeteer-core/src/common/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.ts
@@ -15,16 +15,18 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {assert} from '../util/assert.js';
+import {createDebuggableDeferredPromise} from '../util/DebuggableDeferredPromise.js';
+import {DeferredPromise} from '../util/DeferredPromise.js';
+
+import {CDPSession} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {Frame} from './Frame.js';
 import {HTTPRequest} from './HTTPRequest.js';
 import {HTTPResponse} from './HTTPResponse.js';
 import {FetchRequestId, NetworkEventManager} from './NetworkEventManager.js';
 import {debugError, isString} from './util.js';
-import {DeferredPromise} from '../util/DeferredPromise.js';
-import {createDebuggableDeferredPromise} from '../util/DebuggableDeferredPromise.js';
-import {CDPSession} from './Connection.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/NodeWebSocketTransport.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import NodeWebSocket from 'ws';
+
 import {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {packageVersion} from '../generated/version.js';
 

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
 import type {Readable} from 'stream';
+
+import {Protocol} from 'devtools-protocol';
+
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
 import {ElementHandle} from '../api/ElementHandle.js';
@@ -37,6 +39,7 @@ import {
   DeferredPromise,
 } from '../util/DeferredPromise.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import {Accessibility} from './Accessibility.js';
 import {Binding} from './Binding.js';
 import {

--- a/packages/puppeteer-core/src/common/PierceQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/PierceQueryHandler.ts
@@ -15,6 +15,7 @@
  */
 
 import type PuppeteerUtil from '../injected/injected.js';
+
 import {QueryHandler} from './QueryHandler.js';
 
 /**

--- a/packages/puppeteer-core/src/common/Puppeteer.ts
+++ b/packages/puppeteer-core/src/common/Puppeteer.ts
@@ -15,6 +15,7 @@
  */
 
 import {Browser} from '../api/Browser.js';
+
 import {
   BrowserConnectOptions,
   _connectToCDPBrowser,

--- a/packages/puppeteer-core/src/common/QueryHandler.ts
+++ b/packages/puppeteer-core/src/common/QueryHandler.ts
@@ -19,6 +19,7 @@ import type PuppeteerUtil from '../injected/injected.js';
 import {assert} from '../util/assert.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 import {interpolateFunction, stringifyFunction} from '../util/Function.js';
+
 import type {Frame} from './Frame.js';
 import {transposeIterableHandle} from './HandleIterator.js';
 import type {WaitForSelectorOptions} from './IsolatedWorld.js';

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-import {Page, PageEmittedEvents} from '../api/Page.js';
-import {WebWorker} from './WebWorker.js';
-import {CDPSession} from './Connection.js';
+import {Protocol} from 'devtools-protocol';
+
 import type {Browser, IsPageTargetCallback} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
-import {Viewport} from './PuppeteerViewport.js';
-import {Protocol} from 'devtools-protocol';
-import {TaskQueue} from './TaskQueue.js';
-import {TargetManager} from './TargetManager.js';
+import {Page, PageEmittedEvents} from '../api/Page.js';
+
+import {CDPSession} from './Connection.js';
 import {CDPPage} from './Page.js';
+import {Viewport} from './PuppeteerViewport.js';
+import {TargetManager} from './TargetManager.js';
+import {TaskQueue} from './TaskQueue.js';
+import {WebWorker} from './WebWorker.js';
 
 /**
  * Target represents a

--- a/packages/puppeteer-core/src/common/TargetManager.ts
+++ b/packages/puppeteer-core/src/common/TargetManager.ts
@@ -15,6 +15,7 @@
  */
 
 import {Protocol} from 'devtools-protocol';
+
 import {CDPSession} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {Target} from './Target.js';

--- a/packages/puppeteer-core/src/common/Tracing.ts
+++ b/packages/puppeteer-core/src/common/Tracing.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 import {assert} from '../util/assert.js';
-import {getReadableAsBuffer, getReadableFromProtocolStream} from './util.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import {CDPSession} from './Connection.js';
+import {getReadableAsBuffer, getReadableFromProtocolStream} from './util.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -19,6 +19,7 @@ import {JSHandle} from '../api/JSHandle.js';
 import type {Poller} from '../injected/Poller.js';
 import {createDeferredPromise} from '../util/DeferredPromise.js';
 import {stringifyFunction} from '../util/Function.js';
+
 import {TimeoutError} from './Errors.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {LazyArg} from './LazyArg.js';

--- a/packages/puppeteer-core/src/common/WebWorker.ts
+++ b/packages/puppeteer-core/src/common/WebWorker.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 import {Protocol} from 'devtools-protocol';
+
+import {JSHandle} from '../api/JSHandle.js';
+import {createDeferredPromise} from '../util/DeferredPromise.js';
+
 import {CDPSession} from './Connection.js';
 import {ConsoleMessageType} from './ConsoleMessage.js';
-import {EvaluateFunc, HandleFor} from './types.js';
 import {EventEmitter} from './EventEmitter.js';
 import {ExecutionContext} from './ExecutionContext.js';
-import {JSHandle} from '../api/JSHandle.js';
 import {CDPJSHandle} from './JSHandle.js';
+import {EvaluateFunc, HandleFor} from './types.js';
 import {debugError} from './util.js';
-import {createDeferredPromise} from '../util/DeferredPromise.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/BidiOverCDP.ts
+++ b/packages/puppeteer-core/src/common/bidi/BidiOverCDP.ts
@@ -1,9 +1,11 @@
-import {CDPSession, Connection as CDPPPtrConnection} from '../Connection.js';
-import {Connection as BidiPPtrConnection} from './Connection.js';
 import * as BidiMapper from 'chromium-bidi/lib/cjs/bidiMapper/bidiMapper.js';
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+
+import {CDPSession, Connection as CDPPPtrConnection} from '../Connection.js';
 import {Handler} from '../EventEmitter.js';
+
+import {Connection as BidiPPtrConnection} from './Connection.js';
 
 type CdpEvents = {
   [Property in keyof ProtocolMapping.Events]: ProtocolMapping.Events[Property][0];

--- a/packages/puppeteer-core/src/common/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/common/bidi/Browser.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import {ChildProcess} from 'child_process';
+
 import {
   Browser as BrowserBase,
   BrowserCloseCallback,
   BrowserContextOptions,
 } from '../../api/Browser.js';
 import {BrowserContext as BrowserContextBase} from '../../api/BrowserContext.js';
-import {Connection} from './Connection.js';
-import {ChildProcess} from 'child_process';
+
 import {BrowserContext} from './BrowserContext.js';
+import {Connection} from './Connection.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/common/bidi/BrowserContext.ts
@@ -16,6 +16,7 @@
 
 import {BrowserContext as BrowserContextBase} from '../../api/BrowserContext.js';
 import {Page as PageBase} from '../../api/Page.js';
+
 import {Connection} from './Connection.js';
 import {Page} from './Page.js';
 

--- a/packages/puppeteer-core/src/common/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/common/bidi/Connection.ts
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
+/* eslint-disable import/order */
 import {debug} from '../Debug.js';
 const debugProtocolSend = debug('puppeteer:webDriverBiDi:SEND ►');
 const debugProtocolReceive = debug('puppeteer:webDriverBiDi:RECV ◀');
 
 import {ConnectionTransport} from '../ConnectionTransport.js';
-import {EventEmitter} from '../EventEmitter.js';
 import {ProtocolError} from '../Errors.js';
+import {EventEmitter} from '../EventEmitter.js';
 import {ConnectionCallback} from '../Connection.js';
+
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 /**

--- a/packages/puppeteer-core/src/common/bidi/JSHandle.ts
+++ b/packages/puppeteer-core/src/common/bidi/JSHandle.ts
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import {ElementHandle} from '../../api/ElementHandle.js';
-import {EvaluateFuncWith, HandleFor, HandleOr} from '../../common/types.js';
-import {releaseReference} from './utils.js';
-import {Page} from './Page.js';
-import {JSHandle as BaseJSHandle} from '../../api/JSHandle.js';
-import {BidiSerializer} from './Serializer.js';
-import {Connection} from './Connection.js';
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+
+import {ElementHandle} from '../../api/ElementHandle.js';
+import {JSHandle as BaseJSHandle} from '../../api/JSHandle.js';
+import {EvaluateFuncWith, HandleFor, HandleOr} from '../../common/types.js';
+
+import {Connection} from './Connection.js';
+import {Page} from './Page.js';
+import {BidiSerializer} from './Serializer.js';
+import {releaseReference} from './utils.js';
 
 export class JSHandle<T = unknown> extends BaseJSHandle<T> {
   #disposed = false;

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -15,13 +15,14 @@
  */
 
 import {Page as PageBase} from '../../api/Page.js';
-import {Connection} from './Connection.js';
+import {stringifyFunction} from '../../util/Function.js';
 import type {EvaluateFunc, HandleFor} from '../types.js';
 import {isString} from '../util.js';
-import {BidiSerializer} from './Serializer.js';
+
+import {Connection} from './Connection.js';
 import {JSHandle} from './JSHandle.js';
+import {BidiSerializer} from './Serializer.js';
 import {Reference} from './types.js';
-import {stringifyFunction} from '../../util/Function.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/Serializer.ts
+++ b/packages/puppeteer-core/src/common/bidi/Serializer.ts
@@ -1,5 +1,7 @@
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+
 import {debugError, isDate, isPlainObject, isRegExp} from '../util.js';
+
 import {JSHandle} from './JSHandle.js';
 import {Page} from './Page.js';
 

--- a/packages/puppeteer-core/src/common/bidi/utils.ts
+++ b/packages/puppeteer-core/src/common/bidi/utils.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import {debug} from '../Debug.js';
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+
+import {debug} from '../Debug.js';
+
 import {Connection} from './Connection.js';
 
 /**

--- a/packages/puppeteer-core/src/common/types.ts
+++ b/packages/puppeteer-core/src/common/types.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import type {JSHandle} from '../api/JSHandle.js';
 import type {ElementHandle} from '../api/ElementHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
+
 import type {LazyArg} from './LazyArg.js';
 
 /**

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import type {Protocol} from 'devtools-protocol';
 import type {Readable} from 'stream';
+
+import type {Protocol} from 'devtools-protocol';
+
 import type {ElementHandle} from '../api/ElementHandle.js';
 import type {JSHandle} from '../api/JSHandle.js';
 import {isNode} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import type {CDPSession} from './Connection.js';
 import {debug} from './Debug.js';
 import {CDPElementHandle} from './ElementHandle.js';

--- a/packages/puppeteer-core/src/injected/PQuerySelector.ts
+++ b/packages/puppeteer-core/src/injected/PQuerySelector.ts
@@ -1,6 +1,7 @@
 import type {AwaitableIterable} from '../common/types.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+
 import {ariaQuerySelectorAll} from './ARIAQuerySelector.js';
 import {customQuerySelectors} from './CustomQuerySelector.js';
 import {parsePSelectors, PSelector} from './PSelectorParser.js';

--- a/packages/puppeteer-core/src/injected/injected.ts
+++ b/packages/puppeteer-core/src/injected/injected.ts
@@ -16,16 +16,17 @@
 
 import {createDeferredPromise} from '../util/DeferredPromise.js';
 import {createFunction} from '../util/Function.js';
+
 import * as ARIAQuerySelector from './ARIAQuerySelector.js';
 import * as CustomQuerySelectors from './CustomQuerySelector.js';
 import * as PierceQuerySelector from './PierceQuerySelector.js';
 import {IntervalPoller, MutationPoller, RAFPoller} from './Poller.js';
+import * as PQuerySelector from './PQuerySelector.js';
 import {
   createTextContent,
   isSuitableNodeForTextMatching,
 } from './TextContent.js';
 import * as TextQuerySelector from './TextQuerySelector.js';
-import * as PQuerySelector from './PQuerySelector.js';
 import * as util from './util.js';
 import * as XPathQuerySelector from './XPathQuerySelector.js';
 

--- a/packages/puppeteer-core/src/node/BrowserFetcher.ts
+++ b/packages/puppeteer-core/src/node/BrowserFetcher.ts
@@ -15,24 +15,26 @@
  */
 
 import {exec as execChildProcess} from 'child_process';
-import extractZip from 'extract-zip';
 import {createReadStream, createWriteStream, existsSync, readdirSync} from 'fs';
 import {chmod, mkdir, readdir, unlink} from 'fs/promises';
 import * as http from 'http';
 import * as https from 'https';
+import * as os from 'os';
+import * as path from 'path';
+import * as URL from 'url';
+import * as util from 'util';
+import {promisify} from 'util';
+
+import extractZip from 'extract-zip';
 import createHttpsProxyAgent, {
   HttpsProxyAgent,
   HttpsProxyAgentOptions,
 } from 'https-proxy-agent';
-import * as os from 'os';
-import * as path from 'path';
 import {getProxyForUrl} from 'proxy-from-env';
 import removeRecursive from 'rimraf';
 import tar from 'tar-fs';
 import bzip from 'unbzip2-stream';
-import * as URL from 'url';
-import * as util from 'util';
-import {promisify} from 'util';
+
 import {debug} from '../common/Debug.js';
 import {Product} from '../common/Product.js';
 import {assert} from '../util/assert.js';

--- a/packages/puppeteer-core/src/node/BrowserRunner.ts
+++ b/packages/puppeteer-core/src/node/BrowserRunner.ts
@@ -18,8 +18,10 @@ import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-import removeFolder from 'rimraf';
 import {promisify} from 'util';
+
+import removeFolder from 'rimraf';
+
 import type {Connection as BiDiConnection} from '../common/bidi/bidi.js';
 import {Connection} from '../common/Connection.js';
 import {debug} from '../common/Debug.js';
@@ -34,6 +36,7 @@ import {
 } from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {isErrnoException, isErrorLike} from '../util/ErrorLike.js';
+
 import {LaunchOptions} from './LaunchOptions.js';
 import {PipeTransport} from './PipeTransport.js';
 

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -2,10 +2,12 @@ import {accessSync} from 'fs';
 import {mkdtemp} from 'fs/promises';
 import os from 'os';
 import path from 'path';
+
 import {Browser} from '../api/Browser.js';
-import {assert} from '../util/assert.js';
-import {BrowserRunner} from './BrowserRunner.js';
 import {CDPBrowser} from '../common/Browser.js';
+import {assert} from '../util/assert.js';
+
+import {BrowserRunner} from './BrowserRunner.js';
 import {
   BrowserLaunchArgumentOptions,
   ChromeReleaseChannel,

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+
 import {Browser} from '../api/Browser.js';
 import {CDPBrowser} from '../common/Browser.js';
 import {assert} from '../util/assert.js';
+
 import {BrowserRunner} from './BrowserRunner.js';
 import {
   BrowserLaunchArgumentOptions,

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -16,8 +16,10 @@
 import {existsSync} from 'fs';
 import os, {tmpdir} from 'os';
 import {join} from 'path';
+
 import {Browser} from '../api/Browser.js';
 import {Product} from '../common/Product.js';
+
 import {
   BrowserLaunchArgumentOptions,
   ChromeReleaseChannel,

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -15,16 +15,18 @@
  */
 
 import {join} from 'path';
+
 import {Browser} from '../api/Browser.js';
 import {BrowserConnectOptions} from '../common/BrowserConnector.js';
+import {Configuration} from '../common/Configuration.js';
 import {Product} from '../common/Product.js';
 import {
   CommonPuppeteerSettings,
   ConnectOptions,
   Puppeteer,
 } from '../common/Puppeteer.js';
-import {Configuration} from '../common/Configuration.js';
 import {PUPPETEER_REVISIONS} from '../revisions.js';
+
 import {BrowserFetcher, BrowserFetcherOptions} from './BrowserFetcher.js';
 import {ChromeLauncher} from './ChromeLauncher.js';
 import {FirefoxLauncher} from './FirefoxLauncher.js';

--- a/packages/puppeteer-core/src/util/DebuggableDeferredPromise.ts
+++ b/packages/puppeteer-core/src/util/DebuggableDeferredPromise.ts
@@ -1,4 +1,5 @@
 import {DEFERRED_PROMISE_DEBUG_TIMEOUT} from '../environment.js';
+
 import {DeferredPromise, createDeferredPromise} from './DeferredPromise.js';
 
 /**

--- a/packages/puppeteer-core/tools/ensure-correct-devtools-protocol-package.ts
+++ b/packages/puppeteer-core/tools/ensure-correct-devtools-protocol-package.ts
@@ -34,10 +34,10 @@
  */
 
 // eslint-disable-next-line import/extensions
-import {PUPPETEER_REVISIONS} from '../src/revisions.js';
 import {execSync} from 'child_process';
 
 import packageJson from '../package.json';
+import {PUPPETEER_REVISIONS} from '../src/revisions.js';
 
 const currentProtocolPackageInstalledVersion =
   packageJson.dependencies['devtools-protocol'];

--- a/packages/puppeteer-core/tools/generate_sources.ts
+++ b/packages/puppeteer-core/tools/generate_sources.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-import esbuild from 'esbuild';
 import {mkdir, mkdtemp, readFile, rm, writeFile} from 'fs/promises';
 import path, {join, resolve} from 'path';
 import {chdir} from 'process';
+
+import esbuild from 'esbuild';
+
 import {job} from '../../../tools/internal/job.js';
 
 const packageRoot = resolve(join(__dirname, '..'));

--- a/packages/puppeteer/install.js
+++ b/packages/puppeteer/install.js
@@ -24,9 +24,9 @@
  * necessary.
  */
 
-const path = require('path');
-const fs = require('fs');
 const {execSync} = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 // Need to ensure TS is compiled before loading the installer
 if (!fs.existsSync(path.join(__dirname, 'lib'))) {

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -1,6 +1,7 @@
-import {cosmiconfigSync} from 'cosmiconfig';
 import {homedir} from 'os';
 import {join} from 'path';
+
+import {cosmiconfigSync} from 'cosmiconfig';
 import {Configuration, Product} from 'puppeteer-core';
 
 /**

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -15,12 +15,14 @@
  */
 
 import https, {RequestOptions} from 'https';
+import URL from 'url';
+
 import createHttpsProxyAgent, {HttpsProxyAgentOptions} from 'https-proxy-agent';
 import ProgressBar from 'progress';
 import {getProxyForUrl} from 'proxy-from-env';
 import {PuppeteerNode} from 'puppeteer-core/internal/node/PuppeteerNode.js';
 import {PUPPETEER_REVISIONS} from 'puppeteer-core/internal/revisions.js';
-import URL from 'url';
+
 import {getConfiguration} from '../getConfiguration.js';
 
 /**

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -19,6 +19,7 @@ export {Protocol} from 'puppeteer-core';
 export * from 'puppeteer-core/internal/puppeteer-core.js';
 
 import {PuppeteerNode} from 'puppeteer-core/internal/node/PuppeteerNode.js';
+
 import {getConfiguration} from './getConfiguration.js';
 
 const configuration = getConfiguration();

--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -28,12 +28,13 @@ import {
   Server as HttpsServer,
   ServerOptions as HttpsServerOptions,
 } from 'https';
-import {getType as getMimeType} from 'mime';
 import {AddressInfo} from 'net';
 import {join} from 'path';
 import {Duplex} from 'stream';
-import {Server as WebSocketServer, WebSocket} from 'ws';
 import {gzip} from 'zlib';
+
+import {getType as getMimeType} from 'mime';
+import {Server as WebSocketServer, WebSocket} from 'ws';
 
 interface Subscriber {
   resolve: (msg: IncomingMessage) => void;

--- a/test/installation/src/constants.ts
+++ b/test/installation/src/constants.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import glob from 'glob';
 import {dirname, join, resolve} from 'path';
 import {fileURLToPath} from 'url';
+
+import glob from 'glob';
 
 export const PUPPETEER_CORE_PACKAGE_PATH = resolve(
   glob.sync('puppeteer-core-*.tgz')[0]!

--- a/test/installation/src/describeInstallation.ts
+++ b/test/installation/src/describeInstallation.ts
@@ -18,6 +18,7 @@ import {createHash} from 'crypto';
 import {mkdtemp, rm, writeFile} from 'fs/promises';
 import {tmpdir} from 'os';
 import {join} from 'path';
+
 import {
   PUPPETEER_CORE_PACKAGE_PATH,
   PUPPETEER_PACKAGE_PATH,

--- a/test/installation/src/puppeteer-configuration.spec.ts
+++ b/test/installation/src/puppeteer-configuration.spec.ts
@@ -17,6 +17,7 @@
 import assert from 'assert';
 import {readdir, writeFile} from 'fs/promises';
 import {join} from 'path';
+
 import {describeInstallation} from './describeInstallation.js';
 import {readAsset} from './util.js';
 

--- a/test/installation/src/puppeteer-firefox.spec.ts
+++ b/test/installation/src/puppeteer-firefox.spec.ts
@@ -17,6 +17,7 @@
 import assert from 'assert';
 import {readdir} from 'fs/promises';
 import {join} from 'path';
+
 import {describeInstallation} from './describeInstallation.js';
 import {readAsset} from './util.js';
 

--- a/test/installation/src/puppeteer-webpack.spec.ts
+++ b/test/installation/src/puppeteer-webpack.spec.ts
@@ -16,6 +16,7 @@
 
 import {readFile, rm, writeFile} from 'fs/promises';
 import {join} from 'path';
+
 import {describeInstallation} from './describeInstallation.js';
 import {execFile, readAsset} from './util.js';
 

--- a/test/installation/src/puppeteer.spec.ts
+++ b/test/installation/src/puppeteer.spec.ts
@@ -17,6 +17,7 @@
 import assert from 'assert';
 import {readdir} from 'fs/promises';
 import {join} from 'path';
+
 import {describeInstallation} from './describeInstallation.js';
 import {readAsset} from './util.js';
 

--- a/test/installation/src/util.ts
+++ b/test/installation/src/util.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import {promisify} from 'util';
 import {execFile as execFileAsync} from 'child_process';
-import {join} from 'path';
-import {ASSETS_DIR} from './constants.js';
 import {readFile} from 'fs/promises';
+import {join} from 'path';
+import {promisify} from 'util';
+
+import {ASSETS_DIR} from './constants.js';
 
 export const execFile = promisify(execFileAsync);
 export const readAsset = (...components: string[]): Promise<string> => {

--- a/test/src/CDPSession.spec.ts
+++ b/test/src/CDPSession.spec.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import {waitEvent} from './utils.js';
 import expect from 'expect';
+import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
+import {waitEvent} from './utils.js';
 
 describe('Target.createCDPSession', function () {
   setupTestBrowserHooks();

--- a/test/src/EventEmitter.spec.ts
+++ b/test/src/EventEmitter.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import expect from 'expect';
 import {EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
 import sinon from 'sinon';
-import expect from 'expect';
 
 describe('EventEmitter', () => {
   let emitter: EventEmitter;

--- a/test/src/NetworkManager.spec.ts
+++ b/test/src/NetworkManager.spec.ts
@@ -15,14 +15,14 @@
  */
 
 import expect from 'expect';
+import {EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
+import {Frame} from 'puppeteer-core/internal/common/Frame.js';
+import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
+import {HTTPResponse} from 'puppeteer-core/internal/common/HTTPResponse.js';
 import {
   NetworkManager,
   NetworkManagerEmittedEvents,
 } from 'puppeteer-core/internal/common/NetworkManager.js';
-import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
-import {EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
-import {Frame} from 'puppeteer-core/internal/common/Frame.js';
-import {HTTPResponse} from 'puppeteer-core/internal/common/HTTPResponse.js';
 
 class MockCDPSession extends EventEmitter {
   async send(): Promise<any> {}

--- a/test/src/TargetManager.spec.ts
+++ b/test/src/TargetManager.spec.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import {getTestState} from './mocha-utils'; // eslint-disable-line import/extensions
-import utils from './utils.js';
-
 import expect from 'expect';
-
 import {
   CDPBrowser,
   CDPBrowserContext,
 } from 'puppeteer-core/internal/common/Browser.js';
+
+import {getTestState} from './mocha-utils'; // eslint-disable-line import/extensions
+import utils from './utils.js';
 
 describe('TargetManager', () => {
   /* We use a special browser for this test as we need the --site-per-process flag */

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -15,8 +15,10 @@
  */
 
 import assert from 'assert';
+
 import expect from 'expect';
 import {SerializedAXNode} from 'puppeteer-core/internal/common/Accessibility.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/ariaqueryhandler.spec.ts
+++ b/test/src/ariaqueryhandler.spec.ts
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
+import assert from 'assert';
+
 import expect from 'expect';
+import {TimeoutError} from 'puppeteer';
+import type {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-
-import type {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
 import utils from './utils.js';
-import assert from 'assert';
-import {TimeoutError} from 'puppeteer';
 
 describe('AriaQueryHandler', () => {
   setupTestBrowserHooks();

--- a/test/src/browser.spec.ts
+++ b/test/src/browser.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import expect from 'expect';
+
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 
 describe('Browser specs', function () {

--- a/test/src/browsercontext.spec.ts
+++ b/test/src/browsercontext.spec.ts
@@ -16,6 +16,7 @@
 
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';
+
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {waitEvent} from './utils.js';
 

--- a/test/src/chromiumonly.spec.ts
+++ b/test/src/chromiumonly.spec.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import expect from 'expect';
 import {IncomingMessage} from 'http';
+
+import expect from 'expect';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/click.spec.ts
+++ b/test/src/click.spec.ts
@@ -16,6 +16,7 @@
 
 import expect from 'expect';
 import {KnownDevices} from 'puppeteer';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import expect from 'expect';
+
 import {
   expectCookieEquals,
   getTestState,

--- a/test/src/coverage.spec.ts
+++ b/test/src/coverage.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import expect from 'expect';
+
 import {
   getTestState,
   setupTestPageAndContextHooks,

--- a/test/src/defaultbrowsercontext.spec.ts
+++ b/test/src/defaultbrowsercontext.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import expect from 'expect';
+
 import {
   expectCookieEquals,
   getTestState,

--- a/test/src/drag-and-drop.spec.ts
+++ b/test/src/drag-and-drop.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import expect from 'expect';
+
 import {
   getTestState,
   setupTestPageAndContextHooks,

--- a/test/src/elementhandle.spec.ts
+++ b/test/src/elementhandle.spec.ts
@@ -15,16 +15,16 @@
  */
 
 import expect from 'expect';
+import {Puppeteer} from 'puppeteer';
 import {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
 import sinon from 'sinon';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
   shortWaitForArrayToHaveAtLeastNElements,
 } from './mocha-utils.js';
-
-import {Puppeteer} from 'puppeteer';
 import utils from './utils.js';
 
 describe('ElementHandle specs', function () {

--- a/test/src/emulation.spec.ts
+++ b/test/src/emulation.spec.ts
@@ -16,6 +16,7 @@
 
 import expect from 'expect';
 import {KnownDevices, PredefinedNetworkConditions} from 'puppeteer';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import utils from './utils.js';
 import expect from 'expect';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
+import utils from './utils.js';
 
 const bigint = typeof BigInt !== 'undefined';
 

--- a/test/src/fixtures.spec.ts
+++ b/test/src/fixtures.spec.ts
@@ -16,10 +16,11 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-import expect from 'expect';
-import {getTestState} from './mocha-utils.js';
-
 import path from 'path';
+
+import expect from 'expect';
+
+import {getTestState} from './mocha-utils.js';
 
 describe('Fixtures', function () {
   it('dumpio option should work with pipe option', async () => {

--- a/test/src/frame.spec.ts
+++ b/test/src/frame.spec.ts
@@ -17,6 +17,7 @@
 import expect from 'expect';
 import {CDPSession} from 'puppeteer-core/internal/common/Connection.js';
 import {Frame} from 'puppeteer-core/internal/common/Frame.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/golden-utils.ts
+++ b/test/src/golden-utils.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import assert from 'assert';
-import {diffLines} from 'diff';
 import fs from 'fs';
+import path from 'path';
+
+import {diffLines} from 'diff';
 import jpeg from 'jpeg-js';
 import mime from 'mime';
-import path from 'path';
 import pixelmatch from 'pixelmatch';
 import {PNG} from 'pngjs';
 

--- a/test/src/headful.spec.ts
+++ b/test/src/headful.spec.ts
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-import expect from 'expect';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import rimraf from 'rimraf';
 import {promisify} from 'util';
+
+import expect from 'expect';
 import {
   PuppeteerLaunchOptions,
   PuppeteerNode,
 } from 'puppeteer-core/internal/node/PuppeteerNode.js';
+import rimraf from 'rimraf';
+
 import {getTestState} from './mocha-utils.js';
 
 const rmAsync = promisify(rimraf);

--- a/test/src/idle_override.spec.ts
+++ b/test/src/idle_override.spec.ts
@@ -16,6 +16,7 @@
 
 import expect from 'expect';
 import {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/ignorehttpserrors.spec.ts
+++ b/test/src/ignorehttpserrors.spec.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import expect from 'expect';
 import {TLSSocket} from 'tls';
+
+import expect from 'expect';
 import {Browser} from 'puppeteer-core/internal/api/Browser.js';
 import {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
 import {HTTPResponse} from 'puppeteer-core/internal/common/HTTPResponse.js';
+
 import {getTestState} from './mocha-utils.js';
 
 describe('ignoreHTTPSErrors', function () {

--- a/test/src/injected.spec.ts
+++ b/test/src/injected.spec.ts
@@ -17,6 +17,7 @@
 import expect from 'expect';
 import {PUPPETEER_WORLD} from 'puppeteer-core/internal/common/IsolatedWorlds.js';
 import {LazyArg} from 'puppeteer-core/internal/common/LazyArg.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/input.spec.ts
+++ b/test/src/input.spec.ts
@@ -15,13 +15,15 @@
  */
 
 import path from 'path';
+
 import expect from 'expect';
+import {TimeoutError} from 'puppeteer';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {TimeoutError} from 'puppeteer';
 
 const FILE_TO_UPLOAD = path.join(__dirname, '/../assets/file-to-upload.txt');
 

--- a/test/src/jshandle.spec.ts
+++ b/test/src/jshandle.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import expect from 'expect';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/keyboard.spec.ts
+++ b/test/src/keyboard.spec.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import utils from './utils.js';
 import os from 'os';
+
 import expect from 'expect';
+import {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+import utils from './utils.js';
 
 describe('Keyboard', function () {
   setupTestBrowserHooks();

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
-import expect from 'expect';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {TLSSocket} from 'tls';
+import {promisify} from 'util';
+
+import {Protocol} from 'devtools-protocol';
+import expect from 'expect';
 import {BrowserFetcher, TimeoutError} from 'puppeteer';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
 import rimraf from 'rimraf';
 import sinon from 'sinon';
-import {TLSSocket} from 'tls';
-import {promisify} from 'util';
+
 import {getTestState, itOnlyRegularInstall} from './mocha-utils.js';
 import utils from './utils.js';
 

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -14,28 +14,30 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
-import expect from 'expect';
 import * as fs from 'fs';
 import * as path from 'path';
-import rimraf from 'rimraf';
-import sinon from 'sinon';
+
+import {TestServer} from '@pptr/testserver';
+import {Protocol} from 'devtools-protocol';
+import expect from 'expect';
+import * as Mocha from 'mocha';
 import {Browser} from 'puppeteer-core/internal/api/Browser.js';
 import {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
-import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
-import {
-  PuppeteerLaunchOptions,
-  PuppeteerNode,
-} from 'puppeteer-core/internal/node/PuppeteerNode.js';
-import puppeteer from 'puppeteer/lib/cjs/puppeteer/puppeteer.js';
-import {TestServer} from '@pptr/testserver';
-import {extendExpectWithToBeGolden} from './utils.js';
-import * as Mocha from 'mocha';
 import {
   setLogCapture,
   getCapturedLogs,
 } from 'puppeteer-core/internal/common/Debug.js';
+import {
+  PuppeteerLaunchOptions,
+  PuppeteerNode,
+} from 'puppeteer-core/internal/node/PuppeteerNode.js';
+import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
+import puppeteer from 'puppeteer/lib/cjs/puppeteer/puppeteer.js';
+import rimraf from 'rimraf';
+import sinon from 'sinon';
+
+import {extendExpectWithToBeGolden} from './utils.js';
 
 const setupServer = async () => {
   const assetsPath = path.join(__dirname, '../assets');

--- a/test/src/mouse.spec.ts
+++ b/test/src/mouse.spec.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 import os from 'os';
+
 import expect from 'expect';
+import {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
 
 interface Dimensions {
   x: number;

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-import utils from './utils.js';
+import {ServerResponse} from 'http';
+
 import expect from 'expect';
+import {TimeoutError} from 'puppeteer';
+import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {ServerResponse} from 'http';
-import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
-import {TimeoutError} from 'puppeteer';
+import utils from './utils.js';
 
 describe('navigation', function () {
   setupTestBrowserHooks();

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -15,17 +15,19 @@
  */
 
 import fs from 'fs';
+import {ServerResponse} from 'http';
 import path from 'path';
-import utils from './utils.js';
+
 import expect from 'expect';
+import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
+import {HTTPResponse} from 'puppeteer-core/internal/common/HTTPResponse.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
-import {HTTPResponse} from 'puppeteer-core/internal/common/HTTPResponse.js';
-import {ServerResponse} from 'http';
+import utils from './utils.js';
 
 describe('network', function () {
   setupTestBrowserHooks();

--- a/test/src/oopif.spec.ts
+++ b/test/src/oopif.spec.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import utils from './utils.js';
 import expect from 'expect';
-import {describeWithDebugLogs, getTestState} from './mocha-utils.js';
 import {Browser} from 'puppeteer-core/internal/api/Browser.js';
 import {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
+
+import {describeWithDebugLogs, getTestState} from './mocha-utils.js';
+import utils from './utils.js';
 
 describeWithDebugLogs('OOPIF', function () {
   /* We use a special browser for this test as we need the --site-per-process flag */

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -13,22 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import expect from 'expect';
 import fs from 'fs';
 import {ServerResponse} from 'http';
 import path from 'path';
-import sinon from 'sinon';
+
+import expect from 'expect';
+import {KnownDevices, TimeoutError} from 'puppeteer';
+import {Metrics, Page} from 'puppeteer-core/internal/api/Page.js';
 import {CDPSession} from 'puppeteer-core/internal/common/Connection.js';
 import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
-import {Metrics, Page} from 'puppeteer-core/internal/api/Page.js';
+import {CDPPage} from 'puppeteer-core/internal/common/Page.js';
+import sinon from 'sinon';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
 import utils, {attachFrame, waitEvent} from './utils.js';
-import {CDPPage} from 'puppeteer-core/internal/common/Page.js';
-import {KnownDevices, TimeoutError} from 'puppeteer';
 
 describe('Page', function () {
   setupTestBrowserHooks();

--- a/test/src/proxy.spec.ts
+++ b/test/src/proxy.spec.ts
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import expect from 'expect';
 import http from 'http';
-import os from 'os';
-import {getTestState} from './mocha-utils.js';
 import type {Server, IncomingMessage, ServerResponse} from 'http';
-import type {Browser} from 'puppeteer-core/internal/api/Browser.js';
 import type {AddressInfo} from 'net';
+import os from 'os';
+
 import {TestServer} from '@pptr/testserver';
+import expect from 'expect';
+import type {Browser} from 'puppeteer-core/internal/api/Browser.js';
+
+import {getTestState} from './mocha-utils.js';
 
 let HOSTNAME = os.hostname();
 

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 import assert from 'assert';
+
 import expect from 'expect';
 import {Puppeteer} from 'puppeteer-core';
 import {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/queryselector.spec.ts
+++ b/test/src/queryselector.spec.ts
@@ -16,6 +16,7 @@
 import expect from 'expect';
 import {Puppeteer} from 'puppeteer';
 import type {CustomQueryHandler} from 'puppeteer-core/internal/common/CustomQueryHandler.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -16,19 +16,21 @@
 
 import fs from 'fs';
 import path from 'path';
-import utils from './utils.js';
+
 import expect from 'expect';
-import {
-  getTestState,
-  setupTestBrowserHooks,
-  setupTestPageAndContextHooks,
-} from './mocha-utils.js';
 import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 import {
   ActionResult,
   HTTPRequest,
   InterceptResolutionAction,
 } from 'puppeteer-core/internal/common/HTTPRequest.js';
+
+import {
+  getTestState,
+  setupTestBrowserHooks,
+  setupTestPageAndContextHooks,
+} from './mocha-utils.js';
+import utils from './utils.js';
 
 describe('request interception', function () {
   setupTestBrowserHooks();

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -16,15 +16,17 @@
 
 import fs from 'fs';
 import path from 'path';
-import utils from './utils.js';
+
 import expect from 'expect';
+import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
-import {HTTPRequest} from 'puppeteer-core/internal/common/HTTPRequest.js';
-import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import utils from './utils.js';
 
 describe('request interception', function () {
   setupTestBrowserHooks();

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import expect from 'expect';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import expect from 'expect';
 import {ServerResponse} from 'http';
+
+import expect from 'expect';
 import {TimeoutError} from 'puppeteer';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
 import {Target} from 'puppeteer-core/internal/common/Target.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/touchscreen.spec.ts
+++ b/test/src/touchscreen.spec.ts
@@ -16,6 +16,7 @@
 
 import expect from 'expect';
 import {KnownDevices, BoundingBox} from 'puppeteer';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -16,10 +16,12 @@
 
 import fs from 'fs';
 import path from 'path';
+
 import expect from 'expect';
-import {getTestState} from './mocha-utils.js';
 import {Browser} from 'puppeteer-core/internal/api/Browser.js';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
+
+import {getTestState} from './mocha-utils.js';
 
 describe('Tracing', function () {
   let outputFile!: string;

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import expect from 'expect';
 import path from 'path';
-import {Frame} from 'puppeteer-core/internal/common/Frame.js';
+
+import expect from 'expect';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
 import {EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
+import {Frame} from 'puppeteer-core/internal/common/Frame.js';
+
 import {compare} from './golden-utils.js';
 
 const PROJECT_ROOT = path.join(__dirname, '..', '..');

--- a/test/src/waittask.spec.ts
+++ b/test/src/waittask.spec.ts
@@ -17,6 +17,7 @@
 import expect from 'expect';
 import {TimeoutError, ElementHandle} from 'puppeteer';
 import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
+
 import {
   createTimeout,
   getTestState,

--- a/test/src/worker.spec.ts
+++ b/test/src/worker.spec.ts
@@ -17,6 +17,7 @@
 import expect from 'expect';
 import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 import {WebWorker} from 'puppeteer-core/internal/common/WebWorker.js';
+
 import {
   getTestState,
   setupTestBrowserHooks,

--- a/tools/bisect.ts
+++ b/tools/bisect.ts
@@ -16,14 +16,14 @@
  */
 
 import {execSync, fork, spawn} from 'child_process';
-import debug from 'debug';
 import fs from 'fs';
-import minimist from 'minimist';
 import path from 'path';
-import {BrowserFetcher, BrowserFetcherRevisionInfo} from 'puppeteer';
 import URL from 'url';
 
+import debug from 'debug';
+import minimist from 'minimist';
 import ProgressBar from 'progress';
+import {BrowserFetcher, BrowserFetcherRevisionInfo} from 'puppeteer';
 
 const COLOR_RESET = '\x1b[0m';
 const COLOR_RED = '\x1b[31m';

--- a/tools/check_availability.js
+++ b/tools/check_availability.js
@@ -17,6 +17,7 @@
 
 const assert = require('assert');
 const https = require('https');
+
 const BrowserFetcher =
   require('puppeteer-core/internal/node/BrowserFetcher.js').BrowserFetcher;
 

--- a/tools/ensure-pinned-deps.ts
+++ b/tools/ensure-pinned-deps.ts
@@ -16,6 +16,7 @@
 
 import {readdirSync, readFileSync} from 'fs';
 import {join} from 'path';
+
 import {devDependencies} from '../package.json';
 
 const LOCAL_PACKAGE_NAMES: string[] = [];

--- a/tools/generate_docs.ts
+++ b/tools/generate_docs.ts
@@ -17,7 +17,9 @@
 import {copyFile, readFile, rm, writeFile} from 'fs/promises';
 import {join, resolve} from 'path';
 import {chdir} from 'process';
+
 import semver from 'semver';
+
 import {generateDocs} from './internal/custom_markdown_action.js';
 import {job} from './internal/job.js';
 import {spawnAndLog} from './internal/util.js';

--- a/tools/internal/custom_markdown_action.ts
+++ b/tools/internal/custom_markdown_action.ts
@@ -15,6 +15,7 @@
  */
 
 import {ApiModel} from '@microsoft/api-extractor-model';
+
 import {MarkdownDocumenter} from './custom_markdown_documenter.js';
 
 export const generateDocs = (jsonPath: string, outputDir: string): void => {

--- a/tools/internal/custom_markdown_documenter.ts
+++ b/tools/internal/custom_markdown_documenter.ts
@@ -21,6 +21,24 @@
 // https://github.com/microsoft/rushstack/blob/main/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
 // This file has been edited to morph into Docusaurus's expected inputs.
 
+import * as path from 'path';
+
+import {DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig';
+import {CustomMarkdownEmitter} from '@microsoft/api-documenter/lib/markdown/CustomMarkdownEmitter';
+import {CustomDocNodes} from '@microsoft/api-documenter/lib/nodes/CustomDocNodeKind';
+import {DocEmphasisSpan} from '@microsoft/api-documenter/lib/nodes/DocEmphasisSpan';
+import {DocHeading} from '@microsoft/api-documenter/lib/nodes/DocHeading';
+import {DocNoteBox} from '@microsoft/api-documenter/lib/nodes/DocNoteBox';
+import {DocTable} from '@microsoft/api-documenter/lib/nodes/DocTable';
+import {DocTableCell} from '@microsoft/api-documenter/lib/nodes/DocTableCell';
+import {DocTableRow} from '@microsoft/api-documenter/lib/nodes/DocTableRow';
+import {MarkdownDocumenterAccessor} from '@microsoft/api-documenter/lib/plugin/MarkdownDocumenterAccessor';
+import {
+  IMarkdownDocumenterFeatureOnBeforeWritePageArgs,
+  MarkdownDocumenterFeatureContext,
+} from '@microsoft/api-documenter/lib/plugin/MarkdownDocumenterFeature';
+import {PluginLoader} from '@microsoft/api-documenter/lib/plugin/PluginLoader';
+import {Utilities} from '@microsoft/api-documenter/lib/utils/Utilities';
 import {
   ApiClass,
   ApiDeclaredItem,
@@ -68,24 +86,6 @@ import {
   NewlineKind,
   PackageName,
 } from '@rushstack/node-core-library';
-import * as path from 'path';
-
-import {DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig';
-import {CustomMarkdownEmitter} from '@microsoft/api-documenter/lib/markdown/CustomMarkdownEmitter';
-import {CustomDocNodes} from '@microsoft/api-documenter/lib/nodes/CustomDocNodeKind';
-import {DocEmphasisSpan} from '@microsoft/api-documenter/lib/nodes/DocEmphasisSpan';
-import {DocHeading} from '@microsoft/api-documenter/lib/nodes/DocHeading';
-import {DocNoteBox} from '@microsoft/api-documenter/lib/nodes/DocNoteBox';
-import {DocTable} from '@microsoft/api-documenter/lib/nodes/DocTable';
-import {DocTableCell} from '@microsoft/api-documenter/lib/nodes/DocTableCell';
-import {DocTableRow} from '@microsoft/api-documenter/lib/nodes/DocTableRow';
-import {MarkdownDocumenterAccessor} from '@microsoft/api-documenter/lib/plugin/MarkdownDocumenterAccessor';
-import {
-  IMarkdownDocumenterFeatureOnBeforeWritePageArgs,
-  MarkdownDocumenterFeatureContext,
-} from '@microsoft/api-documenter/lib/plugin/MarkdownDocumenterFeature';
-import {PluginLoader} from '@microsoft/api-documenter/lib/plugin/PluginLoader';
-import {Utilities} from '@microsoft/api-documenter/lib/utils/Utilities';
 
 export interface IMarkdownDocumenterOptions {
   apiModel: ApiModel;

--- a/tools/internal/job.ts
+++ b/tools/internal/job.ts
@@ -1,9 +1,10 @@
 import {createHash} from 'crypto';
 import {existsSync, Stats} from 'fs';
 import {mkdir, readFile, stat, writeFile} from 'fs/promises';
-import {glob} from 'glob';
 import {tmpdir} from 'os';
 import {dirname, join} from 'path';
+
+import {glob} from 'glob';
 
 interface JobContext {
   name: string;

--- a/tools/mochaRunner/src/interface.ts
+++ b/tools/mochaRunner/src/interface.ts
@@ -16,6 +16,7 @@
 
 import Mocha from 'mocha';
 import commonInterface from 'mocha/lib/interfaces/common';
+
 import {getTestId} from './utils.js';
 
 type SuiteFunction = ((this: Mocha.Suite) => void) | undefined;

--- a/tools/mochaRunner/src/main.ts
+++ b/tools/mochaRunner/src/main.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import {spawn, SpawnOptions} from 'node:child_process';
+import os from 'os';
+import path from 'path';
+
 import {
   TestExpectation,
   MochaResults,
@@ -23,11 +28,6 @@ import {
   TestSuiteFile,
   Platform,
 } from './types.js';
-
-import path from 'path';
-import fs from 'fs';
-import os from 'os';
-import {spawn, SpawnOptions} from 'node:child_process';
 import {
   extendProcessEnv,
   filterByPlatform,

--- a/tools/mochaRunner/src/test.ts
+++ b/tools/mochaRunner/src/test.ts
@@ -16,8 +16,9 @@
 
 import assert from 'assert/strict';
 import test from 'node:test';
-import {filterByParameters, getTestResultForFailure} from './utils.js';
+
 import {TestExpectation} from './types.js';
+import {filterByParameters, getTestResultForFailure} from './utils.js';
 import {getFilename, extendProcessEnv} from './utils.js';
 
 test('extendProcessEnv', () => {

--- a/tools/mochaRunner/src/utils.ts
+++ b/tools/mochaRunner/src/utils.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+
 import {
   MochaTestResult,
   TestExpectation,
   MochaResults,
   TestResult,
 } from './types.js';
-import path from 'path';
-import fs from 'fs';
 
 export function extendProcessEnv(envs: object[]): NodeJS.ProcessEnv {
   return envs.reduce(

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,11 +17,12 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
+const assert = require('assert');
+
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const lightCodeTheme = require('prism-react-renderer/themes/github');
 
 const archivedVersions = require('./versionsArchived.json');
-const assert = require('assert');
 
 const DOC_ROUTE_BASE_PATH = '/';
 const DOC_PATH = '../docs';

--- a/website/src/theme/SearchBar/index.js
+++ b/website/src/theme/SearchBar/index.js
@@ -1,16 +1,18 @@
+/* eslint-disable import/order */
+import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
+import Head from '@docusaurus/Head';
+import Link from '@docusaurus/Link';
+import {useHistory} from '@docusaurus/router';
+import {isRegexpStringMatch} from '@docusaurus/theme-common';
+import {useContextualSearchFilters} from '@docusaurus/theme-common';
+import {useSearchPage} from '@docusaurus/theme-common/internal';
+import Translate from '@docusaurus/Translate';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import React, {useState, useRef, useCallback, useMemo} from 'react';
 import {createPortal} from 'react-dom';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import {useHistory} from '@docusaurus/router';
-import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
-import Link from '@docusaurus/Link';
-import Head from '@docusaurus/Head';
-import {isRegexpStringMatch} from '@docusaurus/theme-common';
-import {useSearchPage} from '@docusaurus/theme-common/internal';
-import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
-import Translate from '@docusaurus/Translate';
 import translations from '@theme/SearchTranslations';
-import {useContextualSearchFilters} from '@docusaurus/theme-common';
+
 // eslint-disable-next-line import/extensions
 import {tagToCounter} from '../SearchMetadata';
 let DocSearchModal = null;

--- a/website/src/theme/SearchMetadata/index.js
+++ b/website/src/theme/SearchMetadata/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import Head from '@docusaurus/Head';
+import React from 'react';
 
 // Tracks the global package version as a local, monotonic counter. This
 // prevents Algolia from deleting based on differing package versions and

--- a/website/src/theme/SearchPage/index.js
+++ b/website/src/theme/SearchPage/index.js
@@ -1,10 +1,7 @@
-import React, {useEffect, useState, useReducer, useRef} from 'react';
-import clsx from 'clsx';
-import algoliaSearch from 'algoliasearch/lite';
-import algoliaSearchHelper from 'algoliasearch-helper';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 import {
   HtmlClassNameProvider,
   usePluralForm,
@@ -15,13 +12,18 @@ import {
   useTitleFormatter,
   useSearchPage,
 } from '@docusaurus/theme-common/internal';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
 import Translate, {translate} from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import styles from './styles.module.css';
+import algoliaSearchHelper from 'algoliasearch-helper';
+import algoliaSearch from 'algoliasearch/lite';
+import clsx from 'clsx';
+import React, {useEffect, useState, useReducer, useRef} from 'react';
+
 // eslint-disable-next-line import/extensions
 import {tagToCounter} from '../SearchMetadata';
+
+import styles from './styles.module.css';
 // Very simple pluralization: probably good enough for now
 function useDocumentsFoundPlural() {
   const {selectMessage} = usePluralForm();


### PR DESCRIPTION
Add the import/order rule to EsLint so we have consistent import order.
That will make the PRs easier to review as you can easily see what.

There were 3 files where the auto-fixer did not fully work. I'll play with them later to understand why that happens and report if we need to avoid doing something.