### PR TITLE
fix: restore rimraf for puppeteer-core code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7101,6 +7101,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.0.tgz",
+      "integrity": "sha512-X36S+qpCUR0HjXlkDe4NAOhS//aHH0Z+h8Ckf2auGJk3PTnx5rLmrHkwNdbVQuCSUhOyFrlRvFEllZOYE+yZGQ==",
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.18.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.18.0.tgz",
@@ -8413,13 +8430,14 @@
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
+        "rimraf": "4.4.0",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
         "ws": "8.12.1"
       },
       "devDependencies": {
         "mitt": "3.0.0",
-        "parsel-js": "git+ssh://git@github.com/jrandolf/parsel.git#f3ac5a371c382df9e5a8425d239594802562ee0f"
+        "parsel-js": "github:jrandolf/parsel"
       },
       "engines": {
         "node": ">=14.14.0"
@@ -13387,8 +13405,9 @@
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "mitt": "3.0.0",
-        "parsel-js": "git+ssh://git@github.com/jrandolf/parsel.git#f3ac5a371c382df9e5a8425d239594802562ee0f",
+        "parsel-js": "github:jrandolf/parsel",
         "proxy-from-env": "1.1.0",
+        "rimraf": "4.4.0",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
         "ws": "8.12.1"
@@ -13679,6 +13698,14 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.0.tgz",
+      "integrity": "sha512-X36S+qpCUR0HjXlkDe4NAOhS//aHH0Z+h8Ckf2auGJk3PTnx5rLmrHkwNdbVQuCSUhOyFrlRvFEllZOYE+yZGQ==",
+      "requires": {
+        "glob": "^9.2.0"
+      }
     },
     "rollup": {
       "version": "3.18.0",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -138,6 +138,7 @@
     "extract-zip": "2.0.1",
     "https-proxy-agent": "5.0.1",
     "proxy-from-env": "1.1.0",
+    "rimraf": "4.4.0",
     "tar-fs": "2.1.1",
     "unbzip2-stream": "1.4.3",
     "ws": "8.12.1"

--- a/packages/puppeteer-core/src/node/BrowserFetcher.ts
+++ b/packages/puppeteer-core/src/node/BrowserFetcher.ts
@@ -16,7 +16,7 @@
 
 import {exec as execChildProcess} from 'child_process';
 import {createReadStream, createWriteStream, existsSync, readdirSync} from 'fs';
-import {chmod, mkdir, readdir, rm, unlink} from 'fs/promises';
+import {chmod, mkdir, readdir, unlink} from 'fs/promises';
 import * as http from 'http';
 import * as https from 'https';
 import * as os from 'os';
@@ -31,6 +31,7 @@ import createHttpsProxyAgent, {
   HttpsProxyAgentOptions,
 } from 'https-proxy-agent';
 import {getProxyForUrl} from 'proxy-from-env';
+import rimraf from 'rimraf';
 import tar from 'tar-fs';
 import bzip from 'unbzip2-stream';
 
@@ -412,7 +413,7 @@ export class BrowserFetcher {
       existsSync(folderPath),
       `Failed to remove: revision ${revision} is not downloaded`
     );
-    await rm(folderPath, {recursive: true, force: true});
+    await rimraf(folderPath);
   }
 
   /**

--- a/packages/puppeteer-core/src/node/BrowserRunner.ts
+++ b/packages/puppeteer-core/src/node/BrowserRunner.ts
@@ -16,10 +16,11 @@
 
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import {rm} from 'fs/promises';
 import * as path from 'path';
 import * as readline from 'readline';
 import {promisify} from 'util';
+
+import rimraf from 'rimraf';
 
 import type {Connection as BiDiConnection} from '../common/bidi/bidi.js';
 import {Connection} from '../common/Connection.js';
@@ -124,7 +125,7 @@ export class BrowserRunner {
         // Cleanup as processes exit.
         if (this.#isTempUserDataDir) {
           try {
-            await rm(this.#userDataDir, {recursive: true, force: true});
+            await rimraf(this.#userDataDir);
             fulfill();
           } catch (error) {
             debugError(error);
@@ -238,7 +239,7 @@ export class BrowserRunner {
     // Attempt to remove temporary profile directory to avoid littering.
     try {
       if (this.#isTempUserDataDir) {
-        fs.rmSync(this.#userDataDir, {recursive: true, force: true});
+        rimraf.sync(this.#userDataDir);
       }
     } catch (error) {}
 


### PR DESCRIPTION
Partially reverts https://github.com/puppeteer/puppeteer/pull/9775 as the fs functions provided by node don't seem to work well for Windows.

Closes #9814