### PR TITLE
refactor: use generic implementations

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -982,12 +982,12 @@ export class Page extends EventEmitter implements AsyncDisposable, Disposable {
   >(
     pageFunction: Func | string,
     ...args: Params
-  ): Promise<HandleFor<Awaited<ReturnType<Func>>>>;
-  async evaluateHandle<
-    Params extends unknown[],
-    Func extends EvaluateFunc<Params> = EvaluateFunc<Params>,
-  >(): Promise<HandleFor<Awaited<ReturnType<Func>>>> {
-    throw new Error('Not implemented');
+  ): Promise<HandleFor<Awaited<ReturnType<Func>>>> {
+    pageFunction = withSourcePuppeteerURLIfNone(
+      this.evaluateHandle.name,
+      pageFunction
+    );
+    return await this.mainFrame().evaluateHandle(pageFunction, ...args);
   }
 
   /**
@@ -1440,14 +1440,14 @@ export class Page extends EventEmitter implements AsyncDisposable, Disposable {
    * {@link Frame.url | page.mainFrame().url()}.
    */
   url(): string {
-    throw new Error('Not implemented');
+    return this.mainFrame().url();
   }
 
   /**
    * The full HTML contents of the page, including the DOCTYPE.
    */
   async content(): Promise<string> {
-    throw new Error('Not implemented');
+    return await this.mainFrame().content();
   }
 
   /**
@@ -1476,9 +1476,8 @@ export class Page extends EventEmitter implements AsyncDisposable, Disposable {
    * - `networkidle2` : consider setting content to be finished when there are
    *   no more than 2 network connections for at least `500` ms.
    */
-  async setContent(html: string, options?: WaitForOptions): Promise<void>;
-  async setContent(): Promise<void> {
-    throw new Error('Not implemented');
+  async setContent(html: string, options?: WaitForOptions): Promise<void> {
+    await this.mainFrame().setContent(html, options);
   }
 
   /**
@@ -1541,9 +1540,8 @@ export class Page extends EventEmitter implements AsyncDisposable, Disposable {
   async goto(
     url: string,
     options?: WaitForOptions & {referer?: string; referrerPolicy?: string}
-  ): Promise<HTTPResponse | null>;
-  async goto(): Promise<HTTPResponse | null> {
-    throw new Error('Not implemented');
+  ): Promise<HTTPResponse | null> {
+    return await this.mainFrame().goto(url, options);
   }
 
   /**
@@ -2235,12 +2233,12 @@ export class Page extends EventEmitter implements AsyncDisposable, Disposable {
   >(
     pageFunction: Func | string,
     ...args: Params
-  ): Promise<Awaited<ReturnType<Func>>>;
-  async evaluate<
-    Params extends unknown[],
-    Func extends EvaluateFunc<Params> = EvaluateFunc<Params>,
-  >(): Promise<Awaited<ReturnType<Func>>> {
-    throw new Error('Not implemented');
+  ): Promise<Awaited<ReturnType<Func>>> {
+    pageFunction = withSourcePuppeteerURLIfNone(
+      this.evaluate.name,
+      pageFunction
+    );
+    return await this.mainFrame().evaluate(pageFunction, ...args);
   }
 
   /**
@@ -2473,7 +2471,7 @@ export class Page extends EventEmitter implements AsyncDisposable, Disposable {
    * Shortcut for {@link Frame.title | page.mainFrame().title()}.
    */
   async title(): Promise<string> {
-    throw new Error('Not implemented');
+    return await this.mainFrame().title();
   }
 
   async close(options?: {runBeforeUnload?: boolean}): Promise<void>;

--- a/packages/puppeteer-core/src/api/Realm.ts
+++ b/packages/puppeteer-core/src/api/Realm.ts
@@ -15,20 +15,11 @@
  */
 
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
-import {
-  EvaluateFunc,
-  EvaluateFuncWith,
-  HandleFor,
-  InnerLazyParams,
-  NodeFor,
-} from '../common/types.js';
-import {getPageContent, withSourcePuppeteerURLIfNone} from '../common/util.js';
+import {EvaluateFunc, HandleFor, InnerLazyParams} from '../common/types.js';
 import {TaskManager, WaitTask} from '../common/WaitTask.js';
-import {assert} from '../util/assert.js';
 
-import {ClickOptions, ElementHandle} from './ElementHandle.js';
+import {ElementHandle} from './ElementHandle.js';
 import {Environment} from './Environment.js';
-import {KeyboardTypeOptions} from './Input.js';
 import {JSHandle} from './JSHandle.js';
 
 /**
@@ -60,76 +51,6 @@ export abstract class Realm implements Disposable {
     pageFunction: Func | string,
     ...args: Params
   ): Promise<Awaited<ReturnType<Func>>>;
-
-  async document(): Promise<ElementHandle<Document>> {
-    // TODO(#10813): Implement document caching.
-    return await this.evaluateHandle(() => {
-      return document;
-    });
-  }
-
-  async $<Selector extends string>(
-    selector: Selector
-  ): Promise<ElementHandle<NodeFor<Selector>> | null> {
-    using document = await this.document();
-    return await document.$(selector);
-  }
-
-  async $$<Selector extends string>(
-    selector: Selector
-  ): Promise<Array<ElementHandle<NodeFor<Selector>>>> {
-    using document = await this.document();
-    return await document.$$(selector);
-  }
-
-  async $x(expression: string): Promise<Array<ElementHandle<Node>>> {
-    using document = await this.document();
-    return await document.$x(expression);
-  }
-
-  async $eval<
-    Selector extends string,
-    Params extends unknown[],
-    Func extends EvaluateFuncWith<NodeFor<Selector>, Params> = EvaluateFuncWith<
-      NodeFor<Selector>,
-      Params
-    >,
-  >(
-    selector: Selector,
-    pageFunction: Func | string,
-    ...args: Params
-  ): Promise<Awaited<ReturnType<Func>>> {
-    pageFunction = withSourcePuppeteerURLIfNone(this.$eval.name, pageFunction);
-    using document = await this.document();
-    return await document.$eval(selector, pageFunction, ...args);
-  }
-
-  async $$eval<
-    Selector extends string,
-    Params extends unknown[],
-    Func extends EvaluateFuncWith<
-      Array<NodeFor<Selector>>,
-      Params
-    > = EvaluateFuncWith<Array<NodeFor<Selector>>, Params>,
-  >(
-    selector: Selector,
-    pageFunction: Func | string,
-    ...args: Params
-  ): Promise<Awaited<ReturnType<Func>>> {
-    pageFunction = withSourcePuppeteerURLIfNone(this.$$eval.name, pageFunction);
-    using document = await this.document();
-    return await document.$$eval(selector, pageFunction, ...args);
-  }
-
-  async content(): Promise<string> {
-    return await this.evaluate(getPageContent);
-  }
-
-  async title(): Promise<string> {
-    return await this.evaluate(() => {
-      return document.title;
-    });
-  }
 
   async waitForFunction<
     Params extends unknown[],
@@ -169,50 +90,6 @@ export abstract class Realm implements Disposable {
       ...args
     );
     return await waitTask.result;
-  }
-
-  async click(
-    selector: string,
-    options?: Readonly<ClickOptions>
-  ): Promise<void> {
-    using handle = await this.$(selector);
-    assert(handle, `No element found for selector: ${selector}`);
-    await handle.click(options);
-    await handle.dispose();
-  }
-
-  async focus(selector: string): Promise<void> {
-    using handle = await this.$(selector);
-    assert(handle, `No element found for selector: ${selector}`);
-    await handle.focus();
-  }
-
-  async hover(selector: string): Promise<void> {
-    using handle = await this.$(selector);
-    assert(handle, `No element found for selector: ${selector}`);
-    await handle.hover();
-  }
-
-  async select(selector: string, ...values: string[]): Promise<string[]> {
-    using handle = await this.$(selector);
-    assert(handle, `No element found for selector: ${selector}`);
-    return await handle.select(...values);
-  }
-
-  async tap(selector: string): Promise<void> {
-    using handle = await this.$(selector);
-    assert(handle, `No element found for selector: ${selector}`);
-    await handle.tap();
-  }
-
-  async type(
-    selector: string,
-    text: string,
-    options?: Readonly<KeyboardTypeOptions>
-  ): Promise<void> {
-    using handle = await this.$(selector);
-    assert(handle, `No element found for selector: ${selector}`);
-    await handle.type(text, options);
   }
 
   get disposed(): boolean {

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -43,7 +43,6 @@ import {PDFOptions} from '../PDFOptions.js';
 import {Viewport} from '../PuppeteerViewport.js';
 import {TimeoutSettings} from '../TimeoutSettings.js';
 import {Tracing} from '../Tracing.js';
-import {EvaluateFunc, HandleFor} from '../types.js';
 import {
   debugError,
   evaluationString,
@@ -51,7 +50,6 @@ import {
   validateDialogType,
   waitForEvent,
   waitWithTimeout,
-  withSourcePuppeteerURLIfNone,
 } from '../util.js';
 
 import {BidiBrowser} from './Browser.js';
@@ -426,44 +424,6 @@ export class BidiPage extends Page {
     this.removeAllListeners();
   }
 
-  override async evaluateHandle<
-    Params extends unknown[],
-    Func extends EvaluateFunc<Params> = EvaluateFunc<Params>,
-  >(
-    pageFunction: Func | string,
-    ...args: Params
-  ): Promise<HandleFor<Awaited<ReturnType<Func>>>> {
-    pageFunction = withSourcePuppeteerURLIfNone(
-      this.evaluateHandle.name,
-      pageFunction
-    );
-    return await this.mainFrame().evaluateHandle(pageFunction, ...args);
-  }
-
-  override async evaluate<
-    Params extends unknown[],
-    Func extends EvaluateFunc<Params> = EvaluateFunc<Params>,
-  >(
-    pageFunction: Func | string,
-    ...args: Params
-  ): Promise<Awaited<ReturnType<Func>>> {
-    pageFunction = withSourcePuppeteerURLIfNone(
-      this.evaluate.name,
-      pageFunction
-    );
-    return await this.mainFrame().evaluate(pageFunction, ...args);
-  }
-
-  override async goto(
-    url: string,
-    options?: WaitForOptions & {
-      referer?: string | undefined;
-      referrerPolicy?: string | undefined;
-    }
-  ): Promise<HTTPResponse | null> {
-    return await this.mainFrame().goto(url, options);
-  }
-
   override async reload(
     options?: WaitForOptions
   ): Promise<HTTPResponse | null> {
@@ -486,10 +446,6 @@ export class BidiPage extends Page {
     return response;
   }
 
-  override url(): string {
-    return this.mainFrame().url();
-  }
-
   override setDefaultNavigationTimeout(timeout: number): void {
     this.#timeoutSettings.setDefaultNavigationTimeout(timeout);
   }
@@ -500,17 +456,6 @@ export class BidiPage extends Page {
 
   override getDefaultTimeout(): number {
     return this.#timeoutSettings.timeout();
-  }
-
-  override async setContent(
-    html: string,
-    options: WaitForOptions = {}
-  ): Promise<void> {
-    await this.mainFrame().setContent(html, options);
-  }
-
-  override async content(): Promise<string> {
-    return await this.mainFrame().content();
   }
 
   override isJavaScriptEnabled(): boolean {
@@ -719,10 +664,6 @@ export class BidiPage extends Page {
       timeout,
       this.#closedDeferred
     );
-  }
-
-  override title(): Promise<string> {
-    return this.mainFrame().title();
   }
 
   override async createCDPSession(): Promise<CDPSession> {


### PR DESCRIPTION
This PR upstreams some specific implementations to generic ones. The realm methods are also now DOM-independent.