### PR TITLE
refactor!: use Target for filters

### DIFF
--- a/docs/api/puppeteer.targetfiltercallback.md
+++ b/docs/api/puppeteer.targetfiltercallback.md
@@ -7,7 +7,7 @@ sidebar_label: TargetFilterCallback
 #### Signature:
 
 ```typescript
-export type TargetFilterCallback = (
-  target: Protocol.Target.TargetInfo
-) => boolean;
+export type TargetFilterCallback = (target: Target) => boolean;
 ```
+
+**References:** [Target](./puppeteer.target.md)

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -51,16 +51,12 @@ export type BrowserCloseCallback = () => Promise<void> | void;
 /**
  * @public
  */
-export type TargetFilterCallback = (
-  target: Protocol.Target.TargetInfo
-) => boolean;
+export type TargetFilterCallback = (target: Target) => boolean;
 
 /**
  * @internal
  */
-export type IsPageTargetCallback = (
-  target: Protocol.Target.TargetInfo
-) => boolean;
+export type IsPageTargetCallback = (target: Target) => boolean;
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -115,9 +115,16 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
       targetId,
       targetInfo,
     ] of this.#discoveredTargetsByTargetId.entries()) {
+      const targetForFilter = new Target(
+        targetInfo,
+        undefined,
+        undefined,
+        this,
+        undefined
+      );
       if (
         (!this.#targetFilterCallback ||
-          this.#targetFilterCallback(targetInfo)) &&
+          this.#targetFilterCallback(targetForFilter)) &&
         targetInfo.type !== 'browser'
       ) {
         this.#targetsIdsForInit.add(targetId);
@@ -339,7 +346,7 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
       ? this.#attachedTargetsByTargetId.get(targetInfo.targetId)!
       : this.#targetFactory(targetInfo, session);
 
-    if (this.#targetFilterCallback && !this.#targetFilterCallback(targetInfo)) {
+    if (this.#targetFilterCallback && !this.#targetFilterCallback(target)) {
       this.#ignoredTargets.add(targetInfo.targetId);
       this.#finishInitializationIfReady(targetInfo.targetId);
       await silentDetach();

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -194,10 +194,7 @@ export class FirefoxTargetManager
     }
 
     const target = this.#targetFactory(event.targetInfo, undefined);
-    if (
-      this.#targetFilterCallback &&
-      !this.#targetFilterCallback(event.targetInfo)
-    ) {
+    if (this.#targetFilterCallback && !this.#targetFilterCallback(target)) {
       this.#ignoredTargets.add(event.targetInfo.targetId);
       this.#finishInitializationIfReady(event.targetInfo.targetId);
       return;

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -46,11 +46,13 @@ export enum InitializationStatus {
  * @public
  */
 export class Target {
-  #browserContext: BrowserContext;
+  #browserContext?: BrowserContext;
   #session?: CDPSession;
   #targetInfo: Protocol.Target.TargetInfo;
-  #targetManager: TargetManager;
-  #sessionFactory: (isAutoAttachEmulated: boolean) => Promise<CDPSession>;
+  #targetManager?: TargetManager;
+  #sessionFactory:
+    | ((isAutoAttachEmulated: boolean) => Promise<CDPSession>)
+    | undefined;
 
   /**
    * @internal
@@ -73,9 +75,11 @@ export class Target {
   constructor(
     targetInfo: Protocol.Target.TargetInfo,
     session: CDPSession | undefined,
-    browserContext: BrowserContext,
-    targetManager: TargetManager,
-    sessionFactory: (isAutoAttachEmulated: boolean) => Promise<CDPSession>
+    browserContext: BrowserContext | undefined,
+    targetManager: TargetManager | undefined,
+    sessionFactory:
+      | ((isAutoAttachEmulated: boolean) => Promise<CDPSession>)
+      | undefined
   ) {
     this.#session = session;
     this.#targetManager = targetManager;
@@ -98,6 +102,9 @@ export class Target {
   protected _sessionFactory(): (
     isAutoAttachEmulated: boolean
   ) => Promise<CDPSession> {
+    if (!this.#sessionFactory) {
+      throw new Error('sessionFactory is not initialized');
+    }
     return this.#sessionFactory;
   }
 
@@ -105,6 +112,9 @@ export class Target {
    * Creates a Chrome Devtools Protocol session attached to the target.
    */
   createCDPSession(): Promise<CDPSession> {
+    if (!this.#sessionFactory) {
+      throw new Error('sessionFactory is not initialized');
+    }
     return this.#sessionFactory(false);
   }
 
@@ -112,6 +122,9 @@ export class Target {
    * @internal
    */
   _targetManager(): TargetManager {
+    if (!this.#targetManager) {
+      throw new Error('targetManager is not initialized');
+    }
     return this.#targetManager;
   }
 
@@ -166,6 +179,9 @@ export class Target {
    * Get the browser the target belongs to.
    */
   browser(): Browser {
+    if (!this.#browserContext) {
+      throw new Error('browserContext is not initialised');
+    }
     return this.#browserContext.browser();
   }
 
@@ -173,6 +189,9 @@ export class Target {
    * Get the browser context the target belongs to.
    */
   browserContext(): BrowserContext {
+    if (!this.#browserContext) {
+      throw new Error('browserContext is not initialised');
+    }
     return this.#browserContext;
   }
 

--- a/test/src/headful.spec.ts
+++ b/test/src/headful.spec.ts
@@ -171,7 +171,7 @@ const serviceWorkerExtensionPath = path.join(
         browserWSEndpoint,
         _isPageTarget(target) {
           return (
-            target.type === 'other' && target.url.startsWith('devtools://')
+            target.type() === 'other' && target.url().startsWith('devtools://')
           );
         },
       });

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -19,7 +19,6 @@ import os from 'os';
 import path from 'path';
 import {TLSSocket} from 'tls';
 
-import {Protocol} from 'devtools-protocol';
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';
 import {Page} from 'puppeteer-core/internal/api/Page.js';
@@ -709,7 +708,7 @@ describe('Launcher specs', function () {
         const {browser, close} = await launch(
           {
             targetFilter: target => {
-              return target.type !== 'page';
+              return target.type() !== 'page';
             },
             waitForInitialPage: false,
           },
@@ -746,8 +745,8 @@ describe('Launcher specs', function () {
 
           const remoteBrowser = await puppeteer.connect({
             browserWSEndpoint,
-            targetFilter: (targetInfo: Protocol.Target.TargetInfo) => {
-              return !targetInfo.url?.includes('should-be-ignored');
+            targetFilter: target => {
+              return !target.url().includes('should-be-ignored');
             },
           });
 


### PR DESCRIPTION
The targetFilter parameter previously exposes the CDP's TargetInfo interface. With this PR, the target passed to the filter is now an instance of the Target class.