### PR TITLE
chore: update test expectation data for Firefox for 19.7.2 downstream sync

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -78,6 +78,12 @@
     "expectations": ["SKIP"]
   },
   {
+    "testIdPattern": "[click.spec] Page.click should click on checkbox label and toggle",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["PASS", "FAIL"]
+  },
+  {
     "testIdPattern": "[click.spec] Page.click should click the button with fixed position inside an iframe",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -408,6 +414,12 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails Network redirects should report SecurityDetails",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["PASS", "FAIL"]
+  },
+  {
     "testIdPattern": "[input.spec]",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -510,6 +522,12 @@
     "expectations": ["SKIP"]
   },
   {
+    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath returns executablePath for channel",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -570,6 +588,12 @@
     "expectations": ["PASS", "FAIL"]
   },
   {
+    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch should work with no default arguments",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "headless"],
+    "expectations": ["PASS", "FAIL"]
+  },
+  {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch tmp profile should be cleaned up",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -621,7 +645,7 @@
     "testIdPattern": "[navigation.spec] navigation Frame.goto should return matching responses",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
-    "expectations": ["FAIL"]
+    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Frame.waitForNavigation should fail when frame detaches",


### PR DESCRIPTION
I recently vendored Puppeteer 19.7.2 into our mozilla-central repository. While doing that I noticed a couple of test failures when running tests locally on MacOS and Linux. We are proposing those changes to make test results more stable.