### PR TITLE
chore: convert async describe to sync

### DIFF
--- a/test/src/ariaqueryhandler.spec.ts
+++ b/test/src/ariaqueryhandler.spec.ts
@@ -591,7 +591,7 @@ describe('AriaQueryHandler', () => {
     });
   });
 
-  describe('queryOne (Chromium web test)', async () => {
+  describe('queryOne (Chromium web test)', () => {
     beforeEach(async () => {
       const {page} = getTestState();
       await page.setContent(

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -795,7 +795,7 @@ describe('network', function () {
     });
   });
 
-  describe('raw network headers', async () => {
+  describe('raw network headers', () => {
     it('Same-origin set-cookie navigation', async () => {
       const {page, server} = getTestState();
 
@@ -861,7 +861,7 @@ describe('network', function () {
     });
   });
 
-  describe('Page.setBypassServiceWorker', async () => {
+  describe('Page.setBypassServiceWorker', () => {
     it('bypass for network', async () => {
       const {page, server} = getTestState();
 


### PR DESCRIPTION
`describe` should not be be async