### PR TITLE
chore: rename revision to buildId

### DIFF
--- a/packages/browsers/src/CacheStructure.ts
+++ b/packages/browsers/src/CacheStructure.ts
@@ -23,12 +23,12 @@ import {Browser, BrowserPlatform} from './browsers/types.js';
  *
  * - rootDir
  *   -- <browser1> | browserRoot(browser1)
- *   ---- <platform>-<revision> | installationDir()
- *   ------ the browser-platform-revision
+ *   ---- <platform>-<buildId> | installationDir()
+ *   ------ the browser-platform-buildId
  *   ------ specific structure.
  *   -- <browser2> | browserRoot(browser2)
- *   ---- <platform>-<revision> | installationDir()
- *   ------ the browser-platform-revision
+ *   ---- <platform>-<buildId> | installationDir()
+ *   ------ the browser-platform-buildId
  *   ------ specific structure.
  *   @internal
  */
@@ -46,8 +46,8 @@ export class CacheStructure {
   installationDir(
     browser: Browser,
     platform: BrowserPlatform,
-    revision: string
+    buildId: string
   ): string {
-    return path.join(this.browserRoot(browser), `${platform}-${revision}`);
+    return path.join(this.browserRoot(browser), `${platform}-${buildId}`);
   }
 }

--- a/packages/browsers/src/browsers/browsers.ts
+++ b/packages/browsers/src/browsers/browsers.ts
@@ -30,7 +30,7 @@ export const executablePathByBrowser = {
 
 export {Browser, BrowserPlatform};
 
-export async function resolveRevision(
+export async function resolveBuildId(
   browser: Browser,
   platform: BrowserPlatform,
   tag: string
@@ -39,14 +39,14 @@ export async function resolveRevision(
     case Browser.FIREFOX:
       switch (tag as BrowserTag) {
         case BrowserTag.LATEST:
-          return await firefox.resolveRevision('FIREFOX_NIGHTLY');
+          return await firefox.resolveBuildId('FIREFOX_NIGHTLY');
       }
     case Browser.CHROME:
       switch (tag as BrowserTag) {
         case BrowserTag.LATEST:
-          return await chrome.resolveRevision(platform, 'latest');
+          return await chrome.resolveBuildId(platform, 'latest');
       }
   }
-  // We assume the tag is the revision if it didn't match any keywords.
+  // We assume the tag is the buildId if it didn't match any keywords.
   return tag;
 }

--- a/packages/browsers/src/browsers/chrome.ts
+++ b/packages/browsers/src/browsers/chrome.ts
@@ -20,7 +20,7 @@ import {httpRequest} from '../httpUtil.js';
 
 import {BrowserPlatform} from './types.js';
 
-function archive(platform: BrowserPlatform, revision: string): string {
+function archive(platform: BrowserPlatform, buildId: string): string {
   switch (platform) {
     case BrowserPlatform.LINUX:
       return 'chrome-linux';
@@ -30,7 +30,7 @@ function archive(platform: BrowserPlatform, revision: string): string {
     case BrowserPlatform.WIN32:
     case BrowserPlatform.WIN64:
       // Windows archive name changed at r591479.
-      return parseInt(revision, 10) > 591479 ? 'chrome-win' : 'chrome-win32';
+      return parseInt(buildId, 10) > 591479 ? 'chrome-win' : 'chrome-win32';
   }
 }
 
@@ -51,18 +51,18 @@ function folder(platform: BrowserPlatform): string {
 
 export function resolveDownloadUrl(
   platform: BrowserPlatform,
-  revision: string,
+  buildId: string,
   baseUrl = 'https://storage.googleapis.com/chromium-browser-snapshots'
 ): string {
-  return `${baseUrl}/${folder(platform)}/${revision}/${archive(
+  return `${baseUrl}/${folder(platform)}/${buildId}/${archive(
     platform,
-    revision
+    buildId
   )}.zip`;
 }
 
 export function relativeExecutablePath(
   platform: BrowserPlatform,
-  _revision: string
+  _buildId: string
 ): string {
   switch (platform) {
     case BrowserPlatform.MAC:
@@ -82,7 +82,7 @@ export function relativeExecutablePath(
   }
 }
 
-export async function resolveRevision(
+export async function resolveBuildId(
   platform: BrowserPlatform,
   // We will need it for other channels/keywords.
   _channel: 'latest' = 'latest'

--- a/packages/browsers/src/browsers/firefox.ts
+++ b/packages/browsers/src/browsers/firefox.ts
@@ -20,30 +20,30 @@ import {httpRequest} from '../httpUtil.js';
 
 import {BrowserPlatform} from './types.js';
 
-function archive(platform: BrowserPlatform, revision: string): string {
+function archive(platform: BrowserPlatform, buildId: string): string {
   switch (platform) {
     case BrowserPlatform.LINUX:
-      return `firefox-${revision}.en-US.${platform}-x86_64.tar.bz2`;
+      return `firefox-${buildId}.en-US.${platform}-x86_64.tar.bz2`;
     case BrowserPlatform.MAC_ARM:
     case BrowserPlatform.MAC:
-      return `firefox-${revision}.en-US.mac.dmg`;
+      return `firefox-${buildId}.en-US.mac.dmg`;
     case BrowserPlatform.WIN32:
     case BrowserPlatform.WIN64:
-      return `firefox-${revision}.en-US.${platform}.zip`;
+      return `firefox-${buildId}.en-US.${platform}.zip`;
   }
 }
 
 export function resolveDownloadUrl(
   platform: BrowserPlatform,
-  revision: string,
+  buildId: string,
   baseUrl = 'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central'
 ): string {
-  return `${baseUrl}/${archive(platform, revision)}`;
+  return `${baseUrl}/${archive(platform, buildId)}`;
 }
 
 export function relativeExecutablePath(
   platform: BrowserPlatform,
-  _revision: string
+  _buildId: string
 ): string {
   switch (platform) {
     case BrowserPlatform.MAC_ARM:
@@ -57,7 +57,7 @@ export function relativeExecutablePath(
   }
 }
 
-export async function resolveRevision(
+export async function resolveBuildId(
   channel: 'FIREFOX_NIGHTLY' = 'FIREFOX_NIGHTLY'
 ): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/packages/browsers/src/fetch.ts
+++ b/packages/browsers/src/fetch.ts
@@ -48,10 +48,10 @@ export interface Options {
    */
   browser: Browser;
   /**
-   * Determines which revision to dowloand. Revision should uniquely identify
+   * Determines which buildId to dowloand. BuildId should uniquely identify
    * binaries and they are used for caching.
    */
-  revision: string;
+  buildId: string;
   /**
    * Provides information about the progress of the download.
    */
@@ -64,7 +64,7 @@ export interface Options {
 export type InstalledBrowser = {
   path: string;
   browser: Browser;
-  revision: string;
+  buildId: string;
   platform: BrowserPlatform;
 };
 
@@ -78,7 +78,7 @@ export async function fetch(options: Options): Promise<InstalledBrowser> {
   const url = getDownloadUrl(
     options.browser,
     options.platform,
-    options.revision
+    options.buildId
   );
   const fileName = url.toString().split('/').pop();
   assert(fileName, `A malformed download URL was found: ${url}.`);
@@ -91,14 +91,14 @@ export async function fetch(options: Options): Promise<InstalledBrowser> {
   const outputPath = structure.installationDir(
     options.browser,
     options.platform,
-    options.revision
+    options.buildId
   );
   if (existsSync(outputPath)) {
     return {
       path: outputPath,
       browser: options.browser,
       platform: options.platform,
-      revision: options.revision,
+      buildId: options.buildId,
     };
   }
   try {
@@ -115,7 +115,7 @@ export async function fetch(options: Options): Promise<InstalledBrowser> {
     path: outputPath,
     browser: options.browser,
     platform: options.platform,
-    revision: options.revision,
+    buildId: options.buildId,
   };
 }
 
@@ -127,14 +127,14 @@ export async function canFetch(options: Options): Promise<boolean> {
     );
   }
   return await headHttpRequest(
-    getDownloadUrl(options.browser, options.platform, options.revision)
+    getDownloadUrl(options.browser, options.platform, options.buildId)
   );
 }
 
 function getDownloadUrl(
   browser: Browser,
   platform: BrowserPlatform,
-  revision: string
+  buildId: string
 ): URL {
-  return new URL(downloadUrls[browser](platform, revision));
+  return new URL(downloadUrls[browser](platform, buildId));
 }

--- a/packages/browsers/src/launcher.ts
+++ b/packages/browsers/src/launcher.ts
@@ -48,10 +48,10 @@ export interface Options {
    */
   browser: Browser;
   /**
-   * Determines which revision to dowloand. Revision should uniquely identify
+   * Determines which buildId to dowloand. BuildId should uniquely identify
    * binaries and they are used for caching.
    */
-  revision: string;
+  buildId: string;
 }
 
 export function computeExecutablePath(options: Options): string {
@@ -64,11 +64,11 @@ export function computeExecutablePath(options: Options): string {
   const installationDir = new CacheStructure(options.cacheDir).installationDir(
     options.browser,
     options.platform,
-    options.revision
+    options.buildId
   );
   return path.join(
     installationDir,
-    executablePathByBrowser[options.browser](options.platform, options.revision)
+    executablePathByBrowser[options.browser](options.platform, options.buildId)
   );
 }
 

--- a/packages/browsers/test/src/cli.spec.ts
+++ b/packages/browsers/test/src/cli.spec.ts
@@ -25,8 +25,8 @@ describe('CLI', function () {
   this.timeout(90000);
 
   let tmpDir = '/tmp/puppeteer-browsers-test';
-  const testChromeRevision = '1083080';
-  const testFirefoxRevision = '111.0a1';
+  const testChromeBuildId = '1083080';
+  const testFirefoxBuildId = '111.0a1';
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'puppeteer-browsers-test'));
@@ -41,7 +41,7 @@ describe('CLI', function () {
       'npx',
       '@puppeteer/browsers',
       'install',
-      `chrome@${testChromeRevision}`,
+      `chrome@${testChromeBuildId}`,
       `--path=${tmpDir}`,
       '--platform=linux',
     ]);
@@ -50,7 +50,7 @@ describe('CLI', function () {
         path.join(
           tmpDir,
           'chrome',
-          `linux-${testChromeRevision}`,
+          `linux-${testChromeBuildId}`,
           'chrome-linux'
         )
       )
@@ -62,13 +62,13 @@ describe('CLI', function () {
       'npx',
       '@puppeteer/browsers',
       'install',
-      `firefox@${testFirefoxRevision}`,
+      `firefox@${testFirefoxBuildId}`,
       `--path=${tmpDir}`,
       '--platform=linux',
     ]);
     assert.ok(
       fs.existsSync(
-        path.join(tmpDir, 'firefox', `linux-${testFirefoxRevision}`, 'firefox')
+        path.join(tmpDir, 'firefox', `linux-${testFirefoxBuildId}`, 'firefox')
       )
     );
   });

--- a/packages/browsers/test/src/fetch.spec.ts
+++ b/packages/browsers/test/src/fetch.spec.ts
@@ -30,8 +30,8 @@ import {fetch, canFetch} from '../../lib/cjs/fetch.js';
  */
 describe('fetch', () => {
   let tmpDir = '/tmp/puppeteer-browsers-test';
-  const testChromeRevision = '1083080';
-  const testFirefoxRevision = '111.0a1';
+  const testChromeBuildId = '1083080';
+  const testFirefoxBuildId = '111.0a1';
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'puppeteer-browsers-test'));
@@ -41,42 +41,42 @@ describe('fetch', () => {
     fs.rmSync(tmpDir, {recursive: true});
   });
 
-  it('should check if a revision can be downloaded', async () => {
+  it('should check if a buildId can be downloaded', async () => {
     assert.ok(
       await canFetch({
         cacheDir: tmpDir,
         browser: Browser.CHROME,
         platform: BrowserPlatform.LINUX,
-        revision: testChromeRevision,
+        buildId: testChromeBuildId,
       })
     );
   });
 
-  it('should report if a revision is not downloadable', async () => {
+  it('should report if a buildId is not downloadable', async () => {
     assert.strictEqual(
       await canFetch({
         cacheDir: tmpDir,
         browser: Browser.CHROME,
         platform: BrowserPlatform.LINUX,
-        revision: 'unknown',
+        buildId: 'unknown',
       }),
       false
     );
   });
 
-  it('should download a revision that is a zip archive', async function () {
+  it('should download a buildId that is a zip archive', async function () {
     this.timeout(60000);
     const expectedOutputPath = path.join(
       tmpDir,
       'chrome',
-      `${BrowserPlatform.LINUX}-${testChromeRevision}`
+      `${BrowserPlatform.LINUX}-${testChromeBuildId}`
     );
     assert.strictEqual(fs.existsSync(expectedOutputPath), false);
     let browser = await fetch({
       cacheDir: tmpDir,
       browser: Browser.CHROME,
       platform: BrowserPlatform.LINUX,
-      revision: testChromeRevision,
+      buildId: testChromeBuildId,
     });
     assert.strictEqual(browser.path, expectedOutputPath);
     assert.ok(fs.existsSync(expectedOutputPath));
@@ -85,25 +85,25 @@ describe('fetch', () => {
       cacheDir: tmpDir,
       browser: Browser.CHROME,
       platform: BrowserPlatform.LINUX,
-      revision: testChromeRevision,
+      buildId: testChromeBuildId,
     });
     assert.strictEqual(browser.path, expectedOutputPath);
     assert.ok(fs.existsSync(expectedOutputPath));
   });
 
-  it('should download a revision that is a bzip2 archive', async function () {
+  it('should download a buildId that is a bzip2 archive', async function () {
     this.timeout(60000);
     const expectedOutputPath = path.join(
       tmpDir,
       'firefox',
-      `${BrowserPlatform.LINUX}-${testFirefoxRevision}`
+      `${BrowserPlatform.LINUX}-${testFirefoxBuildId}`
     );
     assert.strictEqual(fs.existsSync(expectedOutputPath), false);
     const browser = await fetch({
       cacheDir: tmpDir,
       browser: Browser.FIREFOX,
       platform: BrowserPlatform.LINUX,
-      revision: testFirefoxRevision,
+      buildId: testFirefoxBuildId,
     });
     assert.strictEqual(browser.path, expectedOutputPath);
     assert.ok(fs.existsSync(expectedOutputPath));
@@ -112,20 +112,20 @@ describe('fetch', () => {
   // Fetch relies on the `hdiutil` utility on MacOS.
   // The utility is not available on other platforms.
   (os.platform() === 'darwin' ? it : it.skip)(
-    'should download a revision that is a dmg archive',
+    'should download a buildId that is a dmg archive',
     async function () {
       this.timeout(120000);
       const expectedOutputPath = path.join(
         tmpDir,
         'firefox',
-        `${BrowserPlatform.MAC}-${testFirefoxRevision}`
+        `${BrowserPlatform.MAC}-${testFirefoxBuildId}`
       );
       assert.strictEqual(fs.existsSync(expectedOutputPath), false);
       const browser = await fetch({
         cacheDir: tmpDir,
         browser: Browser.FIREFOX,
         platform: BrowserPlatform.MAC,
-        revision: testFirefoxRevision,
+        buildId: testFirefoxBuildId,
       });
       assert.strictEqual(browser.path, expectedOutputPath);
       assert.ok(fs.existsSync(expectedOutputPath));
@@ -195,7 +195,7 @@ describe('fetch', () => {
           cacheDir: tmpDir,
           browser: Browser.CHROME,
           platform: BrowserPlatform.LINUX,
-          revision: testChromeRevision,
+          buildId: testChromeBuildId,
         }),
         true
       );
@@ -209,14 +209,14 @@ describe('fetch', () => {
       const expectedOutputPath = path.join(
         tmpDir,
         'chrome',
-        `${BrowserPlatform.LINUX}-${testChromeRevision}`
+        `${BrowserPlatform.LINUX}-${testChromeBuildId}`
       );
       assert.strictEqual(fs.existsSync(expectedOutputPath), false);
       const browser = await fetch({
         cacheDir: tmpDir,
         browser: Browser.CHROME,
         platform: BrowserPlatform.LINUX,
-        revision: testChromeRevision,
+        buildId: testChromeBuildId,
       });
       assert.strictEqual(browser.path, expectedOutputPath);
       assert.ok(fs.existsSync(expectedOutputPath));

--- a/packages/browsers/test/src/launcher.spec.ts
+++ b/packages/browsers/test/src/launcher.spec.ts
@@ -29,7 +29,7 @@ describe('launcher', () => {
       computeExecutablePath({
         browser: Browser.CHROME,
         platform: BrowserPlatform.LINUX,
-        revision: '123',
+        buildId: '123',
         cacheDir: 'cache',
       }),
       path.join('cache', 'chrome', 'linux-123', 'chrome-linux', 'chrome')
@@ -41,7 +41,7 @@ describe('launcher', () => {
       computeExecutablePath({
         browser: Browser.FIREFOX,
         platform: BrowserPlatform.LINUX,
-        revision: '123',
+        buildId: '123',
         cacheDir: 'cache',
       }),
       path.join('cache', 'firefox', 'linux-123', 'firefox', 'firefox')
@@ -52,7 +52,7 @@ describe('launcher', () => {
     this.timeout(60000);
 
     let tmpDir = '/tmp/puppeteer-browsers-test';
-    const testChromeRevision = '1083080';
+    const testChromeBuildId = '1083080';
 
     beforeEach(async () => {
       tmpDir = fs.mkdtempSync(
@@ -61,7 +61,7 @@ describe('launcher', () => {
       await fetch({
         cacheDir: tmpDir,
         browser: Browser.CHROME,
-        revision: testChromeRevision,
+        buildId: testChromeBuildId,
       });
     });
 
@@ -73,7 +73,7 @@ describe('launcher', () => {
       const executablePath = computeExecutablePath({
         cacheDir: tmpDir,
         browser: Browser.CHROME,
-        revision: testChromeRevision,
+        buildId: testChromeBuildId,
       });
       const process = launch({
         executablePath,
@@ -91,7 +91,7 @@ describe('launcher', () => {
     this.timeout(60000);
 
     let tmpDir = '/tmp/puppeteer-browsers-test';
-    const testFirefoxRevision = '111.0a1';
+    const testFirefoxBuildId = '111.0a1';
 
     beforeEach(async () => {
       tmpDir = fs.mkdtempSync(
@@ -100,7 +100,7 @@ describe('launcher', () => {
       await fetch({
         cacheDir: tmpDir,
         browser: Browser.FIREFOX,
-        revision: testFirefoxRevision,
+        buildId: testFirefoxBuildId,
       });
     });
 
@@ -112,7 +112,7 @@ describe('launcher', () => {
       const executablePath = computeExecutablePath({
         cacheDir: tmpDir,
         browser: Browser.FIREFOX,
-        revision: testFirefoxRevision,
+        buildId: testFirefoxBuildId,
       });
       const process = launch({
         executablePath,


### PR DESCRIPTION
Since not every browser will expose revision, we rename revision to a more general name: buildId.