### PR TITLE
chore: report sizes in MB rather than MiB

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -163,8 +163,8 @@ export class CLI {
   }
 
   #toMegabytes(bytes: number) {
-    const mb = bytes / 1024 / 1024;
-    return `${Math.round(mb * 10) / 10} Mb`;
+    const mb = bytes / 1000 / 1000;
+    return `${Math.round(mb * 10) / 10} MB`;
   }
 
   #makeProgressCallback(browser: Browser, buildId: string) {


### PR DESCRIPTION
This patch reports sizes in megabytes (MB) rather than mebibytes (MiB), which seemed to be the intention based on the naming in the code. See https://en.wikipedia.org/wiki/Byte#Multiple-byte_units.

This is also consistent with the way sizes are reported in DevTools across browsers: https://goo.gle/devtools-si