### PR TITLE
feat: add `reset` to mouse

### DIFF
--- a/docs/api/puppeteer.mouse.md
+++ b/docs/api/puppeteer.mouse.md
@@ -87,5 +87,6 @@ await browser
 | [dragOver(target, data)](./puppeteer.mouse.dragover.md)                 |           | Dispatches a <code>dragover</code> event.                                                |
 | [drop(target, data)](./puppeteer.mouse.drop.md)                         |           | Performs a dragenter, dragover, and drop in sequence.                                    |
 | [move(x, y, options)](./puppeteer.mouse.move.md)                        |           | Moves the mouse to the given coordinate.                                                 |
+| [reset()](./puppeteer.mouse.reset.md)                                   |           | Resets the mouse to the default state: No buttons pressed; position at (0,0).            |
 | [up(options)](./puppeteer.mouse.up.md)                                  |           | Releases the mouse.                                                                      |
 | [wheel(options)](./puppeteer.mouse.wheel.md)                            |           | Dispatches a <code>mousewheel</code> event.                                              |

--- a/docs/api/puppeteer.mouse.reset.md
+++ b/docs/api/puppeteer.mouse.reset.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: Mouse.reset
+---
+
+# Mouse.reset() method
+
+Resets the mouse to the default state: No buttons pressed; position at (0,0).
+
+#### Signature:
+
+```typescript
+class Mouse {
+  reset(): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/packages/puppeteer-core/src/common/Input.ts
+++ b/packages/puppeteer-core/src/common/Input.ts
@@ -599,6 +599,29 @@ export class Mouse {
   }
 
   /**
+   * Resets the mouse to the default state: No buttons pressed; position at
+   * (0,0).
+   */
+  async reset(): Promise<void> {
+    const actions = [];
+    for (const [flag, button] of [
+      [MouseButtonFlag.Left, MouseButton.Left],
+      [MouseButtonFlag.Middle, MouseButton.Middle],
+      [MouseButtonFlag.Right, MouseButton.Right],
+      [MouseButtonFlag.Forward, MouseButton.Forward],
+      [MouseButtonFlag.Back, MouseButton.Back],
+    ] as const) {
+      if (this.#state.buttons & flag) {
+        actions.push(this.up({button: button}));
+      }
+    }
+    if (this.#state.position.x !== 0 || this.#state.position.y !== 0) {
+      actions.push(this.move(0, 0));
+    }
+    await Promise.all(actions);
+  }
+
+  /**
    * Moves the mouse to the given coordinate.
    *
    * @param x - Horizontal position of the mouse.

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1461,7 +1461,7 @@
     "testIdPattern": "[mouse.spec] Mouse should reset properly",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"]
+    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[mouse.spec] Mouse should select the text with mouse",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1458,6 +1458,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[mouse.spec] Mouse should reset properly",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[mouse.spec] Mouse should select the text with mouse",
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome"],


### PR DESCRIPTION
This PR gives users the ability to reset their mouse without keeping track of their button presses and position.