### PR TITLE
refactor: add parentSession() to CDPSession

### DIFF
--- a/packages/puppeteer-core/src/common/DeviceRequestPrompt.test.ts
+++ b/packages/puppeteer-core/src/common/DeviceRequestPrompt.test.ts
@@ -36,6 +36,9 @@ class MockCDPSession extends EventEmitter {
   id() {
     return '1';
   }
+  parentSession() {
+    return undefined;
+  }
 }
 
 describe('DeviceRequestPrompt', function () {

--- a/packages/puppeteer-core/src/common/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.test.ts
@@ -37,6 +37,9 @@ class MockCDPSession extends EventEmitter {
   id() {
     return '1';
   }
+  parentSession() {
+    return undefined;
+  }
 }
 
 describe('NetworkManager', () => {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2649,7 +2649,7 @@
     "testIdPattern": "[mouse.spec] Mouse should resize the textarea",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS", "FAIL"]
+    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[mouse.spec] Mouse should select the text with mouse",


### PR DESCRIPTION
It will be useful for the tab target as the pages and main frames will have to make use of the parent (tab) sessions. For now, it's marked as internal.