### PR TITLE
fix: typo

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -55,7 +55,7 @@ export class ChromeLauncher extends ProductLauncher {
         [
           '\x1B[1m\x1B[43m\x1B[30m',
           'Puppeteer old Headless deprecation warning:\x1B[0m\x1B[33m',
-          '  In the near feature `headless: true` will default to the new Headless mode',
+          '  In the near future `headless: true` will default to the new Headless mode',
           '  for Chrome instead of the old Headless implementation. For more',
           '  information, please see https://developer.chrome.com/articles/new-headless/.',
           '  Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`',


### PR DESCRIPTION
This patch fixes a minor typo: `feature` > `future`
