### PR TITLE
chore: Fix BiDi session.status Param type

### DIFF
--- a/packages/puppeteer-core/src/common/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/common/bidi/Connection.ts
@@ -57,7 +57,7 @@ interface Commands {
     returnType: {sessionId: string};
   };
   'session.status': {
-    params: {context: string}; // TODO: Update Types in chromium bidi
+    params: object;
     returnType: Bidi.Session.StatusResult;
   };
   'session.subscribe': {

--- a/test/src/bidi/Connection.spec.ts
+++ b/test/src/bidi/Connection.spec.ts
@@ -36,11 +36,13 @@ describe('WebDriver BiDi', () => {
     it('should work', async () => {
       const transport = new TestConnectionTransport();
       const connection = new Connection(transport);
-      const responsePromise = connection.send('session.status', {
-        context: 'context',
+      const responsePromise = connection.send('session.new', {
+        capabilities: {
+          proxy: {},
+        },
       });
       expect(transport.sent).toEqual([
-        `{"id":1,"method":"session.status","params":{"context":"context"}}`,
+        `{"id":1,"method":"session.new","params":{"capabilities":{"proxy":{}}}}`,
       ]);
       const id = JSON.parse(transport.sent[0]!).id;
       const rawResponse = {


### PR DESCRIPTION
BiDi `session.status`'s parameters are per spec now.

Connection test was changed to use `session.new` as TypeScript was complaining.  