### PR TITLE
chore: sync latest Firefox preference changes for translation feature

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -156,9 +156,8 @@ function defaultProfilePreferences(
     // Do not warn when multiple tabs will be opened
     'browser.tabs.warnOnOpen': false,
 
-    // Disable page translations, which can cause issues with tests.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1836093.
-    'browser.translations.enable': false,
+    // Do not automatically offer translations, as tests do not expect this.
+    'browser.translations.automaticallyPopup': false,
 
     // Disable the UI tour.
     'browser.uitour.enabled': false,


### PR DESCRIPTION
Sync from https://bugzilla.mozilla.org/show_bug.cgi?id=1845518. 

In between the `browser.translations.enable` got removed from the file, and this last bug instead added `browser.translations.automaticallyPopup`. 