### PR TITLE
fix: bind trimCache to the instance

### DIFF
--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -129,6 +129,7 @@ export class PuppeteerNode extends Puppeteer {
     this.launch = this.launch.bind(this);
     this.executablePath = this.executablePath.bind(this);
     this.defaultArgs = this.defaultArgs.bind(this);
+    this.trimCache = this.trimCache.bind(this);
   }
 
   /**


### PR DESCRIPTION
So that it can be used as a named export.

Issue #10174