### PR TITLE
fix: waitForNavigation issue with aborted events

### DIFF
--- a/packages/puppeteer-core/src/common/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.ts
@@ -302,11 +302,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   #onAuthRequired(event: Protocol.Fetch.AuthRequiredEvent): void {
-    /* TODO(jacktfranklin): This is defined in protocol.d.ts but not
-     * in an easily referrable way - we should look at exposing it.
-     */
-    type AuthResponse = 'Default' | 'CancelAuth' | 'ProvideCredentials';
-    let response: AuthResponse = 'Default';
+    let response: Protocol.Fetch.AuthChallengeResponse['response'] = 'Default';
     if (this.#attemptedAuthentications.has(event.requestId)) {
       response = 'CancelAuth';
     } else if (this.#credentials) {

--- a/test/assets/abort-request.html
+++ b/test/assets/abort-request.html
@@ -1,0 +1,13 @@
+<button id="abort"></button>
+
+<script>
+  const button = document.getElementById('abort');
+  button.addEventListener('click', getJson)
+  async function getJson() {
+    const abort = new AbortController();
+    const result = fetch("/simple.json", {
+      signal: abort.signal
+    });
+    abort.abort();
+  }
+</script>

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -1163,6 +1163,21 @@ describe('Page', function () {
       ]);
       expect(result).toBe(undefined);
     });
+    it('should work with aborted requests', async () => {
+      const {page, server} = getTestState();
+
+      await page.goto(server.PREFIX + '/abort-request.html');
+
+      const element = await page.$(`#abort`);
+      await element!.click();
+
+      let error = false;
+      await page.waitForNetworkIdle().catch(() => {
+        return (error = true);
+      });
+
+      expect(error).toBe(false);
+    });
   });
 
   describe('Page.exposeFunction', function () {


### PR DESCRIPTION
Fixes #9881, fixes #8383.
The issue seem to be that we don't listen to all the possible event for Request/Response so we never try to see if there are no requests.

@OrKoN Let's take a closer look together to see if there are other "unhappy" paths that need to handled.