### PR TITLE
chore: disable Firefox preference browser.translations.enable

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -158,6 +158,10 @@ function defaultProfilePreferences(
     // Do not warn when multiple tabs will be opened
     'browser.tabs.warnOnOpen': false,
 
+    // Disable page translations, which can cause issues with tests.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1836093.
+    'browser.translations.enable': false,
+
     // Disable the UI tour.
     'browser.uitour.enabled': false,
     // Turn off search suggestions in the location bar so as not to trigger


### PR DESCRIPTION
Synchronize change from https://bugzilla.mozilla.org/show_bug.cgi?id=1836093