### PR TITLE
fix: change the install output to include the executable path

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -100,7 +100,14 @@ export class CLI {
             ),
           });
           console.log(
-            `${args.browser.name}@${args.browser.buildId} downloaded successfully.`
+            `${args.browser.name}@${
+              args.browser.buildId
+            } ${computeExecutablePath({
+              browser: args.browser.name,
+              buildId: args.browser.buildId,
+              cacheDir: args.path ?? this.#cachePath,
+              platform: args.platform,
+            })}`
           );
         }
       )


### PR DESCRIPTION
With this change, the executable path will be printed to stdout in the following format: `$browser@$revision $executablePath` which makes it easy for tools to save the data for future use.