### PR TITLE
fix: update the command name

### DIFF
--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -9,9 +9,7 @@
     "clean": "tsc --build --clean && rm -rf lib",
     "test": "wireit"
   },
-  "bin": {
-    "@puppeteer/browsers": "lib/cjs/main-cli.js"
-  },
+  "bin": "lib/cjs/main-cli.js",
   "main": "./lib/cjs/main.js",
   "module": "./lib/esm/main.js",
   "type": "commonjs",


### PR DESCRIPTION
It looks like the defining the browser binary name this way does not work for yarn and we probably can just let the package manager pick the name.

Closes #10171