### PR TITLE
docs: clarify the path attribute of InstalledBrowser

### DIFF
--- a/docs/browsers-api/browsers.installedbrowser.md
+++ b/docs/browsers-api/browsers.installedbrowser.md
@@ -12,9 +12,9 @@ export interface InstalledBrowser
 
 ## Properties
 
-| Property | Modifiers | Type                                             | Description | Default |
-| -------- | --------- | ------------------------------------------------ | ----------- | ------- |
-| browser  |           | [Browser](./browsers.browser.md)                 |             |         |
-| buildId  |           | string                                           |             |         |
-| path     |           | string                                           |             |         |
-| platform |           | [BrowserPlatform](./browsers.browserplatform.md) |             |         |
+| Property | Modifiers | Type                                             | Description                                                                                                                                               | Default |
+| -------- | --------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| browser  |           | [Browser](./browsers.browser.md)                 |                                                                                                                                                           |         |
+| buildId  |           | string                                           |                                                                                                                                                           |         |
+| path     |           | string                                           | Path to the root of the installation folder. Use [computeExecutablePath()](./browsers.computeexecutablepath.md) to get the path to the executable binary. |         |
+| platform |           | [BrowserPlatform](./browsers.browserplatform.md) |                                                                                                                                                           |         |

--- a/packages/browsers/src/Cache.ts
+++ b/packages/browsers/src/Cache.ts
@@ -23,6 +23,10 @@ import {Browser, BrowserPlatform} from './browser-data/browser-data.js';
  * @public
  */
 export interface InstalledBrowser {
+  /**
+   * Path to the root of the installation folder. Use
+   * {@link computeExecutablePath} to get the path to the executable binary.
+   */
   path: string;
   browser: Browser;
   buildId: string;


### PR DESCRIPTION
InstalledBrowser.path returns the path to the root of the directory where the browser has been installed to.

Closes #10587