### PR TITLE
chore: create a test helper for launching browser

### DIFF
--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -10,4 +10,20 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['*.spec.ts'],
+      rules: {
+        'no-restricted-syntax': [
+          'warn',
+          {
+            message:
+              'Use helper command `launch` to make sure the browsers get cleaned',
+            selector:
+              'MemberExpression[object.name="puppeteer"][property.name="launch"]',
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -24,6 +24,7 @@ import {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
 import {
   getTestState,
+  launch,
   setupTestBrowserHooks,
   setupTestPageAndContextHooks,
 } from './mocha-utils.js';
@@ -823,15 +824,9 @@ describe('network', function () {
     });
 
     it('Cross-origin set-cookie', async () => {
-      const {httpsServer, puppeteer, defaultBrowserOptions} = getTestState();
-
-      const browser = await puppeteer.launch({
-        ...defaultBrowserOptions,
+      const {page, httpsServer, close} = await launch({
         ignoreHTTPSErrors: true,
       });
-
-      const page = await browser.newPage();
-
       try {
         await page.goto(httpsServer.PREFIX + '/empty.html');
 
@@ -855,8 +850,7 @@ describe('network', function () {
         ]);
         expect(response.headers()['set-cookie']).toBe(setCookieString);
       } finally {
-        await page.close();
-        await browser.close();
+        await close();
       }
     });
   });


### PR DESCRIPTION
Only one test changed at this time (unblocks a BiDi PR for navigation), when approved a follow up PR will make the changes to the other places.

EsLint rule for this created, will be turn on ('error') in the follow up.