### PR TITLE
chore: fix Mocha test runner suggestion when hooks fail

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -25,7 +25,7 @@ The best place to look is an existing test to see how they use the helpers.
 
 ## Skipping tests in specific conditions
 
-To skip tests edit the [TestExpecations](https://github.com/puppeteer/puppeteer/blob/main/test/TestExpectations.json) file. See [test runner documentation](https://github.com/puppeteer/puppeteer/tree/main/tools/mochaRunner) for more details.
+To skip tests edit the [TestExpectations](https://github.com/puppeteer/puppeteer/blob/main/test/TestExpectations.json) file. See [test runner documentation](https://github.com/puppeteer/puppeteer/tree/main/tools/mochaRunner) for more details.
 
 ## Running tests
 

--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -43,7 +43,7 @@
       "expectedLineCoverage": 56
     }
   ],
-  "parameterDefinitons": {
+  "parameterDefinitions": {
     "chrome": {
       "PUPPETEER_PRODUCT": "chrome"
     },

--- a/test/package.json
+++ b/test/package.json
@@ -15,6 +15,7 @@
         "../packages/testserver:build"
       ],
       "files": [
+        "../tools/mochaRunner/**",
         "src/**"
       ],
       "output": [

--- a/tools/mochaRunner/README.md
+++ b/tools/mochaRunner/README.md
@@ -24,7 +24,7 @@ npm run build && npm run test -- --test-suite chrome-headless
 ## TestSuites.json
 
 Define test suites via the `testSuites` attribute. `parameters` can be used in the `TestExpectations.json` to disable tests
-based on parameters. The meaning for parameters is defined in `parameterDefinitons` which tell what env object corresponds
+based on parameters. The meaning for parameters is defined in `parameterDefinitions` which tell what env object corresponds
 to the given parameter.
 
 ## TestExpectations.json

--- a/tools/mochaRunner/src/main.ts
+++ b/tools/mochaRunner/src/main.ts
@@ -109,7 +109,7 @@ async function main() {
 
       const env = extendProcessEnv([
         ...parameters.map(param => {
-          return parsedSuitesFile.parameterDefinitons[param];
+          return parsedSuitesFile.parameterDefinitions[param];
         }),
         {
           PUPPETEER_SKIPPED_TEST_CONFIG: JSON.stringify(

--- a/tools/mochaRunner/src/main.ts
+++ b/tools/mochaRunner/src/main.ts
@@ -31,10 +31,10 @@ import {
 import {
   extendProcessEnv,
   filterByPlatform,
-  prettyPrintJSON,
   readJSON,
   filterByParameters,
   getExpectationUpdates,
+  printSuggestions,
 } from './utils.js';
 
 function getApplicableTestSuites(
@@ -211,45 +211,21 @@ async function main() {
     console.error(err);
   } finally {
     if (!noSuggestions) {
-      const toAdd = recommendations.filter(item => {
-        return item.action === 'add';
-      });
-      if (toAdd.length) {
-        console.log(
-          'Add the following to TestExpectations.json to ignore the error:'
-        );
-        prettyPrintJSON(
-          toAdd.map(item => {
-            return item.expectation;
-          })
-        );
-      }
-      const toRemove = recommendations.filter(item => {
-        return item.action === 'remove';
-      });
-      if (toRemove.length) {
-        console.log(
-          'Remove the following from the TestExpectations.json to ignore the error:'
-        );
-        prettyPrintJSON(
-          toRemove.map(item => {
-            return item.expectation;
-          })
-        );
-      }
-      const toUpdate = recommendations.filter(item => {
-        return item.action === 'update';
-      });
-      if (toUpdate.length) {
-        console.log(
-          'Update the following expectations in the TestExpectations.json to ignore the error:'
-        );
-        prettyPrintJSON(
-          toUpdate.map(item => {
-            return item.expectation;
-          })
-        );
-      }
+      printSuggestions(
+        recommendations,
+        'add',
+        'Add the following to TestExpectations.json to ignore the error:'
+      );
+      printSuggestions(
+        recommendations,
+        'remove',
+        'Remove the following from the TestExpectations.json to ignore the error:'
+      );
+      printSuggestions(
+        recommendations,
+        'update',
+        'Update the following expectations in the TestExpectations.json to ignore the error:'
+      );
     }
     process.exit(fail ? 1 : 0);
   }

--- a/tools/mochaRunner/src/main.ts
+++ b/tools/mochaRunner/src/main.ts
@@ -242,7 +242,7 @@ async function main() {
       });
       if (toUpdate.length) {
         console.log(
-          'Update the following expectations in the TestExpecations.json to ignore the error:'
+          'Update the following expectations in the TestExpectations.json to ignore the error:'
         );
         prettyPrintJSON(
           toUpdate.map(item => {

--- a/tools/mochaRunner/src/types.ts
+++ b/tools/mochaRunner/src/types.ts
@@ -31,7 +31,7 @@ export type TestSuite = z.infer<typeof zTestSuite>;
 
 export const zTestSuiteFile = z.object({
   testSuites: z.array(zTestSuite),
-  parameterDefinitons: z.record(z.any()),
+  parameterDefinitions: z.record(z.any()),
 });
 
 export type TestSuiteFile = z.infer<typeof zTestSuiteFile>;

--- a/tools/mochaRunner/src/utils.ts
+++ b/tools/mochaRunner/src/utils.ts
@@ -57,6 +57,24 @@ export function prettyPrintJSON(json: unknown): void {
   console.log(JSON.stringify(json, null, 2));
 }
 
+export function printSuggestions(
+  recommendations: RecommendedExpectation[],
+  action: RecommendedExpectation['action'],
+  message: string
+): void {
+  const toPrint = recommendations.filter(item => {
+    return item.action === action;
+  });
+  if (toPrint.length) {
+    console.log(message);
+    prettyPrintJSON(
+      toPrint.map(item => {
+        return item.expectation;
+      })
+    );
+  }
+}
+
 export function filterByParameters(
   expectations: TestExpectation[],
   parameters: string[]
@@ -90,7 +108,6 @@ export function findEffectiveExpectationForTest(
 
 type RecommendedExpectation = {
   expectation: TestExpectation;
-  test: MochaTestResult;
   action: 'remove' | 'add' | 'update';
 };
 
@@ -126,7 +143,6 @@ export function getExpectationUpdates(
     if (expectationEntry && !expectationEntry.expectations.includes('PASS')) {
       addEntry({
         expectation: expectationEntry,
-        test: pass,
         action: 'remove',
       });
     }
@@ -163,7 +179,6 @@ export function getExpectationUpdates(
               getTestResultForFailure(failure),
             ],
           },
-          test: failure,
           action: 'update',
         });
       }
@@ -175,14 +190,13 @@ export function getExpectationUpdates(
           parameters: context.parameters,
           expectations: [getTestResultForFailure(failure)],
         },
-        test: failure,
         action: 'add',
       });
     }
   }
 
   function addEntry(value: RecommendedExpectation) {
-    const key = JSON.stringify(value.expectation) + value.action;
+    const key = JSON.stringify(value);
     if (!output.has(key)) {
       output.set(key, value);
     }


### PR DESCRIPTION
A quick patch to MochaRunner. There was an issue with error coming from hooks that prevented the `suggestions` from reporting correctly and throwing a error.

Also did some typo fixes and made the suggestion only report a single entry on duplicates.
And fixed a WireIt issue that prevented changes to MochaRunner to be applied.  