### PR TITLE
chore: run CI on up to date PRs

### DIFF
--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ inputs.check-mergeable-state }}
         run: |
           git fetch origin main --depth 1 &&
-          git merge-base --is-ancestor main @;
+          git merge-base --is-ancestor origin/main @;
       - name: Detect changed packages
         uses: dorny/paths-filter@v2.11.1
         id: changes

--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -4,6 +4,10 @@ permissions: read-all
 
 on:
   workflow_call:
+    inputs:
+      check-mergeable-state:
+        default: false
+        type: boolean
     outputs:
       changes:
         description: 'The packages that were changed for this PR'
@@ -19,6 +23,11 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 2
+      - name: Check if branch is out of date
+        if: ${{ inputs.check-mergeable-state }}
+        run: |
+          git fetch origin main --depth 1 &&
+          git merge-base --is-ancestor main @;
       - name: Detect changed packages
         uses: dorny/paths-filter@v2.11.1
         id: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
   check-changes:
     needs: inspect-code
     uses: ./.github/workflows/changed-packages.yml
+    with:
+      check-mergeable-state: true
 
   deploy-docs:
     needs: check-changes


### PR DESCRIPTION
Test if we can run CI only when the PR is up to date to reduce waiting for runners. If this works I'll explore if it's worth to scope this to error only for Puppeteer changes and run the other packages' tests.
