### PR TITLE
chore: improve recommendations by the test runner

### DIFF
--- a/tools/mochaRunner/README.md
+++ b/tools/mochaRunner/README.md
@@ -5,20 +5,20 @@ Mocha Runner is a test runner on top of mocha. It uses `/test/TestSuites.json` a
 ## Running tests for Mocha Runner itself.
 
 ```
-npm run build:test && npx c8 node tools/mochaRunner/lib/test.js
+npm run build && npx c8 node tools/mochaRunner/lib/test.js
 ```
 
 ## Running tests using Mocha Runner
 
 ```
-npm run build:test && npm run test
+npm run build && npm run test
 ```
 
 By default, the runner runs all test suites applicable to the current platform.
 To pick a test suite, provide the `--test-suite` arguments. For example,
 
 ```
-npm run build:test && npm run test -- --test-suite chrome-headless
+npm run build && npm run test -- --test-suite chrome-headless
 ```
 
 ## TestSuites.json

--- a/tools/mochaRunner/src/test.ts
+++ b/tools/mochaRunner/src/test.ts
@@ -18,7 +18,11 @@ import assert from 'assert/strict';
 import test from 'node:test';
 
 import {TestExpectation} from './types.js';
-import {filterByParameters, getTestResultForFailure} from './utils.js';
+import {
+  filterByParameters,
+  getTestResultForFailure,
+  isWildCardPattern,
+} from './utils.js';
 import {getFilename, extendProcessEnv} from './utils.js';
 
 test('extendProcessEnv', () => {
@@ -60,4 +64,13 @@ test('filterByParameters', () => {
     1
   );
   assert.equal(filterByParameters(expectations, ['other']).length, 0);
+});
+
+test('isWildCardPattern', () => {
+  assert.equal(isWildCardPattern(''), true);
+  assert.equal(isWildCardPattern('a'), false);
+  assert.equal(isWildCardPattern('[queryHandler.spec]'), true);
+  assert.equal(isWildCardPattern('[queryHandler.spec] '), true);
+  assert.equal(isWildCardPattern(' [queryHandler.spec] '), true);
+  assert.equal(isWildCardPattern('[queryHandler.spec] test'), false);
 });


### PR DESCRIPTION
We should not recommend updating wildcards if individual test failures are reported.

Drive-by: renamed local vars for clarity to distinguish between expectation entries in the file and the expectations on the entry.