### PR TITLE
chore: refactor waitForNetworkIdle + waitForEvent

### DIFF
--- a/packages/puppeteer-core/src/common/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkEventManager.ts
@@ -150,13 +150,13 @@ export class NetworkEventManager {
   }
 
   inFlightRequestsCount(): number {
-    let inProgressRequestCounter = 0;
-    for (const [, request] of this.#httpRequestsMap) {
+    let inFlightRequestCounter = 0;
+    for (const request of this.#httpRequestsMap.values()) {
       if (!request.response()) {
-        inProgressRequestCounter++;
+        inFlightRequestCounter++;
       }
     }
-    return inProgressRequestCounter;
+    return inFlightRequestCounter;
   }
 
   storeRequestWillBeSent(

--- a/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
@@ -103,7 +103,7 @@ export class NetworkManager extends EventEmitter {
 
   inFlightRequestsCount(): number {
     let inFlightRequestCounter = 0;
-    for (const [, request] of this.#requestMap) {
+    for (const request of this.#requestMap.values()) {
       if (!request.response() || request._failureText) {
         inFlightRequestCounter++;
       }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2100,6 +2100,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[page.spec] Page Page.waitForNetworkIdle should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.waitForNetworkIdle should work with aborted requests",
     "platforms": ["linux"],
     "parameters": ["firefox", "headful"],


### PR DESCRIPTION
I was looking into `waitForNetworkIdle` for Firefox BiDi - Conclusion is that Firefox is too slow for for the test we have some of the event are triggered more then 500ms between each other and our timeout is called.

But took the time to simplify some of the code to reuse functionality.