### PR TITLE
chore: implement acceptInsecureCerts and version for BiDi

### DIFF
--- a/docs/api/puppeteer.browser.version.md
+++ b/docs/api/puppeteer.browser.version.md
@@ -20,6 +20,6 @@ Promise&lt;string&gt;
 
 ## Remarks
 
-For headless browser, this is similar to `HeadlessChrome/61.0.3153.0`. For non-headless, this is similar to `Chrome/61.0.3153.0`.
+For headless browser, this is similar to `HeadlessChrome/61.0.3153.0`. For non-headless or new-headless, this is similar to `Chrome/61.0.3153.0`. For Firefox, it is similar to `Firefox/116.0a1`.
 
 The format of browser.version() might change with future releases of browsers.

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -405,9 +405,11 @@ export class Browser extends EventEmitter {
    * @remarks
    *
    * For headless browser, this is similar to `HeadlessChrome/61.0.3153.0`. For
-   * non-headless, this is similar to `Chrome/61.0.3153.0`.
+   * non-headless or new-headless, this is similar to `Chrome/61.0.3153.0`. For
+   * Firefox, it is similar to `Firefox/116.0a1`.
    *
-   * The format of browser.version() might change with future releases of browsers.
+   * The format of browser.version() might change with future releases of
+   * browsers.
    */
   version(): Promise<string> {
     throw new Error('Not implemented');

--- a/packages/puppeteer-core/src/common/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/common/bidi/Connection.ts
@@ -26,6 +26,29 @@ import {BrowsingContext} from './BrowsingContext.js';
 const debugProtocolSend = debug('puppeteer:webDriverBiDi:SEND ►');
 const debugProtocolReceive = debug('puppeteer:webDriverBiDi:RECV ◀');
 
+type Capability = {
+  // session.CapabilityRequest = {
+  //   ? acceptInsecureCerts: bool,
+  //   ? browserName: text,
+  //   ? browserVersion: text,
+  //   ? platformName: text,
+  //   ? proxy: {
+  //     ? proxyType: "pac" / "direct" / "autodetect" / "system" / "manual",
+  //     ? proxyAutoconfigUrl: text,
+  //     ? ftpProxy: text,
+  //     ? httpProxy: text,
+  //     ? noProxy: [*text],
+  //     ? sslProxy: text,
+  //     ? socksProxy: text,
+  //     ? socksVersion: 0..255,
+  //   },
+  //   Extensible
+  // };
+  acceptInsecureCerts?: boolean;
+  browserName?: string;
+  browserVersion?: string;
+};
+
 /**
  * @internal
  */
@@ -73,8 +96,19 @@ interface Commands {
   };
 
   'session.new': {
-    params: {capabilities?: Record<any, unknown>}; // TODO: Update Types in chromium bidi
-    returnType: {sessionId: string};
+    params: {
+      // capabilities: session.CapabilitiesRequest
+      capabilities?: {
+        // session.CapabilitiesRequest = {
+        //   ? alwaysMatch: session.CapabilityRequest,
+        //   ? firstMatch: [*session.CapabilityRequest]
+        // }
+        alwaysMatch?: Capability;
+      };
+    }; // TODO: Update Types in chromium bidi
+    returnType: {
+      result: {sessionId: string; capabilities: Capability};
+    };
   };
   'session.status': {
     params: object;

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -143,6 +143,7 @@ export class ProductLauncher {
             protocolTimeout,
             slowMo,
             defaultViewport,
+            ignoreHTTPSErrors,
           }
         );
       } else {
@@ -169,6 +170,7 @@ export class ProductLauncher {
               protocolTimeout,
               slowMo,
               defaultViewport,
+              ignoreHTTPSErrors,
             }
           );
         } else {
@@ -329,6 +331,7 @@ export class ProductLauncher {
       protocolTimeout: number | undefined;
       slowMo: number;
       defaultViewport: Viewport | null;
+      ignoreHTTPSErrors?: boolean;
     }
   ): Promise<Browser> {
     // TODO: use other options too.
@@ -341,6 +344,7 @@ export class ProductLauncher {
       closeCallback,
       process: browserProcess.nodeProcess,
       defaultViewport: opts.defaultViewport,
+      ignoreHTTPSErrors: opts.ignoreHTTPSErrors,
     });
   }
 
@@ -355,6 +359,7 @@ export class ProductLauncher {
       protocolTimeout: number | undefined;
       slowMo: number;
       defaultViewport: Viewport | null;
+      ignoreHTTPSErrors?: boolean;
     }
   ): Promise<Browser> {
     const browserWSEndpoint =
@@ -377,6 +382,7 @@ export class ProductLauncher {
       closeCallback,
       process: browserProcess.nodeProcess,
       defaultViewport: opts.defaultViewport,
+      ignoreHTTPSErrors: opts.ignoreHTTPSErrors,
     });
   }
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -270,6 +270,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[browser.spec] Browser specs Browser.version should return version",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["PASS"]
+  },
+  {
     "testIdPattern": "[chromiumonly.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/bidi/Connection.spec.ts
+++ b/test/src/bidi/Connection.spec.ts
@@ -37,12 +37,10 @@ describe('WebDriver BiDi', () => {
       const transport = new TestConnectionTransport();
       const connection = new Connection(transport);
       const responsePromise = connection.send('session.new', {
-        capabilities: {
-          proxy: {},
-        },
+        capabilities: {},
       });
       expect(transport.sent).toEqual([
-        `{"id":1,"method":"session.new","params":{"capabilities":{"proxy":{}}}}`,
+        `{"id":1,"method":"session.new","params":{"capabilities":{}}}`,
       ]);
       const id = JSON.parse(transport.sent[0]!).id;
       const rawResponse = {

--- a/test/src/browser.spec.ts
+++ b/test/src/browser.spec.ts
@@ -22,14 +22,12 @@ describe('Browser specs', function () {
   setupTestBrowserHooks();
 
   describe('Browser.version', function () {
-    it('should return whether we are in headless', async () => {
-      const {browser, isHeadless, headless} = getTestState();
+    it('should return version', async () => {
+      const {browser} = getTestState();
 
       const version = await browser.version();
       expect(version.length).toBeGreaterThan(0);
-      expect(version.startsWith('Headless')).toBe(
-        isHeadless && headless !== 'new'
-      );
+      expect(version.toLowerCase()).atLeastOneToContain(['firefox', 'chrome']);
     });
   });
 


### PR DESCRIPTION
In BiDi, the version does not include headless or not so I rewrote this test.
AcceptInsecureCerts test is blocked on https://bugzilla.mozilla.org/show_bug.cgi?id=1763122.