### PR TITLE
fix: ElementHandle dragAndDrop should fail when interception is disabled

### DIFF
--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Verify issue
         timeout-minutes: 10
         run: ${{ env.PACKAGE_MANAGER }} run verify
+        env:
+          DEBUG: 'puppeteer:*'
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -502,6 +502,10 @@ export class CDPElementHandle<
     target: CDPElementHandle<Node>,
     options?: {delay: number}
   ): Promise<void> {
+    assert(
+      this.#page.isDragInterceptionEnabled(),
+      'Drag Interception is not enabled!'
+    );
     await this.#scrollIntoViewIfNeeded();
     const startPoint = await this.clickablePoint();
     const targetPoint = await target.clickablePoint();


### PR DESCRIPTION
Closes #10204

Side change: Made analyzer debug logs visible 