### PR TITLE
test: upstream test and expectation for Firefox sync to puppeteer v21…

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2720,20 +2720,14 @@
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch should launch Chrome properly with --no-startup-window and waitForInitialPage=false",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch should launch Chrome properly with --no-startup-window and waitForInitialPage=false",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
+    "parameters": ["firefox"],
     "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch should work with no default arguments",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "headless"],
-    "expectations": ["FAIL", "PASS"]
+    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.launch tmp profile should be cleaned up",

--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -423,11 +423,13 @@ describe('Evaluation specs', function () {
       const {page, server} = await getTestState();
 
       await page.goto(server.PREFIX + '/one-style.html');
+      const onRequestDone = server.waitForRequest('/empty.html');
       const result = await page.evaluate(() => {
         (window as any).location = '/empty.html';
         return [42];
       });
       expect(result).toEqual([42]);
+      await onRequestDone;
     });
     it('should transfer 100Mb of data from page to node.js', async function () {
       this.timeout(25_000);

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -336,7 +336,7 @@ describe('Target', function () {
       await browser
         .waitForTarget(
           target => {
-            return target.url() === server.EMPTY_PAGE;
+            return target.url() === server.PREFIX + '/does-not-exist.html';
           },
           {
             timeout: 1,


### PR DESCRIPTION
Another test update from a Puppeteer/Firefox sync.

> TestExpectations.json
> Launcher specs Puppeteer Puppeteer.launch should launch Chrome properly with 

Those tests can't work on Mozilla CI because we don't perform a regular install of puppeteer there.

> TestExpectations.json
> Launcher specs Puppeteer Puppeteer.launch should work with no default arguments

Same thing.

> evaluation.spec.ts
> should not throw an error when evaluation does a navigation

Is ending too quickly on our CI, and the next test is trying to use the browsing context which is navigating, failing frequently.

> target.spec.ts
> should timeout waiting for a non-existent target

Depending on which test ran before, there could be a `server.EMPTY_PAGE` target available, and for some reason that lead the test to immediately fail with a TIMEOUT. Not quite sure why, but I think using an obviously not matching URL is safer?