### PR TITLE
docs: use bash tag to get better formatting

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,13 +6,13 @@ browser instance.
 
 ## Building the image
 
-```sh
+```bash
 docker build -t puppeteer-chrome-linux . # `puppeteer-chrome-linux` is the name of the image.
 ```
 
 ## Running the image
 
-```sh
+```bash
 docker run -i --init --rm --cap-add=SYS_ADMIN --name puppeteer-chrome puppeteer-chrome-linux node -e "`cat test.js`"
 ```
 

--- a/docs/browsers-api/index.md
+++ b/docs/browsers-api/index.md
@@ -10,13 +10,13 @@ Manage and launch browsers/drivers from a CLI or programmatically.
 
 Use `npx` to run the CLI:
 
-```sh
+```bash
 npx @puppeteer/browsers --help
 ```
 
 CLI help will provide all documentation you need to use the CLI.
 
-```sh
+```bash
 npx @puppeteer/browsers --help # help for all commands
 npx @puppeteer/browsers install --help # help for the install command
 npx @puppeteer/browsers launch --help # help for the launch command

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,7 +19,7 @@ again.
 
 1. Clone this repository
 
-   ```sh
+   ```bash
    git clone https://github.com/puppeteer/puppeteer
    cd puppeteer
    ```
@@ -30,7 +30,7 @@ again.
 
 2. Install the dependencies
 
-   ```sh
+   ```bash
    npm install
    # Or to download Firefox
    PUPPETEER_PRODUCT=firefox npm install
@@ -38,13 +38,13 @@ again.
 
 3. Build all packages
 
-   ```sh
+   ```bash
    npm run build
    ```
 
 4. Run all tests
 
-   ```sh
+   ```bash
    npm test
    ```
 
@@ -69,7 +69,7 @@ again.
 
 To build a single package, you can run:
 
-```sh
+```bash
 npm run build --workspace <package> # e.g. puppeteer
 ```
 
@@ -82,7 +82,7 @@ packages is sufficient. This is all possible due to
 
 To continuously build a package, you can run:
 
-```sh
+```bash
 npm run build --watch --workspace <package> # e.g. puppeteer
 ```
 
@@ -97,7 +97,7 @@ It's possible some generated artifacts (such as
 rely on complex conditions (such as names of distinct files) that cannot be
 captured by the build system. To clean artifacts, you can run
 
-```sh
+```bash
 npm run clean
 # or specify the package
 npm run clean --workspace <package>
@@ -274,7 +274,7 @@ Copy the provided default `.vscode/launch.template.json` to `.vscode/launch.json
 
 Remember to build test before launching via:
 
-```sh
+```bash
 npm run build --workspace @puppeteer-test/test
 ```
 
@@ -316,7 +316,7 @@ revision that changed the behavior. The `bisect` script can be helpful here.
 Given a pattern for one or more unit tests, it will automatically bisect the
 current range:
 
-```sh
+```bash
 npm run bisect -- --good 686378 --bad 706915 script.js
 npm run bisect -- --unit-test Response.fromCache
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -206,7 +206,7 @@ launch, so you don’t need to specify `PUPPETEER_EXECUTABLE_PATH` as well.
 
 For example, if you wish to keep the Chromium download in `~/.npm/chromium`:
 
-```sh
+```bash
 export PUPPETEER_DOWNLOAD_PATH=~/.npm/chromium
 npm ci
 

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -109,7 +109,7 @@ if you want to try something out, you have to add it to your test file.
 
 3. Run your server code with `--inspect-brk`. For example,
 
-   ```sh
+   ```bash
    node --inspect-brk path/to/script.js
    ```
 
@@ -126,7 +126,7 @@ DevTools protocol. You can debug this by setting the `DEBUG` environment
 variable before running your script. This will log internal traffic via
 [`debug`](https://github.com/visionmedia/debug) under the `puppeteer` namespace.
 
-```sh
+```bash
 # Basic verbose logging
 env DEBUG="puppeteer:*" node script.js
 

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -7,7 +7,7 @@ the
 The latest image is tagged as `latest` and other tags match Puppeteer versions.
 For example,
 
-```sh
+```bash
 docker pull ghcr.io/puppeteer/puppeteer:latest # pulls the latest
 docker pull ghcr.io/puppeteer/puppeteer:16.1.0 # pulls the image that contains Puppeteer v16.1.0
 ```
@@ -19,7 +19,7 @@ running the image requires the `SYS_ADMIN` capability.
 
 To use the docker image directly, run:
 
-```sh
+```bash
 docker run -i --init --cap-add=SYS_ADMIN --rm ghcr.io/puppeteer/puppeteer:latest node -e "$(cat path/to/script.js)"
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ the installation directory.
 
 For example,
 
-```sh
+```bash
 PUPPETEER_CACHE_DIR=$(pwd) npm install puppeteer
 PUPPETEER_CACHE_DIR=$(pwd) node <script-path>
 ```
@@ -603,13 +603,13 @@ and if you want to run Puppeteer tests in amazon-linux, follow these steps.
    comes as part of
    [EPEL (Extra Packages for Enterprise Linux)](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/):
 
-   ```sh
+   ```bash
    sudo amazon-linux-extras install epel -y
    ```
 
 1. Next, install Chromium:
 
-   ```sh
+   ```bash
    sudo yum install -y chromium
    ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 Assuming you have a checkout of the Puppeteer repo and have run npm i (or yarn) to install the dependencies, the examples can be run from the root folder like so:
 
-```sh
+```bash
 NODE_PATH=../ node examples/search.js
 ```
 

--- a/packages/browsers/README.md
+++ b/packages/browsers/README.md
@@ -6,13 +6,13 @@ Manage and launch browsers/drivers from a CLI or programmatically.
 
 Use `npx` to run the CLI:
 
-```sh
+```bash
 npx @puppeteer/browsers --help
 ```
 
 CLI help will provide all documentation you need to use the CLI.
 
-```sh
+```bash
 npx @puppeteer/browsers --help # help for all commands
 npx @puppeteer/browsers install --help # help for the install command
 npx @puppeteer/browsers launch --help # help for the launch command


### PR DESCRIPTION
If you look at https://pptr.dev/contributing#getting-started you will see the `sh` block as plain color.
But if you look at https://pptr.dev/#installation where we use `bash` block you will see it in formatted color.