### PR TITLE
refactor: Deferred to a class

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,6 +194,12 @@ module.exports = {
             selector: "CallExpression[callee.name='require']",
             message: '`require` statements are not allowed. Use `import`.',
           },
+          {
+            // We need this as NodeJS will run until all the timers have resolved
+            message: 'Use method `Deferred.race()` instead.',
+            selector:
+              'MemberExpression[object.name="Promise"][property.name="race"]',
+          },
         ],
         '@typescript-eslint/no-floating-promises': [
           'error',

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -33,7 +33,7 @@ import {
 import {BrowserContext} from '../api/BrowserContext.js';
 import {Page} from '../api/Page.js';
 import {assert} from '../util/assert.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {ChromeTargetManager} from './ChromeTargetManager.js';
 import {CDPSession, Connection, ConnectionEmittedEvents} from './Connection.js';
@@ -501,7 +501,7 @@ export class CDPBrowser extends BrowserBase {
     options: WaitForTargetOptions = {}
   ): Promise<Target> {
     const {timeout = 30000} = options;
-    const targetDeferred = createDeferred<Target | PromiseLike<Target>>();
+    const targetDeferred = Deferred.create<Target | PromiseLike<Target>>();
 
     this.on(BrowserEmittedEvents.TargetCreated, check);
     this.on(BrowserEmittedEvents.TargetChanged, check);

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -18,7 +18,7 @@ import {Protocol} from 'devtools-protocol';
 
 import {TargetFilterCallback} from '../api/Browser.js';
 import {assert} from '../util/assert.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CDPSession, Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
@@ -81,7 +81,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
     (event: Protocol.Target.DetachedFromTargetEvent) => void
   > = new WeakMap();
 
-  #initializeDeferred = createDeferred<void>();
+  #initializeDeferred = Deferred.create<void>();
   #targetsIdsForInit: Set<string> = new Set();
 
   constructor(

--- a/packages/puppeteer-core/src/common/Connection.ts
+++ b/packages/puppeteer-core/src/common/Connection.ts
@@ -18,7 +18,7 @@ import {Protocol} from 'devtools-protocol';
 import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
 import {assert} from '../util/assert.js';
-import {createDeferred, Deferred} from '../util/util.js';
+import {Deferred} from '../util/util.js';
 
 import {ConnectionTransport} from './ConnectionTransport.js';
 import {debug} from './Debug.js';
@@ -64,7 +64,7 @@ function createIncrementalIdGenerator(): GetIdFn {
 export class Callback {
   #id: number;
   #error = new ProtocolError();
-  #deferred = createDeferred<unknown>();
+  #deferred = Deferred.create<unknown>();
   #timer?: ReturnType<typeof setTimeout>;
   #label: string;
 

--- a/packages/puppeteer-core/src/common/DeviceRequestPrompt.ts
+++ b/packages/puppeteer-core/src/common/DeviceRequestPrompt.ts
@@ -18,7 +18,7 @@ import Protocol from 'devtools-protocol';
 
 import {WaitTimeoutOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
-import {createDeferred, Deferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CDPSession} from './Connection.js';
 import {TimeoutSettings} from './TimeoutSettings.js';
@@ -151,7 +151,7 @@ export class DeviceRequestPrompt {
     }
 
     const {timeout = this.#timeoutSettings.timeout()} = options;
-    const deferred = createDeferred<DeviceRequestPromptDevice>({
+    const deferred = Deferred.create<DeviceRequestPromptDevice>({
       message: `Waiting for \`DeviceRequestPromptDevice\` failed: ${timeout}ms exceeded`,
       timeout,
     });
@@ -250,7 +250,7 @@ export class DeviceRequestPromptManager {
     }
 
     const {timeout = this.#timeoutSettings.timeout()} = options;
-    const deferred = createDeferred<DeviceRequestPrompt>({
+    const deferred = Deferred.create<DeviceRequestPrompt>({
       message: `Waiting for \`DeviceRequestPrompt\` failed: ${timeout}ms exceeded`,
       timeout,
     });

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -18,7 +18,7 @@ import {Protocol} from 'devtools-protocol';
 
 import {TargetFilterCallback} from '../api/Browser.js';
 import {assert} from '../util/assert.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CDPSession, Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
@@ -88,7 +88,7 @@ export class FirefoxTargetManager
     (event: Protocol.Target.AttachedToTargetEvent) => Promise<void>
   > = new WeakMap();
 
-  #initializeDeferred = createDeferred<void>();
+  #initializeDeferred = Deferred.create<void>();
   #targetsIdsForInit: Set<string> = new Set();
 
   constructor(

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -26,6 +26,7 @@ import {
 import {HTTPResponse} from '../api/HTTPResponse.js';
 import {Page, WaitTimeoutOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
+import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
 import {CDPSession} from './Connection.js';
@@ -123,7 +124,7 @@ export class Frame extends BaseFrame {
       waitUntil,
       timeout
     );
-    let error = await Promise.race([
+    let error = await Deferred.race([
       navigate(
         this.#client,
         url,
@@ -134,7 +135,7 @@ export class Frame extends BaseFrame {
       watcher.timeoutOrTerminationPromise(),
     ]);
     if (!error) {
-      error = await Promise.race([
+      error = await Deferred.race([
         watcher.timeoutOrTerminationPromise(),
         ensureNewDocumentNavigation
           ? watcher.newDocumentNavigationPromise()
@@ -197,7 +198,7 @@ export class Frame extends BaseFrame {
       waitUntil,
       timeout
     );
-    const error = await Promise.race([
+    const error = await Deferred.race([
       watcher.timeoutOrTerminationPromise(),
       watcher.sameDocumentNavigationPromise(),
       watcher.newDocumentNavigationPromise(),
@@ -389,8 +390,8 @@ export class Frame extends BaseFrame {
 
     return this.worlds[MAIN_WORLD].transferHandle(
       await this.worlds[PUPPETEER_WORLD].evaluateHandle(
-        async ({createDeferred}, {url, id, type, content}) => {
-          const deferred = createDeferred<void>();
+        async ({Deferred}, {url, id, type, content}) => {
+          const deferred = Deferred.create<void>();
           const script = document.createElement('script');
           script.type = type;
           script.text = content;
@@ -457,8 +458,8 @@ export class Frame extends BaseFrame {
 
     return this.worlds[MAIN_WORLD].transferHandle(
       await this.worlds[PUPPETEER_WORLD].evaluateHandle(
-        async ({createDeferred}, {url, content}) => {
-          const deferred = createDeferred<void>();
+        async ({Deferred}, {url, content}) => {
+          const deferred = Deferred.create<void>();
           let element: HTMLStyleElement | HTMLLinkElement;
           if (!url) {
             element = document.createElement('style');

--- a/packages/puppeteer-core/src/common/FrameTree.ts
+++ b/packages/puppeteer-core/src/common/FrameTree.ts
@@ -15,7 +15,7 @@
  */
 
 import {Frame as BaseFrame} from '../api/Frame.js';
-import {createDeferred, Deferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 /**
  * Keeps track of the page frame tree and it's is managed by
@@ -50,7 +50,7 @@ export class FrameTree<Frame extends BaseFrame> {
     if (frame) {
       return Promise.resolve(frame);
     }
-    const deferred = createDeferred<Frame>();
+    const deferred = Deferred.create<Frame>();
     const callbacks =
       this.#waitRequests.get(frameId) || new Set<Deferred<Frame>>();
     callbacks.add(deferred);

--- a/packages/puppeteer-core/src/common/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/common/HTTPResponse.ts
@@ -20,7 +20,7 @@ import {
   HTTPResponse as BaseHTTPResponse,
   RemoteAddress,
 } from '../api/HTTPResponse.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CDPSession} from './Connection.js';
 import {ProtocolError} from './Errors.js';
@@ -34,7 +34,7 @@ export class HTTPResponse extends BaseHTTPResponse {
   #client: CDPSession;
   #request: HTTPRequest;
   #contentPromise: Promise<Buffer> | null = null;
-  #bodyLoadedDeferred = createDeferred<Error | void>();
+  #bodyLoadedDeferred = Deferred.create<Error | void>();
   #remoteAddress: RemoteAddress;
   #status: number;
   #statusText: string;

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -19,7 +19,7 @@ import {Protocol} from 'devtools-protocol';
 import type {ClickOptions, ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 import {assert} from '../util/assert.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {Binding} from './Binding.js';
 import {CDPSession} from './Connection.js';
@@ -101,7 +101,7 @@ export interface IsolatedWorldChart {
 export class IsolatedWorld {
   #frame: Frame;
   #document?: ElementHandle<Document>;
-  #context = createDeferred<ExecutionContext>();
+  #context = Deferred.create<ExecutionContext>();
   #detached = false;
 
   // Set of bindings that have been registered in the current context.
@@ -144,7 +144,7 @@ export class IsolatedWorld {
 
   clearContext(): void {
     this.#document = undefined;
-    this.#context = createDeferred();
+    this.#context = Deferred.create();
   }
 
   setContext(context: ExecutionContext): void {
@@ -304,7 +304,7 @@ export class IsolatedWorld {
       waitUntil,
       timeout
     );
-    const error = await Promise.race([
+    const error = await Deferred.race<void | Error | undefined>([
       watcher.timeoutOrTerminationPromise(),
       watcher.lifecyclePromise(),
     ]);

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -43,7 +43,7 @@ import {
   NewDocumentScriptEvaluation,
 } from '../api/Page.js';
 import {assert} from '../util/assert.js';
-import {createDeferred, Deferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
 import {Accessibility} from './Accessibility.js';
@@ -153,7 +153,7 @@ export class CDPPage extends Page {
   #screenshotTaskQueue: TaskQueue;
   #workers = new Map<string, WebWorker>();
   #fileChooserDeferreds = new Set<Deferred<FileChooser>>();
-  #sessionCloseDeferred = createDeferred<TargetCloseError>();
+  #sessionCloseDeferred = Deferred.create<TargetCloseError>();
   #serviceWorkerBypassed = false;
   #userDragInterceptionEnabled = false;
 
@@ -374,7 +374,7 @@ export class CDPPage extends Page {
   ): Promise<FileChooser> {
     const needsEnable = this.#fileChooserDeferreds.size === 0;
     const {timeout = this.#timeoutSettings.timeout()} = options;
-    const deferred = createDeferred<FileChooser>({
+    const deferred = Deferred.create<FileChooser>({
       message: `Waiting for \`FileChooser\` failed: ${timeout}ms exceeded`,
       timeout,
     });
@@ -1029,7 +1029,7 @@ export class CDPPage extends Page {
       };
     }
 
-    const eventRace: Promise<Frame> = Promise.race([
+    const eventRace: Promise<Frame> = Deferred.race([
       waitForEvent(
         this.#frameManager,
         FrameManagerEmittedEvents.FrameAttached,

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -19,7 +19,7 @@ import {Protocol} from 'devtools-protocol';
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
 import {Page, PageEmittedEvents} from '../api/Page.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CDPSession} from './Connection.js';
 import {CDPPage} from './Page.js';
@@ -55,11 +55,11 @@ export class Target {
   /**
    * @internal
    */
-  _initializedDeferred = createDeferred<InitializationStatus>();
+  _initializedDeferred = Deferred.create<InitializationStatus>();
   /**
    * @internal
    */
-  _isClosedDeferred = createDeferred<void>();
+  _isClosedDeferred = Deferred.create<void>();
   /**
    * @internal
    */

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -17,7 +17,7 @@
 import {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 import type {Poller} from '../injected/Poller.js';
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 import {stringifyFunction} from '../util/Function.js';
 
@@ -49,7 +49,7 @@ export class WaitTask<T = unknown> {
 
   #timeout?: NodeJS.Timeout;
 
-  #result = createDeferred<HandleFor<T>>();
+  #result = Deferred.create<HandleFor<T>>();
 
   #poller?: JSHandle<Poller<T>>;
   #signal?: AbortSignal;

--- a/packages/puppeteer-core/src/common/WebWorker.ts
+++ b/packages/puppeteer-core/src/common/WebWorker.ts
@@ -15,7 +15,7 @@
  */
 import {Protocol} from 'devtools-protocol';
 
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CDPSession} from './Connection.js';
 import {ConsoleMessageType} from './ConsoleMessage.js';
@@ -68,7 +68,7 @@ export type ExceptionThrownCallback = (
  * @public
  */
 export class WebWorker extends EventEmitter {
-  #executionContext = createDeferred<ExecutionContext>();
+  #executionContext = Deferred.create<ExecutionContext>();
 
   #client: CDPSession;
   #url: string;

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -25,7 +25,7 @@ import {
   WaitForOptions,
 } from '../../api/Page.js';
 import {assert} from '../../util/assert.js';
-import {createDeferred} from '../../util/Deferred.js';
+import {Deferred} from '../../util/Deferred.js';
 import {ConsoleMessage, ConsoleMessageLocation} from '../ConsoleMessage.js';
 import {TargetCloseError} from '../Errors.js';
 import {Handler} from '../EventEmitter.js';
@@ -61,7 +61,7 @@ export class Page extends PageBase {
   #frameTree = new FrameTree<Frame>();
   #networkManager: NetworkManager;
   #viewport: Viewport | null = null;
-  #closedDeferred = createDeferred<TargetCloseError>();
+  #closedDeferred = Deferred.create<TargetCloseError>();
   #subscribedEvents = new Map<string, Handler<any>>([
     ['log.entryAdded', this.#onLogEntryAdded.bind(this)],
     [

--- a/packages/puppeteer-core/src/injected/Poller.ts
+++ b/packages/puppeteer-core/src/injected/Poller.ts
@@ -15,7 +15,7 @@
  */
 
 import {assert} from '../util/assert.js';
-import {createDeferred, Deferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 
 /**
  * @internal
@@ -42,7 +42,7 @@ export class MutationPoller<T> implements Poller<T> {
   }
 
   async start(): Promise<void> {
-    const deferred = (this.#deferred = createDeferred<T>());
+    const deferred = (this.#deferred = Deferred.create<T>());
     const result = await this.#fn();
     if (result) {
       deferred.resolve(result);
@@ -92,7 +92,7 @@ export class RAFPoller<T> implements Poller<T> {
   }
 
   async start(): Promise<void> {
-    const deferred = (this.#deferred = createDeferred<T>());
+    const deferred = (this.#deferred = Deferred.create<T>());
     const result = await this.#fn();
     if (result) {
       deferred.resolve(result);
@@ -143,7 +143,7 @@ export class IntervalPoller<T> implements Poller<T> {
   }
 
   async start(): Promise<void> {
-    const deferred = (this.#deferred = createDeferred<T>());
+    const deferred = (this.#deferred = Deferred.create<T>());
     const result = await this.#fn();
     if (result) {
       deferred.resolve(result);

--- a/packages/puppeteer-core/src/injected/injected.ts
+++ b/packages/puppeteer-core/src/injected/injected.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {createDeferred} from '../util/Deferred.js';
+import {Deferred} from '../util/Deferred.js';
 import {createFunction} from '../util/Function.js';
 
 import * as ARIAQuerySelector from './ARIAQuerySelector.js';
@@ -41,7 +41,7 @@ const PuppeteerUtil = Object.freeze({
   ...TextQuerySelector,
   ...util,
   ...XPathQuerySelector,
-  createDeferred,
+  Deferred,
   createFunction,
   createTextContent,
   IntervalPoller,

--- a/packages/puppeteer-core/src/util/DebuggableDeferred.ts
+++ b/packages/puppeteer-core/src/util/DebuggableDeferred.ts
@@ -1,6 +1,6 @@
 import {DEFERRED_PROMISE_DEBUG_TIMEOUT} from '../environment.js';
 
-import {Deferred, createDeferred} from './Deferred.js';
+import {Deferred} from './Deferred.js';
 
 /**
  * Creates and returns a deferred promise using DEFERRED_PROMISE_DEBUG_TIMEOUT
@@ -10,10 +10,10 @@ import {Deferred, createDeferred} from './Deferred.js';
  */
 export function createDebuggableDeferred<T>(message: string): Deferred<T> {
   if (DEFERRED_PROMISE_DEBUG_TIMEOUT > 0) {
-    return createDeferred({
+    return Deferred.create({
       message,
       timeout: DEFERRED_PROMISE_DEBUG_TIMEOUT,
     });
   }
-  return createDeferred();
+  return Deferred.create();
 }

--- a/test/src/Deferred.spec.ts
+++ b/test/src/Deferred.spec.ts
@@ -15,10 +15,7 @@
  */
 
 import expect from 'expect';
-import {
-  Deferred,
-  createDeferred,
-} from 'puppeteer-core/internal/util/Deferred.js';
+import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';
 
 describe('DeferredPromise', function () {
   it('should catch errors', async () => {
@@ -30,7 +27,7 @@ describe('DeferredPromise', function () {
     }
     // Async function that fails.
     function fails(): Deferred<void> {
-      const deferred = createDeferred<void>();
+      const deferred = Deferred.create<void>();
       setTimeout(() => {
         deferred.reject(new Error('test'));
       }, 25);


### PR DESCRIPTION
Deferred has 2 static methods:
`create` -> return a new instance;
`race` -> used for clearing timeout deferred as NodeJS process will run until the Timeout has resolved 
(we have `180_000`s timeout :hourglass_flowing_sand:  in our code so we need to handle this).