### PR TITLE
chore: make builder find command

### DIFF
--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -22,6 +22,21 @@ const terminalStyles = {
   clear: '\u001b[0m',
 };
 
+export function getCommandForRunner(runner: TestRunner): [string, ...string[]] {
+  switch (runner) {
+    case TestRunner.Jasmine:
+      return [`jasmine`, '--config=./e2e/support/jasmine.json'];
+    case TestRunner.Jest:
+      return [`jest`, '-c', 'e2e/jest.config.js'];
+    case TestRunner.Mocha:
+      return [`mocha`, '--config=./e2e/.mocharc.js'];
+    case TestRunner.Node:
+      return ['node', '--test', '--test-reporter', 'spec', 'e2e/build/'];
+  }
+
+  throw new Error(`Unknown test runner ${runner}!`);
+}
+
 function getError(executable: string, args: string[]) {
   return (
     `Error running '${executable}' with arguments '${args.join(' ')}'.` +
@@ -147,15 +162,12 @@ async function executeE2ETest(
   try {
     server = await startServer(options, context);
 
-    const commands = options.commands;
-
     message('\n Building tests 🛠️ ... \n', context);
     await executeCommand(context, [`tsc`, '-p', 'e2e/tsconfig.json']);
 
     message('\n Running tests 🧪 ... \n', context);
-    for (const command of commands) {
-      await executeCommand(context, command);
-    }
+    const testRunnerCommand = getCommandForRunner(options.testRunner);
+    await executeCommand(context, testRunnerCommand);
 
     message('\n 🚀 Test ran successfully! 🚀 ', context, 'success');
     return {success: true};

--- a/packages/ng-schematics/src/builders/puppeteer/types.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/types.ts
@@ -16,10 +16,10 @@
 
 import {JsonObject} from '@angular-devkit/core';
 
-type Command = [string, ...string[]];
+import {TestRunner} from '../../schematics/utils/types.js';
 
 export interface PuppeteerBuilderOptions extends JsonObject {
-  commands: Command[];
+  testRunner: TestRunner;
   devServerTarget: string;
   port: number | null;
 }

--- a/packages/ng-schematics/src/schematics/utils/files.ts
+++ b/packages/ng-schematics/src/schematics/utils/files.ts
@@ -28,7 +28,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 
-import {AngularProject, SchematicsOptions, TestRunner} from './types.js';
+import {AngularProject, TestRunner} from './types.js';
 
 export interface FilesOptions {
   options: {
@@ -146,19 +146,6 @@ export function addFrameworkFiles(
   };
 
   return addFilesToProjects(tree, context, projects, options);
-}
-
-export function getScriptFromOptions(options: SchematicsOptions): string[][] {
-  switch (options.testRunner) {
-    case TestRunner.Jasmine:
-      return [[`jasmine`, '--config=./e2e/support/jasmine.json']];
-    case TestRunner.Jest:
-      return [[`jest`, '-c', 'e2e/jest.config.js']];
-    case TestRunner.Mocha:
-      return [[`mocha`, '--config=./e2e/.mocharc.js']];
-    case TestRunner.Node:
-      return [['node', '--test', '--test-reporter', 'spec', 'e2e/build/']];
-  }
 }
 
 export function hasE2ETester(

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -18,7 +18,7 @@ import {get} from 'https';
 
 import {Tree} from '@angular-devkit/schematics';
 
-import {getNgCommandName, getScriptFromOptions} from './files.js';
+import {getNgCommandName} from './files.js';
 import {
   getAngularConfig,
   getJsonFileAsObject,
@@ -165,14 +165,12 @@ export function updateAngularJsonScripts(
   const name = getNgCommandName(angularJson.projects);
 
   Object.keys(angularJson['projects']).forEach(project => {
-    const commands = getScriptFromOptions(options);
     const e2eScript = [
       {
         name,
         value: {
           builder: '@puppeteer/ng-schematics:puppeteer',
           options: {
-            commands,
             devServerTarget: `${project}:serve`,
             testRunner: options.testRunner,
           },

--- a/packages/ng-schematics/test/src/ng-add.spec.ts
+++ b/packages/ng-schematics/test/src/ng-add.spec.ts
@@ -54,9 +54,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
 
       expect(tree.files).toContain('/e2e/support/jasmine.json');
       expect(devDependencies).toContain('jasmine');
-      expect(options['commands']).toEqual([
-        [`jasmine`, '--config=./e2e/support/jasmine.json'],
-      ]);
+      expect(options['testRunner']).toBe('jasmine');
     });
     it('should create Jest files and update "package.json"', async () => {
       const tree = await buildTestingTree('ng-add', 'single', {
@@ -68,9 +66,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tree.files).toContain('/e2e/jest.config.js');
       expect(devDependencies).toContain('jest');
       expect(devDependencies).toContain('@types/jest');
-      expect(options['commands']).toEqual([
-        [`jest`, '-c', 'e2e/jest.config.js'],
-      ]);
+      expect(options['testRunner']).toBe('jest');
     });
     it('should create Mocha files and update "package.json"', async () => {
       const tree = await buildTestingTree('ng-add', 'single', {
@@ -82,9 +78,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tree.files).toContain('/e2e/.mocharc.js');
       expect(devDependencies).toContain('mocha');
       expect(devDependencies).toContain('@types/mocha');
-      expect(options['commands']).toEqual([
-        [`mocha`, '--config=./e2e/.mocharc.js'],
-      ]);
+      expect(options['testRunner']).toBe('mocha');
     });
     it('should create Node files', async () => {
       const tree = await buildTestingTree('ng-add', 'single', {
@@ -95,9 +89,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tree.files).toContain('/e2e/.gitignore');
       expect(tree.files).not.toContain('/e2e/tests/app.e2e.ts');
       expect(tree.files).toContain('/e2e/tests/app.test.ts');
-      expect(options['commands']).toEqual([
-        ['node', '--test', '--test-reporter', 'spec', 'e2e/build/'],
-      ]);
+      expect(options['testRunner']).toBe('node');
     });
     it('should not create port value', async () => {
       const tree = await buildTestingTree('ng-add');
@@ -152,9 +144,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
         getMultiProjectFile('e2e/support/jasmine.json')
       );
       expect(devDependencies).toContain('jasmine');
-      expect(options['commands']).toEqual([
-        [`jasmine`, '--config=./e2e/support/jasmine.json'],
-      ]);
+      expect(options['testRunner']).toBe('jasmine');
     });
     it('should create Jest files and update "package.json"', async () => {
       const tree = await buildTestingTree('ng-add', 'multi', {
@@ -166,9 +156,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tree.files).toContain(getMultiProjectFile('e2e/jest.config.js'));
       expect(devDependencies).toContain('jest');
       expect(devDependencies).toContain('@types/jest');
-      expect(options['commands']).toEqual([
-        [`jest`, '-c', 'e2e/jest.config.js'],
-      ]);
+      expect(options['testRunner']).toBe('jest');
     });
     it('should create Mocha files and update "package.json"', async () => {
       const tree = await buildTestingTree('ng-add', 'multi', {
@@ -180,9 +168,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tree.files).toContain(getMultiProjectFile('e2e/.mocharc.js'));
       expect(devDependencies).toContain('mocha');
       expect(devDependencies).toContain('@types/mocha');
-      expect(options['commands']).toEqual([
-        [`mocha`, '--config=./e2e/.mocharc.js'],
-      ]);
+      expect(options['testRunner']).toBe('mocha');
     });
     it('should create Node files', async () => {
       const tree = await buildTestingTree('ng-add', 'multi', {
@@ -197,9 +183,7 @@ describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tree.files).toContain(
         getMultiProjectFile('e2e/tests/app.test.ts')
       );
-      expect(options['commands']).toEqual([
-        ['node', '--test', '--test-reporter', 'spec', 'e2e/build/'],
-      ]);
+      expect(options['testRunner']).toBe('node');
     });
     it('should not create port value', async () => {
       const tree = await buildTestingTree('ng-add');


### PR DESCRIPTION
Lets the builder handle commands on its own.

BEGIN_COMMIT_OVERRIDE
fix(ng-schematics): builder is responsible for resolving commands 
END_COMMIT_OVERRIDE