### PR TITLE
fix: clear pending TLS socket handle

### DIFF
--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -27,6 +27,8 @@ export function headHttpRequest(url: URL): Promise<boolean> {
       url,
       'HEAD',
       response => {
+        // consume response data free node process
+        response.resume();
         resolve(response.statusCode === 200);
       },
       false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

I recognised when calling `canDownload` the `@puppeteer/browsers` package makes a `HEAD` request, e.g. to `https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5793.0/mac-arm64/chrome-mac-arm64.zip`. This causes the Node.js process to stale as there stay pending `TLSSocket` around

**Did you add tests for your changes?**

I am currently working on https://github.com/webdriverio/webdriverio/pull/10767 and have been encountered this issue. Adding given code line resolves it.

My current workaround is:

```ts
setTimeout(() => {
    for (const handle of process._getActiveHandles()) {
        if (handle.servername && handle.servername.includes('edgedl.me')) {
            handle.destroy()
        }
    }
}, 10)
```

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

I don't think so.

**Other information**
