### PR TITLE
fix: continue requests without network instrumentation

### DIFF
--- a/docs/api/puppeteer.httprequest.initiator.md
+++ b/docs/api/puppeteer.httprequest.initiator.md
@@ -10,10 +10,10 @@ The initiator of the request.
 
 ```typescript
 class HTTPRequest {
-  initiator(): Protocol.Network.Initiator;
+  initiator(): Protocol.Network.Initiator | undefined;
 }
 ```
 
 **Returns:**
 
-Protocol.Network.Initiator
+Protocol.Network.Initiator \| undefined

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,8 +197,8 @@ version of Chrome or Chromium, pass in the executable's path when creating a
 const browser = await puppeteer.launch({executablePath: '/path/to/Chrome'});
 ```
 
-You can also use Puppeteer with Firefox Nightly (experimental support). See
-[`Puppeteer.launch`](https://pptr.dev/api/puppeteer.puppeteernode.launch) for
+You can also use Puppeteer with Firefox. See
+[status of cross-browser support](https://pptr.dev/faq/#q-what-is-the-status-of-cross-browser-support) for
 more information.
 
 See

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -272,7 +272,7 @@ export class HTTPRequest {
   /**
    * The initiator of the request.
    */
-  initiator(): Protocol.Network.Initiator {
+  initiator(): Protocol.Network.Initiator | undefined {
     throw new Error('Not implemented');
   }
 

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -127,6 +127,22 @@ describe('request interception', function () {
       expect(requests[1]!.url()).toContain('/one-style.css');
       expect(requests[1]!.headers()['referer']).toContain('/one-style.html');
     });
+    it('should work with requests without networkId', async () => {
+      const {page, server} = getTestState();
+      await page.goto(server.EMPTY_PAGE);
+      await page.setRequestInterception(true);
+
+      const cdp = await page.target().createCDPSession();
+      await cdp.send('DOM.enable');
+      const urls: string[] = [];
+      page.on('request', request => {
+        urls.push(request.url());
+        return request.continue();
+      });
+      // This causes network requests without networkId.
+      await cdp.send('CSS.enable');
+      expect(urls).toStrictEqual([server.EMPTY_PAGE]);
+    });
     it('should properly return navigation response when URL has cookies', async () => {
       const {page, server} = getTestState();
 


### PR DESCRIPTION
This results in a breaking API change but since it is a bug fix we will not generate a major version.

Closes #10041