### PR TITLE
fix: add an internal page.locatorRace

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -836,6 +836,15 @@ export class Page extends EventEmitter {
   }
 
   /**
+   * A shortcut for {@link Locator.race} that does not require static imports.
+   *
+   * @internal
+   */
+  locatorRace(locators: Locator[]): Locator {
+    return Locator.race(locators);
+  }
+
+  /**
    * Runs `document.querySelector` within the page. If no element matches the
    * selector, the return value resolves to `null`.
    *

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3375,7 +3375,7 @@
     "testIdPattern": "[page.spec] Page Page.title should return the page title",
     "platforms": ["linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS", "FAIL"]
+    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[page.spec] Page Page.waitForNetworkIdle should work",


### PR DESCRIPTION
Using Locator.race is not possible to use via a type-only import whereas page.locatorRace could be used with a type import.
That is useful for libraries like @puppeteer/replay that don't have a static dependency on puppeteer.