### PR TITLE
fix: call _detach on disconnect

### DIFF
--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -567,6 +567,7 @@ export class CDPBrowser extends BrowserBase {
   override disconnect(): void {
     this.#targetManager.dispose();
     this.#connection.dispose();
+    this._detach();
   }
 
   /**


### PR DESCRIPTION
Removing listeners on disconnect to make sure memory is not retained by them. 