### PR TITLE
fix: cannot find startswith of undefined

### DIFF
--- a/packages/puppeteer-core/src/common/GetQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/GetQueryHandler.ts
@@ -59,7 +59,7 @@ export function getQueryHandlerAndSelector(selector: string): {
     for (const [name, QueryHandler] of handlerMap) {
       for (const separator of QUERY_SEPARATORS) {
         const prefix = `${name}${separator}`;
-        if (selector.startsWith(prefix)) {
+        if (selector?.startsWith(prefix)) {
           selector = selector.slice(prefix.length);
           return {updatedSelector: selector, QueryHandler};
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
NA
**Summary**
As we have configured selectors based upon object keys in some condition object properties is not defined, thus the selector resolves to undefined, i.e. await page.waitForSelector(undefined); This results in the following error:
Cannot read property 'startsWith' of undefined

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
