### PR TITLE
chore: add type test for CommonEventEmitter

### DIFF
--- a/test-d/CommonEventEmitter.test-d.ts
+++ b/test-d/CommonEventEmitter.test-d.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line no-restricted-imports
+import {EventEmitter as NodeEventEmitter} from 'node:events';
+
+import {CommonEventEmitter, EventEmitter} from 'puppeteer';
+import {expectAssignable} from 'tsd';
+
+declare const emitter: EventEmitter;
+
+{
+  {
+    expectAssignable<CommonEventEmitter>(new NodeEventEmitter());
+  }
+  {
+    expectAssignable<CommonEventEmitter>(emitter);
+  }
+}


### PR DESCRIPTION
We want to be able to use our EventEmitter for BiDi Mapper, but both classes have slight differences, to align those we should introduce interface (Puppeteer has the CommonEventEmitter) that the original Node one should be assignable to.
That way relay on something external.

This will be added to BiDi Mapper as well.