### PR TITLE
test: upstream test and expectation for Firefox sync to puppeteer v20.9.0

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -216,6 +216,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[page.spec] Page Page.pdf should respect timeout",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.setContent *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -680,25 +686,25 @@
   {
     "testIdPattern": "[headful.spec] headful tests HEADFUL headless should be able to read cookies written by headful",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["webDriverBiDi", "headful"],
     "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[headful.spec] headful tests HEADFUL should close browser with beforeunload page",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["webDriverBiDi", "headful"],
     "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[headful.spec] headful tests HEADFUL should have default url when launching browser",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["webDriverBiDi", "headful"],
     "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[headful.spec] headful tests HEADFUL target.page() should return a DevTools page if custom isPageTarget is provided",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["PASS"]
   },
   {
@@ -836,13 +842,13 @@
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath returns executablePath for channel",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath should work",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["PASS"]
   },
   {
@@ -860,7 +866,7 @@
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch should be able to launch Chrome",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"]
   },
   {
@@ -2162,7 +2168,7 @@
   {
     "testIdPattern": "[headful.spec] headful tests HEADFUL target.page() should return a DevTools page if custom isPageTarget is provided",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
+    "parameters": ["firefox", "webDriverBiDi", "headful"],
     "expectations": ["FAIL"]
   },
   {
@@ -2378,19 +2384,19 @@
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath returns executablePath for channel",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
+    "parameters": ["firefox"],
     "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath should work",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
+    "parameters": ["firefox"],
     "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch should be able to launch Chrome",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
+    "parameters": ["firefox"],
     "expectations": ["SKIP"]
   },
   {

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -830,8 +830,8 @@ describe('Page', function () {
     it('should fire when expected', async () => {
       const {page} = await getTestState();
 
-      page.goto('about:blank');
-      await waitEvent(page, 'domcontentloaded');
+      const navigate = page.goto('about:blank');
+      await Promise.all([waitEvent(page, 'domcontentloaded'), navigate]);
     });
   });
 


### PR DESCRIPTION
This is a sync for test changes we need for the latest sync:
- https://phabricator.services.mozilla.com/D184113
- https://phabricator.services.mozilla.com/D184114
- https://phabricator.services.mozilla.com/D184115
- https://phabricator.services.mozilla.com/D184116

Basically:
- in Mozilla CI, headless environments can really not run headful browsers, so I had to skip headful.spec.ts tests on firefox headful (I'm not 100% how rules can override each other so maybe there is a cleaner way to do that).
- adding a missing await on a page.goto which was sometimes triggering failures later in the suite
- skipping tests which require a regular install (we don't use one on Mozilla CI), but it would be better to have a flag for this in the expectations file
- skipping the pdf timeout test, as it leads to frequent intermittents due to https://bugzilla.mozilla.org/show_bug.cgi?id=1841125

Let us know what you think, cc @OrKoN @Lightning00Blade   