### PR TITLE
refactor: rename _client → getCDPSession

### DIFF
--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -349,7 +349,7 @@ export class Frame {
   /**
    * @internal
    */
-  _client(): CDPSession {
+  getCDPSession(): CDPSession {
     throw new Error('Not implemented');
   }
 

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -163,10 +163,10 @@ export class CDPElementHandle<
         currentFrame = parent;
         continue;
       }
-      const {backendNodeId} = await parent._client().send('DOM.getFrameOwner', {
+      const {backendNodeId} = await parent.getCDPSession().send('DOM.getFrameOwner', {
         frameId: currentFrame._id,
       });
-      const result = await parent._client().send('DOM.getBoxModel', {
+      const result = await parent.getCDPSession().send('DOM.getBoxModel', {
         backendNodeId: backendNodeId,
       });
       if (!result) {
@@ -188,7 +188,7 @@ export class CDPElementHandle<
           objectId: this.id,
         })
         .catch(debugError),
-      (this.#page as CDPPage)._client().send('Page.getLayoutMetrics'),
+      (this.#page as CDPPage).getCDPSession().send('Page.getLayoutMetrics'),
     ]);
     if (!result || !result.quads.length) {
       throw new Error('Node is either not clickable or not an HTMLElement');

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -207,7 +207,7 @@ export class Frame extends BaseFrame {
     }
   }
 
-  override _client(): CDPSession {
+  override getCDPSession(): CDPSession {
     return this.#client;
   }
 

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -360,7 +360,7 @@ export class FrameManager extends EventEmitter {
     await Promise.all(
       this.frames()
         .filter(frame => {
-          return frame._client() === session;
+          return frame.getCDPSession() === session;
         })
         .map(frame => {
           // Frames might be removed before we send this, so we don't want to
@@ -415,7 +415,7 @@ export class FrameManager extends EventEmitter {
     let world: IsolatedWorld | undefined;
     if (frame) {
       // Only care about execution contexts created for the current session.
-      if (frame._client() !== session) {
+      if (frame.getCDPSession() !== session) {
         return;
       }
       if (contextPayload.auxData && contextPayload.auxData['isDefault']) {
@@ -431,7 +431,7 @@ export class FrameManager extends EventEmitter {
       }
     }
     const context = new ExecutionContext(
-      frame?._client() || this.#client,
+      frame?.getCDPSession() || this.#client,
       contextPayload,
       world
     );

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -130,7 +130,7 @@ export class IsolatedWorld implements Realm {
   }
 
   get #client(): CDPSession {
-    return this.#frame._client();
+    return this.#frame.getCDPSession();
   }
 
   get #frameManager(): FrameManager {

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -346,7 +346,7 @@ export class CDPPage extends Page {
   /**
    * @internal
    */
-  _client(): CDPSession {
+  getCDPSession(): CDPSession {
     return this.#client;
   }
 

--- a/test/src/frame.spec.ts
+++ b/test/src/frame.spec.ts
@@ -339,7 +339,7 @@ describe('Frame specs', function () {
   describe('Frame.client', function () {
     it('should return the client instance', async () => {
       const {page} = await getTestState();
-      expect(page.mainFrame()._client()).toBeInstanceOf(CDPSession);
+      expect(page.mainFrame().getCDPSession()).toBeInstanceOf(CDPSession);
     });
   });
 });

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -2370,7 +2370,7 @@ describe('Page', function () {
   describe('Page.client', function () {
     it('should return the client instance', async () => {
       const {page} = await getTestState();
-      expect((page as CDPPage)._client()).toBeInstanceOf(CDPSession);
+      expect((page as CDPPage).getCDPSession()).toBeInstanceOf(CDPSession);
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor

**Did you add tests for your changes?**

Already tested

**Summary**

Sometimes is useful to get the current `CDPSession` associated with a page, e.g., 

https://github.com/microlinkhq/browserless/blob/5b81d2e12abab0726176894365f4fb4b4efd6580/packages/screencast/src/utils.js#L8

I really don't see why this method is supposed to be hide. Why not remove underscore from there? It's still internal method so, but you can intentionally use it and that's okay.

**Does this PR introduce a breaking change?**

Nope

**Other information**
