### PR TITLE
fix: remove Chromium channels

### DIFF
--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -68,7 +68,9 @@ export async function resolveBuildId(
         case BrowserTag.CANARY:
         case BrowserTag.DEV:
         case BrowserTag.STABLE:
-          throw new Error(`${tag} is not supported for ${browser}`);
+          throw new Error(
+            `${tag} is not supported for ${browser}. Use 'latest' instead.`
+          );
       }
     case Browser.CHROME:
       switch (tag as BrowserTag) {
@@ -113,26 +115,13 @@ export async function resolveBuildId(
     case Browser.CHROMIUM:
       switch (tag as BrowserTag) {
         case BrowserTag.LATEST:
-          return await chromium.resolveBuildId(platform, 'latest');
+          return await chromium.resolveBuildId(platform);
         case BrowserTag.BETA:
-          return await chromium.resolveBuildId(
-            platform,
-            ChromeReleaseChannel.BETA
-          );
         case BrowserTag.CANARY:
-          return await chromium.resolveBuildId(
-            platform,
-            ChromeReleaseChannel.CANARY
-          );
         case BrowserTag.DEV:
-          return await chromium.resolveBuildId(
-            platform,
-            ChromeReleaseChannel.DEV
-          );
         case BrowserTag.STABLE:
-          return await chromium.resolveBuildId(
-            platform,
-            ChromeReleaseChannel.STABLE
+          throw new Error(
+            `${tag} is not supported for ${browser}. Use 'latest' instead.`
           );
       }
   }
@@ -167,12 +156,11 @@ export function resolveSystemExecutablePath(
   switch (browser) {
     case Browser.CHROMEDRIVER:
     case Browser.FIREFOX:
+    case Browser.CHROMIUM:
       throw new Error(
         `System browser detection is not supported for ${browser} yet.`
       );
     case Browser.CHROME:
-      return chromium.resolveSystemExecutablePath(platform, channel);
-    case Browser.CHROMIUM:
       return chrome.resolveSystemExecutablePath(platform, channel);
   }
 }

--- a/packages/browsers/src/browser-data/chromium.ts
+++ b/packages/browsers/src/browser-data/chromium.ts
@@ -18,10 +18,7 @@ import path from 'path';
 
 import {getText} from '../httpUtil.js';
 
-import {getLastKnownGoodReleaseForChannel} from './chrome.js';
-import {BrowserPlatform, ChromeReleaseChannel} from './types.js';
-
-export {resolveSystemExecutablePath} from './chrome.js';
+import {BrowserPlatform} from './types.js';
 
 function archive(platform: BrowserPlatform, buildId: string): string {
   switch (platform) {
@@ -89,17 +86,13 @@ export function relativeExecutablePath(
   }
 }
 export async function resolveBuildId(
-  platform: BrowserPlatform,
-  channel: ChromeReleaseChannel | 'latest' = 'latest'
+  platform: BrowserPlatform
 ): Promise<string> {
-  if (channel === 'latest') {
-    return await getText(
-      new URL(
-        `https://storage.googleapis.com/chromium-browser-snapshots/${folder(
-          platform
-        )}/LAST_CHANGE`
-      )
-    );
-  }
-  return (await getLastKnownGoodReleaseForChannel(channel)).revision;
+  return await getText(
+    new URL(
+      `https://storage.googleapis.com/chromium-browser-snapshots/${folder(
+        platform
+      )}/LAST_CHANGE`
+    )
+  );
 }

--- a/packages/browsers/test/src/chromium/chromium-data.spec.ts
+++ b/packages/browsers/test/src/chromium/chromium-data.spec.ts
@@ -17,14 +17,10 @@
 import assert from 'assert';
 import path from 'path';
 
-import {
-  BrowserPlatform,
-  ChromeReleaseChannel,
-} from '../../../lib/cjs/browser-data/browser-data.js';
+import {BrowserPlatform} from '../../../lib/cjs/browser-data/browser-data.js';
 import {
   resolveDownloadUrl,
   relativeExecutablePath,
-  resolveSystemExecutablePath,
 } from '../../../lib/cjs/browser-data/chromium.js';
 
 describe('Chromium', () => {
@@ -72,37 +68,5 @@ describe('Chromium', () => {
       relativeExecutablePath(BrowserPlatform.WIN64, '12372323'),
       path.join('chrome-win', 'chrome.exe')
     );
-  });
-
-  it('should resolve system executable path', () => {
-    process.env['PROGRAMFILES'] = 'C:\\ProgramFiles';
-    try {
-      assert.strictEqual(
-        resolveSystemExecutablePath(
-          BrowserPlatform.WIN32,
-          ChromeReleaseChannel.DEV
-        ),
-        'C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe'
-      );
-    } finally {
-      delete process.env['PROGRAMFILES'];
-    }
-
-    assert.strictEqual(
-      resolveSystemExecutablePath(
-        BrowserPlatform.MAC,
-        ChromeReleaseChannel.BETA
-      ),
-      '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta'
-    );
-    assert.throws(() => {
-      assert.strictEqual(
-        resolveSystemExecutablePath(
-          BrowserPlatform.LINUX,
-          ChromeReleaseChannel.CANARY
-        ),
-        path.join('chrome-linux', 'chrome')
-      );
-    }, new Error(`Unable to detect browser executable path for 'canary' on linux.`));
   });
 });


### PR DESCRIPTION
As fairly pointed out, Chrome channels do not really map to Chromium builds.

Closes #10533