### PR TITLE
chore: release puppeteer-core as 19.8.3

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
       "component": "puppeteer"
     },
     "packages/puppeteer-core": {
-      "component": "puppeteer-core"
+      "component": "puppeteer-core",
+      "release-as": "19.8.3"
     },
     "packages/testserver": {},
     "packages/ng-schematics": {},


### PR DESCRIPTION
release-please is not able to recover if puppeteer and puppeteer-core versions diverge. This PR sets the correct version manually and the change needs to be reverted after the release.