### PR TITLE
chore: Re-enable firefox tests on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Disabled as BiDi has issue on mac https://bugzilla.mozilla.org/show_bug.cgi?id=1832778
-          # - macos-latest
+          - macos-latest
         suite:
           - firefox-bidi
           - firefox-headful


### PR DESCRIPTION
The patch which landed in https://bugzilla.mozilla.org/show_bug.cgi?id=1832891 could help with the macos intermittent issues recently happening on Puppeteer CI, so we want to re-enable the tests.

Closes #10272