### PR TITLE
chore: fix BiDi to use cm

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2171,7 +2171,10 @@ export class Page extends EventEmitter {
   /**
    * @internal
    */
-  _getPDFOptions(options: PDFOptions = {}): ParsedPDFOptions {
+  _getPDFOptions(
+    options: PDFOptions = {},
+    lengthUnit: 'in' | 'cm' = 'in'
+  ): ParsedPDFOptions {
     const defaults = {
       scale: 1,
       displayHeaderFooter: false,
@@ -2194,15 +2197,19 @@ export class Page extends EventEmitter {
       width = format.width;
       height = format.height;
     } else {
-      width = convertPrintParameterToInches(options.width) ?? width;
-      height = convertPrintParameterToInches(options.height) ?? height;
+      width = convertPrintParameterToInches(options.width, lengthUnit) ?? width;
+      height =
+        convertPrintParameterToInches(options.height, lengthUnit) ?? height;
     }
 
     const margin = {
-      top: convertPrintParameterToInches(options.margin?.top) || 0,
-      left: convertPrintParameterToInches(options.margin?.left) || 0,
-      bottom: convertPrintParameterToInches(options.margin?.bottom) || 0,
-      right: convertPrintParameterToInches(options.margin?.right) || 0,
+      top: convertPrintParameterToInches(options.margin?.top, lengthUnit) || 0,
+      left:
+        convertPrintParameterToInches(options.margin?.left, lengthUnit) || 0,
+      bottom:
+        convertPrintParameterToInches(options.margin?.bottom, lengthUnit) || 0,
+      right:
+        convertPrintParameterToInches(options.margin?.right, lengthUnit) || 0,
     };
 
     const output = {
@@ -2698,7 +2705,8 @@ export const unitToPixels = {
 };
 
 function convertPrintParameterToInches(
-  parameter?: string | number
+  parameter?: string | number,
+  lengthUnit: 'in' | 'cm' = 'in'
 ): number | undefined {
   if (typeof parameter === 'undefined') {
     return undefined;
@@ -2727,5 +2735,5 @@ function convertPrintParameterToInches(
       'page.pdf() Cannot handle parameter type: ' + typeof parameter
     );
   }
-  return pixels / 96;
+  return pixels / unitToPixels[lengthUnit];
 }

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -1458,37 +1458,51 @@ export class CDPPage extends Page {
   }
 
   override async createPDFStream(options: PDFOptions = {}): Promise<Readable> {
-    const params = this._getPDFOptions(options);
+    const {
+      landscape,
+      displayHeaderFooter,
+      headerTemplate,
+      footerTemplate,
+      printBackground,
+      scale,
+      width: paperWidth,
+      height: paperHeight,
+      margin,
+      pageRanges,
+      preferCSSPageSize,
+      omitBackground,
+      timeout,
+    } = this._getPDFOptions(options);
 
-    if (params.omitBackground) {
+    if (omitBackground) {
       await this.#setTransparentBackgroundColor();
     }
 
     const printCommandPromise = this.#client.send('Page.printToPDF', {
       transferMode: 'ReturnAsStream',
-      landscape: params.landscape,
-      displayHeaderFooter: params.displayHeaderFooter,
-      headerTemplate: params.headerTemplate,
-      footerTemplate: params.footerTemplate,
-      printBackground: params.printBackground,
-      scale: params.scale,
-      paperWidth: params.width,
-      paperHeight: params.height,
-      marginTop: params.margin.top,
-      marginBottom: params.margin.bottom,
-      marginLeft: params.margin.left,
-      marginRight: params.margin.right,
-      pageRanges: params.pageRanges,
-      preferCSSPageSize: params.preferCSSPageSize,
+      landscape,
+      displayHeaderFooter,
+      headerTemplate,
+      footerTemplate,
+      printBackground,
+      scale,
+      paperWidth,
+      paperHeight,
+      marginTop: margin.top,
+      marginBottom: margin.bottom,
+      marginLeft: margin.left,
+      marginRight: margin.right,
+      pageRanges,
+      preferCSSPageSize,
     });
 
     const result = await waitWithTimeout(
       printCommandPromise,
       'Page.printToPDF',
-      params.timeout
+      timeout
     );
 
-    if (params.omitBackground) {
+    if (omitBackground) {
       await this.#resetDefaultBackgroundColor();
     }
 

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -206,23 +206,33 @@ export class Page extends PageBase {
 
   override async pdf(options: PDFOptions = {}): Promise<Buffer> {
     const {path = undefined} = options;
-    const params = this._getPDFOptions(options);
+    const {
+      printBackground: background,
+      margin,
+      landscape,
+      width,
+      height,
+      pageRanges,
+      scale,
+      preferCSSPageSize,
+      timeout,
+    } = this._getPDFOptions(options, 'cm');
     const {result} = await waitWithTimeout(
       this.#context.connection.send('browsingContext.print', {
         context: this.#context._contextId,
-        background: params.printBackground,
-        margin: params.margin,
-        orientation: params.landscape ? 'landscape' : 'portrait',
+        background,
+        margin,
+        orientation: landscape ? 'landscape' : 'portrait',
         page: {
-          width: params.width,
-          height: params.height,
+          width,
+          height,
         },
-        pageRanges: params.pageRanges.split(', '),
-        scale: params.scale,
-        shrinkToFit: !params.preferCSSPageSize,
+        pageRanges: pageRanges.split(', '),
+        scale,
+        shrinkToFit: !preferCSSPageSize,
       }),
       'browsingContext.print',
-      params.timeout
+      timeout
     );
 
     const buffer = Buffer.from(result.data, 'base64');


### PR DESCRIPTION
As pointed out yesterday in our meeting BiDi uses centimeters, while CDP uses inches. This aligns this difference.