### PR TITLE
feat: implement system channels for chrome in browsers

### DIFF
--- a/packages/browsers/src/browsers/browsers.ts
+++ b/packages/browsers/src/browsers/browsers.ts
@@ -16,7 +16,13 @@
 
 import * as chrome from './chrome.js';
 import * as firefox from './firefox.js';
-import {Browser, BrowserPlatform, BrowserTag, ProfileOptions} from './types.js';
+import {
+  Browser,
+  BrowserPlatform,
+  BrowserTag,
+  ChromeReleaseChannel,
+  ProfileOptions,
+} from './types.js';
 
 export const downloadUrls = {
   [Browser.CHROME]: chrome.resolveDownloadUrl,
@@ -64,5 +70,21 @@ export async function createProfile(
     case Browser.CHROME:
     case Browser.CHROMIUM:
       throw new Error(`Profile creation is not support for ${browser} yet`);
+  }
+}
+
+export function resolveSystemExecutablePath(
+  browser: Browser,
+  platform: BrowserPlatform,
+  channel: ChromeReleaseChannel
+): string {
+  switch (browser) {
+    case Browser.FIREFOX:
+      throw new Error(
+        'System browser detection is not supported for Firefox yet.'
+      );
+    case Browser.CHROME:
+    case Browser.CHROMIUM:
+      return chrome.resolveSystemExecutablePath(platform, channel);
   }
 }

--- a/packages/browsers/src/browsers/chrome.ts
+++ b/packages/browsers/src/browsers/chrome.ts
@@ -18,7 +18,7 @@ import path from 'path';
 
 import {httpRequest} from '../httpUtil.js';
 
-import {BrowserPlatform} from './types.js';
+import {BrowserPlatform, ChromeReleaseChannel} from './types.js';
 
 function archive(platform: BrowserPlatform, buildId: string): string {
   switch (platform) {
@@ -81,7 +81,6 @@ export function relativeExecutablePath(
       return path.join('chrome-win', 'chrome.exe');
   }
 }
-
 export async function resolveBuildId(
   platform: BrowserPlatform,
   // We will need it for other channels/keywords.
@@ -117,4 +116,49 @@ export async function resolveBuildId(
       reject(err);
     });
   });
+}
+
+export function resolveSystemExecutablePath(
+  platform: BrowserPlatform,
+  channel: ChromeReleaseChannel
+): string {
+  switch (platform) {
+    case BrowserPlatform.WIN64:
+    case BrowserPlatform.WIN32:
+      switch (channel) {
+        case ChromeReleaseChannel.STABLE:
+          return `${process.env['PROGRAMFILES']}\\Google\\Chrome\\Application\\chrome.exe`;
+        case ChromeReleaseChannel.BETA:
+          return `${process.env['PROGRAMFILES']}\\Google\\Chrome Beta\\Application\\chrome.exe`;
+        case ChromeReleaseChannel.CANARY:
+          return `${process.env['PROGRAMFILES']}\\Google\\Chrome SxS\\Application\\chrome.exe`;
+        case ChromeReleaseChannel.DEV:
+          return `${process.env['PROGRAMFILES']}\\Google\\Chrome Dev\\Application\\chrome.exe`;
+      }
+    case BrowserPlatform.MAC_ARM:
+    case BrowserPlatform.MAC:
+      switch (channel) {
+        case ChromeReleaseChannel.STABLE:
+          return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+        case ChromeReleaseChannel.BETA:
+          return '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta';
+        case ChromeReleaseChannel.CANARY:
+          return '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary';
+        case ChromeReleaseChannel.DEV:
+          return '/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev';
+      }
+    case BrowserPlatform.LINUX:
+      switch (channel) {
+        case ChromeReleaseChannel.STABLE:
+          return '/opt/google/chrome/chrome';
+        case ChromeReleaseChannel.BETA:
+          return '/opt/google/chrome-beta/chrome';
+        case ChromeReleaseChannel.DEV:
+          return '/opt/google/chrome-unstable/chrome';
+      }
+  }
+
+  throw new Error(
+    `Unable to detect browser executable path for '${channel}' on ${platform}.`
+  );
 }

--- a/packages/browsers/src/browsers/types.ts
+++ b/packages/browsers/src/browsers/types.ts
@@ -52,3 +52,10 @@ export interface ProfileOptions {
   preferences: Record<string, unknown>;
   path: string;
 }
+
+export enum ChromeReleaseChannel {
+  STABLE = 'stable',
+  DEV = 'dev',
+  CANARY = 'canary',
+  BETA = 'beta',
+}

--- a/packages/browsers/src/main.ts
+++ b/packages/browsers/src/main.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  launch,
+  computeExecutablePath,
+  computeSystemExecutablePath,
+  CDP_WEBSOCKET_ENDPOINT_REGEX,
+  WEBDRIVER_BIDI_WEBSOCKET_ENDPOINT_REGEX,
+} from './launcher.js';
+export {fetch, canFetch} from './fetch.js';
+export {detectBrowserPlatform} from './detectPlatform.js';
+export {Browser, BrowserPlatform} from './browsers/browsers.js';

--- a/packages/browsers/test/src/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome-data.spec.ts
@@ -21,7 +21,9 @@ import {BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
 import {
   resolveDownloadUrl,
   relativeExecutablePath,
+  resolveSystemExecutablePath,
 } from '../../lib/cjs/browsers/chrome.js';
+import {ChromeReleaseChannel} from '../../lib/cjs/browsers/types.js';
 
 describe('Chrome', () => {
   it('should resolve download URLs', () => {
@@ -68,5 +70,37 @@ describe('Chrome', () => {
       relativeExecutablePath(BrowserPlatform.WIN64, '12372323'),
       path.join('chrome-win', 'chrome.exe')
     );
+  });
+
+  it('should resolve system executable path', () => {
+    process.env['PROGRAMFILES'] = 'C:\\ProgramFiles';
+    try {
+      assert.strictEqual(
+        resolveSystemExecutablePath(
+          BrowserPlatform.WIN32,
+          ChromeReleaseChannel.DEV
+        ),
+        'C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe'
+      );
+    } finally {
+      delete process.env['PROGRAMFILES'];
+    }
+
+    assert.strictEqual(
+      resolveSystemExecutablePath(
+        BrowserPlatform.MAC,
+        ChromeReleaseChannel.BETA
+      ),
+      '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta'
+    );
+    assert.throws(() => {
+      assert.strictEqual(
+        resolveSystemExecutablePath(
+          BrowserPlatform.LINUX,
+          ChromeReleaseChannel.CANARY
+        ),
+        path.join('chrome-linux', 'chrome')
+      );
+    }, new Error(`Unable to detect browser executable path for 'canary' on linux.`));
   });
 });

--- a/packages/browsers/test/src/fetch.spec.ts
+++ b/packages/browsers/test/src/fetch.spec.ts
@@ -92,7 +92,7 @@ describe('fetch', () => {
   });
 
   it('should download a buildId that is a bzip2 archive', async function () {
-    this.timeout(60000);
+    this.timeout(90000);
     const expectedOutputPath = path.join(
       tmpDir,
       'firefox',


### PR DESCRIPTION
it is a bit difficult to test the integration with system browsers (it would require installing them on CI) so I opted into testing only the path computation for now and relying on the launch tests to verify that the correct executable paths can be launched.