### PR TITLE
feat: add executablePath to InstalledBrowser

### DIFF
--- a/docs/browsers-api/browsers.install_1.md
+++ b/docs/browsers-api/browsers.install_1.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: install
+sidebar_label: install_1
 ---
 
 # install() function
@@ -9,17 +9,17 @@ sidebar_label: install
 ```typescript
 export declare function install(
   options: InstallOptions & {
-    unpack?: true;
+    unpack: false;
   }
-): Promise<InstalledBrowser>;
+): Promise<string>;
 ```
 
 ## Parameters
 
 | Parameter | Type                                                                    | Description |
 | --------- | ----------------------------------------------------------------------- | ----------- |
-| options   | [InstallOptions](./browsers.installoptions.md) &amp; { unpack?: true; } |             |
+| options   | [InstallOptions](./browsers.installoptions.md) &amp; { unpack: false; } |             |
 
 **Returns:**
 
-Promise&lt;[InstalledBrowser](./browsers.installedbrowser.md)&gt;
+Promise&lt;string&gt;

--- a/docs/browsers-api/browsers.installedbrowser.md
+++ b/docs/browsers-api/browsers.installedbrowser.md
@@ -2,19 +2,24 @@
 sidebar_label: InstalledBrowser
 ---
 
-# InstalledBrowser interface
+# InstalledBrowser class
 
 #### Signature:
 
 ```typescript
-export interface InstalledBrowser
+export declare class InstalledBrowser
 ```
+
+## Remarks
+
+The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `InstalledBrowser` class.
 
 ## Properties
 
-| Property | Modifiers | Type                                             | Description                                                                                                                                               | Default |
-| -------- | --------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| browser  |           | [Browser](./browsers.browser.md)                 |                                                                                                                                                           |         |
-| buildId  |           | string                                           |                                                                                                                                                           |         |
-| path     |           | string                                           | Path to the root of the installation folder. Use [computeExecutablePath()](./browsers.computeexecutablepath.md) to get the path to the executable binary. |         |
-| platform |           | [BrowserPlatform](./browsers.browserplatform.md) |                                                                                                                                                           |         |
+| Property       | Modifiers             | Type                                             | Description                                                                                                                                               |
+| -------------- | --------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| browser        |                       | [Browser](./browsers.browser.md)                 |                                                                                                                                                           |
+| buildId        |                       | string                                           |                                                                                                                                                           |
+| executablePath | <code>readonly</code> | string                                           |                                                                                                                                                           |
+| path           | <code>readonly</code> | string                                           | Path to the root of the installation folder. Use [computeExecutablePath()](./browsers.computeexecutablepath.md) to get the path to the executable binary. |
+| platform       |                       | [BrowserPlatform](./browsers.browserplatform.md) |                                                                                                                                                           |

--- a/docs/browsers-api/index.md
+++ b/docs/browsers-api/index.md
@@ -33,11 +33,12 @@ The programmatic API allows installing and launching browsers from your code. Se
 
 ## Classes
 
-| Class                                      | Description |
-| ------------------------------------------ | ----------- |
-| [CLI](./browsers.cli.md)                   |             |
-| [Process](./browsers.process.md)           |             |
-| [TimeoutError](./browsers.timeouterror.md) |             |
+| Class                                              | Description |
+| -------------------------------------------------- | ----------- |
+| [CLI](./browsers.cli.md)                           |             |
+| [InstalledBrowser](./browsers.installedbrowser.md) |             |
+| [Process](./browsers.process.md)                   |             |
+| [TimeoutError](./browsers.timeouterror.md)         |             |
 
 ## Enumerations
 
@@ -58,6 +59,7 @@ The programmatic API allows installing and launching browsers from your code. Se
 | [detectBrowserPlatform()](./browsers.detectbrowserplatform.md)                    |                                                                   |
 | [getInstalledBrowsers(options)](./browsers.getinstalledbrowsers.md)               | Returns metadata about browsers installed in the cache directory. |
 | [install(options)](./browsers.install.md)                                         |                                                                   |
+| [install(options)](./browsers.install_1.md)                                       |                                                                   |
 | [launch(opts)](./browsers.launch.md)                                              |                                                                   |
 | [makeProgressCallback(browser, buildId)](./browsers.makeprogresscallback.md)      |                                                                   |
 | [resolveBuildId(browser, platform, tag)](./browsers.resolvebuildid.md)            |                                                                   |
@@ -68,7 +70,6 @@ The programmatic API allows installing and launching browsers from your code. Se
 | Interface                                                                | Description |
 | ------------------------------------------------------------------------ | ----------- |
 | [GetInstalledBrowsersOptions](./browsers.getinstalledbrowsersoptions.md) |             |
-| [InstalledBrowser](./browsers.installedbrowser.md)                       |             |
 | [InstallOptions](./browsers.installoptions.md)                           |             |
 | [LaunchOptions](./browsers.launchoptions.md)                             |             |
 | [Options](./browsers.options.md)                                         |             |

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -100,9 +100,15 @@ export interface InstallOptions {
 /**
  * @public
  */
+export function install(
+  options: InstallOptions & {unpack?: true}
+): Promise<InstalledBrowser>;
+export function install(
+  options: InstallOptions & {unpack: false}
+): Promise<string>;
 export async function install(
   options: InstallOptions
-): Promise<InstalledBrowser> {
+): Promise<InstalledBrowser | string> {
   options.platform ??= detectBrowserPlatform();
   options.unpack ??= true;
   if (!options.platform) {
@@ -118,8 +124,8 @@ export async function install(
   );
   const fileName = url.toString().split('/').pop();
   assert(fileName, `A malformed download URL was found: ${url}.`);
-  const structure = new Cache(options.cacheDir);
-  const browserRoot = structure.browserRoot(options.browser);
+  const cache = new Cache(options.cacheDir);
+  const browserRoot = cache.browserRoot(options.browser);
   const archivePath = path.join(browserRoot, fileName);
   if (!existsSync(browserRoot)) {
     await mkdir(browserRoot, {recursive: true});
@@ -127,37 +133,27 @@ export async function install(
 
   if (!options.unpack) {
     if (existsSync(archivePath)) {
-      return {
-        path: archivePath,
-        browser: options.browser,
-        platform: options.platform,
-        buildId: options.buildId,
-      };
+      return archivePath;
     }
     debugInstall(`Downloading binary from ${url}`);
     debugTime('download');
     await downloadFile(url, archivePath, options.downloadProgressCallback);
     debugTimeEnd('download');
-    return {
-      path: archivePath,
-      browser: options.browser,
-      platform: options.platform,
-      buildId: options.buildId,
-    };
+    return archivePath;
   }
 
-  const outputPath = structure.installationDir(
+  const outputPath = cache.installationDir(
     options.browser,
     options.platform,
     options.buildId
   );
   if (existsSync(outputPath)) {
-    return {
-      path: outputPath,
-      browser: options.browser,
-      platform: options.platform,
-      buildId: options.buildId,
-    };
+    return new InstalledBrowser(
+      cache,
+      options.browser,
+      options.buildId,
+      options.platform
+    );
   }
   try {
     debugInstall(`Downloading binary from ${url}`);
@@ -180,12 +176,12 @@ export async function install(
       await unlink(archivePath);
     }
   }
-  return {
-    path: outputPath,
-    browser: options.browser,
-    platform: options.platform,
-    buildId: options.buildId,
-  };
+  return new InstalledBrowser(
+    cache,
+    options.browser,
+    options.buildId,
+    options.platform
+  );
 }
 
 /**

--- a/packages/browsers/test/src/chrome/install.spec.ts
+++ b/packages/browsers/test/src/chrome/install.spec.ts
@@ -104,6 +104,10 @@ describe('Chrome install', () => {
     const cache = new Cache(tmpDir);
     const installed = cache.getInstalledBrowsers();
     assert.deepStrictEqual(browser, installed[0]);
+    assert.deepStrictEqual(
+      browser!.executablePath,
+      installed[0]?.executablePath
+    );
   });
 
   it('throws on invalid URL', async function () {

--- a/packages/browsers/test/src/chromedriver/install.spec.ts
+++ b/packages/browsers/test/src/chromedriver/install.spec.ts
@@ -98,5 +98,6 @@ describe('ChromeDriver install', () => {
     });
     assert.strictEqual(browser.path, expectedOutputPath);
     assert.ok(fs.existsSync(expectedOutputPath));
+    assert.ok(fs.existsSync(browser.executablePath));
   });
 });

--- a/packages/browsers/tools/downloadTestBrowsers.mjs
+++ b/packages/browsers/tools/downloadTestBrowsers.mjs
@@ -59,7 +59,7 @@ for (const version of Object.keys(versions)) {
       continue;
     }
 
-    const result = await install({
+    const archivePath = await install({
       browser,
       buildId,
       platform,
@@ -70,7 +70,7 @@ for (const version of Object.keys(versions)) {
     fs.mkdirSync(path.dirname(targetPath), {
       recursive: true,
     });
-    fs.copyFileSync(result.path, targetPath);
+    fs.copyFileSync(archivePath, targetPath);
   }
 }
 


### PR DESCRIPTION
Turn InstalledBrowser into a class and properly handle downloads without unpacking.