### PR TITLE
fix: content() not showing comments outside html tag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -200,6 +200,12 @@ module.exports = {
             selector:
               'MemberExpression[object.name="Promise"][property.name="race"]',
           },
+          {
+            message:
+              'Deferred `valueOrThrow` should not be called in `Deferred.race()` pass deferred directly',
+            selector:
+              'CallExpression[callee.object.name="Deferred"][callee.property.name="race"] MemberExpression[property.name="valueOrThrow"]',
+          },
         ],
         '@typescript-eslint/no-floating-promises': [
           'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -204,7 +204,7 @@ module.exports = {
             message:
               'Deferred `valueOrThrow` should not be called in `Deferred.race()` pass deferred directly',
             selector:
-              'CallExpression[callee.object.name="Deferred"][callee.property.name="race"] MemberExpression[property.name="valueOrThrow"]',
+              'CallExpression[callee.object.name="Deferred"][callee.property.name="race"] > ArrayExpression > CallExpression[callee.property.name="valueOrThrow"]',
           },
         ],
         '@typescript-eslint/no-floating-promises': [

--- a/packages/puppeteer-core/src/api/Locator.ts
+++ b/packages/puppeteer-core/src/api/Locator.ts
@@ -22,7 +22,10 @@ import {isErrorLike} from '../util/ErrorLike.js';
 import {ElementHandle, BoundingBox, ClickOptions} from './ElementHandle.js';
 import type {Page} from './Page.js';
 
-type VisibilityOption = 'hidden' | 'visible' | null;
+/**
+ * @internal
+ */
+export type VisibilityOption = 'hidden' | 'visible' | null;
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/common/bidi/BrowsingContext.ts
@@ -11,6 +11,7 @@ import {TimeoutSettings} from '../TimeoutSettings.js';
 import {EvaluateFunc, HandleFor} from '../types.js';
 import {
   PuppeteerURL,
+  getPageContent,
   getSourcePuppeteerURLIfAvailable,
   isString,
   setPageContent,
@@ -240,7 +241,7 @@ export class BrowsingContext extends EventEmitter {
       timeout = this.#timeoutSettings.navigationTimeout(),
     } = options;
 
-    const waitUntilCommand = lifeCycleToSubscribedEvent.get(
+    const waitUntilEvent = lifeCycleToSubscribedEvent.get(
       getWaitUntilSingle(waitUntil)
     ) as string;
 
@@ -248,27 +249,18 @@ export class BrowsingContext extends EventEmitter {
       setPageContent(this, html),
       waitWithTimeout(
         new Promise<void>(resolve => {
-          this.once(waitUntilCommand, () => {
+          this.once(waitUntilEvent, () => {
             resolve();
           });
         }),
-        waitUntilCommand,
+        waitUntilEvent,
         timeout
       ),
     ]);
   }
 
   async content(): Promise<string> {
-    return await this.evaluate(() => {
-      let retVal = '';
-      if (document.doctype) {
-        retVal = new XMLSerializer().serializeToString(document.doctype);
-      }
-      if (document.documentElement) {
-        retVal += document.documentElement.outerHTML;
-      }
-      return retVal;
-    });
+    return await this.evaluate(getPageContent);
   }
 
   async sendCDPCommand(

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -510,7 +510,7 @@ export async function waitWithTimeout<T>(
     timeout,
   });
 
-  return await Deferred.race([promise, deferred.valueOrThrow()]).finally(() => {
+  return await Deferred.race([promise, deferred]).finally(() => {
     deferred.reject(new Error('Cleared'));
   });
 }
@@ -626,4 +626,23 @@ export async function setPageContent(
     document.write(html);
     document.close();
   }, content);
+}
+
+/**
+ * @internal
+ */
+export function getPageContent(): string {
+  let content = '';
+  for (const node of document.childNodes) {
+    switch (node) {
+      case document.documentElement:
+        content += document.documentElement.outerHTML;
+        break;
+      default:
+        content += new XMLSerializer().serializeToString(node);
+        break;
+    }
+  }
+
+  return content;
 }

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -1555,6 +1555,14 @@ describe('Page', function () {
         })
       ).toBe('\n');
     });
+    it('should work with comments outside HTML tag', async () => {
+      const {page} = getTestState();
+
+      const comment = '<!-- Comment -->';
+      await page.setContent(`${comment}<div>hello</div>`);
+      const result = await page.content();
+      expect(result).toBe(`${comment}${expectedOutput}`);
+    });
   });
 
   describe('Page.setBypassCSP', function () {


### PR DESCRIPTION
Sadly we can't just use `new XMLSerializer().serializeToString(document)` as that creates an attribute on the `html` tag -> `xmlns="http://www.w3.org/1999/xhtml"`

Closes #10291
