### PR TITLE
chore: stop CI if search crawler is blocked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,15 @@ jobs:
           publish_dir: ./website/build
           user_name: release-please[bot]
           user_email: 55107282+release-please[bot]@users.noreply.github.com
+      - name: Test Algolia if Crawler is blocked
+        env:
+          CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
+          CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
+          CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
+        run: |
+          curl -H "Content-Type: application/json" -X GET --user "$CRAWLER_USER_ID:$CRAWLER_API_KEY" \
+            "https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID" | grep "\"blocked\":true1"; \
+          if [ $? -eq 0 ]; then echo "Please go to https://crawler.algolia.com/" && exit 1; fi && exit 0;
       - name: Trigger Algolia reindexing
         env:
           CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}


### PR DESCRIPTION
Crawler may get stuck. For example we recently broke the site on accident an that stopped if for the past week. Also atm we have more then 10% changes which stop it as well. This will let us know and incentivize action.

Note: Doc change to be reverted.