### PR TITLE
fix: use supported node range for types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/diff": "5.0.3",
         "@types/mime": "3.0.1",
         "@types/mocha": "10.0.1",
-        "@types/node": "20.5.9",
+        "@types/node": "18.17.15",
         "@types/pixelmatch": "5.2.4",
         "@types/pngjs": "6.0.1",
         "@types/progress": "2.0.5",
@@ -2377,9 +2377,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==",
       "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -7871,9 +7871,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11044,18 +11044,11 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "devDependencies": {
-        "@types/node": "^16.11.7",
         "@types/yargs": "17.0.22"
       },
       "engines": {
         "node": ">=16.3.0"
       }
-    },
-    "packages/browsers/node_modules/@types/node": {
-      "version": "16.18.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
-      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
-      "dev": true
     },
     "packages/ng-schematics": {
       "name": "@puppeteer/ng-schematics",
@@ -11077,9 +11070,9 @@
       }
     },
     "packages/ng-schematics/node_modules/@types/node": {
-      "version": "16.18.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
-      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
+      "version": "16.18.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
+      "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
       "dev": true
     },
     "packages/ng-schematics/node_modules/rxjs": {
@@ -12325,7 +12318,6 @@
     "@puppeteer/browsers": {
       "version": "file:packages/browsers",
       "requires": {
-        "@types/node": "^16.11.7",
         "@types/yargs": "17.0.22",
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -12334,14 +12326,6 @@
         "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.18.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
-          "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
-          "dev": true
-        }
       }
     },
     "@puppeteer/eslint": {
@@ -12360,9 +12344,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.18.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
-          "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
+          "version": "16.18.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
+          "integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
           "dev": true
         },
         "rxjs": {
@@ -12768,9 +12752,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==",
       "devOptional": true
     },
     "@types/normalize-package-data": {
@@ -16489,9 +16473,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@types/diff": "5.0.3",
     "@types/mime": "3.0.1",
     "@types/mocha": "10.0.1",
-    "@types/node": "20.5.9",
+    "@types/node": "18.17.15",
     "@types/pixelmatch": "5.2.4",
     "@types/pngjs": "6.0.1",
     "@types/progress": "2.0.5",

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -106,7 +106,6 @@
     "yargs": "17.7.1"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
     "@types/yargs": "17.0.22"
   }
 }

--- a/packages/puppeteer-core/third_party/disposablestack/disposablestack.ts
+++ b/packages/puppeteer-core/third_party/disposablestack/disposablestack.ts
@@ -1,6 +1,26 @@
 import 'disposablestack/auto';
 
 declare global {
+  interface SymbolConstructor {
+    /**
+     * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+     */
+    readonly dispose: unique symbol;
+
+    /**
+     * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+     */
+    readonly asyncDispose: unique symbol;
+  }
+
+  interface Disposable {
+    [Symbol.dispose](): void;
+  }
+
+  interface AsyncDisposable {
+    [Symbol.asyncDispose](): PromiseLike<void>;
+  }
+
   class DisposableStack implements Disposable {
     constructor();
 


### PR DESCRIPTION
Using the supported node range for types ensures Puppeteer compiles to the correct types.

Fixed: https://github.com/puppeteer/puppeteer/issues/10891