### PR TITLE
fix: implement flag for disabling headless warning

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -48,7 +48,9 @@ export class ChromeLauncher extends ProductLauncher {
     const headless = options.headless ?? true;
     if (
       headless === true &&
-      this.puppeteer.configuration.logLevel !== 'silent'
+      (!this.puppeteer.configuration.logLevel ||
+        this.puppeteer.configuration.logLevel === 'warn') &&
+      !Boolean(process.env['PUPPETEER_DISABLE_HEADLESS_WARNING'])
     ) {
       console.warn(
         [


### PR DESCRIPTION
Ref #10039.

Adds a ENV variable to disable `old Headless deprecation` warning;
Set `PUPPETEER_DISABLE_HEADLESS_WARNING` to disable the message

Side change:
Don't show warning when LogLevel set to `error`.

Post Merge:
Update the PR above to include the changes.

Closes #10070