### PR TITLE
fix(docs): typo in puppeteer.coverage.md

### DIFF
--- a/docs/api/puppeteer.coverage.md
+++ b/docs/api/puppeteer.coverage.md
@@ -4,7 +4,7 @@ sidebar_label: Coverage
 
 # Coverage class
 
-The Coverage class provides methods to gathers information about parts of JavaScript and CSS that were used by the page.
+The Coverage class provides methods to gather information about parts of JavaScript and CSS that were used by the page.
 
 #### Signature:
 


### PR DESCRIPTION
The sentence:

> ...methods to **gathers** information...

Should read:

> ...methods to **gather** information...