### PR TITLE
feat: add warn for `headless: true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 > Chrome/Chromium over the
 > [DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
 > Puppeteer runs in
-> [headless](https://developers.google.com/web/updates/2017/04/headless-chrome)
+> [headless](https://developer.chrome.com/articles/new-headless/)
 > mode by default, but can be configured to run in full (non-headless)
 > Chrome/Chromium.
 
@@ -177,20 +177,24 @@ import puppeteer from 'puppeteer';
 **1. Uses Headless mode**
 
 By default Puppeteer launches Chromium in
-[headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome).
+[old headless mode](https://developer.chrome.com/articles/new-headless/).
 
-> Note: Deprecated please consider using `headless: 'new'`
-> See example bellow.
+```ts
+const browser = await puppeteer.launch();
+// Equivalent to
+const browser = await puppeteer.launch({headless: true});
+```
 
-This behavior will change in the feature with the introduction of [--headless=new](https://developer.chrome.com/articles/new-headless/).
-You can already try it out:
+[Chrome 112 launched a new Headless mode](https://developer.chrome.com/articles/new-headless/) that might cause some differences in behavior compared to the old Headless implementation.
+In the future Puppeteer will start defaulting to new implementation.
+We recommend you try it out before the switch:
 
 ```ts
 const browser = await puppeteer.launch({headless: 'new'});
 ```
 
 To launch a full version of Chromium, set the
-[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions)
+[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions) to `"true"`
 option when launching a browser:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ import puppeteer from 'puppeteer';
 **1. Uses Headless mode**
 
 By default Puppeteer launches Chromium in
-[old headless mode](https://developer.chrome.com/articles/new-headless/).
+[old Headless mode](https://developer.chrome.com/articles/new-headless/).
 
 ```ts
 const browser = await puppeteer.launch();
@@ -194,7 +194,7 @@ const browser = await puppeteer.launch({headless: 'new'});
 ```
 
 To launch a full version of Chromium, set the
-[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions) to `"true"`
+[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions) to `true`
 option when launching a browser:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -176,14 +176,25 @@ import puppeteer from 'puppeteer';
 
 **1. Uses Headless mode**
 
-Puppeteer launches Chromium in
+By default Puppeteer launches Chromium in
 [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome).
+
+> Note: Deprecated please consider using `headless: 'new'`
+> See example bellow.
+
+This behavior will change in the feature with the introduction of [--headless=new](https://developer.chrome.com/articles/new-headless/).
+You can already try it out:
+
+```ts
+const browser = await puppeteer.launch({headless: 'new'});
+```
+
 To launch a full version of Chromium, set the
 [`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions)
 option when launching a browser:
 
 ```ts
-const browser = await puppeteer.launch({headless: false}); // default is true
+const browser = await puppeteer.launch({headless: false});
 ```
 
 **2. Runs a bundled version of Chromium**

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@
 > Chrome/Chromium over the
 > [DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
 > Puppeteer runs in
-> [headless](https://developers.google.com/web/updates/2017/04/headless-chrome)
+> [headless](https://developer.chrome.com/articles/new-headless/)
 > mode by default, but can be configured to run in full (non-headless)
 > Chrome/Chromium.
 
@@ -177,20 +177,24 @@ import puppeteer from 'puppeteer';
 **1. Uses Headless mode**
 
 By default Puppeteer launches Chromium in
-[headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome).
+[old headless mode](https://developer.chrome.com/articles/new-headless/).
 
-> Note: Deprecated please consider using `headless: 'new'`
-> See example bellow.
+```ts
+const browser = await puppeteer.launch();
+// Equivalent to
+const browser = await puppeteer.launch({headless: true});
+```
 
-This behavior will change in the feature with the introduction of [--headless=new](https://developer.chrome.com/articles/new-headless/).
-You can already try it out:
+[Chrome 112 launched a new Headless mode](https://developer.chrome.com/articles/new-headless/) that might cause some differences in behavior compared to the old Headless implementation.
+In the future Puppeteer will start defaulting to new implementation.
+We recommend you try it out before the switch:
 
 ```ts
 const browser = await puppeteer.launch({headless: 'new'});
 ```
 
 To launch a full version of Chromium, set the
-[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions)
+[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions) to `"true"`
 option when launching a browser:
 
 ```ts

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,7 +177,7 @@ import puppeteer from 'puppeteer';
 **1. Uses Headless mode**
 
 By default Puppeteer launches Chromium in
-[old headless mode](https://developer.chrome.com/articles/new-headless/).
+[old Headless mode](https://developer.chrome.com/articles/new-headless/).
 
 ```ts
 const browser = await puppeteer.launch();
@@ -194,7 +194,7 @@ const browser = await puppeteer.launch({headless: 'new'});
 ```
 
 To launch a full version of Chromium, set the
-[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions) to `"true"`
+[`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions) to `true`
 option when launching a browser:
 
 ```ts

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,14 +176,25 @@ import puppeteer from 'puppeteer';
 
 **1. Uses Headless mode**
 
-Puppeteer launches Chromium in
+By default Puppeteer launches Chromium in
 [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome).
+
+> Note: Deprecated please consider using `headless: 'new'`
+> See example bellow.
+
+This behavior will change in the feature with the introduction of [--headless=new](https://developer.chrome.com/articles/new-headless/).
+You can already try it out:
+
+```ts
+const browser = await puppeteer.launch({headless: 'new'});
+```
+
 To launch a full version of Chromium, set the
 [`headless`](https://pptr.dev/api/puppeteer.browserlaunchargumentoptions)
 option when launching a browser:
 
 ```ts
-const browser = await puppeteer.launch({headless: false}); // default is true
+const browser = await puppeteer.launch({headless: false});
 ```
 
 **2. Runs a bundled version of Chromium**

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -52,12 +52,13 @@ export class ChromeLauncher extends ProductLauncher {
     ) {
       console.warn(
         [
-          '\u001b[1m\u001B[43m\u001b[30m',
-          'Puppeteer `Old headless` deprecation warning:\u001b[0m\u001b[33m',
-          '  In the near feature "headless" for Chrome will run `--headless=new` by default.',
-          '  For more information, please see https://developer.chrome.com/articles/new-headless/.',
+          '\x1B[1m\x1B[43m\x1B[30m',
+          'Puppeteer old Headless deprecation warning:\x1B[0m\x1B[33m',
+          '  In the near feature `headless: true` will default to the new Headless mode',
+          '  for Chrome instead of the old Headless implementation. For more',
+          '  information, please see https://developer.chrome.com/articles/new-headless/.',
           '  Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`',
-          '  If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.\u001b[0m\n',
+          '  If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.\x1B[0m\n',
         ].join('\n  ')
       );
     }

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -24,6 +24,7 @@ import {
 } from '@puppeteer/browsers';
 
 import {debugError} from '../common/util.js';
+import {Browser} from '../puppeteer-core.js';
 import {assert} from '../util/assert.js';
 
 import {
@@ -41,6 +42,27 @@ import {rm} from './util/fs.js';
 export class ChromeLauncher extends ProductLauncher {
   constructor(puppeteer: PuppeteerNode) {
     super(puppeteer, 'chrome');
+  }
+
+  override launch(options: PuppeteerNodeLaunchOptions = {}): Promise<Browser> {
+    const headless = options.headless ?? true;
+    if (
+      headless === true &&
+      this.puppeteer.configuration.logLevel !== 'silent'
+    ) {
+      console.warn(
+        [
+          '\u001b[1m\u001B[43m\u001b[30m',
+          'Puppeteer `Old headless` deprecation warning:\u001b[0m\u001b[33m',
+          '  In the near feature "headless" for Chrome will run `--headless=new` by default.',
+          '  For more information, please see https://developer.chrome.com/articles/new-headless/.',
+          '  Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`',
+          '  If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.\u001b[0m\n',
+        ].join('\n  ')
+      );
+    }
+
+    return super.launch(options);
   }
 
   /**

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -25,6 +25,12 @@ import {Product} from '../common/Product.js';
 export interface BrowserLaunchArgumentOptions {
   /**
    * Whether to run the browser in headless mode.
+   *
+   * @remarks
+   * In the future `headless: true` will be equivalent to `headless: 'new'`.
+   * You can read more about the change {@link https://developer.chrome.com/articles/new-headless/ | here}.
+   * Consider opting in early by setting the value to `new`.
+   *
    * @defaultValue `true`
    */
   headless?: boolean | 'new';

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -29,7 +29,7 @@ export interface BrowserLaunchArgumentOptions {
    * @remarks
    * In the future `headless: true` will be equivalent to `headless: 'new'`.
    * You can read more about the change {@link https://developer.chrome.com/articles/new-headless/ | here}.
-   * Consider opting in early by setting the value to `new`.
+   * Consider opting in early by setting the value to `"new"`.
    *
    * @defaultValue `true`
    */


### PR DESCRIPTION
Warn for future behavior change of `puppeteer.launch({headless: true})`

The message can be suppressed by setting:
Env -  `PUPPETEER_DISABLE_HEADLESS_WARNING=true`, (or via general logging `PUPPETEER_LOGLEVEL=silent`, `PUPPETEER_LOGLEVEL=error`,)
Config - `logLevel: 'silent'`, `logLevel: 'error'`
NPM LogLevel - https://docs.npmjs.com/cli/v9/using-npm/logging (`silent` or `error`)

Warning:
![image](https://user-images.githubusercontent.com/34244704/233022348-b74c70b6-19dc-4436-a507-6069f151ac65.png)
