### PR TITLE
fix: pass on the auth from the download URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/diff": "5.0.2",
         "@types/mime": "3.0.1",
         "@types/mocha": "10.0.1",
-        "@types/node": "18.14.6",
+        "@types/node": "20.2.5",
         "@types/pixelmatch": "5.2.4",
         "@types/pngjs": "6.0.1",
         "@types/progress": "2.0.5",
@@ -1815,9 +1815,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.14.6",
-      "devOptional": true,
-      "license": "MIT"
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
+      "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11256,7 +11257,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.14.6",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "devOptional": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@types/diff": "5.0.2",
     "@types/mime": "3.0.1",
     "@types/mocha": "10.0.1",
-    "@types/node": "18.14.6",
+    "@types/node": "20.2.5",
     "@types/pixelmatch": "5.2.4",
     "@types/pngjs": "6.0.1",
     "@types/progress": "2.0.5",

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -17,7 +17,7 @@
 import {createWriteStream} from 'fs';
 import * as http from 'http';
 import * as https from 'https';
-import {URL} from 'url';
+import {URL, urlToHttpOptions} from 'url';
 
 import {ProxyAgent} from 'proxy-agent';
 
@@ -50,6 +50,7 @@ export function httpRequest(
     path: url.pathname + url.search,
     method,
     headers: keepAlive ? {Connection: 'keep-alive'} : undefined,
+    auth: urlToHttpOptions(url).auth,
     agent: new ProxyAgent(),
   };
 


### PR DESCRIPTION
Updated node types but the method should be available from Node 15.