### PR TITLE
chore: cache wireit for the inspect-code action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@setup-github-actions-caching/v1
       - name: Check code
         run: npm run check
       - name: Lint code


### PR DESCRIPTION
This PR adds wireit cache to the inspect code action that makes the build step almost instant if the cache is available.