### PR TITLE
chore: emit target configuration via CDP session

### DIFF
--- a/packages/browsers/test/src/versions.ts
+++ b/packages/browsers/test/src/versions.ts
@@ -16,6 +16,6 @@
 
 export const testChromeBuildId = '113.0.5672.0';
 export const testChromiumBuildId = '1083080';
-export const testFirefoxBuildId = '118.0a1';
+export const testFirefoxBuildId = '119.0a1';
 export const testChromeDriverBuildId = '115.0.5763.0';
 export const testChromeHeadlessShellBuildId = '118.0.5950.0';

--- a/packages/puppeteer-core/src/common/Connection.ts
+++ b/packages/puppeteer-core/src/common/Connection.ts
@@ -431,6 +431,11 @@ export interface CDPSessionOnMessageObject {
 export const CDPSessionEmittedEvents = {
   Disconnected: Symbol('CDPSession.Disconnected'),
   Swapped: Symbol('CDPSession.Swapped'),
+  /**
+   * Emitted when the session is ready to be configured during the auto-attach
+   * process. Right after the event is handled, the session will be resumed.
+   */
+  Ready: Symbol('CDPSession.Ready'),
 } as const;
 
 /**

--- a/packages/puppeteer-core/src/common/TargetManager.ts
+++ b/packages/puppeteer-core/src/common/TargetManager.ts
@@ -30,14 +30,6 @@ export type TargetFactory = (
 ) => CDPTarget;
 
 /**
- * @internal
- */
-export type TargetInterceptor = (
-  createdTarget: CDPTarget,
-  parentTarget: CDPTarget | null
-) => void;
-
-/**
  * TargetManager encapsulates all interactions with CDP targets and is
  * responsible for coordinating the configuration of targets with the rest of
  * Puppeteer. Code outside of this class should not subscribe `Target.*` events
@@ -52,14 +44,6 @@ export interface TargetManager extends EventEmitter {
   getAvailableTargets(): Map<string, CDPTarget>;
   initialize(): Promise<void>;
   dispose(): void;
-  addTargetInterceptor(
-    session: CDPSession,
-    interceptor: TargetInterceptor
-  ): void;
-  removeTargetInterceptor(
-    session: CDPSession,
-    interceptor: TargetInterceptor
-  ): void;
 }
 
 /**


### PR DESCRIPTION
The initial idea of having async interceptor does not seem useful anymore and subscribing to session attachment via the addInterceptor API is less ergonomic than doing it via the CDP session.