### PR TITLE
chore: rename BiDi classes with `Bidi` prefix

### DIFF
--- a/packages/puppeteer-core/src/common/Dialog.ts
+++ b/packages/puppeteer-core/src/common/Dialog.ts
@@ -16,14 +16,14 @@
 
 import {Protocol} from 'devtools-protocol';
 
-import {Dialog as BaseDialog} from '../api/Dialog.js';
+import {Dialog} from '../api/Dialog.js';
 
 import {CDPSession} from './Connection.js';
 
 /**
  * @internal
  */
-export class CDPDialog extends BaseDialog {
+export class CDPDialog extends Dialog {
   #client: CDPSession;
 
   /**

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -22,7 +22,7 @@ import {assert} from '../util/assert.js';
 
 import {CDPSession} from './Connection.js';
 import {ExecutionContext} from './ExecutionContext.js';
-import {Frame} from './Frame.js';
+import {CDPFrame} from './Frame.js';
 import {FrameManager} from './FrameManager.js';
 import {WaitForSelectorOptions} from './IsolatedWorld.js';
 import {CDPJSHandle} from './JSHandle.js';
@@ -39,13 +39,13 @@ import {debugError} from './util.js';
 export class CDPElementHandle<
   ElementType extends Node = Element,
 > extends ElementHandle<ElementType> {
-  #frame: Frame;
+  #frame: CDPFrame;
   declare handle: CDPJSHandle<ElementType>;
 
   constructor(
     context: ExecutionContext,
     remoteObject: Protocol.Runtime.RemoteObject,
-    frame: Frame
+    frame: CDPFrame
   ) {
     super(new CDPJSHandle(context, remoteObject));
     this.#frame = frame;
@@ -77,7 +77,7 @@ export class CDPElementHandle<
     return this.#frame.page();
   }
 
-  override get frame(): Frame {
+  override get frame(): CDPFrame {
     return this.#frame;
   }
 
@@ -108,8 +108,8 @@ export class CDPElementHandle<
 
   override async contentFrame(
     this: ElementHandle<HTMLIFrameElement>
-  ): Promise<Frame>;
-  override async contentFrame(): Promise<Frame | null> {
+  ): Promise<CDPFrame>;
+  override async contentFrame(): Promise<CDPFrame | null> {
     const nodeInfo = await this.client.send('DOM.describeNode', {
       objectId: this.id,
     });

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -17,7 +17,7 @@
 import {Protocol} from 'devtools-protocol';
 
 import {ElementHandle} from '../api/ElementHandle.js';
-import {Frame as BaseFrame} from '../api/Frame.js';
+import {Frame} from '../api/Frame.js';
 import {HTTPResponse} from '../api/HTTPResponse.js';
 import {Page, WaitTimeoutOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
@@ -54,7 +54,7 @@ export const FrameEmittedEvents = {
 /**
  * @internal
  */
-export class Frame extends BaseFrame {
+export class CDPFrame extends Frame {
   #url = '';
   #detached = false;
   #client!: CDPSession;
@@ -280,11 +280,11 @@ export class Frame extends BaseFrame {
     return this.#url;
   }
 
-  override parentFrame(): Frame | null {
+  override parentFrame(): CDPFrame | null {
     return this._frameManager._frameTree.parentFrame(this._id) || null;
   }
 
-  override childFrames(): Frame[] {
+  override childFrames(): CDPFrame[] {
     return this._frameManager._frameTree.childFrames(this._id);
   }
 

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -30,7 +30,7 @@ import {
 import {DeviceRequestPromptManager} from './DeviceRequestPrompt.js';
 import {EventEmitter} from './EventEmitter.js';
 import {ExecutionContext} from './ExecutionContext.js';
-import {Frame, FrameEmittedEvents} from './Frame.js';
+import {CDPFrame, FrameEmittedEvents} from './Frame.js';
 import {FrameTree} from './FrameTree.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
@@ -78,7 +78,7 @@ export class FrameManager extends EventEmitter {
   /**
    * @internal
    */
-  _frameTree = new FrameTree<Frame>();
+  _frameTree = new FrameTree<CDPFrame>();
 
   /**
    * Set of frame IDs stored to indicate if a frame has received a
@@ -272,17 +272,17 @@ export class FrameManager extends EventEmitter {
     return this.#page;
   }
 
-  mainFrame(): Frame {
+  mainFrame(): CDPFrame {
     const mainFrame = this._frameTree.getMainFrame();
     assert(mainFrame, 'Requesting main frame too early!');
     return mainFrame;
   }
 
-  frames(): Frame[] {
+  frames(): CDPFrame[] {
     return Array.from(this._frameTree.frames());
   }
 
-  frame(frameId: string): Frame | null {
+  frame(frameId: string): CDPFrame | null {
     return this._frameTree.getById(frameId) || null;
   }
 
@@ -381,7 +381,7 @@ export class FrameManager extends EventEmitter {
       return;
     }
 
-    frame = new Frame(this, frameId, parentFrameId, session);
+    frame = new CDPFrame(this, frameId, parentFrameId, session);
     this._frameTree.addFrame(frame);
     this.emit(FrameManagerEmittedEvents.FrameAttached, frame);
   }
@@ -407,7 +407,7 @@ export class FrameManager extends EventEmitter {
         frame._id = frameId;
       } else {
         // Initial main frame navigation.
-        frame = new Frame(this, frameId, undefined, this.#client);
+        frame = new CDPFrame(this, frameId, undefined, this.#client);
       }
       this._frameTree.addFrame(frame);
     }
@@ -547,7 +547,7 @@ export class FrameManager extends EventEmitter {
     }
   }
 
-  #removeFramesRecursively(frame: Frame): void {
+  #removeFramesRecursively(frame: CDPFrame): void {
     for (const child of frame.childFrames()) {
       this.#removeFramesRecursively(child);
     }

--- a/packages/puppeteer-core/src/common/FrameTree.ts
+++ b/packages/puppeteer-core/src/common/FrameTree.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Frame as BaseFrame} from '../api/Frame.js';
+import {Frame} from '../api/Frame.js';
 import {Deferred} from '../util/Deferred.js';
 
 /**
@@ -24,20 +24,20 @@ import {Deferred} from '../util/Deferred.js';
  * structure is eventually consistent.
  * @internal
  */
-export class FrameTree<Frame extends BaseFrame> {
-  #frames = new Map<string, Frame>();
+export class FrameTree<FrameType extends Frame> {
+  #frames = new Map<string, FrameType>();
   // frameID -> parentFrameID
   #parentIds = new Map<string, string>();
   // frameID -> childFrameIDs
   #childIds = new Map<string, Set<string>>();
-  #mainFrame?: Frame;
-  #waitRequests = new Map<string, Set<Deferred<Frame>>>();
+  #mainFrame?: FrameType;
+  #waitRequests = new Map<string, Set<Deferred<FrameType>>>();
 
-  getMainFrame(): Frame | undefined {
+  getMainFrame(): FrameType | undefined {
     return this.#mainFrame;
   }
 
-  getById(frameId: string): Frame | undefined {
+  getById(frameId: string): FrameType | undefined {
     return this.#frames.get(frameId);
   }
 
@@ -45,23 +45,23 @@ export class FrameTree<Frame extends BaseFrame> {
    * Returns a promise that is resolved once the frame with
    * the given ID is added to the tree.
    */
-  waitForFrame(frameId: string): Promise<Frame> {
+  waitForFrame(frameId: string): Promise<FrameType> {
     const frame = this.getById(frameId);
     if (frame) {
       return Promise.resolve(frame);
     }
-    const deferred = Deferred.create<Frame>();
+    const deferred = Deferred.create<FrameType>();
     const callbacks =
-      this.#waitRequests.get(frameId) || new Set<Deferred<Frame>>();
+      this.#waitRequests.get(frameId) || new Set<Deferred<FrameType>>();
     callbacks.add(deferred);
     return deferred.valueOrThrow();
   }
 
-  frames(): Frame[] {
+  frames(): FrameType[] {
     return Array.from(this.#frames.values());
   }
 
-  addFrame(frame: Frame): void {
+  addFrame(frame: FrameType): void {
     this.#frames.set(frame._id, frame);
     if (frame._parentId) {
       this.#parentIds.set(frame._id, frame._parentId);
@@ -77,7 +77,7 @@ export class FrameTree<Frame extends BaseFrame> {
     });
   }
 
-  removeFrame(frame: Frame): void {
+  removeFrame(frame: FrameType): void {
     this.#frames.delete(frame._id);
     this.#parentIds.delete(frame._id);
     if (frame._parentId) {
@@ -87,7 +87,7 @@ export class FrameTree<Frame extends BaseFrame> {
     }
   }
 
-  childFrames(frameId: string): Frame[] {
+  childFrames(frameId: string): FrameType[] {
     const childIds = this.#childIds.get(frameId);
     if (!childIds) {
       return [];
@@ -96,12 +96,12 @@ export class FrameTree<Frame extends BaseFrame> {
       .map(id => {
         return this.getById(id);
       })
-      .filter((frame): frame is Frame => {
+      .filter((frame): frame is FrameType => {
         return frame !== undefined;
       });
   }
 
-  parentFrame(frameId: string): Frame | undefined {
+  parentFrame(frameId: string): FrameType | undefined {
     const parentId = this.#parentIds.get(frameId);
     return parentId ? this.getById(parentId) : undefined;
   }

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -23,7 +23,7 @@ import {Deferred} from '../util/Deferred.js';
 import {Binding} from './Binding.js';
 import {CDPSession} from './Connection.js';
 import {ExecutionContext} from './ExecutionContext.js';
-import {Frame} from './Frame.js';
+import {CDPFrame} from './Frame.js';
 import {FrameManager} from './FrameManager.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import {CDPJSHandle} from './JSHandle.js';
@@ -90,7 +90,7 @@ export interface IsolatedWorldChart {
  * @internal
  */
 export class IsolatedWorld extends Realm {
-  #frame: Frame;
+  #frame: CDPFrame;
   #context = Deferred.create<ExecutionContext>();
 
   // Set of bindings that have been registered in the current context.
@@ -103,7 +103,7 @@ export class IsolatedWorld extends Realm {
     return this.#bindings;
   }
 
-  constructor(frame: Frame) {
+  constructor(frame: CDPFrame) {
     super(frame._frameManager.timeoutSettings);
     this.#frame = frame;
     this.frameUpdated();
@@ -121,7 +121,7 @@ export class IsolatedWorld extends Realm {
     return this.#frame._frameManager;
   }
 
-  frame(): Frame {
+  frame(): CDPFrame {
     return this.#frame;
   }
 

--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -19,7 +19,7 @@ import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
 import {TimeoutError} from './Errors.js';
-import {Frame, FrameEmittedEvents} from './Frame.js';
+import {CDPFrame, FrameEmittedEvents} from './Frame.js';
 import {HTTPRequest} from './HTTPRequest.js';
 import {NetworkManager, NetworkManagerEmittedEvents} from './NetworkManager.js';
 import {
@@ -60,7 +60,7 @@ const puppeteerToProtocolLifecycle = new Map<
  */
 export class LifecycleWatcher {
   #expectedLifecycle: ProtocolLifeCycleEvent[];
-  #frame: Frame;
+  #frame: CDPFrame;
   #timeout: number;
   #navigationRequest: HTTPRequest | null = null;
   #eventListeners: PuppeteerEventListener[];
@@ -78,7 +78,7 @@ export class LifecycleWatcher {
 
   constructor(
     networkManager: NetworkManager,
-    frame: Frame,
+    frame: CDPFrame,
     waitUntil: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[],
     timeout: number
   ) {
@@ -181,7 +181,7 @@ export class LifecycleWatcher {
     this.#navigationResponseReceived?.resolve();
   }
 
-  #onFrameDetached(frame: Frame): void {
+  #onFrameDetached(frame: CDPFrame): void {
     if (this.#frame === frame) {
       this.#terminationDeferred.resolve(
         new Error('Navigating frame was detached')
@@ -241,7 +241,7 @@ export class LifecycleWatcher {
     }
 
     function checkLifecycle(
-      frame: Frame,
+      frame: CDPFrame,
       expectedLifecycle: ProtocolLifeCycleEvent[]
     ): boolean {
       for (const event of expectedLifecycle) {

--- a/packages/puppeteer-core/src/common/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.test.ts
@@ -22,7 +22,7 @@ import {HTTPRequest} from '../api/HTTPRequest.js';
 import {HTTPResponse} from '../api/HTTPResponse.js';
 
 import {EventEmitter} from './EventEmitter.js';
-import {Frame} from './Frame.js';
+import {CDPFrame} from './Frame.js';
 import {NetworkManager, NetworkManagerEmittedEvents} from './NetworkManager.js';
 
 // TODO: develop a helper to generate fake network events for attributes that
@@ -46,7 +46,7 @@ describe('NetworkManager', () => {
   it('should process extra info on multiple redirects', async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });
@@ -478,7 +478,7 @@ describe('NetworkManager', () => {
   it(`should handle "double pause" (crbug.com/1196004) Fetch.requestPaused events for the same Network.requestWillBeSent event`, async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });
@@ -565,7 +565,7 @@ describe('NetworkManager', () => {
   it(`should handle Network.responseReceivedExtraInfo event after Network.responseReceived event (github.com/puppeteer/puppeteer/issues/8234)`, async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });
@@ -684,7 +684,7 @@ describe('NetworkManager', () => {
   it(`should resolve the response once the late responseReceivedExtraInfo event arrives`, async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });
@@ -837,7 +837,7 @@ describe('NetworkManager', () => {
   it(`should send responses for iframe that don't receive loadingFinished event`, async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });
@@ -1001,7 +1001,7 @@ describe('NetworkManager', () => {
   it(`should send responses for iframe that don't receive loadingFinished event`, async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });
@@ -1148,7 +1148,7 @@ describe('NetworkManager', () => {
   it(`should handle cached redirects`, async () => {
     const mockCDPSession = new MockCDPSession();
     const manager = new NetworkManager(true, {
-      frame(): Frame | null {
+      frame(): CDPFrame | null {
         return null;
       },
     });

--- a/packages/puppeteer-core/src/common/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/common/bidi/BrowserContext.ts
@@ -16,14 +16,14 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {BrowserContext as BrowserContextBase} from '../../api/BrowserContext.js';
-import {Page as PageBase} from '../../api/Page.js';
+import {BrowserContext} from '../../api/BrowserContext.js';
+import {Page} from '../../api/Page.js';
 import {Target} from '../../api/Target.js';
 import {Viewport} from '../PuppeteerViewport.js';
 
-import {Browser} from './Browser.js';
+import {BidiBrowser} from './Browser.js';
 import {Connection} from './Connection.js';
-import {Page} from './Page.js';
+import {BidiPage} from './Page.js';
 
 interface BrowserContextOptions {
   defaultViewport: Viewport | null;
@@ -33,13 +33,13 @@ interface BrowserContextOptions {
 /**
  * @internal
  */
-export class BrowserContext extends BrowserContextBase {
-  #browser: Browser;
+export class BidiBrowserContext extends BrowserContext {
+  #browser: BidiBrowser;
   #connection: Connection;
   #defaultViewport: Viewport | null;
   #isDefault = false;
 
-  constructor(browser: Browser, options: BrowserContextOptions) {
+  constructor(browser: BidiBrowser, options: BrowserContextOptions) {
     super();
     this.#browser = browser;
     this.#connection = this.#browser.connection;
@@ -66,7 +66,7 @@ export class BrowserContext extends BrowserContextBase {
     return this.#connection;
   }
 
-  override async newPage(): Promise<PageBase> {
+  override async newPage(): Promise<Page> {
     const {result} = await this.#connection.send('browsingContext.create', {
       type: Bidi.BrowsingContext.CreateType.Tab,
     });
@@ -102,17 +102,17 @@ export class BrowserContext extends BrowserContextBase {
     await this.#browser._closeContext(this);
   }
 
-  override browser(): Browser {
+  override browser(): BidiBrowser {
     return this.#browser;
   }
 
-  override async pages(): Promise<PageBase[]> {
+  override async pages(): Promise<BidiPage[]> {
     const results = await Promise.all(
       [...this.targets()].map(t => {
         return t.page();
       })
     );
-    return results.filter((p): p is Page => {
+    return results.filter((p): p is BidiPage => {
       return p !== null;
     });
   }

--- a/packages/puppeteer-core/src/common/bidi/Dialog.ts
+++ b/packages/puppeteer-core/src/common/bidi/Dialog.ts
@@ -16,14 +16,14 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {Dialog as BaseDialog} from '../../api/Dialog.js';
+import {Dialog} from '../../api/Dialog.js';
 
 import {BrowsingContext} from './BrowsingContext.js';
 
 /**
  * @internal
  */
-export class Dialog extends BaseDialog {
+export class BidiDialog extends Dialog {
   #context: BrowsingContext;
 
   /**

--- a/packages/puppeteer-core/src/common/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/bidi/ElementHandle.ts
@@ -16,34 +16,31 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {
-  AutofillData,
-  ElementHandle as BaseElementHandle,
-} from '../../api/ElementHandle.js';
+import {AutofillData, ElementHandle} from '../../api/ElementHandle.js';
 
-import {Frame} from './Frame.js';
-import {JSHandle as BidiJSHandle, JSHandle} from './JSHandle.js';
+import {BidiFrame} from './Frame.js';
+import {BidiJSHandle} from './JSHandle.js';
 import {Realm} from './Realm.js';
 
 /**
  * @internal
  */
-export class ElementHandle<
+export class BidiElementHandle<
   ElementType extends Node = Element,
-> extends BaseElementHandle<ElementType> {
-  declare handle: JSHandle<ElementType>;
-  #frame: Frame;
+> extends ElementHandle<ElementType> {
+  declare handle: BidiJSHandle<ElementType>;
+  #frame: BidiFrame;
 
   constructor(
     realm: Realm,
     remoteValue: Bidi.Script.RemoteValue,
-    frame: Frame
+    frame: BidiFrame
   ) {
-    super(new JSHandle(realm, remoteValue));
+    super(new BidiJSHandle(realm, remoteValue));
     this.#frame = frame;
   }
 
-  override get frame(): Frame {
+  override get frame(): BidiFrame {
     return this.#frame;
   }
 
@@ -82,9 +79,9 @@ export class ElementHandle<
   }
 
   override async contentFrame(
-    this: ElementHandle<HTMLIFrameElement>
-  ): Promise<Frame>;
-  override async contentFrame(): Promise<Frame | null> {
+    this: BidiElementHandle<HTMLIFrameElement>
+  ): Promise<BidiFrame>;
+  override async contentFrame(): Promise<BidiFrame | null> {
     using adoptedThis = await this.frame.isolatedRealm().adoptHandle(this);
     using handle = (await adoptedThis.evaluateHandle(element => {
       if (element instanceof HTMLIFrameElement) {

--- a/packages/puppeteer-core/src/common/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/common/bidi/Frame.ts
@@ -16,7 +16,7 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {Frame as BaseFrame} from '../../api/Frame.js';
+import {Frame} from '../../api/Frame.js';
 import {Deferred} from '../../util/Deferred.js';
 import {CDPSession} from '../Connection.js';
 import {UTILITY_WORLD_NAME} from '../FrameManager.js';
@@ -30,7 +30,7 @@ import {
   lifeCycleToSubscribedEvent,
 } from './BrowsingContext.js';
 import {HTTPResponse} from './HTTPResponse.js';
-import {Page} from './Page.js';
+import {BidiPage} from './Page.js';
 import {
   MAIN_SANDBOX,
   PUPPETEER_SANDBOX,
@@ -42,8 +42,8 @@ import {
  * Puppeteer's Frame class could be viewed as a BiDi BrowsingContext implementation
  * @internal
  */
-export class Frame extends BaseFrame {
-  #page: Page;
+export class BidiFrame extends Frame {
+  #page: BidiPage;
   #context: BrowsingContext;
   #timeoutSettings: TimeoutSettings;
   #abortDeferred = Deferred.create<Error>();
@@ -52,7 +52,7 @@ export class Frame extends BaseFrame {
   override _id: string;
 
   constructor(
-    page: Page,
+    page: BidiPage,
     context: BrowsingContext,
     timeoutSettings: TimeoutSettings,
     parentId?: string | null
@@ -86,7 +86,7 @@ export class Frame extends BaseFrame {
     return this.sandboxes[PUPPETEER_SANDBOX];
   }
 
-  override page(): Page {
+  override page(): BidiPage {
     return this.#page;
   }
 
@@ -94,11 +94,11 @@ export class Frame extends BaseFrame {
     return this.#context.url;
   }
 
-  override parentFrame(): Frame | null {
+  override parentFrame(): BidiFrame | null {
     return this.#page.frame(this._parentId ?? '');
   }
 
-  override childFrames(): Frame[] {
+  override childFrames(): BidiFrame[] {
     return this.#page.childFrames(this.#context.id);
   }
 

--- a/packages/puppeteer-core/src/common/bidi/JSHandle.ts
+++ b/packages/puppeteer-core/src/common/bidi/JSHandle.ts
@@ -18,7 +18,7 @@ import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import Protocol from 'devtools-protocol';
 
 import {ElementHandle} from '../../api/ElementHandle.js';
-import {JSHandle as BaseJSHandle} from '../../api/JSHandle.js';
+import {JSHandle} from '../../api/JSHandle.js';
 import {EvaluateFuncWith, HandleFor, HandleOr} from '../../common/types.js';
 import {withSourcePuppeteerURLIfNone} from '../util.js';
 
@@ -26,7 +26,7 @@ import {Realm} from './Realm.js';
 import {BidiSerializer} from './Serializer.js';
 import {releaseReference} from './utils.js';
 
-export class JSHandle<T = unknown> extends BaseJSHandle<T> {
+export class BidiJSHandle<T = unknown> extends JSHandle<T> {
   #disposed = false;
   #realm: Realm;
   #remoteValue: Bidi.Script.RemoteValue;
@@ -85,7 +85,7 @@ export class JSHandle<T = unknown> extends BaseJSHandle<T> {
     }, propertyName);
   }
 
-  override async getProperties(): Promise<Map<string, BaseJSHandle>> {
+  override async getProperties(): Promise<Map<string, BidiJSHandle>> {
     // TODO(lightning00blade): Either include return of depth Handles in RemoteValue
     // or new BiDi command that returns array of remote value
     const keys = await this.evaluate(object => {
@@ -98,7 +98,7 @@ export class JSHandle<T = unknown> extends BaseJSHandle<T> {
       }
       return enumerableKeys;
     });
-    const map = new Map<string, BaseJSHandle>();
+    const map = new Map<string, BidiJSHandle>();
     const results = await Promise.all(
       keys.map(key => {
         return this.getProperty(key);
@@ -108,7 +108,7 @@ export class JSHandle<T = unknown> extends BaseJSHandle<T> {
     for (const [key, value] of Object.entries(keys)) {
       using handle = results[key as any];
       if (handle) {
-        map.set(value, handle.move());
+        map.set(value, handle.move() as BidiJSHandle);
       }
     }
 

--- a/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
@@ -20,17 +20,17 @@ import {EventEmitter, Handler} from '../EventEmitter.js';
 import {NetworkManagerEmittedEvents} from '../NetworkManager.js';
 
 import {Connection} from './Connection.js';
-import {Frame} from './Frame.js';
+import {BidiFrame} from './Frame.js';
 import {HTTPRequest} from './HTTPRequest.js';
 import {HTTPResponse} from './HTTPResponse.js';
-import {Page} from './Page.js';
+import {BidiPage} from './Page.js';
 
 /**
  * @internal
  */
 export class NetworkManager extends EventEmitter {
   #connection: Connection;
-  #page: Page;
+  #page: BidiPage;
   #subscribedEvents = new Map<string, Handler<any>>([
     ['network.beforeRequestSent', this.#onBeforeRequestSent.bind(this)],
     ['network.responseStarted', this.#onResponseStarted.bind(this)],
@@ -41,7 +41,7 @@ export class NetworkManager extends EventEmitter {
   #requestMap = new Map<string, HTTPRequest>();
   #navigationMap = new Map<string, HTTPResponse>();
 
-  constructor(connection: Connection, page: Page) {
+  constructor(connection: Connection, page: BidiPage) {
     super();
     this.#connection = connection;
     this.#page = page;
@@ -121,7 +121,7 @@ export class NetworkManager extends EventEmitter {
     return inFlightRequestCounter;
   }
 
-  clearMapAfterFrameDispose(frame: Frame): void {
+  clearMapAfterFrameDispose(frame: BidiFrame): void {
     for (const [id, request] of this.#requestMap.entries()) {
       if (request.frame() === frame) {
         this.#requestMap.delete(id);

--- a/packages/puppeteer-core/src/common/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/common/bidi/Realm.ts
@@ -13,9 +13,9 @@ import {
 } from '../util.js';
 
 import {Connection} from './Connection.js';
-import {ElementHandle} from './ElementHandle.js';
-import {Frame} from './Frame.js';
-import {JSHandle} from './JSHandle.js';
+import {BidiElementHandle} from './ElementHandle.js';
+import {BidiFrame} from './Frame.js';
+import {BidiJSHandle} from './JSHandle.js';
 import {BidiSerializer} from './Serializer.js';
 import {createEvaluationError} from './utils.js';
 
@@ -27,7 +27,7 @@ export const getSourceUrlComment = (url: string): string => {
 
 export class Realm extends EventEmitter {
   connection: Connection;
-  #frame!: Frame;
+  #frame!: BidiFrame;
   #id: string;
   #sandbox?: string;
 
@@ -45,7 +45,7 @@ export class Realm extends EventEmitter {
     };
   }
 
-  setFrame(frame: Frame): void {
+  setFrame(frame: BidiFrame): void {
     this.#frame = frame;
 
     // TODO(jrandolf): We should try to find a less brute-force way of doing
@@ -64,8 +64,8 @@ export class Realm extends EventEmitter {
     );
   }
 
-  protected internalPuppeteerUtil?: Promise<JSHandle<PuppeteerUtil>>;
-  get puppeteerUtil(): Promise<JSHandle<PuppeteerUtil>> {
+  protected internalPuppeteerUtil?: Promise<BidiJSHandle<PuppeteerUtil>>;
+  get puppeteerUtil(): Promise<BidiJSHandle<PuppeteerUtil>> {
     const promise = Promise.resolve() as Promise<unknown>;
     scriptInjector.inject(script => {
       if (this.internalPuppeteerUtil) {
@@ -74,10 +74,12 @@ export class Realm extends EventEmitter {
         });
       }
       this.internalPuppeteerUtil = promise.then(() => {
-        return this.evaluateHandle(script) as Promise<JSHandle<PuppeteerUtil>>;
+        return this.evaluateHandle(script) as Promise<
+          BidiJSHandle<PuppeteerUtil>
+        >;
       });
     }, !this.internalPuppeteerUtil);
-    return this.internalPuppeteerUtil as Promise<JSHandle<PuppeteerUtil>>;
+    return this.internalPuppeteerUtil as Promise<BidiJSHandle<PuppeteerUtil>>;
   }
 
   async evaluateHandle<
@@ -182,10 +184,10 @@ export class Realm extends EventEmitter {
 export function getBidiHandle(
   realmOrContext: Realm,
   result: Bidi.Script.RemoteValue,
-  frame: Frame
-): JSHandle | ElementHandle<Node> {
+  frame: BidiFrame
+): BidiJSHandle | BidiElementHandle<Node> {
   if (result.type === 'node' || result.type === 'window') {
-    return new ElementHandle(realmOrContext, result, frame);
+    return new BidiElementHandle(realmOrContext, result, frame);
   }
-  return new JSHandle(realmOrContext, result);
+  return new BidiJSHandle(realmOrContext, result);
 }

--- a/packages/puppeteer-core/src/common/bidi/Sandbox.ts
+++ b/packages/puppeteer-core/src/common/bidi/Sandbox.ts
@@ -16,15 +16,15 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {JSHandle as BaseJSHandle} from '../../api/JSHandle.js';
-import {Realm as RealmApi} from '../../api/Realm.js';
+import {JSHandle} from '../../api/JSHandle.js';
+import {Realm} from '../../api/Realm.js';
 import {TimeoutSettings} from '../TimeoutSettings.js';
 import {EvaluateFunc, HandleFor} from '../types.js';
 import {withSourcePuppeteerURLIfNone} from '../util.js';
 
 import {BrowsingContext} from './BrowsingContext.js';
-import {JSHandle} from './JSHandle.js';
-import {Realm} from './Realm.js';
+import {BidiJSHandle} from './JSHandle.js';
+import {Realm as BidiRealm} from './Realm.js';
 /**
  * A unique key for {@link SandboxChart} to denote the default world.
  * Realms are automatically created in the default sandbox.
@@ -52,12 +52,12 @@ export interface SandboxChart {
 /**
  * @internal
  */
-export class Sandbox extends RealmApi {
-  #realm: Realm;
+export class Sandbox extends Realm {
+  #realm: BidiRealm;
 
   constructor(
     // TODO: We should split the Realm and BrowsingContext
-    realm: Realm | BrowsingContext,
+    realm: BidiRealm | BrowsingContext,
     timeoutSettings: TimeoutSettings
   ) {
     super(timeoutSettings);
@@ -100,14 +100,14 @@ export class Sandbox extends RealmApi {
     return this.#realm.evaluate(pageFunction, ...args);
   }
 
-  async adoptHandle<T extends BaseJSHandle<Node>>(handle: T): Promise<T> {
+  async adoptHandle<T extends JSHandle<Node>>(handle: T): Promise<T> {
     return (await this.evaluateHandle(node => {
       return node;
     }, handle)) as unknown as T;
   }
 
-  async transferHandle<T extends BaseJSHandle<Node>>(handle: T): Promise<T> {
-    if ((handle as unknown as JSHandle).context() === this.#realm) {
+  async transferHandle<T extends JSHandle<Node>>(handle: T): Promise<T> {
+    if ((handle as unknown as BidiJSHandle).context() === this.#realm) {
       return handle;
     }
     const transferredHandle = await this.evaluateHandle(node => {

--- a/packages/puppeteer-core/src/common/bidi/Serializer.ts
+++ b/packages/puppeteer-core/src/common/bidi/Serializer.ts
@@ -20,8 +20,8 @@ import {LazyArg} from '../LazyArg.js';
 import {debugError, isDate, isPlainObject, isRegExp} from '../util.js';
 
 import {BrowsingContext} from './BrowsingContext.js';
-import {ElementHandle} from './ElementHandle.js';
-import {JSHandle} from './JSHandle.js';
+import {BidiElementHandle} from './ElementHandle.js';
+import {BidiJSHandle} from './JSHandle.js';
 
 /**
  * @internal
@@ -151,7 +151,7 @@ export class BidiSerializer {
     }
     // eslint-disable-next-line rulesdir/use-using -- We want this to continue living.
     const objectHandle =
-      arg && (arg instanceof JSHandle || arg instanceof ElementHandle)
+      arg && (arg instanceof BidiJSHandle || arg instanceof BidiElementHandle)
         ? arg
         : null;
     if (objectHandle) {

--- a/packages/puppeteer-core/src/common/bidi/Target.ts
+++ b/packages/puppeteer-core/src/common/bidi/Target.ts
@@ -18,15 +18,15 @@ import {Target, TargetType} from '../../api/Target.js';
 import {CDPSession} from '../Connection.js';
 import type {WebWorker} from '../WebWorker.js';
 
-import {Browser} from './Browser.js';
-import {BrowserContext} from './BrowserContext.js';
+import {BidiBrowser} from './Browser.js';
+import {BidiBrowserContext} from './BrowserContext.js';
 import {BrowsingContext, CDPSessionWrapper} from './BrowsingContext.js';
-import {Page} from './Page.js';
+import {BidiPage} from './Page.js';
 
-export class BiDiTarget extends Target {
-  protected _browserContext: BrowserContext;
+export class BidiTarget extends Target {
+  protected _browserContext: BidiBrowserContext;
 
-  constructor(browserContext: BrowserContext) {
+  constructor(browserContext: BidiBrowserContext) {
     super();
     this._browserContext = browserContext;
   }
@@ -35,11 +35,11 @@ export class BiDiTarget extends Target {
     return null;
   }
 
-  override browser(): Browser {
+  override browser(): BidiBrowser {
     return this._browserContext.browser();
   }
 
-  override browserContext(): BrowserContext {
+  override browserContext(): BidiBrowserContext {
     return this._browserContext;
   }
 
@@ -47,7 +47,7 @@ export class BiDiTarget extends Target {
     throw new Error('Not implemented');
   }
 
-  _setBrowserContext(browserContext: BrowserContext): void {
+  _setBrowserContext(browserContext: BidiBrowserContext): void {
     this._browserContext = browserContext;
   }
 }
@@ -55,7 +55,7 @@ export class BiDiTarget extends Target {
 /**
  * @internal
  */
-export class BiDiBrowserTarget extends BiDiTarget {
+export class BiDiBrowserTarget extends BidiTarget {
   override url(): string {
     return '';
   }
@@ -68,11 +68,11 @@ export class BiDiBrowserTarget extends BiDiTarget {
 /**
  * @internal
  */
-export class BiDiBrowsingContextTarget extends BiDiTarget {
+export class BiDiBrowsingContextTarget extends BidiTarget {
   protected _browsingContext: BrowsingContext;
 
   constructor(
-    browserContext: BrowserContext,
+    browserContext: BidiBrowserContext,
     browsingContext: BrowsingContext
   ) {
     super(browserContext);
@@ -104,22 +104,22 @@ export class BiDiBrowsingContextTarget extends BiDiTarget {
  * @internal
  */
 export class BiDiPageTarget extends BiDiBrowsingContextTarget {
-  #page: Page;
+  #page: BidiPage;
 
   constructor(
-    browserContext: BrowserContext,
+    browserContext: BidiBrowserContext,
     browsingContext: BrowsingContext
   ) {
     super(browserContext, browsingContext);
 
-    this.#page = new Page(browsingContext, browserContext);
+    this.#page = new BidiPage(browsingContext, browserContext);
   }
 
-  override async page(): Promise<Page | null> {
+  override async page(): Promise<BidiPage | null> {
     return this.#page;
   }
 
-  override _setBrowserContext(browserContext: BrowserContext): void {
+  override _setBrowserContext(browserContext: BidiBrowserContext): void {
     super._setBrowserContext(browserContext);
     this.#page._setBrowserContext(browserContext);
   }

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -339,7 +339,7 @@ export class ProductLauncher {
       /* webpackIgnore: true */ '../common/bidi/bidi.js'
     );
     const bidiConnection = await BiDi.connectBidiOverCDP(connection);
-    return await BiDi.Browser.create({
+    return await BiDi.BidiBrowser.create({
       connection: bidiConnection,
       closeCallback,
       process: browserProcess.nodeProcess,
@@ -378,7 +378,7 @@ export class ProductLauncher {
       opts.protocolTimeout
     );
     // TODO: use other options too.
-    return await BiDi.Browser.create({
+    return await BiDi.BidiBrowser.create({
       connection: bidiConnection,
       closeCallback,
       process: browserProcess.nodeProcess,


### PR DESCRIPTION
We shouldn't be renaming the API classes using `...Base`, etc. It's better to prefix the implementations with a implementation-specific value.