### PR TITLE
fix: add Host header when used with http_proxy

### DIFF
--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -61,6 +61,8 @@ export function httpRequest(
       options.hostname = proxy.hostname;
       options.protocol = proxy.protocol;
       options.port = proxy.port;
+      options.headers ||= {};
+      options.headers.Host ||= url.host;
     } else {
       options.agent = createHttpsProxyAgent({
         host: proxy.host,

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -61,8 +61,8 @@ export function httpRequest(
       options.hostname = proxy.hostname;
       options.protocol = proxy.protocol;
       options.port = proxy.port;
-      options.headers ||= {};
-      options.headers.Host ||= url.host;
+      options.headers ??= {};
+      options.headers['Host'] ||= url.host;
     } else {
       options.agent = createHttpsProxyAgent({
         host: proxy.host,

--- a/packages/browsers/test/src/chrome/install.spec.ts
+++ b/packages/browsers/test/src/chrome/install.spec.ts
@@ -136,9 +136,11 @@ describe('Chrome install', () => {
     const proxyUrl = new URL(`http://localhost:54321`);
     let proxyServer: http.Server;
     let proxiedRequestUrls: string[] = [];
+    let proxiedRequestHosts: string[] = [];
 
     beforeEach(() => {
       proxiedRequestUrls = [];
+      proxiedRequestHosts = [];
       proxyServer = http
         .createServer(
           (
@@ -164,6 +166,7 @@ describe('Chrome install', () => {
             );
             originalRequest.pipe(proxyRequest, {end: true});
             proxiedRequestUrls.push(url);
+            proxiedRequestHosts.push(originalRequest.headers?.host || '');
           }
         )
         .listen({
@@ -203,6 +206,9 @@ describe('Chrome install', () => {
       assert.deepStrictEqual(proxiedRequestUrls, [
         getServerUrl() + '/113.0.5672.0/linux64/chrome-linux64.zip',
       ]);
+      assert.deepStrictEqual(proxiedRequestHosts, [
+        getServerUrl().replace('http://', ''),
+      ]);
     });
 
     it('can download via a proxy', async function () {
@@ -224,6 +230,9 @@ describe('Chrome install', () => {
       assert.ok(fs.existsSync(expectedOutputPath));
       assert.deepStrictEqual(proxiedRequestUrls, [
         getServerUrl() + '/113.0.5672.0/linux64/chrome-linux64.zip',
+      ]);
+      assert.deepStrictEqual(proxiedRequestHosts, [
+        getServerUrl().replace('http://', ''),
       ]);
     });
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
fix: add Host header when used with http_proxy

**What kind of change does this PR introduce?**
a bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

manual `http.get()` differs from use a `agent = HttpProxyAgent()` (imported from http-proxy-agent package) instance, for `Host` header.

say proxy for `https://httpbin.org/headers`
- use `https.get('https://httpbin.org/headers', { agent: HttpProxyAgent('http://127.0.0.1:54321') })` will have `Host: httpbin.org` sent to `127.0.0.1:54321`
- `https.get` without Host set will use proxy's host `127.0.0.1:54321` which breaks my current proxy server.

I found some evidence indicates it's client's job to make it right.

- https://datatracker.ietf.org/doc/html/rfc2616#section-14.23 
- from http: the definitive guide Book, page 419

> If the URL contains a hostname, the Host header must contain the same name.

> Host headers and proxies
> Some browser versions send incorrect Host headers, especially when configured to use proxies. > For example, when configured to use a proxy, some older versions of Apple and PointCast clients mistakenly sent the name of the proxy instead of the ori- gin server in the Host header.
 

---------

AND why https-proxy-agent but not http-proxy-agent?


