### PR TITLE
fix: include src into published package

### DIFF
--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -94,6 +94,7 @@
   },
   "files": [
     "lib",
+    "src",
     "!*.tsbuildinfo"
   ],
   "dependencies": {

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -127,6 +127,7 @@
   },
   "files": [
     "lib",
+    "src",
     "!*.tsbuildinfo"
   ],
   "author": "The Chromium Authors",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -113,6 +113,7 @@
   },
   "files": [
     "lib",
+    "src",
     "install.js",
     "!*.tsbuildinfo"
   ],


### PR DESCRIPTION
It is required for source maps to work.

Fixes #10403