### PR TITLE
fix: send capabilities property in session.new command

### DIFF
--- a/packages/puppeteer-core/src/common/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/common/bidi/Browser.ts
@@ -38,7 +38,7 @@ export class Browser extends BrowserBase {
   static async create(opts: Options): Promise<Browser> {
     // TODO: await until the connection is established.
     try {
-      await opts.connection.send('session.new', {});
+      await opts.connection.send('session.new', {capabilities: {}});
     } catch {}
 
     await opts.connection.send('session.subscribe', {


### PR DESCRIPTION
In the scope of https://bugzilla.mozilla.org/show_bug.cgi?id=1731730 we're going to start requiring `capabilities` field in `session.new` command as it's specified in the spec. This is going to break the integration with puppeteer, so this PR is fixing this.

Since this PR is blocking previously mentioned change, it would be perfect if the release of this fix happens rather sooner than later.