### PR TITLE
fix: add parenthesis to JS values in interpolateFunction

### DIFF
--- a/packages/puppeteer-core/src/util/Function.ts
+++ b/packages/puppeteer-core/src/util/Function.ts
@@ -82,7 +82,10 @@ export const interpolateFunction = <T extends (...args: never[]) => unknown>(
   for (const [name, jsValue] of Object.entries(replacements)) {
     value = value.replace(
       new RegExp(`PLACEHOLDER\\(\\s*(?:'${name}'|"${name}")\\s*\\)`, 'g'),
-      jsValue
+      // Wrapping this ensures tersers that accidently inline PLACEHOLDER calls
+      // are still valid. Without, we may get calls like ()=>{...}() which is
+      // not valid.
+      `(${jsValue})`
     );
   }
   return createFunction(value) as unknown as T;

--- a/test/src/function.spec.ts
+++ b/test/src/function.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+import {interpolateFunction} from 'puppeteer-core/internal/util/Function.js';
+
+describe('Function', function () {
+  describe('interpolateFunction', function () {
+    it('should work', async () => {
+      const test = interpolateFunction(
+        () => {
+          const test = PLACEHOLDER('test') as () => number;
+          return test();
+        },
+        {test: `() => 5`}
+      );
+      expect(test()).toBe(5);
+    });
+    it('should work inlined', async () => {
+      const test = interpolateFunction(
+        () => {
+          // Note the parenthesis will be removed by the typescript compiler.
+          return (PLACEHOLDER('test') as () => number)();
+        },
+        {test: `() => 5`}
+      );
+      expect(test()).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This fixes an issue where minifiers would inline `PLACEHOLDER(...)` calls causing invalid JS to be evaluated at runtime.