### PR TITLE
refactor: misc refactoring around browsers debugging and stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,11 +399,6 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
-      - name: Setup cache for browser binaries
-        uses: actions/cache@v3
-        with:
-          path: packages/browsers/test/cache
-          key: browsers-${{ hashFiles('packages/browsers/tools/downloadTestBrowsers.mjs') }}-${{ hashFiles('packages/browsers/test/src/versions.ts') }}
       - name: Run tests
         run: npm run test --workspace @puppeteer/browsers
 

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -60,7 +60,7 @@
       ]
     },
     "test": {
-      "command": "node tools/downloadTestBrowsers.mjs && mocha",
+      "command": "node tools/downloadTestBrowsers.mjs && cross-env DEBUG=puppeteer:* mocha",
       "files": [
         ".mocharc.cjs"
       ],

--- a/packages/browsers/src/Cache.ts
+++ b/packages/browsers/src/Cache.ts
@@ -62,7 +62,7 @@ export class Cache {
       force: true,
       recursive: true,
       maxRetries: 10,
-      retryDelay: 200,
+      retryDelay: 500,
     });
   }
 }

--- a/packages/browsers/test/src/chrome/fetch.spec.ts
+++ b/packages/browsers/test/src/chrome/fetch.spec.ts
@@ -176,7 +176,7 @@ describe('Chrome fetch', () => {
     });
 
     it('can fetch via a proxy', async function () {
-      this.timeout(60000);
+      this.timeout(120000);
       const expectedOutputPath = path.join(
         tmpDir,
         'chrome',

--- a/packages/browsers/test/src/chrome/launcher.spec.ts
+++ b/packages/browsers/test/src/chrome/launcher.spec.ts
@@ -26,9 +26,8 @@ import {
   fetch,
   Browser,
   BrowserPlatform,
-  Cache,
 } from '../../../lib/cjs/main.js';
-import {getServerUrl, setupTestServer} from '../utils.js';
+import {getServerUrl, setupTestServer, clearCache} from '../utils.js';
 import {testChromeBuildId} from '../versions.js';
 
 describe('Chrome', () => {
@@ -64,7 +63,7 @@ describe('Chrome', () => {
     });
 
     afterEach(() => {
-      new Cache(tmpDir).clear();
+      clearCache(tmpDir);
     });
 
     function getArgs() {

--- a/packages/browsers/test/src/chrome/launcher.spec.ts
+++ b/packages/browsers/test/src/chrome/launcher.spec.ts
@@ -67,6 +67,41 @@ describe('Chrome', () => {
       new Cache(tmpDir).clear();
     });
 
+    function getArgs() {
+      return [
+        '--allow-pre-commit-input',
+        '--disable-background-networking',
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-breakpad',
+        '--disable-client-side-phishing-detection',
+        '--disable-component-extensions-with-background-pages',
+        '--disable-component-update',
+        '--disable-default-apps',
+        '--disable-dev-shm-usage',
+        '--disable-extensions',
+        '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider',
+        '--disable-hang-monitor',
+        '--disable-ipc-flooding-protection',
+        '--disable-popup-blocking',
+        '--disable-prompt-on-repost',
+        '--disable-renderer-backgrounding',
+        '--disable-sync',
+        '--enable-automation',
+        '--enable-features=NetworkServiceInProcess2',
+        '--export-tagged-pdf',
+        '--force-color-profile=srgb',
+        '--headless=new',
+        '--metrics-recording-only',
+        '--no-first-run',
+        '--password-store=basic',
+        '--remote-debugging-port=9222',
+        '--use-mock-keychain',
+        `--user-data-dir=${path.join(tmpDir, 'profile')}`,
+        'about:blank',
+      ];
+    }
+
     it('should launch a Chrome browser', async () => {
       const executablePath = computeExecutablePath({
         cacheDir: tmpDir,
@@ -75,12 +110,7 @@ describe('Chrome', () => {
       });
       const process = launch({
         executablePath,
-        args: [
-          '--headless=new',
-          '--use-mock-keychain',
-          '--disable-features=DialMediaRouteProvider',
-          `--user-data-dir=${path.join(tmpDir, 'profile')}`,
-        ],
+        args: getArgs(),
       });
       await process.close();
     });
@@ -93,38 +123,7 @@ describe('Chrome', () => {
       });
       const process = launch({
         executablePath,
-        args: [
-          '--allow-pre-commit-input',
-          '--disable-background-networking',
-          '--disable-background-timer-throttling',
-          '--disable-backgrounding-occluded-windows',
-          '--disable-breakpad',
-          '--disable-client-side-phishing-detection',
-          '--disable-component-extensions-with-background-pages',
-          '--disable-component-update',
-          '--disable-default-apps',
-          '--disable-dev-shm-usage',
-          '--disable-extensions',
-          '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider',
-          '--disable-hang-monitor',
-          '--disable-ipc-flooding-protection',
-          '--disable-popup-blocking',
-          '--disable-prompt-on-repost',
-          '--disable-renderer-backgrounding',
-          '--disable-sync',
-          '--enable-automation',
-          '--enable-features=NetworkServiceInProcess2',
-          '--export-tagged-pdf',
-          '--force-color-profile=srgb',
-          '--headless=new',
-          '--metrics-recording-only',
-          '--no-first-run',
-          '--password-store=basic',
-          '--remote-debugging-port=9222',
-          '--use-mock-keychain',
-          `--user-data-dir=${path.join(tmpDir, 'profile')}`,
-          'about:blank',
-        ],
+        args: getArgs(),
       });
       const url = await process.waitForLineOutput(CDP_WEBSOCKET_ENDPOINT_REGEX);
       await process.close();

--- a/packages/browsers/test/src/chromium/launcher.spec.ts
+++ b/packages/browsers/test/src/chromium/launcher.spec.ts
@@ -26,9 +26,8 @@ import {
   fetch,
   Browser,
   BrowserPlatform,
-  Cache,
 } from '../../../lib/cjs/main.js';
-import {getServerUrl, setupTestServer} from '../utils.js';
+import {getServerUrl, setupTestServer, clearCache} from '../utils.js';
 import {testChromiumBuildId} from '../versions.js';
 
 describe('Chromium', () => {
@@ -47,7 +46,7 @@ describe('Chromium', () => {
   describe('launcher', function () {
     setupTestServer();
 
-    this.timeout(60000);
+    this.timeout(120000);
 
     let tmpDir = '/tmp/puppeteer-browsers-test';
 
@@ -64,7 +63,7 @@ describe('Chromium', () => {
     });
 
     afterEach(() => {
-      new Cache(tmpDir).clear();
+      clearCache(tmpDir);
     });
 
     function getArgs() {

--- a/packages/browsers/test/src/chromium/launcher.spec.ts
+++ b/packages/browsers/test/src/chromium/launcher.spec.ts
@@ -67,7 +67,42 @@ describe('Chromium', () => {
       new Cache(tmpDir).clear();
     });
 
-    it('should launch a Chrome browser', async () => {
+    function getArgs() {
+      return [
+        '--allow-pre-commit-input',
+        '--disable-background-networking',
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-breakpad',
+        '--disable-client-side-phishing-detection',
+        '--disable-component-extensions-with-background-pages',
+        '--disable-component-update',
+        '--disable-default-apps',
+        '--disable-dev-shm-usage',
+        '--disable-extensions',
+        '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider',
+        '--disable-hang-monitor',
+        '--disable-ipc-flooding-protection',
+        '--disable-popup-blocking',
+        '--disable-prompt-on-repost',
+        '--disable-renderer-backgrounding',
+        '--disable-sync',
+        '--enable-automation',
+        '--enable-features=NetworkServiceInProcess2',
+        '--export-tagged-pdf',
+        '--force-color-profile=srgb',
+        '--headless=new',
+        '--metrics-recording-only',
+        '--no-first-run',
+        '--password-store=basic',
+        '--remote-debugging-port=9222',
+        '--use-mock-keychain',
+        `--user-data-dir=${path.join(tmpDir, 'profile')}`,
+        'about:blank',
+      ];
+    }
+
+    it('should launch a Chromium browser', async () => {
       const executablePath = computeExecutablePath({
         cacheDir: tmpDir,
         browser: Browser.CHROMIUM,
@@ -75,12 +110,7 @@ describe('Chromium', () => {
       });
       const process = launch({
         executablePath,
-        args: [
-          '--headless=new',
-          '--use-mock-keychain',
-          '--disable-features=DialMediaRouteProvider',
-          `--user-data-dir=${path.join(tmpDir, 'profile')}`,
-        ],
+        args: getArgs(),
       });
       await process.close();
     });
@@ -93,13 +123,7 @@ describe('Chromium', () => {
       });
       const process = launch({
         executablePath,
-        args: [
-          '--headless=new',
-          '--use-mock-keychain',
-          '--disable-features=DialMediaRouteProvider',
-          '--remote-debugging-port=9222',
-          `--user-data-dir=${path.join(tmpDir, 'profile')}`,
-        ],
+        args: getArgs(),
       });
       const url = await process.waitForLineOutput(CDP_WEBSOCKET_ENDPOINT_REGEX);
       await process.close();

--- a/packages/browsers/test/src/firefox/fetch.spec.ts
+++ b/packages/browsers/test/src/firefox/fetch.spec.ts
@@ -19,8 +19,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import {fetch, Browser, BrowserPlatform, Cache} from '../../../lib/cjs/main.js';
-import {setupTestServer, getServerUrl} from '../utils.js';
+import {fetch, Browser, BrowserPlatform} from '../../../lib/cjs/main.js';
+import {setupTestServer, getServerUrl, clearCache} from '../utils.js';
 import {testFirefoxBuildId} from '../versions.js';
 
 /**
@@ -37,7 +37,7 @@ describe('Firefox fetch', () => {
   });
 
   afterEach(() => {
-    new Cache(tmpDir).clear();
+    clearCache(tmpDir);
   });
 
   it('should download a buildId that is a bzip2 archive', async function () {

--- a/packages/browsers/test/src/firefox/launcher.spec.ts
+++ b/packages/browsers/test/src/firefox/launcher.spec.ts
@@ -15,7 +15,6 @@
  */
 
 import assert from 'assert';
-import {execSync} from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -26,10 +25,9 @@ import {
   fetch,
   Browser,
   BrowserPlatform,
-  Cache,
   createProfile,
 } from '../../../lib/cjs/main.js';
-import {setupTestServer, getServerUrl} from '../utils.js';
+import {setupTestServer, getServerUrl, clearCache} from '../utils.js';
 import {testFirefoxBuildId} from '../versions.js';
 
 describe('Firefox', () => {
@@ -65,14 +63,7 @@ describe('Firefox', () => {
     });
 
     afterEach(() => {
-      try {
-        new Cache(tmpDir).clear();
-      } catch (err) {
-        if (os.platform() === 'win32') {
-          console.log(execSync('tasklist').toString('utf-8'));
-        }
-        throw err;
-      }
+      clearCache(tmpDir);
     });
 
     it('should launch a Firefox browser', async () => {

--- a/packages/browsers/tools/downloadTestBrowsers.mjs
+++ b/packages/browsers/tools/downloadTestBrowsers.mjs
@@ -38,7 +38,6 @@ function getBrowser(str) {
 }
 
 const cacheDir = path.normalize(path.join('.', 'test', 'cache'));
-const promises = [];
 
 for (const version of Object.keys(versions)) {
   const browser = getBrowser(version);
@@ -50,36 +49,30 @@ for (const version of Object.keys(versions)) {
   const buildId = versions[version];
 
   for (const platform of Object.values(BrowserPlatform)) {
-    promises.push(
-      (async function download(buildId, platform) {
-        const targetPath = path.join(
-          cacheDir,
-          'server',
-          ...downloadPaths[browser](platform, buildId)
-        );
-
-        if (fs.existsSync(targetPath)) {
-          return;
-        }
-
-        const result = await fetch({
-          browser,
-          buildId,
-          platform,
-          cacheDir: path.join(cacheDir, 'tmp'),
-          install: false,
-        });
-
-        fs.mkdirSync(path.dirname(targetPath), {
-          recursive: true,
-        });
-        fs.copyFileSync(result.path, targetPath);
-      })(buildId, platform)
+    const targetPath = path.join(
+      cacheDir,
+      'server',
+      ...downloadPaths[browser](platform, buildId)
     );
+
+    if (fs.existsSync(targetPath)) {
+      continue;
+    }
+
+    const result = await fetch({
+      browser,
+      buildId,
+      platform,
+      cacheDir: path.join(cacheDir, 'tmp'),
+      install: false,
+    });
+
+    fs.mkdirSync(path.dirname(targetPath), {
+      recursive: true,
+    });
+    fs.copyFileSync(result.path, targetPath);
   }
 }
-
-await Promise.all(promises);
 
 fs.rmSync(path.join(cacheDir, 'tmp'), {
   recursive: true,


### PR DESCRIPTION
- removed the CI cache because it's size is too big
- removed parallel download as it seems to lead to archive corruption sometimes
- added platform-specific defaults for the detached flag
- suppressed EBUSY errors on Windows 
- added debug logging with timing information
- increased the retry delay for cache removal
- added same arguments to tests as used by Puppeteer 