### PR TITLE
chore: add more debugging info on Debug Runs

### DIFF
--- a/tools/mochaRunner/src/main.ts
+++ b/tools/mochaRunner/src/main.ts
@@ -107,6 +107,19 @@ async function main() {
         parameters
       );
 
+      // Add more logging when the GitHub Action Debugging option is set
+      // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+      const githubActionDebugging = process.env['RUNNER_DEBUG']
+        ? {
+            DEBUG: 'puppeteer:*',
+            EXTRA_LAUNCH_OPTIONS: {
+              extraPrefsFirefox: {
+                'remote.log.level': 'Trace',
+              },
+            },
+          }
+        : {};
+
       const env = extendProcessEnv([
         ...parameters.map(param => {
           return parsedSuitesFile.parameterDefinitions[param];
@@ -121,6 +134,7 @@ async function main() {
             })
           ),
         },
+        githubActionDebugging,
       ]);
 
       const tmpDir = fs.mkdtempSync(


### PR DESCRIPTION
There is a Firefox BiDi test that is failing occasionally,  the problem is there are not enough logs.
Firefox team suggested adding `Trace`, but the bug is reproducible on MacOS only, so can't use local.
The extra logs will be shown only when you Re-run a GitHub Action with debug logs.