### PR TITLE
chore: support Tab targets

### DIFF
--- a/packages/puppeteer-core/src/api/Target.ts
+++ b/packages/puppeteer-core/src/api/Target.ts
@@ -31,6 +31,10 @@ export enum TargetType {
   BROWSER = 'browser',
   WEBVIEW = 'webview',
   OTHER = 'other',
+  /**
+   * @internal
+   */
+  TAB = 'tab',
 }
 
 /**

--- a/packages/puppeteer-core/src/common/Accessibility.ts
+++ b/packages/puppeteer-core/src/common/Accessibility.ts
@@ -142,6 +142,13 @@ export class Accessibility {
   }
 
   /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
+    this.#client = client;
+  }
+
+  /**
    * Captures the current state of the accessibility tree.
    * The returned object represents the root accessible node of the page.
    *

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -442,7 +442,9 @@ export class CDPBrowser extends BrowserBase {
       url: 'about:blank',
       browserContextId: contextId || undefined,
     });
-    const target = this.#targetManager.getAvailableTargets().get(targetId);
+    const target = (await this.waitForTarget(t => {
+      return (t as CDPTarget)._targetId === targetId;
+    })) as CDPTarget;
     if (!target) {
       throw new Error(`Missing target for page (id = ${targetId})`);
     }
@@ -581,7 +583,11 @@ export class CDPBrowserContext extends BrowserContext {
     options: {timeout?: number} = {}
   ): Promise<Target> {
     return this.#browser.waitForTarget(target => {
-      return target.browserContext() === this && predicate(target);
+      return (
+        target.browserContext() === this &&
+        target.type() !== 'tab' &&
+        predicate(target)
+      );
     }, options);
   }
 

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -583,11 +583,7 @@ export class CDPBrowserContext extends BrowserContext {
     options: {timeout?: number} = {}
   ): Promise<Target> {
     return this.#browser.waitForTarget(target => {
-      return (
-        target.browserContext() === this &&
-        target.type() !== 'tab' &&
-        predicate(target)
-      );
+      return target.browserContext() === this && predicate(target);
     }, options);
   }
 

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -86,6 +86,9 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
   #targetsIdsForInit = new Set<string>();
   #waitForInitiallyDiscoveredTargets = true;
 
+  #tabMode = true;
+  #discoveryFilter = this.#tabMode ? [{}] : [{type: 'tab', exclude: true}, {}];
+
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
@@ -107,7 +110,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
     this.#connection
       .send('Target.setDiscoverTargets', {
         discover: true,
-        filter: [{type: 'tab', exclude: true}, {}],
+        filter: this.#discoveryFilter,
       })
       .then(this.#storeExistingTargetsForInit)
       .catch(debugError);
@@ -143,6 +146,15 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
       waitForDebuggerOnStart: true,
       flatten: true,
       autoAttach: true,
+      filter: this.#tabMode
+        ? [
+            {
+              type: 'page',
+              exclude: true,
+            },
+            ...this.#discoveryFilter,
+          ]
+        : this.#discoveryFilter,
     });
     this.#finishInitializationIfReady();
     await this.#initializeDeferred.valueOrThrow();
@@ -158,7 +170,13 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
   }
 
   getAvailableTargets(): Map<string, CDPTarget> {
-    return this.#attachedTargetsByTargetId;
+    const result = new Map<string, CDPTarget>();
+    for (const [id, target] of this.#attachedTargetsByTargetId.entries()) {
+      if (target.type() !== 'tab' && !target._subtype()) {
+        result.set(id, target);
+      }
+    }
+    return result;
   }
 
   addTargetInterceptor(
@@ -285,6 +303,16 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
     const wasInitialized =
       target._initializedDeferred.value() === InitializationStatus.SUCCESS;
 
+    if (target._subtype() && !event.targetInfo.subtype) {
+      const target = this.#attachedTargetsByTargetId.get(
+        event.targetInfo.targetId
+      );
+      const session = target?._session();
+      if (session) {
+        session.parentSession()?.emit('sessionswapped', session);
+      }
+    }
+
     target._targetInfoChanged(event.targetInfo);
 
     if (wasInitialized && previousURL !== target.url()) {
@@ -350,7 +378,11 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
 
     const target = existingTarget
       ? this.#attachedTargetsByTargetId.get(targetInfo.targetId)!
-      : this.#targetFactory(targetInfo, session);
+      : this.#targetFactory(
+          targetInfo,
+          session,
+          parentSession instanceof CDPSession ? parentSession : undefined
+        );
 
     if (this.#targetFilterCallback && !this.#targetFilterCallback(target)) {
       this.#ignoredTargets.add(targetInfo.targetId);
@@ -391,7 +423,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
     }
 
     this.#targetsIdsForInit.delete(target._targetId);
-    if (!existingTarget) {
+    if (!existingTarget && target.type() !== 'tab' && !target._subtype()) {
       this.emit(TargetManagerEmittedEvents.TargetAvailable, target);
     }
     this.#finishInitializationIfReady();
@@ -403,6 +435,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
         waitForDebuggerOnStart: true,
         flatten: true,
         autoAttach: true,
+        filter: this.#discoveryFilter,
       }),
       session.send('Runtime.runIfWaitingForDebugger'),
     ]).catch(debugError);
@@ -428,6 +461,8 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
     }
 
     this.#attachedTargetsByTargetId.delete(target._targetId);
-    this.emit(TargetManagerEmittedEvents.TargetGone, target);
+    if (target.type() !== 'tab') {
+      this.emit(TargetManagerEmittedEvents.TargetGone, target);
+    }
   };
 }

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -17,10 +17,11 @@
 import {Protocol} from 'devtools-protocol';
 
 import {TargetFilterCallback} from '../api/Browser.js';
+import {TargetType} from '../api/Target.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {CDPSession, Connection} from './Connection.js';
+import {CDPSession, CDPSessionEmittedEvents, Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {InitializationStatus, CDPTarget} from './Target.js';
 import {
@@ -32,7 +33,7 @@ import {
 import {debugError} from './util.js';
 
 function isTargetExposed(target: CDPTarget): boolean {
-  return target.type() !== 'tab' && !target._subtype();
+  return target.type() !== TargetType.TAB && !target._subtype();
 }
 
 function isPageTargetBecomingPrimary(
@@ -324,7 +325,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
         session,
         'Target that is being activated is missing a CDPSession.'
       );
-      session.parentSession()?.emit('sessionswapped', session);
+      session.parentSession()?.emit(CDPSessionEmittedEvents.Swapped, session);
     }
 
     target._targetInfoChanged(event.targetInfo);

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -99,7 +99,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
   #waitForInitiallyDiscoveredTargets = true;
 
   // TODO: remove the flag once the testing/rollout is done.
-  #tabMode = true;
+  #tabMode = false;
   #discoveryFilter = this.#tabMode ? [{}] : [{type: 'tab', exclude: true}, {}];
 
   constructor(

--- a/packages/puppeteer-core/src/common/Connection.ts
+++ b/packages/puppeteer-core/src/common/Connection.ts
@@ -308,7 +308,6 @@ export class Connection extends EventEmitter {
     const object = JSON.parse(message);
     if (object.method === 'Target.attachedToTarget') {
       const sessionId = object.params.sessionId;
-      const parentSession = this.#sessions.get(object.sessionId);
       const session = new CDPSessionImpl(
         this,
         object.params.targetInfo.type,
@@ -317,6 +316,7 @@ export class Connection extends EventEmitter {
       );
       this.#sessions.set(sessionId, session);
       this.emit('sessionattached', session);
+      const parentSession = this.#sessions.get(object.sessionId);
       if (parentSession) {
         parentSession.emit('sessionattached', session);
       }
@@ -535,6 +535,8 @@ export class CDPSessionImpl extends CDPSession {
   }
 
   /**
+   * Sets the CDPTarget associated with the session instance.
+   *
    * @internal
    */
   _setTarget(target: CDPTarget): void {
@@ -542,9 +544,12 @@ export class CDPSessionImpl extends CDPSession {
   }
 
   /**
+   * Gets the CDPTarget associated with the session instance.
+   *
    * @internal
    */
-  _target(): CDPTarget | undefined {
+  _target(): CDPTarget {
+    assert(this.#target, 'Target must exist');
     return this.#target;
   }
 

--- a/packages/puppeteer-core/src/common/Connection.ts
+++ b/packages/puppeteer-core/src/common/Connection.ts
@@ -430,6 +430,7 @@ export interface CDPSessionOnMessageObject {
  */
 export const CDPSessionEmittedEvents = {
   Disconnected: Symbol('CDPSession.Disconnected'),
+  Swapped: Symbol('CDPSession.Swapped'),
 } as const;
 
 /**

--- a/packages/puppeteer-core/src/common/Coverage.ts
+++ b/packages/puppeteer-core/src/common/Coverage.ts
@@ -145,6 +145,14 @@ export class Coverage {
   }
 
   /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
+    this.#jsCoverage.updateClient(client);
+    this.#cssCoverage.updateClient(client);
+  }
+
+  /**
    * @param options - Set of configurable options for coverage defaults to
    * `resetOnNavigation : true, reportAnonymousScripts : false,`
    * `includeRawScriptCoverage : false, useBlockCoverage : true`
@@ -209,6 +217,13 @@ export class JSCoverage {
   #includeRawScriptCoverage = false;
 
   constructor(client: CDPSession) {
+    this.#client = client;
+  }
+
+  /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
     this.#client = client;
   }
 
@@ -339,6 +354,13 @@ export class CSSCoverage {
   #resetOnNavigation = false;
 
   constructor(client: CDPSession) {
+    this.#client = client;
+  }
+
+  /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
     this.#client = client;
   }
 

--- a/packages/puppeteer-core/src/common/EmulationManager.ts
+++ b/packages/puppeteer-core/src/common/EmulationManager.ts
@@ -35,6 +35,10 @@ export class EmulationManager {
     this.#client = client;
   }
 
+  updateClient(client: CDPSession): void {
+    this.#client = client;
+  }
+
   get javascriptEnabled(): boolean {
     return this.#javascriptEnabled;
   }

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -108,13 +108,6 @@ export class FirefoxTargetManager
     this.setupAttachmentListeners(this.#connection);
   }
 
-  /**
-   * @internal
-   */
-  _tabTargetBySession(_session?: CDPSession): CDPSession | undefined {
-    return undefined;
-  }
-
   addTargetInterceptor(
     client: CDPSession | Connection,
     interceptor: TargetInterceptor

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -108,6 +108,13 @@ export class FirefoxTargetManager
     this.setupAttachmentListeners(this.#connection);
   }
 
+  /**
+   * @internal
+   */
+  _tabTargetBySession(_session?: CDPSession): CDPSession | undefined {
+    return undefined;
+  }
+
   addTargetInterceptor(
     client: CDPSession | Connection,
     interceptor: TargetInterceptor

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -85,11 +85,16 @@ export class Frame extends BaseFrame {
     this.updateClient(client);
 
     this.on(FrameEmittedEvents.FrameSwappedByActivation, () => {
+      // Emulate loading process for swapped frames.
       this._onLoadingStarted();
       this._onLoadingStopped();
     });
   }
 
+  /**
+   * Updates the frame ID with the new ID. This happens when the main frame is
+   * replaced by a different frame.
+   */
   updateId(id: string): void {
     this._id = id;
   }

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -49,6 +49,7 @@ export const FrameEmittedEvents = {
   LifecycleEvent: Symbol('Frame.LifecycleEvent'),
   FrameNavigatedWithinDocument: Symbol('Frame.FrameNavigatedWithinDocument'),
   FrameDetached: Symbol('Frame.FrameDetached'),
+  FrameSwappedByActivation: Symbol('Frame.FrameSwappedByActivation'),
 };
 
 /**
@@ -82,6 +83,15 @@ export class Frame extends BaseFrame {
     this._loaderId = '';
 
     this.updateClient(client);
+
+    this.on(FrameEmittedEvents.FrameSwappedByActivation, () => {
+      this._onLoadingStarted();
+      this._onLoadingStopped();
+    });
+  }
+
+  updateId(id: string): void {
+    this._id = id;
   }
 
   updateClient(client: CDPSession): void {

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -99,12 +99,17 @@ export class Frame extends BaseFrame {
     this._id = id;
   }
 
-  updateClient(client: CDPSession): void {
+  updateClient(client: CDPSession, keepWorlds = false): void {
     this.#client = client;
-    this.worlds = {
-      [MAIN_WORLD]: new IsolatedWorld(this),
-      [PUPPETEER_WORLD]: new IsolatedWorld(this),
-    };
+    if (!keepWorlds) {
+      this.worlds = {
+        [MAIN_WORLD]: new IsolatedWorld(this),
+        [PUPPETEER_WORLD]: new IsolatedWorld(this),
+      };
+    } else {
+      this.worlds[MAIN_WORLD].frameUpdated();
+      this.worlds[PUPPETEER_WORLD].frameUpdated();
+    }
   }
 
   override page(): Page {

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -131,6 +131,9 @@ export class FrameManager extends EventEmitter {
     if (!mainFrame) {
       return;
     }
+    for (const child of mainFrame.childFrames()) {
+      this.#removeFramesRecursively(child);
+    }
     const swapped = Deferred.create<void>({
       timeout: TIME_FOR_WAITING_FOR_SWAP,
       message: 'Frame was not swapped',
@@ -140,9 +143,6 @@ export class FrameManager extends EventEmitter {
     });
     try {
       await swapped.valueOrThrow();
-      for (const child of mainFrame.childFrames()) {
-        this.#removeFramesRecursively(child);
-      }
     } catch (err) {
       this.#removeFramesRecursively(mainFrame);
     }

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -163,8 +163,13 @@ export class FrameManager extends EventEmitter {
     );
     const frame = this._frameTree.getMainFrame();
     if (frame) {
+      this.#frameNavigatedReceived.add(this.#client._target()._targetId);
       this._frameTree.removeFrame(frame);
       frame.updateId(this.#client._target()._targetId);
+      frame.mainRealm().clearContext();
+      frame.isolatedRealm().clearContext();
+      this._frameTree.addFrame(frame);
+      frame.updateClient(client, true);
     }
     this.setupEventListeners(client);
     client.once(CDPSessionEmittedEvents.Disconnected, () => {

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -144,9 +144,7 @@ export class FrameManager extends EventEmitter {
         this.#removeFramesRecursively(child);
       }
     } catch (err) {
-      if (mainFrame) {
-        this.#removeFramesRecursively(mainFrame);
-      }
+      this.#removeFramesRecursively(mainFrame);
     }
   }
 
@@ -173,6 +171,7 @@ export class FrameManager extends EventEmitter {
       this.#onClientDisconnect().catch(debugError);
     });
     await this.initialize(client);
+    await this.#networkManager.updateClient(client);
     if (frame) {
       frame.emit(FrameEmittedEvents.FrameSwappedByActivation);
     }

--- a/packages/puppeteer-core/src/common/Input.ts
+++ b/packages/puppeteer-core/src/common/Input.ts
@@ -59,6 +59,13 @@ export class CDPKeyboard extends Keyboard {
     this.#client = client;
   }
 
+  /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
+    this.#client = client;
+  }
+
   override async down(
     key: KeyInput,
     options: Readonly<KeyDownOptions> = {
@@ -288,6 +295,13 @@ export class CDPMouse extends Mouse {
     super();
     this.#client = client;
     this.#keyboard = keyboard;
+  }
+
+  /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
+    this.#client = client;
   }
 
   #_state: Readonly<MouseState> = {
@@ -569,6 +583,13 @@ export class CDPTouchscreen extends Touchscreen {
     super();
     this.#client = client;
     this.#keyboard = keyboard;
+  }
+
+  /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
+    this.#client = client;
   }
 
   override async tap(x: number, y: number): Promise<void> {

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -124,9 +124,11 @@ export class IsolatedWorld implements Realm {
   }
 
   constructor(frame: Frame) {
-    // Keep own reference to client because it might differ from the FrameManager's
-    // client for OOP iframes.
     this.#frame = frame;
+    this.frameUpdated();
+  }
+
+  frameUpdated(): void {
     this.#client.on('Runtime.bindingCalled', this.#onBindingCalled);
   }
 

--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -119,6 +119,11 @@ export class LifecycleWatcher {
       ),
       addEventListener(
         frame,
+        FrameEmittedEvents.FrameSwappedByActivation,
+        this.#frameSwappedByActivation.bind(this)
+      ),
+      addEventListener(
+        frame,
         FrameEmittedEvents.FrameDetached,
         this.#onFrameDetached.bind(this)
       ),
@@ -218,6 +223,11 @@ export class LifecycleWatcher {
   }
 
   #frameSwapped(): void {
+    this.#swapped = true;
+    this.#checkLifecycleComplete();
+  }
+
+  #frameSwappedByActivation(): void {
     this.#swapped = true;
     this.#checkLifecycleComplete();
   }

--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -120,7 +120,7 @@ export class LifecycleWatcher {
       addEventListener(
         frame,
         FrameEmittedEvents.FrameSwappedByActivation,
-        this.#frameSwappedByActivation.bind(this)
+        this.#frameSwapped.bind(this)
       ),
       addEventListener(
         frame,
@@ -223,11 +223,6 @@ export class LifecycleWatcher {
   }
 
   #frameSwapped(): void {
-    this.#swapped = true;
-    this.#checkLifecycleComplete();
-  }
-
-  #frameSwappedByActivation(): void {
     this.#swapped = true;
     this.#checkLifecycleComplete();
   }

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -311,7 +311,7 @@ export class CDPPage extends Page {
 
     this.#setupEventListeners();
 
-    this.#tabSession?.on('sessionswapped', async newSession => {
+    this.#tabSession?.on(CDPSessionEmittedEvents.Swapped, async newSession => {
       this.#client = newSession;
       assert(
         this.#client instanceof CDPSessionImpl,
@@ -319,7 +319,13 @@ export class CDPPage extends Page {
       );
       this.#target = this.#client._target();
       assert(this.#target, 'Missing target on swap');
-      // TODO: swap the session for other members.
+      this.#keyboard.updateClient(newSession);
+      this.#mouse.updateClient(newSession);
+      this.#touchscreen.updateClient(newSession);
+      this.#accessibility.updateClient(newSession);
+      this.#emulationManager.updateClient(newSession);
+      this.#tracing.updateClient(newSession);
+      this.#coverage.updateClient(newSession);
       await this.#frameManager.swapFrameTree(newSession);
       this.#setupEventListeners();
     });

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -313,8 +313,13 @@ export class CDPPage extends Page {
 
     this.#tabSession?.on('sessionswapped', async newSession => {
       this.#client = newSession;
-      this.#target = (this.#client as CDPSessionImpl)._target()!;
+      assert(
+        this.#client instanceof CDPSessionImpl,
+        'CDPSession is not instance of CDPSessionImpl'
+      );
+      this.#target = this.#client._target();
       assert(this.#target, 'Missing target on swap');
+      // TODO: swap the session for other members.
       await this.#frameManager.swapFrameTree(newSession);
       this.#setupEventListeners();
     });

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -22,7 +22,7 @@ import {Page, PageEmittedEvents} from '../api/Page.js';
 import {Target, TargetType} from '../api/Target.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {CDPSession} from './Connection.js';
+import {CDPSession, CDPSessionImpl} from './Connection.js';
 import {CDPPage} from './Page.js';
 import {Viewport} from './PuppeteerViewport.js';
 import {TargetManager} from './TargetManager.js';
@@ -84,6 +84,14 @@ export class CDPTarget extends Target {
     this.#browserContext = browserContext;
     this._targetId = targetInfo.targetId;
     this.#sessionFactory = sessionFactory;
+    (this.#session as CDPSessionImpl | undefined)?._setTarget(this);
+  }
+
+  /**
+   * @internal
+   */
+  _subtype(): string | undefined {
+    return this.#targetInfo.subtype;
   }
 
   /**
@@ -109,7 +117,10 @@ export class CDPTarget extends Target {
     if (!this.#sessionFactory) {
       throw new Error('sessionFactory is not initialized');
     }
-    return this.#sessionFactory(false);
+    return this.#sessionFactory(false).then(session => {
+      (session as CDPSessionImpl)._setTarget(this);
+      return session;
+    });
   }
 
   override url(): string {
@@ -131,6 +142,8 @@ export class CDPTarget extends Target {
         return TargetType.BROWSER;
       case 'webview':
         return TargetType.WEBVIEW;
+      case 'tab':
+        return TargetType.TAB;
       default:
         return TargetType.OTHER;
     }

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -84,7 +84,9 @@ export class CDPTarget extends Target {
     this.#browserContext = browserContext;
     this._targetId = targetInfo.targetId;
     this.#sessionFactory = sessionFactory;
-    (this.#session as CDPSessionImpl | undefined)?._setTarget(this);
+    if (this.#session && this.#session instanceof CDPSessionImpl) {
+      this.#session._setTarget(this);
+    }
   }
 
   /**

--- a/packages/puppeteer-core/src/common/TargetManager.ts
+++ b/packages/puppeteer-core/src/common/TargetManager.ts
@@ -25,7 +25,8 @@ import {CDPTarget} from './Target.js';
  */
 export type TargetFactory = (
   targetInfo: Protocol.Target.TargetInfo,
-  session?: CDPSession
+  session?: CDPSession,
+  parentSession?: CDPSession
 ) => CDPTarget;
 
 /**

--- a/packages/puppeteer-core/src/common/Tracing.ts
+++ b/packages/puppeteer-core/src/common/Tracing.ts
@@ -58,6 +58,13 @@ export class Tracing {
   }
 
   /**
+   * @internal
+   */
+  updateClient(client: CDPSession): void {
+    this.#client = client;
+  }
+
+  /**
    * Starts a trace for the current page.
    * @remarks
    * Only one trace can be active at a time per browser.

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -178,7 +178,7 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-dev-shm-usage',
       '--disable-extensions',
       // AcceptCHFrame disabled because of crbug.com/1348106.
-      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints',
+      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,Prerender2',
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',

--- a/test/assets/prerender/index.html
+++ b/test/assets/prerender/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<head>
+<script>
+  function addRules() {
+    const script = document.createElement('script');
+    script.type = 'speculationrules';
+    script.innerText = `
+      {
+        "prerender": [
+          {"source": "list", "urls": ["target.html"]}
+        ]
+      }
+    `;
+    document.head.append(script);
+  }
+</script>
+</head>
+<body>
+  <button onclick="addRules()">add rules</button>
+  <a href="target.html">test</a>
+</body>

--- a/test/assets/prerender/target.html
+++ b/test/assets/prerender/target.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<head></head>
+</head>
+<body>target</body>

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -82,7 +82,7 @@ describe('Launcher specs', function () {
             });
           remote.disconnect();
           const error = await watchdog;
-          expect(error.message).toContain('frame got detached');
+          expect(error.message).toContain('Session closed.');
         } finally {
           await close();
         }

--- a/test/src/prerender.spec.ts
+++ b/test/src/prerender.spec.ts
@@ -21,7 +21,7 @@ import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 describe('Prerender', function () {
   setupTestBrowserHooks();
 
-  it('can navigate to a prerendered page', async () => {
+  it('can navigate to a prerendered page via input', async () => {
     const {page, server} = await getTestState();
     await page.goto(server.PREFIX + '/prerender/index.html');
 
@@ -30,6 +30,21 @@ describe('Prerender', function () {
 
     const link = await page.waitForSelector('a');
     await Promise.all([page.waitForNavigation(), link?.click()]);
+    expect(
+      await page.evaluate(() => {
+        return document.body.innerText;
+      })
+    ).toBe('target');
+  });
+
+  it('can navigate to a prerendered page via Puppeteer', async () => {
+    const {page, server} = await getTestState();
+    await page.goto(server.PREFIX + '/prerender/index.html');
+
+    const button = await page.waitForSelector('button');
+    await button?.click();
+
+    await page.goto(server.PREFIX + '/prerender/target.html');
     expect(
       await page.evaluate(() => {
         return document.body.innerText;

--- a/test/src/prerender.spec.ts
+++ b/test/src/prerender.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+
+import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+
+describe('Prerender', function () {
+  setupTestBrowserHooks();
+
+  it('can navigate to a prerendered page', async () => {
+    const {page, server} = await getTestState();
+    await page.goto(server.PREFIX + '/prerender/index.html');
+
+    const button = await page.waitForSelector('button');
+    await button?.click();
+
+    const link = await page.waitForSelector('a');
+    await Promise.all([page.waitForNavigation(), link?.click()]);
+    expect(
+      await page.evaluate(() => {
+        return document.body.innerText;
+      })
+    ).toBe('target');
+  });
+});

--- a/test/src/prerender.spec.ts
+++ b/test/src/prerender.spec.ts
@@ -51,4 +51,42 @@ describe('Prerender', function () {
       })
     ).toBe('target');
   });
+
+  describe('via frame', () => {
+    it('can navigate to a prerendered page via input', async () => {
+      const {page, server} = await getTestState();
+      await page.goto(server.PREFIX + '/prerender/index.html');
+
+      const button = await page.waitForSelector('button');
+      await button?.click();
+
+      const mainFrame = page.mainFrame();
+      const link = await mainFrame.waitForSelector('a');
+      await Promise.all([mainFrame.waitForNavigation(), link?.click()]);
+      expect(mainFrame).toBe(page.mainFrame());
+      expect(
+        await mainFrame.evaluate(() => {
+          return document.body.innerText;
+        })
+      ).toBe('target');
+      expect(mainFrame).toBe(page.mainFrame());
+    });
+
+    it('can navigate to a prerendered page via Puppeteer', async () => {
+      const {page, server} = await getTestState();
+      await page.goto(server.PREFIX + '/prerender/index.html');
+
+      const button = await page.waitForSelector('button');
+      await button?.click();
+
+      const mainFrame = page.mainFrame();
+      await mainFrame.goto(server.PREFIX + '/prerender/target.html');
+      expect(
+        await mainFrame.evaluate(() => {
+          return document.body.innerText;
+        })
+      ).toBe('target');
+      expect(mainFrame).toBe(page.mainFrame());
+    });
+  });
 });


### PR DESCRIPTION
[Tab target is a new type of target in CDP](https://docs.google.com/document/d/14aeiC_zga2SS0OXJd6eIFj8N0o5LGwUpuqa4L8NKoR4/edit) that reflects the architectural changes in Chromium that were needed for features such as bfcache, portal and prerendering.

Previously, the `page` targets were the top-level targets representing the entire tab. If you navigate to a new URL, the page target would remain the same. With the introduction of the `tab` target, it's not possible to have multiple page targets active within one tab. For example, one page would be the currently shown page and the other one would be a [prerendered](https://github.com/WICG/nav-speculation/) page. When the user navigates to the prerendered page, the secondary page becomes the primary and the primary page target gets destroyed (the process is called activation). 

Puppeteer does not support this interaction so this PR disabled the prerendering feature in addition to the previously disabled bfcache.

This change adds support for the tab target behind the flag. Currently, we don't plan on exposing the `tab` target via the Puppeteer API and aim at keeping it an implementation detail. The support for the tab target is also limited for now: we support the target activation but the tracing/network/a11y/coverage might not work as expected if the activation happens. We will aim at improving it in the future. For the scenarios, where no activation happens there should be no difference between the tab target and non-tab target modes.

The current level of support is relatively basic: emulation/tracing/coverage might not work as expected if an activation happens. We will enable the tab mode by default once the emulation/tracing/coverage is handled in a solid way.

Issue #10147