### PR TITLE
chore: skip building on install

### DIFF
--- a/packages/puppeteer/install.js
+++ b/packages/puppeteer/install.js
@@ -24,15 +24,15 @@
  * necessary.
  */
 
-const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
 // Need to ensure TS is compiled before loading the installer
 if (!fs.existsSync(path.join(__dirname, 'lib'))) {
-  console.log('It seems we are installing from the git repo.');
-  console.log('Building install tools from scratch...');
-  execSync('npm run build --workspace puppeteer');
+  console.warn(
+    'Skipping browser installation because the Puppeteer build is not available. Run `npm install` again after you have re-built Puppeteer.'
+  );
+  process.exit(0);
 }
 
 try {


### PR DESCRIPTION
Currently, we try to compile the installation script during `npm i` in the development repository. This is a fragile process because the build might not succeed during the installation (missing packages) and it adds to the installation time. This PR removes the build step and instead recommends running the install after a build.