### PR TITLE
fix: specify the context id when adding bindings

### DIFF
--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -369,10 +369,18 @@ export class IsolatedWorld {
 
     await this.#mutex.acquire();
     try {
-      await context._client.send('Runtime.addBinding', {
-        name,
-        executionContextName: context._contextName,
-      });
+      await context._client.send(
+        'Runtime.addBinding',
+        context._contextName
+          ? {
+              name,
+              executionContextName: context._contextName,
+            }
+          : {
+              name,
+              executionContextId: context._contextId,
+            }
+      );
 
       await context.evaluate(addPageBinding, 'internal', name);
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -804,6 +804,12 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[queryhandler.spec] Query handler tests P selectors should work for ARIA selectors in multiple isolated worlds",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[queryhandler.spec] Query handler tests P selectors should work with :hover",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -2425,6 +2431,12 @@
   },
   {
     "testIdPattern": "[queryhandler.spec] Query handler tests P selectors should work ARIA selectors with role",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[queryhandler.spec] Query handler tests P selectors should work for ARIA selectors in multiple isolated worlds",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"]

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -446,6 +446,26 @@ describe('Query handler tests', function () {
       ).toBeTruthy();
     });
 
+    it('should work for ARIA selectors in multiple isolated worlds', async () => {
+      const {page} = getTestState();
+      let element = await page.waitForSelector('::-p-aria(world)');
+      assert(element, 'Could not find element');
+      expect(
+        await element.evaluate(element => {
+          return element.id === 'b';
+        })
+      ).toBeTruthy();
+      // $ would add ARIA query handler to the main world.
+      await element.$('::-p-aria(world)');
+      element = await page.waitForSelector('::-p-aria(world)');
+      assert(element, 'Could not find element');
+      expect(
+        await element.evaluate(element => {
+          return element.id === 'b';
+        })
+      ).toBeTruthy();
+    });
+
     it('should work ARIA selectors with role', async () => {
       const {page} = getTestState();
       const element = await page.$('::-p-aria(world[role="button"])');


### PR DESCRIPTION
Missing contextId would override bindings in all isolated worlds.