### PR TITLE
chore: fix esbuild problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Check code
         run: npm run check
       - name: Lint code
@@ -126,7 +126,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build packages
         run: npm run build --workspace @puppeteer-test/test
       - name: Setup cache for Chromium binary
@@ -182,7 +182,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build packages
         run: npm run build --workspace @puppeteer-test/test
       - name: Setup cache for Firefox binary
@@ -230,7 +230,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build installation test
         run: npm run build --workspace @puppeteer-test/installation
       - name: Pack installation test
@@ -310,7 +310,7 @@ jobs:
           cache: npm
           node-version: ${{ matrix.node }}
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build packages
         run: npm run build --workspace puppeteer
       - name: Pack packages
@@ -338,7 +338,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Run tests
         run: npm run test --workspace @puppeteer/ng-schematics
 
@@ -363,7 +363,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Run tests
         run: npm run test --workspace @puppeteer/browsers
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Check code
         run: npm run check
       - name: Lint code
@@ -127,6 +129,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build --workspace @puppeteer-test/test
       - name: Setup cache for Chromium binary
@@ -183,6 +187,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build --workspace @puppeteer-test/test
       - name: Setup cache for Firefox binary
@@ -231,6 +237,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build installation test
         run: npm run build --workspace @puppeteer-test/installation
       - name: Pack installation test
@@ -311,6 +319,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build --workspace puppeteer
       - name: Pack packages
@@ -339,6 +349,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Run tests
         run: npm run test --workspace @puppeteer/ng-schematics
 
@@ -364,6 +376,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Run tests
         run: npm run test --workspace @puppeteer/browsers
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.0.2
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build packages
         run: npm run build
       - name: Set npm registry
@@ -51,7 +51,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.0.2
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Build packages
         run: npm run build
       - name: Pack packages for docker

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v3.0.2
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build
       - name: Set npm registry
@@ -52,6 +54,8 @@ jobs:
         uses: actions/checkout@v3.0.2
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build
       - name: Pack packages for docker

--- a/.github/workflows/tot-ci.yml
+++ b/.github/workflows/tot-ci.yml
@@ -35,6 +35,8 @@ jobs:
           node-version: latest
       - name: Install dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
       - name: Install linux dependencies.
         run: sudo apt-get install xvfb
       - name: Build packages

--- a/.github/workflows/tot-ci.yml
+++ b/.github/workflows/tot-ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache: npm
           node-version: latest
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Install linux dependencies.
         run: sudo apt-get install xvfb
       - name: Build packages

--- a/packages/puppeteer/install.js
+++ b/packages/puppeteer/install.js
@@ -35,6 +35,9 @@ if (!fs.existsSync(path.join(__dirname, 'lib'))) {
   execSync('npm run build --workspace puppeteer');
 }
 
-const {downloadBrowser} = require('puppeteer/internal/node/install.js');
-
-downloadBrowser();
+try {
+  const {downloadBrowser} = require('puppeteer/internal/node/install.js');
+  downloadBrowser();
+} catch (err) {
+  console.warn('Browser download failed', err);
+}


### PR DESCRIPTION
It looks like for whatever reasons --ignore-scripts started to affect esbuild installation leading to errors. I think we should gracefully handle installation on a checkout that has no lib folder and use Puppeteer-specific env variables to skip the browser download whenever needed.