### PR TITLE
refactor: separate target init from construction

### DIFF
--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -187,11 +187,13 @@ export class FirefoxTargetManager
 
     if (event.targetInfo.type === 'browser' && event.targetInfo.attached) {
       const target = this.#targetFactory(event.targetInfo, undefined);
+      target._initialize();
       this.#availableTargetsByTargetId.set(event.targetInfo.targetId, target);
       this.#finishInitializationIfReady(target._targetId);
       return;
     }
 
+    const target = this.#targetFactory(event.targetInfo, undefined);
     if (
       this.#targetFilterCallback &&
       !this.#targetFilterCallback(event.targetInfo)
@@ -200,8 +202,7 @@ export class FirefoxTargetManager
       this.#finishInitializationIfReady(event.targetInfo.targetId);
       return;
     }
-
-    const target = this.#targetFactory(event.targetInfo, undefined);
+    target._initialize();
     this.#availableTargetsByTargetId.set(event.targetInfo.targetId, target);
     this.emit(TargetManagerEmittedEvents.TargetAvailable, target);
     this.#finishInitializationIfReady(target._targetId);

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -66,6 +66,8 @@ export class Target {
   _targetId: string;
 
   /**
+   * To initialize the target for use, call initialize.
+   *
    * @internal
    */
   constructor(
@@ -81,7 +83,6 @@ export class Target {
     this.#browserContext = browserContext;
     this._targetId = targetInfo.targetId;
     this.#sessionFactory = sessionFactory;
-    this._initialize();
   }
 
   /**
@@ -197,7 +198,7 @@ export class Target {
   /**
    * @internal
    */
-  protected _initialize(): void {
+  _initialize(): void {
     this._initializedDeferred.resolve(InitializationStatus.SUCCESS);
   }
 
@@ -247,7 +248,7 @@ export class PageTarget extends Target {
     this.#screenshotTaskQueue = screenshotTaskQueue;
   }
 
-  protected override _initialize(): void {
+  override _initialize(): void {
     this._initializedDeferred
       .valueOrThrow()
       .then(async result => {


### PR DESCRIPTION
This allows using Target for filters to decide how the target is to be initialised.