### PR TITLE
fix: fix escaping algo for P selectors

### DIFF
--- a/packages/puppeteer-core/src/injected/PSelectorParser.ts
+++ b/packages/puppeteer-core/src/injected/PSelectorParser.ts
@@ -33,19 +33,15 @@ TOKENS['combinator'] = /\s*(>>>>?|[\s>+~])\s*/g;
 
 const ESCAPE_REGEXP = /\\[\s\S]/g;
 const unquote = (text: string): string => {
-  if (text.length > 1) {
-    for (const char of ['"', "'"]) {
-      if (!text.startsWith(char) || !text.endsWith(char)) {
-        continue;
-      }
-      return text
-        .slice(char.length, -char.length)
-        .replace(ESCAPE_REGEXP, match => {
-          return match.slice(1);
-        });
-    }
+  if (text.length <= 1) {
+    return text;
   }
-  return text;
+  if ((text[0] === '"' || text[0] === "'") && text.endsWith(text[0])) {
+    text = text.slice(1, -1);
+  }
+  return text.replace(ESCAPE_REGEXP, match => {
+    return match[1] as string;
+  });
 };
 
 export function parsePSelectors(

--- a/test/assets/p-selectors.html
+++ b/test/assets/p-selectors.html
@@ -2,6 +2,7 @@
     <span id="f"></span>
     <div id="c"></div>
 </div>
+<a>My name is Jun (pronounced like "June")</a>
 
 <script>
     const topShadow = document.querySelector('#c');

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -637,5 +637,26 @@ describe('Query handler tests', function () {
       const elements = await page.$$('::-p-text(world), button');
       expect(elements).toHaveLength(1);
     });
+
+    it.only('should handle escapes', async () => {
+      const {server, page} = await getTestState();
+      await page.goto(`${server.PREFIX}/p-selectors.html`);
+      let element = await page.$(
+        ':scope >>> ::-p-text(My name is Jun \\(pronounced like "June"\\))'
+      );
+      expect(element).toBeTruthy();
+      element = await page.$(
+        ':scope >>> ::-p-text("My name is Jun (pronounced like \\"June\\")")'
+      );
+      expect(element).toBeTruthy();
+      element = await page.$(
+        ':scope >>> ::-p-text(My name is Jun \\(pronounced like "June"\\)")'
+      );
+      expect(element).toBeFalsy();
+      element = await page.$(
+        ':scope >>> ::-p-text("My name is Jun \\(pronounced like "June"\\))'
+      );
+      expect(element).toBeFalsy();
+    });
   });
 });

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -638,7 +638,7 @@ describe('Query handler tests', function () {
       expect(elements).toHaveLength(1);
     });
 
-    it.only('should handle escapes', async () => {
+    it('should handle escapes', async () => {
       const {server, page} = await getTestState();
       await page.goto(`${server.PREFIX}/p-selectors.html`);
       let element = await page.$(


### PR DESCRIPTION
Fixed: #10473 