### PR TITLE
refactor: change target promises to be deferred

### DIFF
--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -22,7 +22,7 @@ import {createDeferredPromise} from '../util/DeferredPromise.js';
 
 import {CDPSession, Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
-import {Target} from './Target.js';
+import {InitializationStatus, Target} from './Target.js';
 import {
   TargetInterceptor,
   TargetFactory,
@@ -267,7 +267,8 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
       return;
     }
     const previousURL = target.url();
-    const wasInitialized = target._isInitialized;
+    const wasInitialized =
+      target._initializedPromise.value() === InitializationStatus.SUCCESS;
 
     target._targetInfoChanged(event.targetInfo);
 

--- a/packages/puppeteer-core/src/util/DeferredPromise.ts
+++ b/packages/puppeteer-core/src/util/DeferredPromise.ts
@@ -8,6 +8,7 @@ export interface DeferredPromise<T> extends Promise<T> {
   resolved: () => boolean;
   resolve: (value: T) => void;
   reject: (reason?: unknown) => void;
+  value: () => T | undefined;
 }
 
 /**
@@ -32,6 +33,7 @@ export function createDeferredPromise<T>(
 ): DeferredPromise<T> {
   let isResolved = false;
   let isRejected = false;
+  let _value: T | undefined;
   let resolver: (value: T) => void;
   let rejector: (reason?: unknown) => void;
   const taskPromise = new Promise<T>((resolve, reject) => {
@@ -57,12 +59,16 @@ export function createDeferredPromise<T>(
         clearTimeout(timeoutId);
       }
       isResolved = true;
+      _value = value;
       resolver(value);
     },
     reject: (err?: unknown) => {
       clearTimeout(timeoutId);
       isRejected = true;
       rejector(err);
+    },
+    value: () => {
+      return _value;
     },
   });
 }


### PR DESCRIPTION
- Adds InitializationStatus enum instead of booleans. We need to see if we can get rid of this status completely as only the page target relies on it.
- Adds a value getter to the deferred promise to check the value without waiting.