### PR TITLE
chore: add waitForInitiallyDiscoveredTargets

### DIFF
--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -64,7 +64,8 @@ export class CDPBrowser extends BrowserBase {
     process?: ChildProcess,
     closeCallback?: BrowserCloseCallback,
     targetFilterCallback?: TargetFilterCallback,
-    isPageTargetCallback?: IsPageTargetCallback
+    isPageTargetCallback?: IsPageTargetCallback,
+    waitForInitiallyDiscoveredTargets = true
   ): Promise<CDPBrowser> {
     const browser = new CDPBrowser(
       product,
@@ -75,7 +76,8 @@ export class CDPBrowser extends BrowserBase {
       process,
       closeCallback,
       targetFilterCallback,
-      isPageTargetCallback
+      isPageTargetCallback,
+      waitForInitiallyDiscoveredTargets
     );
     await browser._attach();
     return browser;
@@ -111,7 +113,8 @@ export class CDPBrowser extends BrowserBase {
     process?: ChildProcess,
     closeCallback?: BrowserCloseCallback,
     targetFilterCallback?: TargetFilterCallback,
-    isPageTargetCallback?: IsPageTargetCallback
+    isPageTargetCallback?: IsPageTargetCallback,
+    waitForInitiallyDiscoveredTargets = true
   ) {
     super();
     product = product || 'chrome';
@@ -137,7 +140,8 @@ export class CDPBrowser extends BrowserBase {
       this.#targetManager = new ChromeTargetManager(
         connection,
         this.#createTarget,
-        this.#targetFilterCallback
+        this.#targetFilterCallback,
+        waitForInitiallyDiscoveredTargets
       );
     }
     this.#defaultContext = new CDPBrowserContext(this.#connection, this);

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -84,16 +84,19 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
 
   #initializeDeferred = Deferred.create<void>();
   #targetsIdsForInit = new Set<string>();
+  #waitForInitiallyDiscoveredTargets = true;
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
-    targetFilterCallback?: TargetFilterCallback
+    targetFilterCallback?: TargetFilterCallback,
+    waitForInitiallyDiscoveredTargets = true
   ) {
     super();
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;
+    this.#waitForInitiallyDiscoveredTargets = waitForInitiallyDiscoveredTargets;
 
     this.#connection.on('Target.targetCreated', this.#onTargetCreated);
     this.#connection.on('Target.targetDestroyed', this.#onTargetDestroyed);
@@ -111,6 +114,9 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
   }
 
   #storeExistingTargetsForInit = () => {
+    if (!this.#waitForInitiallyDiscoveredTargets) {
+      return;
+    }
     for (const [
       targetId,
       targetInfo,


### PR DESCRIPTION
This feature (currently, exposed internally) is usefull for running Puppeteer in a partitioned mode (within DevTools) to ensure that we don't await for unrelated targets to init.