### PR TITLE
refactor: getInstalledBrowsers is not async

### DIFF
--- a/docs/browsers-api/browsers.getinstalledbrowsers.md
+++ b/docs/browsers-api/browsers.getinstalledbrowsers.md
@@ -11,7 +11,7 @@ Returns metadata about browsers installed in the cache directory.
 ```typescript
 export declare function getInstalledBrowsers(
   options: GetInstalledBrowsersOptions
-): Promise<InstalledBrowser[]>;
+): InstalledBrowser[];
 ```
 
 ## Parameters
@@ -22,4 +22,4 @@ export declare function getInstalledBrowsers(
 
 **Returns:**
 
-Promise&lt;[InstalledBrowser](./browsers.installedbrowser.md)\[\]&gt;
+[InstalledBrowser](./browsers.installedbrowser.md)\[\]

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -242,9 +242,9 @@ export interface GetInstalledBrowsersOptions {
  *
  * @public
  */
-export async function getInstalledBrowsers(
+export function getInstalledBrowsers(
   options: GetInstalledBrowsersOptions
-): Promise<InstalledBrowser[]> {
+): InstalledBrowser[] {
   return new Cache(options.cacheDir).getInstalledBrowsers();
 }
 

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -296,7 +296,7 @@ export class PuppeteerNode extends Puppeteer {
 
     const cacheDir =
       this.configuration.downloadPath ?? this.configuration.cacheDirectory!;
-    const installedBrowsers = await getInstalledBrowsers({
+    const installedBrowsers = getInstalledBrowsers({
       cacheDir,
     });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This is a refactor.  `Cache.getInstalledBrowsers` is not async.

**Did you add tests for your changes?**

Not needed

**If relevant, did you update the documentation?**

Yes.
