### PR TITLE
fix: prevent erroneous new main frame

### DIFF
--- a/packages/puppeteer-core/src/common/FrameTree.ts
+++ b/packages/puppeteer-core/src/common/FrameTree.ts
@@ -69,7 +69,7 @@ export class FrameTree<Frame extends BaseFrame> {
         this.#childIds.set(frame._parentId, new Set());
       }
       this.#childIds.get(frame._parentId)!.add(frame._id);
-    } else {
+    } else if (!this.#mainFrame) {
       this.#mainFrame = frame;
     }
     this.#waitRequests.get(frame._id)?.forEach(request => {


### PR DESCRIPTION
For reasons I am still investigating, Chrome will sometimes emit a random `Page.frameNavigated` event that looks like this:

```json
{
  "id": "FC1767E7420AFDD8D5D7CD935DA4C788",
  "loaderId": "E4B73E277690F2C9755A2D0C950D2FA0",
  "url": ":",
  "domainAndRegistry": "",
  "securityOrigin": "://",
  "mimeType": "text/html",
  "adFrameStatus": {
    "adFrameType": "none"
  },
  "secureContextType": "InsecureScheme",
  "crossOriginIsolatedContextType": "NotIsolatedFeatureDisabled",
  "gatedAPIFeatures": []
}
```

The frame ID of this event is *not* the same frame id as the actual main frame of the tree, however it is set as the main frame since it doesn't have a parent id.

It happens when running Lighthouse in DevTools:
https://github.com/GoogleChrome/lighthouse/issues/15073

This patch ensures that the main frame of a frame tree can only be set one time so this random event does not influence the frame tree.