### PR TITLE
fix: use shadowRoot for tree walker

### DIFF
--- a/packages/puppeteer-core/src/injected/util.ts
+++ b/packages/puppeteer-core/src/injected/util.ts
@@ -49,7 +49,8 @@ export function* pierce(root: Node): IterableIterator<Node | ShadowRoot> {
  * @internal
  */
 export function* pierceAll(root: Node): IterableIterator<Node | ShadowRoot> {
-  yield* pierce(root);
+  root = pierce(root).next().value;
+  yield root;
   const walkers = [document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)];
   for (const walker of walkers) {
     let node: Element | null;

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -404,6 +404,24 @@ describe('Query handler tests', function () {
           })
         ).toBeTruthy();
       }
+      {
+        const elements = await page.$$('#c >>>> div');
+        assert(elements[0], 'Could not find element');
+        expect(
+          await elements[0]?.evaluate(element => {
+            return element.id === 'd';
+          })
+        ).toBeTruthy();
+      }
+      {
+        const elements = await page.$$('#c >>> div');
+        assert(elements[0], 'Could not find element');
+        expect(
+          await elements[0]?.evaluate(element => {
+            return element.id === 'd';
+          })
+        ).toBeTruthy();
+      }
     });
 
     it('should work with text selectors', async () => {


### PR DESCRIPTION
Fixes an issue where deep descendent selectors do not go into shadow root of a host element.