### PR TITLE
feat: Add new PUPPETEER_DOWNLOAD_HOST_NEW to set download host

### DIFF
--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -58,6 +58,7 @@ export const getConfiguration = (): Configuration => {
       process.env['npm_package_config_puppeteer_browser_revision'] ??
       configuration.browserRevision;
     configuration.downloadHost =
+      process.env['PUPPETEER_DOWNLOAD_HOST_NEW'] ??
       process.env['PUPPETEER_DOWNLOAD_HOST'] ??
       process.env['npm_config_puppeteer_download_host'] ??
       process.env['npm_package_config_puppeteer_download_host'] ??


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

compatibility issues with inconsistent download paths between old(puppeteer < v20) and new versions

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

```
PUPPETEER_DOWNLOAD_HOST_NEW=https://demo.com/path-for-v20 \
  PUPPETEER_DOWNLOAD_HOST=https://demo.com/path-for-v19 npm i
```

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
