### PR TITLE
chore: update puppeteer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9382,9 +9382,6 @@
       "dependencies": {
         "@puppeteer/browsers": "1.0.1",
         "cosmiconfig": "8.1.3",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
         "puppeteer-core": "20.1.1"
       }
     },
@@ -9397,11 +9394,6 @@
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1120988",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
         "ws": "8.13.0"
       },
       "devDependencies": {
@@ -14374,9 +14366,6 @@
       "requires": {
         "@puppeteer/browsers": "1.0.1",
         "cosmiconfig": "8.1.3",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
         "puppeteer-core": "20.1.1"
       }
     },
@@ -14388,13 +14377,8 @@
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1120988",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
         "mitt": "3.0.0",
         "parsel-js": "1.1.0",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
         "ws": "8.13.0"
       }
     },

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -136,11 +136,6 @@
     "cross-fetch": "3.1.5",
     "debug": "4.3.4",
     "devtools-protocol": "0.0.1120988",
-    "extract-zip": "2.0.1",
-    "https-proxy-agent": "5.0.1",
-    "proxy-from-env": "1.1.0",
-    "tar-fs": "2.1.1",
-    "unbzip2-stream": "1.4.3",
     "ws": "8.13.0",
     "@puppeteer/browsers": "1.0.1"
   },

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -117,9 +117,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cosmiconfig": "8.1.3",
-    "https-proxy-agent": "5.0.1",
-    "progress": "2.0.3",
-    "proxy-from-env": "1.1.0",
     "puppeteer-core": "20.1.1",
     "@puppeteer/browsers": "1.0.1"
   }


### PR DESCRIPTION
These dependencies are now part of `@puppeteer/browsers` we should not include them for puppeteer or puppeteer-core