### PR TITLE
chore: remove long jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
         exclude:
           - os: windows-latest
             suite: chrome-bidi
+          - os: macos-latest
+            suite: chrome-headful
     steps:
       - name: Check out repository
         uses: actions/checkout@v3.3.0
@@ -186,6 +188,11 @@ jobs:
           - firefox-bidi
           - firefox-headful
           - firefox-headless
+        exclude:
+          - os: macos-latest
+            suite: firefox-headful
+          - os: macos-latest
+            suite: firefox-headless
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -276,8 +283,6 @@ jobs:
           - macos-latest
           - windows-latest
         node:
-          - 14
-          - 16
           - 18
         pkg_manager:
           - npm


### PR DESCRIPTION
Let's try to keep any job within 15 min. Also, let's keep installation tests only for the latest node LTS version. 