### PR TITLE
chore: don't skip only test

### DIFF
--- a/tools/mochaRunner/src/interface.ts
+++ b/tools/mochaRunner/src/interface.ts
@@ -86,7 +86,9 @@ function customBDDInterface(suite: Mocha.Suite) {
         const test = new Mocha.Test(title, suite.isPending() ? undefined : fn);
         test.file = file;
         test.parent = suite;
-        if (shouldSkipTest(test)) {
+        // If we use `.only` the function will not have an `only` property
+        const isExclusiveTest = typeof fn?.only !== 'function';
+        if (shouldSkipTest(test) && !isExclusiveTest) {
           const test = new Mocha.Test(title);
           test.file = file;
           suite.addTest(test);


### PR DESCRIPTION
This allows us to bypass the `TestExpectations.json` while developing and using `.only` in test (Tested with both `describe.only` and `it.only`).
We should not worry about it in CI as we will fail the EsLint rule before trying to run the tests. 

Note: Recommended to use `--no-suggestions` with this as they are just wrong.