### PR TITLE
fix: sort elements based on selector matching algorithm

### DIFF
--- a/packages/puppeteer-core/src/util/AsyncIterableUtil.ts
+++ b/packages/puppeteer-core/src/util/AsyncIterableUtil.ts
@@ -28,10 +28,10 @@ export class AsyncIterableUtil {
     }
   }
 
-  static async *flatMap<T>(
+  static async *flatMap<T, U>(
     iterable: AwaitableIterable<T>,
-    map: (item: T) => AwaitableIterable<T>
-  ): AsyncIterable<T> {
+    map: (item: T) => AwaitableIterable<U>
+  ): AsyncIterable<U> {
     for await (const value of iterable) {
       yield* map(value);
     }


### PR DESCRIPTION
The CSS Selector spec (https://www.w3.org/TR/selectors-4/#match-against-tree) defines selector ordering as the ordering determined by breadth-first search of the DOM tree. To mimic this in P selectors, we sort results based on this ordering.
