### PR TITLE
chore: add rimraf for browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9130,6 +9130,7 @@
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
+        "rimraf": "4.4.0",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.1"
@@ -10087,6 +10088,7 @@
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
+        "rimraf": "4.4.0",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.1"

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -75,6 +75,7 @@
     "https-proxy-agent": "5.0.1",
     "progress": "2.0.3",
     "proxy-from-env": "1.1.0",
+    "rimraf": "4.4.0",
     "tar-fs": "2.1.1",
     "unbzip2-stream": "1.4.3",
     "yargs": "17.7.1"

--- a/packages/browsers/test/src/cli.spec.ts
+++ b/packages/browsers/test/src/cli.spec.ts
@@ -19,6 +19,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import rimraf from 'rimraf';
+
 import {CLI} from '../../lib/cjs/CLI.js';
 
 import {testChromeBuildId, testFirefoxBuildId} from './versions.js';
@@ -33,7 +35,7 @@ describe('CLI', function () {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, {recursive: true});
+    rimraf.sync(tmpDir);
   });
 
   it('should download Chromium binaries', async () => {

--- a/packages/browsers/test/src/fetch.spec.ts
+++ b/packages/browsers/test/src/fetch.spec.ts
@@ -21,6 +21,8 @@ import https from 'https';
 import os from 'os';
 import path from 'path';
 
+import rimraf from 'rimraf';
+
 import {fetch, canFetch, Browser, BrowserPlatform} from '../../lib/cjs/main.js';
 
 import {testChromeBuildId, testFirefoxBuildId} from './versions.js';
@@ -37,7 +39,7 @@ describe('fetch', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, {recursive: true});
+    rimraf.sync(tmpDir);
   });
 
   it('should check if a buildId can be downloaded', async () => {

--- a/packages/browsers/test/src/firefox-data.spec.ts
+++ b/packages/browsers/test/src/firefox-data.spec.ts
@@ -19,6 +19,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import rimraf from 'rimraf';
+
 import {BrowserPlatform} from '../../lib/cjs/browsers/browsers.js';
 import {
   createProfile,
@@ -83,7 +85,7 @@ describe('Firefox', () => {
     });
 
     afterEach(() => {
-      fs.rmSync(tmpDir, {recursive: true});
+      rimraf.sync(tmpDir);
     });
 
     it('should create a profile', async () => {

--- a/packages/browsers/test/src/launcher.spec.ts
+++ b/packages/browsers/test/src/launcher.spec.ts
@@ -19,6 +19,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import rimraf from 'rimraf';
+
 import {
   CDP_WEBSOCKET_ENDPOINT_REGEX,
   computeExecutablePath,
@@ -84,7 +86,7 @@ describe('launcher', () => {
     });
 
     afterEach(() => {
-      fs.rmSync(tmpDir, {recursive: true});
+      rimraf.sync(tmpDir);
     });
 
     it('should launch a Chrome browser', async () => {
@@ -144,7 +146,7 @@ describe('launcher', () => {
     });
 
     afterEach(() => {
-      fs.rmSync(tmpDir, {recursive: true});
+      rimraf.sync(tmpDir);
     });
 
     it('should launch a Firefox browser', async () => {


### PR DESCRIPTION
Added as a prod dependency so that it can be used in the future commands such as clearing the cache folder.