### PR TITLE
fix: make page.goBack work with bfcache in tab mode

### DIFF
--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import Protocol from 'devtools-protocol';
+
 import {HTTPResponse} from '../api/HTTPResponse.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
@@ -218,7 +220,10 @@ export class LifecycleWatcher {
     this.#checkLifecycleComplete();
   }
 
-  #navigated(): void {
+  #navigated(navigationType: Protocol.Page.NavigationType): void {
+    if (navigationType === 'BackForwardCacheRestore') {
+      return this.#frameSwapped();
+    }
     this.#checkLifecycleComplete();
   }
 

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -179,8 +179,10 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-dev-shm-usage',
       '--disable-extensions',
       // AcceptCHFrame disabled because of crbug.com/1348106.
-      '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints',
-      ...(USE_TAB_TARGET ? [] : ['--disable-features=Prerender2']),
+      '--disable-features=Translate,AcceptCHFrame,MediaRouter,OptimizationHints',
+      ...(USE_TAB_TARGET
+        ? []
+        : ['--disable-features=Prerender2,BackForwardCache']),
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3900,6 +3900,12 @@
     "expectations": ["PASS", "TIMEOUT"]
   },
   {
+    "testIdPattern": "[bfcache.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[prerender.spec] Prerender can navigate to a prerendered page via input",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/assets/cached/bfcache/index.html
+++ b/test/assets/cached/bfcache/index.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<body>BFCached<a href="target.html">next</a></body>

--- a/test/assets/cached/bfcache/target.html
+++ b/test/assets/cached/bfcache/target.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<body>target</body>

--- a/test/src/bfcache.spec.ts
+++ b/test/src/bfcache.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import expect from 'expect';
+
+import {launch} from './mocha-utils.js';
+
+describe('BFCache', function () {
+  it('can navigate to a BFCached page', async () => {
+    const {httpsServer, page, close} = await launch({
+      ignoreHTTPSErrors: true,
+    });
+
+    try {
+      page.setDefaultTimeout(2000);
+
+      await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');
+
+      await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
+
+      expect(page.url()).toContain('target.html');
+
+      await Promise.all([page.waitForNavigation(), page.goBack()]);
+
+      expect(
+        await page.evaluate(() => {
+          return document.body.innerText;
+        })
+      ).toBe('BFCachednext');
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
BFCache works slightly differently from the prerender (it's more similar to a navigation and sends navigation events) but we also need to detect it and swap the frame.