### PR TITLE
chore: add support for waitForNetworkIdle

### DIFF
--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Check if branch is out of date
-        if: ${{ inputs.check-mergeable-state }}
+        if: ${{ inputs.check-mergeable-state &&  github.base_ref == 'main' }}
         run: |
           git fetch origin main --depth 1 &&
           git merge-base --is-ancestor origin/main @;

--- a/packages/puppeteer-core/src/common/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkEventManager.ts
@@ -149,10 +149,14 @@ export class NetworkEventManager {
     return this.queuedRedirectInfo(fetchRequestId).shift();
   }
 
-  numRequestsInProgress(): number {
-    return [...this.#httpRequestsMap].filter(([, request]) => {
-      return !request.response();
-    }).length;
+  inFlightRequestsCount(): number {
+    let inProgressRequestCounter = 0;
+    for (const [, request] of this.#httpRequestsMap) {
+      if (!request.response()) {
+        inProgressRequestCounter++;
+      }
+    }
+    return inProgressRequestCounter;
   }
 
   storeRequestWillBeSent(

--- a/packages/puppeteer-core/src/common/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.ts
@@ -181,8 +181,8 @@ export class NetworkManager extends EventEmitter {
     return Object.assign({}, this.#extraHTTPHeaders);
   }
 
-  numRequestsInProgress(): number {
-    return this.#networkEventManager.numRequestsInProgress();
+  inFlightRequestsCount(): number {
+    return this.#networkEventManager.inFlightRequestsCount();
   }
 
   async setOfflineMode(value: boolean): Promise<void> {

--- a/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
@@ -88,7 +88,7 @@ export class NetworkManager extends EventEmitter {
     }
   }
 
-  #onFetchError(event: any) {
+  #onFetchError(event: Bidi.Network.FetchErrorParams) {
     const request = this.#requestMap.get(event.request.request);
     if (!request) {
       return;
@@ -99,6 +99,17 @@ export class NetworkManager extends EventEmitter {
 
   getNavigationResponse(navigationId: string | null): HTTPResponse | null {
     return this.#navigationMap.get(navigationId ?? '') ?? null;
+  }
+
+  inFlightRequestsCount(): number {
+    let inFlightRequestCounter = 0;
+    for (const [, request] of this.#requestMap) {
+      if (!request.response() || request._failureText) {
+        inFlightRequestCounter++;
+      }
+    }
+
+    return inFlightRequestCounter;
   }
 
   dispose(): void {

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -497,6 +497,19 @@ export class Page extends PageBase {
     );
   }
 
+  override async waitForNetworkIdle(
+    options: {idleTime?: number; timeout?: number} = {}
+  ): Promise<void> {
+    const {idleTime = 500, timeout = this.#timeoutSettings.timeout()} = options;
+
+    await this._waitForNetworkIdle(
+      this.#networkManager,
+      idleTime,
+      timeout,
+      this.#closedDeferred
+    );
+  }
+
   override title(): Promise<string> {
     return this.mainFrame().title();
   }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -168,6 +168,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[page.spec] Page Page.waitForNetworkIdle *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["PASS"]
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.waitForRequest *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -583,6 +589,12 @@
   },
   {
     "testIdPattern": "[page.spec] Page Page.setContent should work with tricky content",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[page.spec] Page Page.waitForNetworkIdle should work with aborted requests",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
     "expectations": ["FAIL"]


### PR DESCRIPTION
Let's discuss if we want to use this implementation for navigation (`page.goto`, `page.reload` etc.) `waitUntil: network[]` 