### PR TITLE
fix: bump chromium-bidi to a version that does not declare mitt as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2663,14 +2663,14 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.3.tgz",
-      "integrity": "sha512-A40H1rdpJqkTdnGhnYDzMhtDdIbkXNFj2wgIfivMXL7LyHFDmBtv1hdyycDhnxtYunbPLDZtTs/n+ZT5j7Vnew==",
-      "optional": true,
-      "peer": true,
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.4.tgz",
+      "integrity": "sha512-4BX5cSaponuvVT1+SbLYTOAgDoVtX/Khoc9UsbFJ/AsPVUeFAM3RiIDFI6XFhLYMi9WmVJqh1ZH+dRpNKkKwiQ==",
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
       "peerDependencies": {
-        "devtools-protocol": "*",
-        "mitt": "*"
+        "devtools-protocol": "*"
       }
     },
     "node_modules/cli-cursor": {
@@ -6039,8 +6039,7 @@
     "node_modules/mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "devOptional": true
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -8678,6 +8677,7 @@
       "version": "19.7.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "chromium-bidi": "0.4.4",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1094867",
@@ -8693,13 +8693,9 @@
         "node": ">=14.1.0"
       },
       "peerDependencies": {
-        "chromium-bidi": "0.4.3",
         "typescript": ">= 4.7.4"
       },
       "peerDependenciesMeta": {
-        "chromium-bidi": {
-          "optional": true
-        },
         "typescript": {
           "optional": true
         }
@@ -11017,12 +11013,12 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromium-bidi": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.3.tgz",
-      "integrity": "sha512-A40H1rdpJqkTdnGhnYDzMhtDdIbkXNFj2wgIfivMXL7LyHFDmBtv1hdyycDhnxtYunbPLDZtTs/n+ZT5j7Vnew==",
-      "optional": true,
-      "peer": true,
-      "requires": {}
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.4.tgz",
+      "integrity": "sha512-4BX5cSaponuvVT1+SbLYTOAgDoVtX/Khoc9UsbFJ/AsPVUeFAM3RiIDFI6XFhLYMi9WmVJqh1ZH+dRpNKkKwiQ==",
+      "requires": {
+        "mitt": "3.0.0"
+      }
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -13421,8 +13417,7 @@
     "mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "devOptional": true
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -14123,6 +14118,7 @@
     "puppeteer-core": {
       "version": "file:packages/puppeteer-core",
       "requires": {
+        "chromium-bidi": "0.4.4",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1094867",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -131,6 +131,7 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "chromium-bidi": "0.4.4",
     "cross-fetch": "3.1.5",
     "debug": "4.3.4",
     "devtools-protocol": "0.0.1094867",
@@ -143,14 +144,10 @@
     "ws": "8.11.0"
   },
   "peerDependencies": {
-    "typescript": ">= 4.7.4",
-    "chromium-bidi": "0.4.3"
+    "typescript": ">= 4.7.4"
   },
   "peerDependenciesMeta": {
     "typescript": {
-      "optional": true
-    },
-    "chromium-bidi": {
       "optional": true
     }
   }

--- a/packages/puppeteer-core/src/common/bidi/BidiOverCDP.ts
+++ b/packages/puppeteer-core/src/common/bidi/BidiOverCDP.ts
@@ -102,9 +102,9 @@ class CDPClientAdapter<
     this.#client.on('*', this.#forwardMessage as Handler<any>);
   }
 
-  #forwardMessage = (
-    method: keyof ProtocolMapping.Events,
-    event: ProtocolMapping.Events[keyof ProtocolMapping.Events]
+  #forwardMessage = <T extends keyof CdpEvents>(
+    method: T,
+    event: CdpEvents[T]
   ) => {
     this.emit(method, event);
   };


### PR DESCRIPTION
The release makes mitt a proper dependency so we don't need to have chromium-bidi as an optional peer dependency that proved to not work well with some projects such as Webpack.