### PR TITLE
refactor: introduce an internal PageTarget subclass

### DIFF
--- a/docs/api/puppeteer.target.md
+++ b/docs/api/puppeteer.target.md
@@ -18,13 +18,13 @@ The constructor for this class is marked as internal. Third-party code should no
 
 ## Methods
 
-| Method                                                       | Modifiers | Description                                                                                                                                |
-| ------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [browser()](./puppeteer.target.browser.md)                   |           | Get the browser the target belongs to.                                                                                                     |
-| [browserContext()](./puppeteer.target.browsercontext.md)     |           | Get the browser context the target belongs to.                                                                                             |
-| [createCDPSession()](./puppeteer.target.createcdpsession.md) |           | Creates a Chrome Devtools Protocol session attached to the target.                                                                         |
-| [opener()](./puppeteer.target.opener.md)                     |           | Get the target that opened this target. Top-level targets return <code>null</code>.                                                        |
-| [page()](./puppeteer.target.page.md)                         |           | If the target is not of type <code>&quot;page&quot;</code> or <code>&quot;background_page&quot;</code>, returns <code>null</code>.         |
-| [type()](./puppeteer.target.type.md)                         |           | Identifies what kind of target this is.                                                                                                    |
-| [url()](./puppeteer.target.url.md)                           |           |                                                                                                                                            |
-| [worker()](./puppeteer.target.worker.md)                     |           | If the target is not of type <code>&quot;service_worker&quot;</code> or <code>&quot;shared_worker&quot;</code>, returns <code>null</code>. |
+| Method                                                       | Modifiers | Description                                                                                                                                                          |
+| ------------------------------------------------------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [browser()](./puppeteer.target.browser.md)                   |           | Get the browser the target belongs to.                                                                                                                               |
+| [browserContext()](./puppeteer.target.browsercontext.md)     |           | Get the browser context the target belongs to.                                                                                                                       |
+| [createCDPSession()](./puppeteer.target.createcdpsession.md) |           | Creates a Chrome Devtools Protocol session attached to the target.                                                                                                   |
+| [opener()](./puppeteer.target.opener.md)                     |           | Get the target that opened this target. Top-level targets return <code>null</code>.                                                                                  |
+| [page()](./puppeteer.target.page.md)                         |           | If the target is not of type <code>&quot;page&quot;</code>, <code>&quot;webview&quot;</code> or <code>&quot;background_page&quot;</code>, returns <code>null</code>. |
+| [type()](./puppeteer.target.type.md)                         |           | Identifies what kind of target this is.                                                                                                                              |
+| [url()](./puppeteer.target.url.md)                           |           |                                                                                                                                                                      |
+| [worker()](./puppeteer.target.worker.md)                     |           | If the target is not of type <code>&quot;service_worker&quot;</code> or <code>&quot;shared_worker&quot;</code>, returns <code>null</code>.                           |

--- a/docs/api/puppeteer.target.page.md
+++ b/docs/api/puppeteer.target.page.md
@@ -4,7 +4,7 @@ sidebar_label: Target.page
 
 # Target.page() method
 
-If the target is not of type `"page"` or `"background_page"`, returns `null`.
+If the target is not of type `"page"`, `"webview"` or `"background_page"`, returns `null`.
 
 #### Signature:
 

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -39,7 +39,7 @@ import {ChromeTargetManager} from './ChromeTargetManager.js';
 import {CDPSession, Connection, ConnectionEmittedEvents} from './Connection.js';
 import {FirefoxTargetManager} from './FirefoxTargetManager.js';
 import {Viewport} from './PuppeteerViewport.js';
-import {Target} from './Target.js';
+import {PageTarget, Target} from './Target.js';
 import {TargetManager, TargetManagerEmittedEvents} from './TargetManager.js';
 import {TaskQueue} from './TaskQueue.js';
 import {waitWithTimeout} from './util.js';
@@ -318,6 +318,23 @@ export class CDPBrowser extends BrowserBase {
       throw new Error('Missing browser context');
     }
 
+    if (this.#isPageTargetCallback(targetInfo)) {
+      return new PageTarget(
+        targetInfo,
+        session,
+        context,
+        this.#targetManager,
+        (isAutoAttachEmulated: boolean) => {
+          return this.#connection._createSession(
+            targetInfo,
+            isAutoAttachEmulated
+          );
+        },
+        this.#ignoreHTTPSErrors,
+        this.#defaultViewport ?? null,
+        this.#screenshotTaskQueue
+      );
+    }
     return new Target(
       targetInfo,
       session,
@@ -328,11 +345,7 @@ export class CDPBrowser extends BrowserBase {
           targetInfo,
           isAutoAttachEmulated
         );
-      },
-      this.#ignoreHTTPSErrors,
-      this.#defaultViewport ?? null,
-      this.#screenshotTaskQueue,
-      this.#isPageTargetCallback
+      }
     );
   };
 


### PR DESCRIPTION
In preparation for supporting the tab target, we introduce classes for various target types. This allows encapsulating various target-specific init steps and allows avoid constantly checking the current target type. This PR extracts a PageTarget that would wrap target types that support pages. The next PR will refactor worker targets. 