### PR TITLE
fix: webpack tests to use dirname

### DIFF
--- a/test/installation/assets/puppeteer/webpack/webpack.config.js
+++ b/test/installation/assets/puppeteer/webpack/webpack.config.js
@@ -22,4 +22,7 @@ export default {
     path: process.cwd(),
     filename: 'bundle.js',
   },
+  node: {
+    __dirname: true,
+  },
 };


### PR DESCRIPTION
The vm2 dependency of proxy-agent uses __dirname and the default configuration does not work for this module. 