### PR TITLE
chore: implement `throwIfDisposed`

### DIFF
--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -66,7 +66,6 @@ export class CDPElementHandle<
     return this.handle.client;
   }
 
-  @throwIfDisposed()
   override remoteObject(): Protocol.Runtime.RemoteObject {
     return this.handle.remoteObject();
   }
@@ -114,6 +113,7 @@ export class CDPElementHandle<
   override async contentFrame(
     this: ElementHandle<HTMLIFrameElement>
   ): Promise<CDPFrame>;
+  @throwIfDisposed()
   override async contentFrame(): Promise<CDPFrame | null> {
     const nodeInfo = await this.client.send('DOM.describeNode', {
       objectId: this.id,

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -19,6 +19,7 @@ import {Protocol} from 'devtools-protocol';
 import {AutofillData, ElementHandle, Point} from '../api/ElementHandle.js';
 import {Page, ScreenshotOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
+import {throwIfDisposed} from '../util/decorators.js';
 
 import {CDPSession} from './Connection.js';
 import {ExecutionContext} from './ExecutionContext.js';
@@ -65,6 +66,7 @@ export class CDPElementHandle<
     return this.handle.client;
   }
 
+  @throwIfDisposed()
   override remoteObject(): Protocol.Runtime.RemoteObject {
     return this.handle.remoteObject();
   }
@@ -81,6 +83,7 @@ export class CDPElementHandle<
     return this.#frame;
   }
 
+  @throwIfDisposed()
   override async $<Selector extends string>(
     selector: Selector
   ): Promise<CDPElementHandle<NodeFor<Selector>> | null> {
@@ -89,6 +92,7 @@ export class CDPElementHandle<
     > | null>;
   }
 
+  @throwIfDisposed()
   override async $$<Selector extends string>(
     selector: Selector
   ): Promise<Array<CDPElementHandle<NodeFor<Selector>>>> {
@@ -97,6 +101,7 @@ export class CDPElementHandle<
     >;
   }
 
+  @throwIfDisposed()
   override async waitForSelector<Selector extends string>(
     selector: Selector,
     options?: WaitForSelectorOptions
@@ -119,6 +124,7 @@ export class CDPElementHandle<
     return this.#frameManager.frame(nodeInfo.node.frameId);
   }
 
+  @throwIfDisposed()
   override async scrollIntoView(
     this: CDPElementHandle<Element>
   ): Promise<void> {
@@ -137,6 +143,7 @@ export class CDPElementHandle<
   /**
    * This method creates and captures a dragevent from the element.
    */
+  @throwIfDisposed()
   override async drag(
     this: CDPElementHandle<Element>,
     target: Point
@@ -150,6 +157,7 @@ export class CDPElementHandle<
     return await this.#page.mouse.drag(start, target);
   }
 
+  @throwIfDisposed()
   override async dragEnter(
     this: CDPElementHandle<Element>,
     data: Protocol.Input.DragData = {items: [], dragOperationsMask: 1}
@@ -159,6 +167,7 @@ export class CDPElementHandle<
     await this.#page.mouse.dragEnter(target, data);
   }
 
+  @throwIfDisposed()
   override async dragOver(
     this: CDPElementHandle<Element>,
     data: Protocol.Input.DragData = {items: [], dragOperationsMask: 1}
@@ -168,6 +177,7 @@ export class CDPElementHandle<
     await this.#page.mouse.dragOver(target, data);
   }
 
+  @throwIfDisposed()
   override async drop(
     this: CDPElementHandle<Element>,
     data: Protocol.Input.DragData = {items: [], dragOperationsMask: 1}
@@ -177,6 +187,7 @@ export class CDPElementHandle<
     await this.#page.mouse.drop(destination, data);
   }
 
+  @throwIfDisposed()
   override async dragAndDrop(
     this: CDPElementHandle<Element>,
     target: CDPElementHandle<Node>,
@@ -192,6 +203,7 @@ export class CDPElementHandle<
     await this.#page.mouse.dragAndDrop(startPoint, targetPoint, options);
   }
 
+  @throwIfDisposed()
   override async uploadFile(
     this: CDPElementHandle<HTMLInputElement>,
     ...filePaths: string[]
@@ -249,6 +261,7 @@ export class CDPElementHandle<
     }
   }
 
+  @throwIfDisposed()
   override async screenshot(
     this: CDPElementHandle<Element>,
     options: ScreenshotOptions = {}
@@ -307,6 +320,7 @@ export class CDPElementHandle<
     return imageData;
   }
 
+  @throwIfDisposed()
   override async autofill(data: AutofillData): Promise<void> {
     const nodeInfo = await this.client.send('DOM.describeNode', {
       objectId: this.handle.id,

--- a/packages/puppeteer-core/src/common/types.ts
+++ b/packages/puppeteer-core/src/common/types.ts
@@ -32,6 +32,13 @@ export interface Moveable {
 /**
  * @internal
  */
+export interface Disposed {
+  get disposed(): boolean;
+}
+
+/**
+ * @internal
+ */
 export interface BindingPayload {
   type: string;
   name: string;

--- a/packages/puppeteer-core/src/util/decorators.ts
+++ b/packages/puppeteer-core/src/util/decorators.ts
@@ -66,7 +66,7 @@ export function throwIfDisposed(message?: string) {
     return function (this: This, ...args: Args): Ret {
       if (this.disposed) {
         throw new Error(
-          message ?? `${this.constructor.name} is already disposed.`
+          message ?? `Attempted to use disposed ${this.constructor.name}.`
         );
       }
       return target.call(this, ...args);

--- a/packages/puppeteer-core/src/util/decorators.ts
+++ b/packages/puppeteer-core/src/util/decorators.ts
@@ -15,7 +15,7 @@
  */
 
 import {Symbol} from '../../third_party/disposablestack/disposablestack.js';
-import {Moveable} from '../common/types.js';
+import {Disposed, Moveable} from '../common/types.js';
 
 const instances = new WeakSet<object>();
 
@@ -56,4 +56,20 @@ export function moveable<
     };
   }
   return Class;
+}
+
+export function throwIfDisposed(message?: string) {
+  return <This extends Disposed, Args extends unknown[], Ret>(
+    target: (this: This, ...args: Args) => Ret,
+    _: unknown
+  ) => {
+    return function (this: This, ...args: Args): Ret {
+      if (this.disposed) {
+        throw new Error(
+          message ?? `${this.constructor.name} is already disposed.`
+        );
+      }
+      return target.call(this, ...args);
+    };
+  };
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -18,6 +18,12 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[bfcache.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[chromiumonly.spec] Chromium-Specific Launcher tests *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -3898,12 +3904,6 @@
     "platforms": ["linux"],
     "parameters": ["firefox", "headful"],
     "expectations": ["PASS", "TIMEOUT"]
-  },
-  {
-    "testIdPattern": "[bfcache.spec] *",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[prerender.spec] Prerender can navigate to a prerendered page via input",


### PR DESCRIPTION
If an object is already disposed, the `throwIfDisposed` decorator ensures that methods decorated with it will throw when the parent object is disposed.