### PR TITLE
fix: add --disable-search-engine-choice-screen to default arguments

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -188,6 +188,7 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-popup-blocking',
       '--disable-prompt-on-repost',
       '--disable-renderer-backgrounding',
+      '--disable-search-engine-choice-screen',
       '--disable-sync',
       '--enable-automation',
       // TODO(sadym): remove '--enable-blink-features=IdleDetection' once
@@ -200,7 +201,6 @@ export class ChromeLauncher extends ProductLauncher {
       '--no-first-run',
       '--password-store=basic',
       '--use-mock-keychain',
-      '--disable-search-engine-choice-screen',
     ];
     const {
       devtools = false,

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -200,6 +200,7 @@ export class ChromeLauncher extends ProductLauncher {
       '--no-first-run',
       '--password-store=basic',
       '--use-mock-keychain',
+      '--disable-search-engine-choice-screen',
     ];
     const {
       devtools = false,


### PR DESCRIPTION
The screen might block automation clients like Puppeteer. Therefore, adding it to the list of arguments specified by default. The flag is added in https://chromium-review.googlesource.com/c/chromium/src/+/4853540.