### PR TITLE
chore: allow enabling the tab target for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,16 @@ jobs:
           - chrome-headful
           - chrome-new-headless
           - chrome-bidi
+          - chrome-new-headless-tab
         exclude:
           - os: windows-latest
             suite: chrome-bidi
           - os: macos-latest
             suite: chrome-headful
+          - os: windows-latest
+            suite: chrome-new-headless-tab
+          - os: macos-latest
+            suite: chrome-new-headless-tab
     steps:
       - name: Check out repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -32,6 +32,7 @@ import {
 import {BrowserContext} from '../api/BrowserContext.js';
 import {Page} from '../api/Page.js';
 import {Target} from '../api/Target.js';
+import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {ChromeTargetManager} from './ChromeTargetManager.js';
@@ -65,7 +66,8 @@ export class CDPBrowser extends BrowserBase {
     closeCallback?: BrowserCloseCallback,
     targetFilterCallback?: TargetFilterCallback,
     isPageTargetCallback?: IsPageTargetCallback,
-    waitForInitiallyDiscoveredTargets = true
+    waitForInitiallyDiscoveredTargets = true,
+    useTabTarget = USE_TAB_TARGET
   ): Promise<CDPBrowser> {
     const browser = new CDPBrowser(
       product,
@@ -77,7 +79,8 @@ export class CDPBrowser extends BrowserBase {
       closeCallback,
       targetFilterCallback,
       isPageTargetCallback,
-      waitForInitiallyDiscoveredTargets
+      waitForInitiallyDiscoveredTargets,
+      useTabTarget
     );
     await browser._attach();
     return browser;
@@ -114,7 +117,8 @@ export class CDPBrowser extends BrowserBase {
     closeCallback?: BrowserCloseCallback,
     targetFilterCallback?: TargetFilterCallback,
     isPageTargetCallback?: IsPageTargetCallback,
-    waitForInitiallyDiscoveredTargets = true
+    waitForInitiallyDiscoveredTargets = true,
+    useTabTarget = USE_TAB_TARGET
   ) {
     super();
     product = product || 'chrome';
@@ -141,7 +145,8 @@ export class CDPBrowser extends BrowserBase {
         connection,
         this.#createTarget,
         this.#targetFilterCallback,
-        waitForInitiallyDiscoveredTargets
+        waitForInitiallyDiscoveredTargets,
+        useTabTarget
       );
     }
     this.#defaultContext = new CDPBrowserContext(this.#connection, this);

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -99,16 +99,21 @@ export class ChromeTargetManager extends EventEmitter implements TargetManager {
   #waitForInitiallyDiscoveredTargets = true;
 
   // TODO: remove the flag once the testing/rollout is done.
-  #tabMode = false;
-  #discoveryFilter = this.#tabMode ? [{}] : [{type: 'tab', exclude: true}, {}];
+  #tabMode: boolean;
+  #discoveryFilter: Protocol.Target.FilterEntry[];
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
     targetFilterCallback?: TargetFilterCallback,
-    waitForInitiallyDiscoveredTargets = true
+    waitForInitiallyDiscoveredTargets = true,
+    useTabTarget = false
   ) {
     super();
+    this.#tabMode = useTabTarget;
+    this.#discoveryFilter = this.#tabMode
+      ? [{}]
+      : [{type: 'tab', exclude: true}, {}];
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -27,3 +27,13 @@ export const DEFERRED_PROMISE_DEBUG_TIMEOUT =
   typeof process.env['PUPPETEER_DEFERRED_PROMISE_DEBUG_TIMEOUT'] !== 'undefined'
     ? Number(process.env['PUPPETEER_DEFERRED_PROMISE_DEBUG_TIMEOUT'])
     : -1;
+
+/**
+ * Only used for internal testing.
+ *
+ * @internal
+ */
+export const USE_TAB_TARGET =
+  typeof process !== 'undefined'
+    ? process.env['PUPPETEER_INTERNAL_TAB_TARGET'] === 'true'
+    : false;

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -25,6 +25,7 @@ import {
 
 import {Browser} from '../api/Browser.js';
 import {debugError} from '../common/util.js';
+import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {
@@ -178,7 +179,8 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-dev-shm-usage',
       '--disable-extensions',
       // AcceptCHFrame disabled because of crbug.com/1348106.
-      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,Prerender2',
+      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints',
+      ...(USE_TAB_TARGET ? [] : ['--disable-features=Prerender2']),
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',

--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -19,6 +19,12 @@
       "expectedLineCoverage": 93
     },
     {
+      "id": "chrome-new-headless-tab",
+      "platforms": ["linux"],
+      "parameters": ["chrome", "new-headless", "cdp", "tabTarget"],
+      "expectedLineCoverage": 93
+    },
+    {
       "id": "firefox-headless",
       "platforms": ["linux", "darwin"],
       "parameters": ["firefox", "headless", "cdp"],
@@ -63,6 +69,9 @@
     "webDriverBiDi": {
       "PUPPETEER_PROTOCOL": "webDriverBiDi"
     },
-    "cdp": {}
+    "cdp": {},
+    "tabTarget": {
+      "PUPPETEER_INTERNAL_TAB_TARGET": "true"
+    }
   }
 }


### PR DESCRIPTION
This PR adds a flag that allows turning on the tab target mode via an internal test flag or via the internal browser creation API. It also adds a new test suite for this configuration (only Linux + new headless).