### PR TITLE
chore: enable Firefox preference browser.translations.enable

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -158,10 +158,6 @@ function defaultProfilePreferences(
     // Do not warn when multiple tabs will be opened
     'browser.tabs.warnOnOpen': false,
 
-    // Disable page translations, which can cause issues with tests.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1836093.
-    'browser.translations.enable': false,
-
     // Disable the UI tour.
     'browser.uitour.enabled': false,
     // Turn off search suggestions in the location bar so as not to trigger


### PR DESCRIPTION
This reverts commit cf8402b711a4990493fe9832a92c9eecd4962f1e, given https://phabricator.services.mozilla.com/D182926.

We might want to wait a few days after merging https://phabricator.services.mozilla.com/D182926 to make sure it sticks.