### PR TITLE
fix: add filter to setDiscoverTargets for Firefox

### DIFF
--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -168,7 +168,7 @@ export class FirefoxTargetManager
   async initialize(): Promise<void> {
     await this.#connection.send('Target.setDiscoverTargets', {
       discover: true,
-      filter: [{type: 'tab', exclude: true}, {}],
+      filter: [{}],
     });
     this.#targetsIdsForInit = new Set(this.#discoveredTargetsByTargetId.keys());
     await this.#initializePromise;

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -166,7 +166,10 @@ export class FirefoxTargetManager
   }
 
   async initialize(): Promise<void> {
-    await this.#connection.send('Target.setDiscoverTargets', {discover: true});
+    await this.#connection.send('Target.setDiscoverTargets', {
+      discover: true,
+      filter: [{type: 'tab', exclude: true}, {}],
+    });
     this.#targetsIdsForInit = new Set(this.#discoveredTargetsByTargetId.keys());
     await this.#initializePromise;
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

No, existing tests cover change.

**Summary**

The filter option will likely be soon supported by Firefox, and the browser type will be filtered out by default. So the same filter as Chrome should be supplied to include all wanted targets to avoid a regression.

**Does this PR introduce a breaking change?**

No.

**Other information**

Firefox patch: https://phabricator.services.mozilla.com/D167209