### PR TITLE
chore: simplify installation tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "pngjs": "7.0.0",
         "prettier": "2.8.4",
         "puppeteer": "file:packages/puppeteer",
+        "rimraf": "3.0.2",
         "rollup": "3.18.0",
         "semver": "7.3.8",
         "sinon": "15.0.1",
@@ -1137,41 +1138,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@npmcli/move-file/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/move-file/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@npmcli/node-gyp": {
@@ -2400,41 +2366,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/c8/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/c8/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/c8/node_modules/yargs": {
@@ -4028,41 +3959,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flat-cache/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/flat-cache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/flatted": {
       "version": "3.2.7",
       "dev": true,
@@ -4368,26 +4264,6 @@
         "typescript": ">=3"
       }
     },
-    "node_modules/gts/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/gts/node_modules/meow": {
       "version": "9.0.0",
       "dev": true,
@@ -4425,21 +4301,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/gts/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gts/node_modules/type-fest": {
@@ -5782,63 +5643,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/make-fetch-happen/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/make-fetch-happen/node_modules/ssri": {
       "version": "9.0.1",
       "dev": true,
@@ -6483,21 +6287,6 @@
       },
       "engines": {
         "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-gyp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7893,6 +7682,41 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {
@@ -10294,31 +10118,6 @@
       "requires": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "@npmcli/node-gyp": {
@@ -11248,29 +11047,6 @@
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
             "wrap-ansi": "^7.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
           }
         },
         "yargs": {
@@ -12294,31 +12070,6 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "flatted": {
@@ -12521,20 +12272,6 @@
         "write-file-atomic": "^4.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "meow": {
           "version": "9.0.0",
           "dev": true,
@@ -12556,15 +12293,6 @@
         "prettier": {
           "version": "2.7.1",
           "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         },
         "type-fest": {
           "version": "0.18.1",
@@ -13427,50 +13155,6 @@
             "yallist": "^4.0.0"
           }
         },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          },
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.11",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "glob": {
-              "version": "7.2.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
         "ssri": {
           "version": "9.0.1",
           "dev": true,
@@ -13902,15 +13586,6 @@
             "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
           }
         }
       }
@@ -14831,6 +14506,31 @@
     "reusify": {
       "version": "1.0.4",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "rollup": {
       "version": "3.18.0",

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "pngjs": "7.0.0",
     "prettier": "2.8.4",
     "puppeteer": "file:packages/puppeteer",
+    "rimraf": "3.0.2",
     "rollup": "3.18.0",
     "semver": "7.3.8",
     "sinon": "15.0.1",

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2116,18 +2116,9 @@ export class Page extends EventEmitter {
       return;
     }
 
-    try {
-      const fs = await importFSPromises();
+    const fs = await importFSPromises();
 
-      await fs.writeFile(path, buffer);
-    } catch (error) {
-      if (error instanceof TypeError) {
-        throw new Error(
-          'Can only pass a file path in a Node-like environment.'
-        );
-      }
-      throw error;
-    }
+    await fs.writeFile(path, buffer);
   }
 
   /**

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -883,17 +883,7 @@ export class Frame {
     }
 
     if (path) {
-      let fs: typeof import('fs/promises');
-      try {
-        fs = await importFSPromises();
-      } catch (error) {
-        if (error instanceof TypeError) {
-          throw new Error(
-            'Can only pass a file path in a Node-like environment.'
-          );
-        }
-        throw error;
-      }
+      const fs = await importFSPromises();
 
       content = await fs.readFile(path, 'utf8');
       content += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';

--- a/test/installation/.mocharc.cjs
+++ b/test/installation/.mocharc.cjs
@@ -18,6 +18,4 @@
 module.exports = {
   spec: ['build/**/*.spec.js'],
   timeout: '240000ms',
-  // Parallel processing fails on other package managers due to caching.
-  parallel: (process.env['PKG_MANAGER'] ?? 'npm') === 'npm',
 };

--- a/test/installation/src/puppeteer-core.spec.ts
+++ b/test/installation/src/puppeteer-core.spec.ts
@@ -14,31 +14,31 @@
  * limitations under the License.
  */
 
-import {describeInstallation} from './describeInstallation.js';
+import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';
 
-describeInstallation(
-  '`puppeteer-core`',
-  {dependencies: ['@puppeteer/browsers', 'puppeteer-core']},
-  ({itEvaluates}) => {
-    itEvaluates('CommonJS', {commonjs: true}, async () => {
-      return readAsset('puppeteer-core', 'requires.cjs');
-    });
+describe('`puppeteer-core`', () => {
+  configureSandbox({
+    dependencies: ['@puppeteer/browsers', 'puppeteer-core'],
+  });
 
-    itEvaluates('ES modules', async () => {
-      return readAsset('puppeteer-core', 'imports.js');
-    });
+  it('evaluates CommonJS', async function () {
+    const script = await readAsset('puppeteer-core', 'requires.cjs');
+    await this.runScript(script, 'cjs');
+  });
 
-    for (const product of ['firefox', 'chrome']) {
-      itEvaluates(
-        `\`launch\` for \`${product}\` with a bad \`executablePath\``,
-        async () => {
-          return (await readAsset('puppeteer-core', 'launch.js')).replace(
-            '${product}',
-            product
-          );
-        }
+  it('evaluates ES modules', async function () {
+    const script = await readAsset('puppeteer-core', 'imports.js');
+    await this.runScript(script, 'mjs');
+  });
+
+  for (const product of ['firefox', 'chrome']) {
+    it(`\`launch\` for \`${product}\` with a bad \`executablePath\``, async function () {
+      const script = (await readAsset('puppeteer-core', 'launch.js')).replace(
+        '${product}',
+        product
       );
-    }
+      await this.runScript(script, 'mjs');
+    });
   }
-);
+});

--- a/test/installation/src/puppeteer-firefox.spec.ts
+++ b/test/installation/src/puppeteer-firefox.spec.ts
@@ -18,12 +18,11 @@ import assert from 'assert';
 import {readdir} from 'fs/promises';
 import {join} from 'path';
 
-import {describeInstallation} from './describeInstallation.js';
+import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';
 
-describeInstallation(
-  '`puppeteer` with Firefox',
-  {
+describe('`puppeteer` with Firefox', () => {
+  configureSandbox({
     dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
     env: cwd => {
       return {
@@ -31,18 +30,18 @@ describeInstallation(
         PUPPETEER_PRODUCT: 'firefox',
       };
     },
-  },
-  ({itEvaluates}) => {
-    itEvaluates('CommonJS', {commonjs: true}, async cwd => {
-      const files = await readdir(join(cwd, '.cache', 'puppeteer'));
-      assert.equal(files.length, 1);
-      assert.equal(files[0], 'firefox');
+  });
 
-      return readAsset('puppeteer-core', 'requires.cjs');
-    });
+  it('evaluates CommonJS', async function () {
+    const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
+    assert.equal(files.length, 1);
+    assert.equal(files[0], 'firefox');
+    const script = await readAsset('puppeteer-core', 'requires.cjs');
+    await this.runScript(script, 'cjs');
+  });
 
-    itEvaluates('ES modules', async () => {
-      return readAsset('puppeteer-core', 'imports.js');
-    });
-  }
-);
+  it('evaluates ES modules', async function () {
+    const script = await readAsset('puppeteer-core', 'imports.js');
+    await this.runScript(script, 'mjs');
+  });
+});

--- a/test/installation/src/puppeteer.spec.ts
+++ b/test/installation/src/puppeteer.spec.ts
@@ -18,30 +18,29 @@ import assert from 'assert';
 import {readdir} from 'fs/promises';
 import {join} from 'path';
 
-import {describeInstallation} from './describeInstallation.js';
+import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';
 
-describeInstallation(
-  '`puppeteer`',
-  {
+describe('`puppeteer`', () => {
+  configureSandbox({
     dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
     env: cwd => {
       return {
         PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
       };
     },
-  },
-  ({itEvaluates}) => {
-    itEvaluates('CommonJS', {commonjs: true}, async cwd => {
-      const files = await readdir(join(cwd, '.cache', 'puppeteer'));
-      assert.equal(files.length, 1);
-      assert.equal(files[0], 'chrome');
+  });
 
-      return readAsset('puppeteer-core', 'requires.cjs');
-    });
+  it('evaluates CommonJS', async function () {
+    const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
+    assert.equal(files.length, 1);
+    assert.equal(files[0], 'chrome');
+    const script = await readAsset('puppeteer-core', 'requires.cjs');
+    await this.runScript(script, 'cjs');
+  });
 
-    itEvaluates('ES modules', async () => {
-      return readAsset('puppeteer-core', 'imports.js');
-    });
-  }
-);
+  it('evaluates ES modules', async function () {
+    const script = await readAsset('puppeteer-core', 'imports.js');
+    await this.runScript(script, 'mjs');
+  });
+});

--- a/test/installation/src/sandbox.ts
+++ b/test/installation/src/sandbox.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2022 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import crypto from 'crypto';
+import {mkdtemp, rm, writeFile} from 'fs/promises';
+import {tmpdir} from 'os';
+import {join} from 'path';
+
+import {
+  PUPPETEER_CORE_PACKAGE_PATH,
+  PUPPETEER_PACKAGE_PATH,
+  PUPPETEER_BROWSERS_PACKAGE_PATH,
+} from './constants.js';
+import {execFile} from './util.js';
+
+const PKG_MANAGER = process.env['PKG_MANAGER'] || 'npm';
+
+let ADD_PKG_SUBCOMMAND = 'install';
+if (PKG_MANAGER !== 'npm') {
+  ADD_PKG_SUBCOMMAND = 'add';
+}
+
+export interface ItEvaluatesOptions {
+  commonjs?: boolean;
+}
+
+export interface ItEvaluatesFn {
+  (
+    title: string,
+    options: ItEvaluatesOptions,
+    getScriptContent: (cwd: string) => Promise<string>
+  ): void;
+  (title: string, getScriptContent: (cwd: string) => Promise<string>): void;
+}
+
+export interface SandboxOptions {
+  dependencies?: string[];
+  devDependencies?: string[];
+  /**
+   * This should be idempotent.
+   */
+  env?: ((cwd: string) => NodeJS.ProcessEnv) | NodeJS.ProcessEnv;
+  before?: (cwd: string) => Promise<void>;
+}
+
+declare module 'mocha' {
+  export interface Context {
+    /**
+     * The path to the root of the sandbox folder.
+     */
+    sandbox: string;
+    env: NodeJS.ProcessEnv | undefined;
+    runScript: (content: string, type: 'cjs' | 'mjs') => Promise<void>;
+  }
+}
+
+/**
+ * Configures mocha before/after hooks to create a temp folder and install
+ * specified dependencies.
+ */
+export const configureSandbox = (options: SandboxOptions): void => {
+  before(async function (): Promise<void> {
+    const sandbox = await mkdtemp(join(tmpdir(), 'puppeteer-'));
+    const dependencies = (options.dependencies ?? []).map(module => {
+      switch (module) {
+        case 'puppeteer':
+          return PUPPETEER_PACKAGE_PATH;
+        case 'puppeteer-core':
+          return PUPPETEER_CORE_PACKAGE_PATH;
+        case '@puppeteer/browsers':
+          return PUPPETEER_BROWSERS_PACKAGE_PATH;
+        default:
+          return module;
+      }
+    });
+    const devDependencies = options.devDependencies ?? [];
+
+    let getEnv: (cwd: string) => NodeJS.ProcessEnv | undefined;
+    if (typeof options.env === 'function') {
+      getEnv = options.env;
+    } else {
+      const env = options.env;
+      getEnv = () => {
+        return env;
+      };
+    }
+    const env = {...process.env, ...getEnv(sandbox)};
+
+    await options.before?.(sandbox);
+    if (dependencies.length > 0) {
+      await execFile(PKG_MANAGER, [ADD_PKG_SUBCOMMAND, ...dependencies], {
+        cwd: sandbox,
+        env,
+        shell: true,
+      });
+    }
+    if (devDependencies.length > 0) {
+      await execFile(
+        PKG_MANAGER,
+        [ADD_PKG_SUBCOMMAND, '-D', ...devDependencies],
+        {
+          cwd: sandbox,
+          env,
+          shell: true,
+        }
+      );
+    }
+
+    this.sandbox = sandbox;
+    this.env = env;
+    this.runScript = async (content: string, type: 'cjs' | 'mjs') => {
+      const script = join(sandbox, `script-${crypto.randomUUID()}.${type}`);
+      await writeFile(script, content);
+      await execFile('node', [script], {cwd: sandbox, env});
+    };
+  });
+
+  after(async function () {
+    if (!process.env['KEEP_SANDBOX']) {
+      await rm(this.sandbox, {recursive: true, force: true, maxRetries: 5});
+    } else {
+      console.log('sandbox saved in', this.sandbox);
+    }
+  });
+};


### PR DESCRIPTION
This PR changes the installation tests to use mocha context to pass state which allows easily identifying tests and reasoning about the execution steps. It sacrifies the parallel mode because the context cannot be parallelised but that is beneficial because the parallel mode does not support .only, works only for npm and makes it hard to debug tests. I see no difference between the parallel mode and sequential mode in terms of performance.
