### PR TITLE
chore(browser): remove unused detach function

### DIFF
--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -235,13 +235,6 @@ export class Browser extends EventEmitter {
   /**
    * @internal
    */
-  _detach(): void {
-    throw new Error('Not implemented');
-  }
-
-  /**
-   * @internal
-   */
   get _targets(): Map<string, Target> {
     throw new Error('Not implemented');
   }

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -177,32 +177,6 @@ export class CDPBrowser extends BrowserBase {
   }
 
   /**
-   * @internal
-   */
-  override _detach(): void {
-    this.#connection.off(
-      ConnectionEmittedEvents.Disconnected,
-      this.#emitDisconnected
-    );
-    this.#targetManager.off(
-      TargetManagerEmittedEvents.TargetAvailable,
-      this.#onAttachedToTarget
-    );
-    this.#targetManager.off(
-      TargetManagerEmittedEvents.TargetGone,
-      this.#onDetachedFromTarget
-    );
-    this.#targetManager.off(
-      TargetManagerEmittedEvents.TargetChanged,
-      this.#onTargetChanged
-    );
-    this.#targetManager.off(
-      TargetManagerEmittedEvents.TargetDiscovered,
-      this.#onTargetDiscovered
-    );
-  }
-
-  /**
    * The spawned browser process. Returns `null` if the browser instance was created with
    * {@link Puppeteer.connect}.
    */


### PR DESCRIPTION
The `_detach ` function is not being used anymore. Is that ok?