### PR TITLE
refactor: make deferred promises more robust to use

### DIFF
--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -131,7 +131,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
       autoAttach: true,
     });
     this.#finishInitializationIfReady();
-    await this.#initializePromise;
+    await this.#initializePromise.valueOrThrow();
   }
 
   dispose(): void {

--- a/packages/puppeteer-core/src/common/DeviceRequestPrompt.ts
+++ b/packages/puppeteer-core/src/common/DeviceRequestPrompt.ts
@@ -161,7 +161,7 @@ export class DeviceRequestPrompt {
     const handle = {filter, promise};
     this.#waitForDevicePromises.add(handle);
     try {
-      return await promise;
+      return await promise.valueOrThrow();
     } finally {
       this.#waitForDevicePromises.delete(handle);
     }
@@ -262,7 +262,10 @@ export class DeviceRequestPromptManager {
     this.#deviceRequestPromptPromises.add(promise);
 
     try {
-      const [result] = await Promise.all([promise, enablePromise]);
+      const [result] = await Promise.all([
+        promise.valueOrThrow(),
+        enablePromise,
+      ]);
       return result;
     } finally {
       this.#deviceRequestPromptPromises.delete(promise);

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -169,7 +169,7 @@ export class FirefoxTargetManager
       filter: [{}],
     });
     this.#targetsIdsForInit = new Set(this.#discoveredTargetsByTargetId.keys());
-    await this.#initializePromise;
+    await this.#initializePromise.valueOrThrow();
   }
 
   #onTargetCreated = async (

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -419,7 +419,7 @@ export class Frame extends BaseFrame {
             script.id = id;
           }
           document.head.appendChild(script);
-          await promise;
+          await promise.valueOrThrow();
           return script;
         },
         LazyArg.create(context => {
@@ -488,7 +488,7 @@ export class Frame extends BaseFrame {
             {once: true}
           );
           document.head.appendChild(element);
-          await promise;
+          await promise.valueOrThrow();
           return element;
         },
         LazyArg.create(context => {

--- a/packages/puppeteer-core/src/common/FrameTree.ts
+++ b/packages/puppeteer-core/src/common/FrameTree.ts
@@ -57,7 +57,7 @@ export class FrameTree<Frame extends BaseFrame> {
     const callbacks =
       this.#waitRequests.get(frameId) || new Set<DeferredPromise<Frame>>();
     callbacks.add(deferred);
-    return deferred;
+    return deferred.valueOrThrow();
   }
 
   frames(): Frame[] {

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -174,7 +174,7 @@ export class IsolatedWorld {
     if (this.#context === null) {
       throw new Error(`Execution content promise is missing`);
     }
-    return this.#context;
+    return this.#context.valueOrThrow();
   }
 
   async evaluateHandle<
@@ -425,13 +425,17 @@ export class IsolatedWorld {
       return;
     }
 
-    const context = await this.#context;
-    if (event.executionContextId !== context._contextId) {
-      return;
-    }
+    try {
+      const context = await this.#context.valueOrThrow();
+      if (event.executionContextId !== context._contextId) {
+        return;
+      }
 
-    const binding = this._bindings.get(name);
-    await binding?.run(context, seq, args, isTrivial);
+      const binding = this._bindings.get(name);
+      await binding?.run(context, seq, args, isTrivial);
+    } catch (err) {
+      debugError(err);
+    }
   };
 
   waitForFunction<

--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -204,7 +204,7 @@ export class LifecycleWatcher {
 
   async navigationResponse(): Promise<HTTPResponse | null> {
     // Continue with a possibly null response.
-    await this.#navigationResponseReceived?.catch(() => {});
+    await this.#navigationResponseReceived?.valueOrThrow();
     return this.#navigationRequest ? this.#navigationRequest.response() : null;
   }
 
@@ -213,19 +213,22 @@ export class LifecycleWatcher {
   }
 
   sameDocumentNavigationPromise(): Promise<Error | undefined> {
-    return this.#sameDocumentNavigationPromise;
+    return this.#sameDocumentNavigationPromise.valueOrThrow();
   }
 
   newDocumentNavigationPromise(): Promise<Error | undefined> {
-    return this.#newDocumentNavigationPromise;
+    return this.#newDocumentNavigationPromise.valueOrThrow();
   }
 
   lifecyclePromise(): Promise<void> {
-    return this.#lifecyclePromise;
+    return this.#lifecyclePromise.valueOrThrow();
   }
 
   timeoutOrTerminationPromise(): Promise<Error | TimeoutError | undefined> {
-    return Promise.race([this.#timeoutPromise, this.#terminationPromise]);
+    return Promise.race([
+      this.#timeoutPromise,
+      this.#terminationPromise.valueOrThrow(),
+    ]);
   }
 
   async #createTimeoutPromise(): Promise<TimeoutError | undefined> {

--- a/packages/puppeteer-core/src/common/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.ts
@@ -131,7 +131,7 @@ export class NetworkManager extends EventEmitter {
    */
   initialize(): Promise<void> {
     if (this.#deferredInitPromise) {
-      return this.#deferredInitPromise;
+      return this.#deferredInitPromise.valueOrThrow();
     }
     this.#deferredInitPromise = createDebuggableDeferredPromise(
       'NetworkManager initialization timed out'
@@ -152,7 +152,7 @@ export class NetworkManager extends EventEmitter {
       .catch(err => {
         deferredInitPromise.reject(err);
       });
-    return this.#deferredInitPromise;
+    return this.#deferredInitPromise.valueOrThrow();
   }
 
   async authenticate(credentials?: Credentials): Promise<void> {

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -249,6 +249,7 @@ export class PageTarget extends Target {
 
   protected override _initialize(): void {
     this._initializedPromise
+      .valueOrThrow()
       .then(async result => {
         if (result === InitializationStatus.ABORTED) {
           return;

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -18,6 +18,7 @@ import {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 import type {Poller} from '../injected/Poller.js';
 import {createDeferredPromise} from '../util/DeferredPromise.js';
+import {isErrorLike} from '../util/ErrorLike.js';
 import {stringifyFunction} from '../util/Function.js';
 
 import {TimeoutError} from './Errors.js';
@@ -97,7 +98,7 @@ export class WaitTask<T = unknown> {
   }
 
   get result(): Promise<HandleFor<T>> {
-    return this.#result;
+    return this.#result.valueOrThrow();
   }
 
   async rerun(): Promise<void> {
@@ -170,7 +171,7 @@ export class WaitTask<T = unknown> {
     }
   }
 
-  async terminate(error?: unknown): Promise<void> {
+  async terminate(error?: Error): Promise<void> {
     this.#world.taskManager.delete(this);
 
     if (this.#timeout) {
@@ -199,8 +200,8 @@ export class WaitTask<T = unknown> {
   /**
    * Not all errors lead to termination. They usually imply we need to rerun the task.
    */
-  getBadError(error: unknown): unknown {
-    if (error instanceof Error) {
+  getBadError(error: unknown): Error | undefined {
+    if (isErrorLike(error)) {
       // When frame is detached the task should have been terminated by the IsolatedWorld.
       // This can fail if we were adding this task while the frame was detached,
       // so we terminate here instead.
@@ -223,9 +224,14 @@ export class WaitTask<T = unknown> {
       if (error.message.includes('Cannot find context with specified id')) {
         return;
       }
+
+      return error;
     }
 
-    return error;
+    // @ts-expect-error TODO: uncomment once cause is supported in Node types.
+    return new Error('WaitTask failed with an error', {
+      cause: error,
+    });
   }
 }
 

--- a/packages/puppeteer-core/src/injected/Poller.ts
+++ b/packages/puppeteer-core/src/injected/Poller.ts
@@ -80,7 +80,7 @@ export class MutationPoller<T> implements Poller<T> {
 
   result(): Promise<T> {
     assert(this.#promise, 'Polling never started.');
-    return this.#promise;
+    return this.#promise.valueOrThrow();
   }
 }
 
@@ -126,7 +126,7 @@ export class RAFPoller<T> implements Poller<T> {
 
   result(): Promise<T> {
     assert(this.#promise, 'Polling never started.');
-    return this.#promise;
+    return this.#promise.valueOrThrow();
   }
 }
 
@@ -176,6 +176,6 @@ export class IntervalPoller<T> implements Poller<T> {
 
   result(): Promise<T> {
     assert(this.#promise, 'Polling never started.');
-    return this.#promise;
+    return this.#promise.valueOrThrow();
   }
 }

--- a/packages/puppeteer-core/src/util/DeferredPromise.ts
+++ b/packages/puppeteer-core/src/util/DeferredPromise.ts
@@ -3,12 +3,13 @@ import {TimeoutError} from '../common/Errors.js';
 /**
  * @internal
  */
-export interface DeferredPromise<T> extends Promise<T> {
+export interface DeferredPromise<T> {
   finished: () => boolean;
   resolved: () => boolean;
   resolve: (value: T) => void;
-  reject: (reason?: unknown) => void;
-  value: () => T | undefined;
+  reject: (error: Error) => void;
+  value: () => T | Error | undefined;
+  valueOrThrow: () => Promise<T>;
 }
 
 /**
@@ -20,10 +21,10 @@ export interface DeferredPromiseOptions {
 }
 
 /**
- * Creates and returns a promise along with the resolve/reject functions.
+ * Creates and returns a deferred object along with the resolve/reject functions.
  *
- * If the promise has not been resolved/rejected within the `timeout` period,
- * the promise gets rejected with a timeout error. `timeout` has to be greater than 0 or
+ * If the deferred has not been resolved/rejected within the `timeout` period,
+ * the deferred gets resolves with a timeout error. `timeout` has to be greater than 0 or
  * it is ignored.
  *
  * @internal
@@ -33,42 +34,58 @@ export function createDeferredPromise<T>(
 ): DeferredPromise<T> {
   let isResolved = false;
   let isRejected = false;
-  let _value: T | undefined;
-  let resolver: (value: T) => void;
-  let rejector: (reason?: unknown) => void;
-  const taskPromise = new Promise<T>((resolve, reject) => {
+  let _value: T | Error | undefined;
+  let resolver: (value: void) => void;
+  const taskPromise = new Promise<void>(resolve => {
     resolver = resolve;
-    rejector = reject;
   });
   const timeoutId =
     opts && opts.timeout > 0
       ? setTimeout(() => {
-          isRejected = true;
-          rejector(new TimeoutError(opts.message));
+          reject(new TimeoutError(opts.message));
         }, opts.timeout)
       : undefined;
-  return Object.assign(taskPromise, {
+
+  function finish(value: T | Error) {
+    clearTimeout(timeoutId);
+    _value = value;
+    resolver();
+  }
+
+  function resolve(value: T) {
+    if (isRejected || isResolved) {
+      return;
+    }
+    isResolved = true;
+    finish(value);
+  }
+
+  function reject(error: Error) {
+    if (isRejected || isResolved) {
+      return;
+    }
+    isRejected = true;
+    finish(error);
+  }
+
+  return {
     resolved: () => {
       return isResolved;
     },
     finished: () => {
       return isResolved || isRejected;
     },
-    resolve: (value: T) => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      isResolved = true;
-      _value = value;
-      resolver(value);
-    },
-    reject: (err?: unknown) => {
-      clearTimeout(timeoutId);
-      isRejected = true;
-      rejector(err);
-    },
+    resolve,
+    reject,
     value: () => {
       return _value;
     },
-  });
+    async valueOrThrow() {
+      await taskPromise;
+      if (isRejected) {
+        throw _value;
+      }
+      return _value as T;
+    },
+  };
 }

--- a/test/src/DeferredPromise.spec.ts
+++ b/test/src/DeferredPromise.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+import {
+  DeferredPromise,
+  createDeferredPromise,
+} from 'puppeteer-core/internal/util/DeferredPromise.js';
+
+describe('DeferredPromise', function () {
+  it('should catch errors', async () => {
+    // Async function before try/catch.
+    async function task() {
+      await new Promise(resolve => {
+        return setTimeout(resolve, 50);
+      });
+    }
+    // Async function that fails.
+    function fails(): DeferredPromise<void> {
+      const deferred = createDeferredPromise<void>();
+      setTimeout(() => {
+        deferred.reject(new Error('test'));
+      }, 25);
+      return deferred;
+    }
+
+    const expectedToFail = fails();
+    await task();
+    let caught = false;
+    try {
+      await expectedToFail.valueOrThrow();
+    } catch (err) {
+      expect((err as Error).message).toEqual('test');
+      caught = true;
+    }
+    expect(caught).toBeTruthy();
+  });
+});

--- a/test/src/DeviceRequestPrompt.spec.ts
+++ b/test/src/DeviceRequestPrompt.spec.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';
 import {


### PR DESCRIPTION
Changed the DeferredPromise to not inherit from Promise because awaiting such a promise leads to unexpected results in Node. Consider the following example:

```
const task = createDeferredPromise();
await someOtherTask();
try {
   await task;
} catch (error) {}
```

While it looks like the code is save it actually might cause unhandled exceptions in NodeJS depending on the timing and the nature of the intermediate tasks such as someOtherTask and whether the rejection of the task promise actually happens before or after try/catch is executed. Unhandled promise exceptions in Node cause the process termination. In the Puppeteer codebase, where many promises depend on the CDP events, it introduces hard to debug bugs because whether something is unhandled or not would completely depend on the timing of the browser events. We also don't want to override global unhandled event handler as we don't want to affect the user code.

Next: rename DeferredPromise to Deferred