### PR TITLE
chore: clean NetworkManager Maps for BiDi

### DIFF
--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -269,6 +269,7 @@ export class Page extends PageBase {
       this.#removeFramesRecursively(child);
     }
     frame.dispose();
+    this.#networkManager.clearMapAfterFrameDispose(frame);
     this.#frameTree.removeFrame(frame);
     this.emit(PageEmittedEvents.FrameDetached, frame);
   }


### PR DESCRIPTION
Clears some Memory if the user is not actively listening to the requests.
Also remove the request if the frame is disposed.