### PR TITLE
docs: add webp to captureScreenshot.format

### DIFF
--- a/docs/api/puppeteer.page.screenshot.md
+++ b/docs/api/puppeteer.page.screenshot.md
@@ -36,7 +36,7 @@ Options object which might have the following properties:
 
 - `path` : The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd). If no path is provided, the image won't be saved to the disk.
 
-- `type` : Specify screenshot type, can be either `jpeg` or `png`. Defaults to 'png'.
+- `type` : Specify screenshot type, can be `jpeg`, `png` or `webp`. Defaults to 'png'.
 
 - `quality` : The quality of the image, between 0-100. Not applicable to `png` images.
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2248,7 +2248,7 @@ export class Page extends EventEmitter {
    *   | current working directory}.
    *   If no path is provided, the image won't be saved to the disk.
    *
-   * - `type` : Specify screenshot type, can be either `jpeg` or `png`.
+   * - `type` : Specify screenshot type, can be `jpeg`, `png` or `webp`.
    *   Defaults to 'png'.
    *
    * - `quality` : The quality of the image, between 0-100. Not


### PR DESCRIPTION
This matches CDP and the status quo:
https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot