### PR TITLE
chore: use `@typescript-eslint/consistent-type-imports`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -220,6 +220,14 @@ module.exports = {
         '@typescript-eslint/prefer-ts-expect-error': 'error',
         // This is more performant; see https://v8.dev/blog/fast-async.
         '@typescript-eslint/return-await': ['error', 'always'],
+        // This optimizes the dependency tracking for type-only files.
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            disallowTypeAnnotations: false,
+            fixStyle: 'inline-type-imports',
+          },
+        ],
       },
       overrides: [
         {

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -24,9 +24,9 @@ import yargs from 'yargs/yargs';
 
 import {
   resolveBuildId,
-  Browser,
+  type Browser,
   BrowserPlatform,
-  ChromeReleaseChannel,
+  type ChromeReleaseChannel,
 } from './browser-data/browser-data.js';
 import {Cache} from './Cache.js';
 import {detectBrowserPlatform} from './detectPlatform.js';

--- a/packages/browsers/src/Cache.ts
+++ b/packages/browsers/src/Cache.ts
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import {Browser, BrowserPlatform} from './browser-data/browser-data.js';
+import {Browser, type BrowserPlatform} from './browser-data/browser-data.js';
 import {computeExecutablePath} from './launch.js';
 
 /**

--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -19,7 +19,7 @@ import path from 'path';
 
 import {getJSON} from '../httpUtil.js';
 
-import {BrowserPlatform, ProfileOptions} from './types.js';
+import {BrowserPlatform, type ProfileOptions} from './types.js';
 
 function archive(platform: BrowserPlatform, buildId: string): string {
   switch (platform) {

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -21,8 +21,8 @@ import os from 'os';
 import path from 'path';
 
 import {
-  Browser,
-  BrowserPlatform,
+  type Browser,
+  type BrowserPlatform,
   downloadUrls,
 } from './browser-data/browser-data.js';
 import {Cache, InstalledBrowser} from './Cache.js';

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -21,11 +21,11 @@ import path from 'path';
 import readline from 'readline';
 
 import {
-  Browser,
-  BrowserPlatform,
+  type Browser,
+  type BrowserPlatform,
   executablePathByBrowser,
   resolveSystemExecutablePath,
-  ChromeReleaseChannel,
+  type ChromeReleaseChannel,
 } from './browser-data/browser-data.js';
 import {Cache} from './Cache.js';
 import {debug} from './debug.js';

--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -2,16 +2,16 @@ import {spawn} from 'child_process';
 
 import {
   createBuilder,
-  BuilderContext,
-  BuilderOutput,
+  type BuilderContext,
+  type BuilderOutput,
   targetFromTargetString,
-  BuilderRun,
+  type BuilderRun,
 } from '@angular-devkit/architect';
-import {JsonObject} from '@angular-devkit/core';
+import {type JsonObject} from '@angular-devkit/core';
 
 import {TestRunner} from '../../schematics/utils/types.js';
 
-import {PuppeteerBuilderOptions} from './types.js';
+import {type PuppeteerBuilderOptions} from './types.js';
 
 const terminalStyles = {
   cyan: '\u001b[36;1m',

--- a/packages/ng-schematics/src/builders/puppeteer/types.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/types.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {JsonObject} from '@angular-devkit/core';
+import {type JsonObject} from '@angular-devkit/core';
 
-import {TestRunner} from '../../schematics/utils/types.js';
+import {type TestRunner} from '../../schematics/utils/types.js';
 
 export interface PuppeteerBuilderOptions extends JsonObject {
   testRunner: TestRunner;

--- a/packages/ng-schematics/src/schematics/config/index.ts
+++ b/packages/ng-schematics/src/schematics/config/index.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-import {chain, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
+import {
+  chain,
+  type Rule,
+  type SchematicContext,
+  type Tree,
+} from '@angular-devkit/schematics';
 
 import {addFilesSingle} from '../utils/files.js';
-import {TestRunner, AngularProject} from '../utils/types.js';
+import {TestRunner, type AngularProject} from '../utils/types.js';
 
 // You don't have to export the function as default. You can also have more than one rule
 // factory per file.

--- a/packages/ng-schematics/src/schematics/e2e/index.ts
+++ b/packages/ng-schematics/src/schematics/e2e/index.ts
@@ -16,19 +16,19 @@
 
 import {
   chain,
-  Rule,
-  SchematicContext,
+  type Rule,
+  type SchematicContext,
   SchematicsException,
-  Tree,
+  type Tree,
 } from '@angular-devkit/schematics';
 
 import {addCommonFiles} from '../utils/files.js';
 import {getApplicationProjects} from '../utils/json.js';
 import {
   TestRunner,
-  SchematicsSpec,
-  AngularProject,
-  PuppeteerSchematicsConfig,
+  type SchematicsSpec,
+  type AngularProject,
+  type PuppeteerSchematicsConfig,
 } from '../utils/types.js';
 
 // You don't have to export the function as default. You can also have more than one rule

--- a/packages/ng-schematics/src/schematics/ng-add/index.ts
+++ b/packages/ng-schematics/src/schematics/ng-add/index.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import {chain, Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
+import {
+  chain,
+  type Rule,
+  type SchematicContext,
+  type Tree,
+} from '@angular-devkit/schematics';
 import {NodePackageInstallTask} from '@angular-devkit/schematics/tasks';
 import {of} from 'rxjs';
 import {concatMap, map, scan} from 'rxjs/operators';

--- a/packages/ng-schematics/src/schematics/utils/files.ts
+++ b/packages/ng-schematics/src/schematics/utils/files.ts
@@ -18,8 +18,8 @@ import {relative, resolve} from 'path';
 
 import {getSystemPath, normalize, strings} from '@angular-devkit/core';
 import {
-  SchematicContext,
-  Tree,
+  type SchematicContext,
+  type Tree,
   apply,
   applyTemplates,
   chain,
@@ -28,7 +28,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 
-import {AngularProject, TestRunner} from './types.js';
+import {type AngularProject, type TestRunner} from './types.js';
 
 export interface FilesOptions {
   options: {

--- a/packages/ng-schematics/src/schematics/utils/json.ts
+++ b/packages/ng-schematics/src/schematics/utils/json.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {SchematicsException, Tree} from '@angular-devkit/schematics';
+import {SchematicsException, type Tree} from '@angular-devkit/schematics';
 
 import type {AngularJson, AngularProject} from './types.js';
 

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -16,7 +16,7 @@
 
 import {get} from 'https';
 
-import {Tree} from '@angular-devkit/schematics';
+import {type Tree} from '@angular-devkit/schematics';
 
 import {getNgCommandName} from './files.js';
 import {
@@ -25,7 +25,7 @@ import {
   getJsonFileAsObject,
   getObjectAsJson,
 } from './json.js';
-import {SchematicsOptions, TestRunner} from './types.js';
+import {type SchematicsOptions, TestRunner} from './types.js';
 export interface NodePackage {
   name: string;
   version: string;

--- a/packages/ng-schematics/test/src/utils.ts
+++ b/packages/ng-schematics/test/src/utils.ts
@@ -1,10 +1,10 @@
 import https from 'https';
 import {join} from 'path';
 
-import {JsonObject} from '@angular-devkit/core';
+import {type JsonObject} from '@angular-devkit/core';
 import {
   SchematicTestRunner,
-  UnitTestTree,
+  type UnitTestTree,
 } from '@angular-devkit/schematics/testing';
 import sinon from 'sinon';
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -16,12 +16,12 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import {ChildProcess} from 'child_process';
+import {type ChildProcess} from 'child_process';
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 import {Symbol} from '../../third_party/disposablestack/disposablestack.js';
-import {EventEmitter, EventType} from '../common/EventEmitter.js';
+import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {debugError, waitWithTimeout} from '../common/util.js';
 import {Deferred} from '../util/Deferred.js';
 

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {EventEmitter, EventType} from '../common/EventEmitter.js';
+import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 
 import type {Browser, Permission} from './Browser.js';
-import {Page} from './Page.js';
+import {type Page} from './Page.js';
 import type {Target} from './Target.js';
 
 /**

--- a/packages/puppeteer-core/src/api/CDPSession.ts
+++ b/packages/puppeteer-core/src/api/CDPSession.ts
@@ -1,7 +1,7 @@
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
 import type {Connection} from '../common/Connection.js';
-import {EventEmitter, EventType} from '../common/EventEmitter.js';
+import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/Dialog.ts
+++ b/packages/puppeteer-core/src/api/Dialog.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 import {assert} from '../util/assert.js';
 

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -14,32 +14,32 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {Frame} from '../api/Frame.js';
+import {type Frame} from '../api/Frame.js';
 import {getQueryHandlerAndSelector} from '../common/GetQueryHandler.js';
-import {WaitForSelectorOptions} from '../common/IsolatedWorld.js';
+import {type WaitForSelectorOptions} from '../common/IsolatedWorld.js';
 import {LazyArg} from '../common/LazyArg.js';
 import {
-  ElementFor,
-  EvaluateFuncWith,
-  HandleFor,
-  HandleOr,
-  NodeFor,
+  type ElementFor,
+  type EvaluateFuncWith,
+  type HandleFor,
+  type HandleOr,
+  type NodeFor,
 } from '../common/types.js';
-import {KeyInput} from '../common/USKeyboardLayout.js';
+import {type KeyInput} from '../common/USKeyboardLayout.js';
 import {isString, withSourcePuppeteerURLIfNone} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
 import {
-  KeyboardTypeOptions,
-  KeyPressOptions,
-  MouseClickOptions,
+  type KeyboardTypeOptions,
+  type KeyPressOptions,
+  type MouseClickOptions,
 } from './Input.js';
 import {JSHandle} from './JSHandle.js';
-import {ScreenshotOptions} from './Page.js';
+import {type ScreenshotOptions} from './Page.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/Environment.ts
+++ b/packages/puppeteer-core/src/api/Environment.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {CDPSession} from './CDPSession.js';
-import {Realm} from './Realm.js';
+import {type CDPSession} from './CDPSession.js';
+import {type Realm} from './Realm.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
-import {ClickOptions, ElementHandle} from '../api/ElementHandle.js';
-import {HTTPResponse} from '../api/HTTPResponse.js';
-import {Page, WaitTimeoutOptions} from '../api/Page.js';
-import {DeviceRequestPrompt} from '../common/DeviceRequestPrompt.js';
-import {EventEmitter, EventType} from '../common/EventEmitter.js';
+import {type ClickOptions, type ElementHandle} from '../api/ElementHandle.js';
+import {type HTTPResponse} from '../api/HTTPResponse.js';
+import {type Page, type WaitTimeoutOptions} from '../api/Page.js';
+import {type DeviceRequestPrompt} from '../common/DeviceRequestPrompt.js';
+import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {getQueryHandlerAndSelector} from '../common/GetQueryHandler.js';
 import {transposeIterableHandle} from '../common/HandleIterator.js';
 import {
-  IsolatedWorldChart,
-  WaitForSelectorOptions,
+  type IsolatedWorldChart,
+  type WaitForSelectorOptions,
 } from '../common/IsolatedWorld.js';
 import {LazyArg} from '../common/LazyArg.js';
-import {PuppeteerLifeCycleEvent} from '../common/LifecycleWatcher.js';
+import {type PuppeteerLifeCycleEvent} from '../common/LifecycleWatcher.js';
 import {
-  Awaitable,
-  EvaluateFunc,
-  EvaluateFuncWith,
-  HandleFor,
-  NodeFor,
+  type Awaitable,
+  type EvaluateFunc,
+  type EvaluateFuncWith,
+  type HandleFor,
+  type NodeFor,
 } from '../common/types.js';
 import {
   getPageContent,
@@ -44,10 +44,14 @@ import {
 import {assert} from '../util/assert.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
-import {CDPSession} from './CDPSession.js';
-import {KeyboardTypeOptions} from './Input.js';
-import {FunctionLocator, Locator, NodeLocator} from './locators/locators.js';
-import {Realm} from './Realm.js';
+import {type CDPSession} from './CDPSession.js';
+import {type KeyboardTypeOptions} from './Input.js';
+import {
+  FunctionLocator,
+  type Locator,
+  NodeLocator,
+} from './locators/locators.js';
+import {type Realm} from './Realm.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from './CDPSession.js';
-import {Frame} from './Frame.js';
-import {HTTPResponse} from './HTTPResponse.js';
+import {type CDPSession} from './CDPSession.js';
+import {type Frame} from './Frame.js';
+import {type HTTPResponse} from './HTTPResponse.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
-import {SecurityDetails} from '../common/SecurityDetails.js';
+import {type SecurityDetails} from '../common/SecurityDetails.js';
 
-import {Frame} from './Frame.js';
-import {HTTPRequest} from './HTTPRequest.js';
+import {type Frame} from './Frame.js';
+import {type HTTPRequest} from './HTTPRequest.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/Input.ts
+++ b/packages/puppeteer-core/src/api/Input.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {KeyInput} from '../common/USKeyboardLayout.js';
+import {type KeyInput} from '../common/USKeyboardLayout.js';
 
-import {Point} from './ElementHandle.js';
+import {type Point} from './ElementHandle.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/JSHandle.ts
+++ b/packages/puppeteer-core/src/api/JSHandle.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
 import {Symbol} from '../../third_party/disposablestack/disposablestack.js';
 import {
-  EvaluateFuncWith,
-  HandleFor,
-  HandleOr,
-  Moveable,
+  type EvaluateFuncWith,
+  type HandleFor,
+  type HandleOr,
+  type Moveable,
 } from '../common/types.js';
 import {debugError, withSourcePuppeteerURLIfNone} from '../common/util.js';
 import {moveable, throwIfDisposed} from '../util/decorators.js';
 
-import {ElementHandle} from './ElementHandle.js';
-import {Realm} from './Realm.js';
+import {type ElementHandle} from './ElementHandle.js';
+import {type Realm} from './Realm.js';
 
 /**
  * Represents a reference to a JavaScript object. Instances can be created using

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -16,7 +16,7 @@
 
 import type {Readable} from 'stream';
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 import {
   delay,
@@ -28,7 +28,7 @@ import {
   fromEvent,
   map,
   merge,
-  Observable,
+  type Observable,
   of,
   raceWith,
   startWith,
@@ -40,29 +40,29 @@ import type {Accessibility} from '../common/Accessibility.js';
 import type {BidiNetworkManager} from '../common/bidi/NetworkManager.js';
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
 import type {Coverage} from '../common/Coverage.js';
-import {Device} from '../common/Device.js';
-import {DeviceRequestPrompt} from '../common/DeviceRequestPrompt.js';
+import {type Device} from '../common/Device.js';
+import {type DeviceRequestPrompt} from '../common/DeviceRequestPrompt.js';
 import {TargetCloseError} from '../common/Errors.js';
 import {
   EventEmitter,
-  EventsWithWildcard,
-  EventType,
-  Handler,
+  type EventsWithWildcard,
+  type EventType,
+  type Handler,
 } from '../common/EventEmitter.js';
 import type {FileChooser} from '../common/FileChooser.js';
 import type {WaitForSelectorOptions} from '../common/IsolatedWorld.js';
 import type {PuppeteerLifeCycleEvent} from '../common/LifecycleWatcher.js';
 import {
-  NetworkManager as CdpNetworkManager,
-  Credentials,
-  NetworkConditions,
+  type NetworkManager as CdpNetworkManager,
+  type Credentials,
+  type NetworkConditions,
   NetworkManagerEvent,
 } from '../common/NetworkManager.js';
 import {
-  LowerCasePaperFormat,
+  type LowerCasePaperFormat,
   paperFormats,
-  ParsedPDFOptions,
-  PDFOptions,
+  type ParsedPDFOptions,
+  type PDFOptions,
 } from '../common/PDFOptions.js';
 import type {Viewport} from '../common/PuppeteerViewport.js';
 import type {Tracing} from '../common/Tracing.js';
@@ -83,7 +83,7 @@ import {
 } from '../common/util.js';
 import type {WebWorker} from '../common/WebWorker.js';
 import {assert} from '../util/assert.js';
-import {Deferred} from '../util/Deferred.js';
+import {type Deferred} from '../util/Deferred.js';
 
 import type {Browser} from './Browser.js';
 import type {BrowserContext} from './BrowserContext.js';
@@ -96,10 +96,15 @@ import type {
   FrameAddStyleTagOptions,
   FrameWaitForFunctionOptions,
 } from './Frame.js';
-import {Keyboard, KeyboardTypeOptions, Mouse, Touchscreen} from './Input.js';
+import {
+  type Keyboard,
+  type KeyboardTypeOptions,
+  type Mouse,
+  type Touchscreen,
+} from './Input.js';
 import type {JSHandle} from './JSHandle.js';
 import {
-  AwaitedLocator,
+  type AwaitedLocator,
   FunctionLocator,
   Locator,
   NodeLocator,

--- a/packages/puppeteer-core/src/api/Realm.ts
+++ b/packages/puppeteer-core/src/api/Realm.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-import {TimeoutSettings} from '../common/TimeoutSettings.js';
-import {EvaluateFunc, HandleFor, InnerLazyParams} from '../common/types.js';
+import {type TimeoutSettings} from '../common/TimeoutSettings.js';
+import {
+  type EvaluateFunc,
+  type HandleFor,
+  type InnerLazyParams,
+} from '../common/types.js';
 import {TaskManager, WaitTask} from '../common/WaitTask.js';
 
-import {ElementHandle} from './ElementHandle.js';
-import {Environment} from './Environment.js';
-import {JSHandle} from './JSHandle.js';
+import {type ElementHandle} from './ElementHandle.js';
+import {type Environment} from './Environment.js';
+import {type JSHandle} from './JSHandle.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/Target.ts
+++ b/packages/puppeteer-core/src/api/Target.ts
@@ -16,10 +16,10 @@
 
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
-import {Page} from '../api/Page.js';
-import {WebWorker} from '../common/WebWorker.js';
+import {type Page} from '../api/Page.js';
+import {type WebWorker} from '../common/WebWorker.js';
 
-import {CDPSession} from './CDPSession.js';
+import {type CDPSession} from './CDPSession.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/locators/DelegatedLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/DelegatedLocator.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {Observable} from '../../../third_party/rxjs/rxjs.js';
-import {HandleFor} from '../../common/common.js';
+import {type Observable} from '../../../third_party/rxjs/rxjs.js';
+import {type HandleFor} from '../../common/common.js';
 
-import {Locator, VisibilityOption} from './locators.js';
+import {Locator, type VisibilityOption} from './locators.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/locators/FilteredLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/FilteredLocator.ts
@@ -15,17 +15,17 @@
  */
 
 import {
-  Observable,
+  type Observable,
   filter,
   from,
   map,
   mergeMap,
   throwIfEmpty,
 } from '../../../third_party/rxjs/rxjs.js';
-import {Awaitable, HandleFor} from '../../common/common.js';
+import {type Awaitable, type HandleFor} from '../../common/common.js';
 
 import {DelegatedLocator} from './DelegatedLocator.js';
-import {ActionOptions, Locator} from './locators.js';
+import {type ActionOptions, type Locator} from './locators.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/locators/FunctionLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/FunctionLocator.ts
@@ -15,16 +15,16 @@
  */
 
 import {
-  Observable,
+  type Observable,
   defer,
   from,
   throwIfEmpty,
 } from '../../../third_party/rxjs/rxjs.js';
-import {Awaitable, HandleFor} from '../../common/types.js';
-import {Frame} from '../Frame.js';
-import {Page} from '../Page.js';
+import {type Awaitable, type HandleFor} from '../../common/types.js';
+import {type Frame} from '../Frame.js';
+import {type Page} from '../Page.js';
 
-import {ActionOptions, Locator} from './locators.js';
+import {type ActionOptions, Locator} from './locators.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/locators/Locator.ts
+++ b/packages/puppeteer-core/src/api/locators/Locator.ts
@@ -16,8 +16,8 @@
 
 import {
   EMPTY,
-  Observable,
-  OperatorFunction,
+  type Observable,
+  type OperatorFunction,
   catchError,
   defaultIfEmpty,
   defer,
@@ -37,19 +37,23 @@ import {
   retry,
   tap,
 } from '../../../third_party/rxjs/rxjs.js';
-import {EventEmitter, EventType} from '../../common/EventEmitter.js';
-import {HandleFor} from '../../common/types.js';
+import {EventEmitter, type EventType} from '../../common/EventEmitter.js';
+import {type HandleFor} from '../../common/types.js';
 import {debugError, timeout} from '../../common/util.js';
-import {BoundingBox, ClickOptions, ElementHandle} from '../ElementHandle.js';
+import {
+  type BoundingBox,
+  type ClickOptions,
+  type ElementHandle,
+} from '../ElementHandle.js';
 
 import {
-  Action,
-  AwaitedLocator,
+  type Action,
+  type AwaitedLocator,
   FilteredLocator,
-  HandleMapper,
+  type HandleMapper,
   MappedLocator,
-  Mapper,
-  Predicate,
+  type Mapper,
+  type Predicate,
   RaceLocator,
 } from './locators.js';
 

--- a/packages/puppeteer-core/src/api/locators/MappedLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/MappedLocator.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
-import {Observable, from, mergeMap} from '../../../third_party/rxjs/rxjs.js';
-import {Awaitable, HandleFor} from '../../common/common.js';
+import {
+  type Observable,
+  from,
+  mergeMap,
+} from '../../../third_party/rxjs/rxjs.js';
+import {type Awaitable, type HandleFor} from '../../common/common.js';
 
-import {ActionOptions, DelegatedLocator, Locator} from './locators.js';
+import {
+  type ActionOptions,
+  DelegatedLocator,
+  type Locator,
+} from './locators.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/locators/NodeLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/NodeLocator.ts
@@ -16,7 +16,7 @@
 
 import {
   EMPTY,
-  Observable,
+  type Observable,
   defer,
   filter,
   first,
@@ -26,11 +26,11 @@ import {
   retry,
   throwIfEmpty,
 } from '../../../third_party/rxjs/rxjs.js';
-import {HandleFor, NodeFor} from '../../common/types.js';
-import {Frame} from '../Frame.js';
-import {Page} from '../Page.js';
+import {type HandleFor, type NodeFor} from '../../common/types.js';
+import {type Frame} from '../Frame.js';
+import {type Page} from '../Page.js';
 
-import {ActionOptions, Locator, RETRY_DELAY} from './locators.js';
+import {type ActionOptions, Locator, RETRY_DELAY} from './locators.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/locators/RaceLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/RaceLocator.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {Observable, race} from '../../../third_party/rxjs/rxjs.js';
-import {HandleFor} from '../../puppeteer-core.js';
+import {type Observable, race} from '../../../third_party/rxjs/rxjs.js';
+import {type HandleFor} from '../../puppeteer-core.js';
 
-import {ActionOptions, Locator} from './locators.js';
+import {type ActionOptions, Locator} from './locators.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/Accessibility.ts
+++ b/packages/puppeteer-core/src/common/Accessibility.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {ElementHandle} from '../api/ElementHandle.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type ElementHandle} from '../api/ElementHandle.js';
 
 /**
  * Represents a Node and the properties of it that are relevant to Accessibility.

--- a/packages/puppeteer-core/src/common/AriaQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/AriaQueryHandler.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {ElementHandle} from '../api/ElementHandle.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type ElementHandle} from '../api/ElementHandle.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 
-import {IsolatedWorld} from './IsolatedWorld.js';
-import {QueryHandler, QuerySelector} from './QueryHandler.js';
-import {AwaitableIterable} from './types.js';
+import {type IsolatedWorld} from './IsolatedWorld.js';
+import {QueryHandler, type QuerySelector} from './QueryHandler.js';
+import {type AwaitableIterable} from './types.js';
 
 const queryAXTree = async (
   client: CDPSession,

--- a/packages/puppeteer-core/src/common/Binding.ts
+++ b/packages/puppeteer-core/src/common/Binding.ts
@@ -1,7 +1,7 @@
 import {JSHandle} from '../api/JSHandle.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
-import {ExecutionContext} from './ExecutionContext.js';
+import {type ExecutionContext} from './ExecutionContext.js';
 import {debugError} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/Browser.ts
+++ b/packages/puppeteer-core/src/common/Browser.ts
@@ -14,40 +14,40 @@
  * limitations under the License.
  */
 
-import {ChildProcess} from 'child_process';
+import {type ChildProcess} from 'child_process';
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 import {
   Browser as BrowserBase,
-  BrowserCloseCallback,
-  BrowserContextOptions,
+  type BrowserCloseCallback,
+  type BrowserContextOptions,
   BrowserEvent,
-  IsPageTargetCallback,
-  Permission,
-  TargetFilterCallback,
+  type IsPageTargetCallback,
+  type Permission,
+  type TargetFilterCallback,
   WEB_PERMISSION_TO_PROTOCOL_PERMISSION,
 } from '../api/Browser.js';
 import {BrowserContext, BrowserContextEvent} from '../api/BrowserContext.js';
-import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
-import {Page} from '../api/Page.js';
-import {Target} from '../api/Target.js';
+import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {type Page} from '../api/Page.js';
+import {type Target} from '../api/Target.js';
 import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {ChromeTargetManager} from './ChromeTargetManager.js';
-import {Connection} from './Connection.js';
+import {type Connection} from './Connection.js';
 import {FirefoxTargetManager} from './FirefoxTargetManager.js';
-import {Viewport} from './PuppeteerViewport.js';
+import {type Viewport} from './PuppeteerViewport.js';
 import {
-  CdpTarget,
+  type CdpTarget,
   DevToolsTarget,
   InitializationStatus,
   OtherTarget,
   PageTarget,
   WorkerTarget,
 } from './Target.js';
-import {TargetManager, TargetManagerEvent} from './TargetManager.js';
+import {type TargetManager, TargetManagerEvent} from './TargetManager.js';
 import {TaskQueue} from './TaskQueue.js';
 
 /**

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-import {IsPageTargetCallback, TargetFilterCallback} from '../api/Browser.js';
+import {
+  type IsPageTargetCallback,
+  type TargetFilterCallback,
+} from '../api/Browser.js';
 import {isNode} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
 import {CdpBrowser} from './Browser.js';
 import {Connection} from './Connection.js';
-import {ConnectionTransport} from './ConnectionTransport.js';
+import {type ConnectionTransport} from './ConnectionTransport.js';
 import {getFetch} from './fetch.js';
 import type {ConnectOptions} from './Puppeteer.js';
-import {Viewport} from './PuppeteerViewport.js';
+import {type Viewport} from './PuppeteerViewport.js';
 import {debugError} from './util.js';
 /**
  * Generic browser options that can be passed when launching any browser or when

--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ConnectionTransport} from './ConnectionTransport.js';
+import {type ConnectionTransport} from './ConnectionTransport.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/CDPSession.ts
+++ b/packages/puppeteer-core/src/common/CDPSession.ts
@@ -1,15 +1,19 @@
-import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+import {type ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
-import {CDPEvents, CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {
+  type CDPEvents,
+  CDPSession,
+  CDPSessionEvent,
+} from '../api/CDPSession.js';
 import {assert} from '../util/assert.js';
 
 import {
   CallbackRegistry,
-  Connection,
+  type Connection,
   createProtocolErrorMessage,
 } from './Connection.js';
 import {TargetCloseError} from './Errors.js';
-import {CdpTarget} from './Target.js';
+import {type CdpTarget} from './Target.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/common/ChromeTargetManager.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {TargetFilterCallback} from '../api/Browser.js';
+import {type TargetFilterCallback} from '../api/Browser.js';
 import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {TargetType} from '../api/Target.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {Connection} from './Connection.js';
+import {type Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
 import {CdpTarget, InitializationStatus} from './Target.js';
 import {
-  TargetFactory,
-  TargetManager,
+  type TargetFactory,
+  type TargetManager,
   TargetManagerEvent,
-  TargetManagerEvents,
+  type TargetManagerEvents,
 } from './TargetManager.js';
 import {debugError} from './util.js';
 

--- a/packages/puppeteer-core/src/common/Configuration.ts
+++ b/packages/puppeteer-core/src/common/Configuration.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Product} from './Product.js';
+import {type Product} from './Product.js';
 
 /**
  * Defines experiment options for Puppeteer.

--- a/packages/puppeteer-core/src/common/Connection.ts
+++ b/packages/puppeteer-core/src/common/Connection.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
 import {
-  CDPSession,
+  type CDPSession,
   CDPSessionEvent,
-  CDPSessionEvents,
+  type CDPSessionEvents,
 } from '../api/CDPSession.js';
 import {Deferred} from '../util/Deferred.js';
 

--- a/packages/puppeteer-core/src/common/ConsoleMessage.ts
+++ b/packages/puppeteer-core/src/common/ConsoleMessage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {JSHandle} from '../api/JSHandle.js';
+import {type JSHandle} from '../api/JSHandle.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/Coverage.ts
+++ b/packages/puppeteer-core/src/common/Coverage.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 import {assert} from '../util/assert.js';
 
 import {EventSubscription} from './EventEmitter.js';

--- a/packages/puppeteer-core/src/common/CustomQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/CustomQueryHandler.ts
@@ -18,7 +18,11 @@ import type PuppeteerUtil from '../injected/injected.js';
 import {assert} from '../util/assert.js';
 import {interpolateFunction, stringifyFunction} from '../util/Function.js';
 
-import {QueryHandler, QuerySelector, QuerySelectorAll} from './QueryHandler.js';
+import {
+  QueryHandler,
+  type QuerySelector,
+  type QuerySelectorAll,
+} from './QueryHandler.js';
 import {scriptInjector} from './ScriptInjector.js';
 
 /**

--- a/packages/puppeteer-core/src/common/Device.ts
+++ b/packages/puppeteer-core/src/common/Device.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Viewport} from './PuppeteerViewport.js';
+import {type Viewport} from './PuppeteerViewport.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/DeviceRequestPrompt.test.ts
+++ b/packages/puppeteer-core/src/common/DeviceRequestPrompt.test.ts
@@ -18,7 +18,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {CDPSessionEvents} from '../api/CDPSession.js';
+import {type CDPSessionEvents} from '../api/CDPSession.js';
 
 import {
   DeviceRequestPrompt,

--- a/packages/puppeteer-core/src/common/DeviceRequestPrompt.ts
+++ b/packages/puppeteer-core/src/common/DeviceRequestPrompt.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {WaitTimeoutOptions} from '../api/Page.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type WaitTimeoutOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {TimeoutSettings} from './TimeoutSettings.js';
+import {type TimeoutSettings} from './TimeoutSettings.js';
 
 /**
  * Device in a request prompt.

--- a/packages/puppeteer-core/src/common/Dialog.ts
+++ b/packages/puppeteer-core/src/common/Dialog.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 import {Dialog} from '../api/Dialog.js';
 
 /**

--- a/packages/puppeteer-core/src/common/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/ElementHandle.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {AutofillData, ElementHandle} from '../api/ElementHandle.js';
-import {Page, ScreenshotOptions} from '../api/Page.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type AutofillData, ElementHandle} from '../api/ElementHandle.js';
+import {type Page, type ScreenshotOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
-import {CdpFrame} from './Frame.js';
-import {FrameManager} from './FrameManager.js';
-import {IsolatedWorld} from './IsolatedWorld.js';
+import {type CdpFrame} from './Frame.js';
+import {type FrameManager} from './FrameManager.js';
+import {type IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
 import {debugError} from './util.js';
 

--- a/packages/puppeteer-core/src/common/EmulationManager.ts
+++ b/packages/puppeteer-core/src/common/EmulationManager.ts
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
-import {GeolocationOptions, MediaFeature} from '../api/Page.js';
+import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {type GeolocationOptions, type MediaFeature} from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {invokeAtMostOnceForArguments} from '../util/decorators.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
-import {Viewport} from './PuppeteerViewport.js';
+import {type Viewport} from './PuppeteerViewport.js';
 import {debugError} from './util.js';
 
 interface ViewportState {

--- a/packages/puppeteer-core/src/common/EventEmitter.ts
+++ b/packages/puppeteer-core/src/common/EventEmitter.ts
@@ -16,9 +16,9 @@
 
 import {Symbol} from '../../third_party/disposablestack/disposablestack.js';
 import mitt, {
-  Emitter,
-  EventHandlerMap,
-  EventType,
+  type Emitter,
+  type EventHandlerMap,
+  type EventType,
 } from '../../third_party/mitt/index.js';
 
 export {

--- a/packages/puppeteer-core/src/common/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/common/ExecutionContext.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 import type {ElementHandle} from '../api/ElementHandle.js';
-import {JSHandle} from '../api/JSHandle.js';
+import {type JSHandle} from '../api/JSHandle.js';
 import type PuppeteerUtil from '../injected/injected.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {stringifyFunction} from '../util/Function.js';
@@ -26,11 +26,11 @@ import {stringifyFunction} from '../util/Function.js';
 import {ARIAQueryHandler} from './AriaQueryHandler.js';
 import {Binding} from './Binding.js';
 import {CdpElementHandle} from './ElementHandle.js';
-import {IsolatedWorld} from './IsolatedWorld.js';
+import {type IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
 import {LazyArg} from './LazyArg.js';
 import {scriptInjector} from './ScriptInjector.js';
-import {EvaluateFunc, HandleFor} from './types.js';
+import {type EvaluateFunc, type HandleFor} from './types.js';
 import {
   PuppeteerURL,
   createEvaluationError,

--- a/packages/puppeteer-core/src/common/FileChooser.ts
+++ b/packages/puppeteer-core/src/common/FileChooser.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {ElementHandle} from '../api/ElementHandle.js';
+import {type ElementHandle} from '../api/ElementHandle.js';
 import {assert} from '../util/assert.js';
 
 /**

--- a/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/common/FirefoxTargetManager.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {TargetFilterCallback} from '../api/Browser.js';
-import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {type TargetFilterCallback} from '../api/Browser.js';
+import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {Connection} from './Connection.js';
+import {type Connection} from './Connection.js';
 import {EventEmitter} from './EventEmitter.js';
-import {CdpTarget} from './Target.js';
+import {type CdpTarget} from './Target.js';
 import {
-  TargetFactory,
+  type TargetFactory,
   TargetManagerEvent,
-  TargetManager,
-  TargetManagerEvents,
+  type TargetManager,
+  type TargetManagerEvents,
 } from './TargetManager.js';
 
 /**

--- a/packages/puppeteer-core/src/common/Frame.ts
+++ b/packages/puppeteer-core/src/common/Frame.ts
@@ -14,24 +14,27 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 import {Frame, FrameEvent, throwIfDetached} from '../api/Frame.js';
-import {HTTPResponse} from '../api/HTTPResponse.js';
-import {Page, WaitTimeoutOptions} from '../api/Page.js';
+import {type HTTPResponse} from '../api/HTTPResponse.js';
+import {type Page, type WaitTimeoutOptions} from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
 import {
-  DeviceRequestPrompt,
-  DeviceRequestPromptManager,
+  type DeviceRequestPrompt,
+  type DeviceRequestPromptManager,
 } from './DeviceRequestPrompt.js';
-import {FrameManager} from './FrameManager.js';
+import {type FrameManager} from './FrameManager.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
-import {LifecycleWatcher, PuppeteerLifeCycleEvent} from './LifecycleWatcher.js';
+import {
+  LifecycleWatcher,
+  type PuppeteerLifeCycleEvent,
+} from './LifecycleWatcher.js';
 import {setPageContent} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/FrameManager.ts
+++ b/packages/puppeteer-core/src/common/FrameManager.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {FrameEvent} from '../api/Frame.js';
-import {Page} from '../api/Page.js';
+import {type Page} from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
@@ -26,15 +26,15 @@ import {isErrorLike} from '../util/ErrorLike.js';
 import {CdpCDPSession} from './CDPSession.js';
 import {isTargetClosedError} from './Connection.js';
 import {DeviceRequestPromptManager} from './DeviceRequestPrompt.js';
-import {EventEmitter, EventType} from './EventEmitter.js';
+import {EventEmitter, type EventType} from './EventEmitter.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {CdpFrame} from './Frame.js';
 import {FrameTree} from './FrameTree.js';
-import {IsolatedWorld} from './IsolatedWorld.js';
+import {type IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import {NetworkManager} from './NetworkManager.js';
-import {CdpTarget} from './Target.js';
-import {TimeoutSettings} from './TimeoutSettings.js';
+import {type CdpTarget} from './Target.js';
+import {type TimeoutSettings} from './TimeoutSettings.js';
 import {debugError, PuppeteerURL} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/FrameTree.ts
+++ b/packages/puppeteer-core/src/common/FrameTree.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Frame} from '../api/Frame.js';
+import {type Frame} from '../api/Frame.js';
 import {Deferred} from '../util/Deferred.js';
 
 /**

--- a/packages/puppeteer-core/src/common/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/common/HTTPRequest.ts
@@ -13,25 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {Frame} from '../api/Frame.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type Frame} from '../api/Frame.js';
 import {
-  ContinueRequestOverrides,
-  ErrorCode,
+  type ContinueRequestOverrides,
+  type ErrorCode,
   headersArray,
   HTTPRequest,
   InterceptResolutionAction,
-  InterceptResolutionState,
-  ResourceType,
-  ResponseForRequest,
+  type InterceptResolutionState,
+  type ResourceType,
+  type ResponseForRequest,
   STATUS_TEXTS,
 } from '../api/HTTPRequest.js';
-import {HTTPResponse} from '../api/HTTPResponse.js';
+import {type HTTPResponse} from '../api/HTTPResponse.js';
 import {assert} from '../util/assert.js';
 
-import {ProtocolError} from './Errors.js';
+import {type ProtocolError} from './Errors.js';
 import {debugError, isString} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/common/HTTPResponse.ts
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {Frame} from '../api/Frame.js';
-import {HTTPResponse, RemoteAddress} from '../api/HTTPResponse.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type Frame} from '../api/Frame.js';
+import {HTTPResponse, type RemoteAddress} from '../api/HTTPResponse.js';
 import {Deferred} from '../util/Deferred.js';
 
 import {ProtocolError} from './Errors.js';
-import {CdpHTTPRequest} from './HTTPRequest.js';
+import {type CdpHTTPRequest} from './HTTPRequest.js';
 import {SecurityDetails} from './SecurityDetails.js';
 
 /**

--- a/packages/puppeteer-core/src/common/HandleIterator.ts
+++ b/packages/puppeteer-core/src/common/HandleIterator.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {JSHandle} from '../api/JSHandle.js';
+import {type JSHandle} from '../api/JSHandle.js';
 
-import {AwaitableIterable, HandleFor} from './types.js';
+import {type AwaitableIterable, type HandleFor} from './types.js';
 
 const DEFAULT_BATCH_SIZE = 20;
 

--- a/packages/puppeteer-core/src/common/Input.ts
+++ b/packages/puppeteer-core/src/common/Input.ts
@@ -14,26 +14,30 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {Point} from '../api/ElementHandle.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type Point} from '../api/ElementHandle.js';
 import {
   Keyboard,
-  KeyDownOptions,
-  KeyPressOptions,
+  type KeyDownOptions,
+  type KeyPressOptions,
   Mouse,
   MouseButton,
-  MouseClickOptions,
-  MouseMoveOptions,
-  MouseOptions,
-  MouseWheelOptions,
+  type MouseClickOptions,
+  type MouseMoveOptions,
+  type MouseOptions,
+  type MouseWheelOptions,
   Touchscreen,
-  KeyboardTypeOptions,
+  type KeyboardTypeOptions,
 } from '../api/Input.js';
 import {assert} from '../util/assert.js';
 
-import {_keyDefinitions, KeyDefinition, KeyInput} from './USKeyboardLayout.js';
+import {
+  _keyDefinitions,
+  type KeyDefinition,
+  type KeyInput,
+} from './USKeyboardLayout.js';
 
 type KeyDescription = Required<
   Pick<KeyDefinition, 'keyCode' | 'key' | 'text' | 'code' | 'location'>

--- a/packages/puppeteer-core/src/common/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/common/IsolatedWorld.ts
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {JSHandle} from '../api/JSHandle.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type JSHandle} from '../api/JSHandle.js';
 import {Realm} from '../api/Realm.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {Binding} from './Binding.js';
-import {ExecutionContext} from './ExecutionContext.js';
+import {type Binding} from './Binding.js';
+import {type ExecutionContext} from './ExecutionContext.js';
 import {CdpFrame} from './Frame.js';
-import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
-import {TimeoutSettings} from './TimeoutSettings.js';
-import {BindingPayload, EvaluateFunc, HandleFor} from './types.js';
+import {type MAIN_WORLD, type PUPPETEER_WORLD} from './IsolatedWorlds.js';
+import {type TimeoutSettings} from './TimeoutSettings.js';
+import {
+  type BindingPayload,
+  type EvaluateFunc,
+  type HandleFor,
+} from './types.js';
 import {
   addPageBinding,
   createCdpHandle,
@@ -34,7 +38,7 @@ import {
   Mutex,
   withSourcePuppeteerURLIfNone,
 } from './util.js';
-import {WebWorker} from './WebWorker.js';
+import {type WebWorker} from './WebWorker.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/JSHandle.ts
+++ b/packages/puppeteer-core/src/common/JSHandle.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 import {JSHandle} from '../api/JSHandle.js';
 
 import type {CdpElementHandle} from './ElementHandle.js';
-import {IsolatedWorld} from './IsolatedWorld.js';
+import {type IsolatedWorld} from './IsolatedWorld.js';
 import {releaseObject, valueFromRemoteObject} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/LazyArg.ts
+++ b/packages/puppeteer-core/src/common/LazyArg.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {JSHandle} from '../api/JSHandle.js';
-import PuppeteerUtil from '../injected/injected.js';
+import {type JSHandle} from '../api/JSHandle.js';
+import type PuppeteerUtil from '../injected/injected.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/common/LifecycleWatcher.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
-import {Frame, FrameEvent} from '../api/Frame.js';
-import {HTTPResponse} from '../api/HTTPResponse.js';
+import {type Frame, FrameEvent} from '../api/Frame.js';
+import {type HTTPResponse} from '../api/HTTPResponse.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {TimeoutError} from './Errors.js';
+import {type TimeoutError} from './Errors.js';
 import {EventSubscription} from './EventEmitter.js';
-import {CdpFrame} from './Frame.js';
+import {type CdpFrame} from './Frame.js';
 import {FrameManagerEvent} from './FrameManager.js';
-import {CdpHTTPRequest} from './HTTPRequest.js';
-import {NetworkManager, NetworkManagerEvent} from './NetworkManager.js';
+import {type CdpHTTPRequest} from './HTTPRequest.js';
+import {type NetworkManager, NetworkManagerEvent} from './NetworkManager.js';
 /**
  * @public
  */

--- a/packages/puppeteer-core/src/common/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkEventManager.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CdpHTTPRequest} from './HTTPRequest.js';
+import {type CdpHTTPRequest} from './HTTPRequest.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.test.ts
@@ -18,12 +18,12 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {CDPSessionEvents} from '../api/CDPSession.js';
-import {HTTPRequest} from '../api/HTTPRequest.js';
-import {HTTPResponse} from '../api/HTTPResponse.js';
+import {type CDPSessionEvents} from '../api/CDPSession.js';
+import {type HTTPRequest} from '../api/HTTPRequest.js';
+import {type HTTPResponse} from '../api/HTTPResponse.js';
 
 import {EventEmitter} from './EventEmitter.js';
-import {CdpFrame} from './Frame.js';
+import {type CdpFrame} from './Frame.js';
 import {NetworkManager, NetworkManagerEvent} from './NetworkManager.js';
 
 // TODO: develop a helper to generate fake network events for attributes that

--- a/packages/puppeteer-core/src/common/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/NetworkManager.ts
@@ -16,14 +16,21 @@
 
 import type {Protocol} from 'devtools-protocol';
 
-import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import type {Frame} from '../api/Frame.js';
 import {assert} from '../util/assert.js';
 
-import {EventEmitter, EventSubscription, EventType} from './EventEmitter.js';
+import {
+  EventEmitter,
+  EventSubscription,
+  type EventType,
+} from './EventEmitter.js';
 import {CdpHTTPRequest} from './HTTPRequest.js';
 import {CdpHTTPResponse} from './HTTPResponse.js';
-import {FetchRequestId, NetworkEventManager} from './NetworkEventManager.js';
+import {
+  type FetchRequestId,
+  NetworkEventManager,
+} from './NetworkEventManager.js';
 import {debugError, isString} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/NodeWebSocketTransport.ts
@@ -15,7 +15,7 @@
  */
 import NodeWebSocket from 'ws';
 
-import {ConnectionTransport} from '../common/ConnectionTransport.js';
+import {type ConnectionTransport} from '../common/ConnectionTransport.js';
 import {packageVersion} from '../generated/version.js';
 
 /**

--- a/packages/puppeteer-core/src/common/PQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/PQueryHandler.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {QueryHandler, QuerySelector, QuerySelectorAll} from './QueryHandler.js';
+import {
+  QueryHandler,
+  type QuerySelector,
+  type QuerySelectorAll,
+} from './QueryHandler.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/Page.ts
+++ b/packages/puppeteer-core/src/common/Page.ts
@@ -20,23 +20,23 @@ import {Protocol} from 'devtools-protocol';
 
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
-import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
-import {ElementHandle} from '../api/ElementHandle.js';
-import {Frame} from '../api/Frame.js';
-import {HTTPRequest} from '../api/HTTPRequest.js';
-import {HTTPResponse} from '../api/HTTPResponse.js';
-import {JSHandle} from '../api/JSHandle.js';
+import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {type ElementHandle} from '../api/ElementHandle.js';
+import {type Frame} from '../api/Frame.js';
+import {type HTTPRequest} from '../api/HTTPRequest.js';
+import {type HTTPResponse} from '../api/HTTPResponse.js';
+import {type JSHandle} from '../api/JSHandle.js';
 import {
-  GeolocationOptions,
-  MediaFeature,
-  Metrics,
-  NewDocumentScriptEvaluation,
+  type GeolocationOptions,
+  type MediaFeature,
+  type Metrics,
+  type NewDocumentScriptEvaluation,
   Page,
   PageEvent,
-  ScreenshotClip,
-  ScreenshotOptions,
-  WaitForOptions,
-  WaitTimeoutOptions,
+  type ScreenshotClip,
+  type ScreenshotOptions,
+  type WaitForOptions,
+  type WaitTimeoutOptions,
 } from '../api/Page.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
@@ -46,30 +46,30 @@ import {Accessibility} from './Accessibility.js';
 import {Binding} from './Binding.js';
 import {CdpCDPSession} from './CDPSession.js';
 import {isTargetClosedError} from './Connection.js';
-import {ConsoleMessage, ConsoleMessageType} from './ConsoleMessage.js';
+import {ConsoleMessage, type ConsoleMessageType} from './ConsoleMessage.js';
 import {Coverage} from './Coverage.js';
-import {DeviceRequestPrompt} from './DeviceRequestPrompt.js';
+import {type DeviceRequestPrompt} from './DeviceRequestPrompt.js';
 import {CdpDialog} from './Dialog.js';
 import {EmulationManager} from './EmulationManager.js';
 import {TargetCloseError} from './Errors.js';
 import {FileChooser} from './FileChooser.js';
-import {CdpFrame} from './Frame.js';
+import {type CdpFrame} from './Frame.js';
 import {FrameManager, FrameManagerEvent} from './FrameManager.js';
 import {CdpKeyboard, CdpMouse, CdpTouchscreen} from './Input.js';
 import {MAIN_WORLD} from './IsolatedWorlds.js';
 import {
-  Credentials,
-  NetworkConditions,
+  type Credentials,
+  type NetworkConditions,
   NetworkManagerEvent,
 } from './NetworkManager.js';
-import {PDFOptions} from './PDFOptions.js';
-import {Viewport} from './PuppeteerViewport.js';
-import {CdpTarget} from './Target.js';
+import {type PDFOptions} from './PDFOptions.js';
+import {type Viewport} from './PuppeteerViewport.js';
+import {type CdpTarget} from './Target.js';
 import {TargetManagerEvent} from './TargetManager.js';
-import {TaskQueue} from './TaskQueue.js';
+import {type TaskQueue} from './TaskQueue.js';
 import {TimeoutSettings} from './TimeoutSettings.js';
 import {Tracing} from './Tracing.js';
-import {BindingPayload, HandleFor} from './types.js';
+import {type BindingPayload, type HandleFor} from './types.js';
 import {
   createCdpHandle,
   createClientError,

--- a/packages/puppeteer-core/src/common/PredefinedNetworkConditions.ts
+++ b/packages/puppeteer-core/src/common/PredefinedNetworkConditions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {NetworkConditions} from './NetworkManager.js';
+import {type NetworkConditions} from './NetworkManager.js';
 
 /**
  * A list of network conditions to be used with

--- a/packages/puppeteer-core/src/common/Puppeteer.ts
+++ b/packages/puppeteer-core/src/common/Puppeteer.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-import {Browser} from '../api/Browser.js';
+import {type Browser} from '../api/Browser.js';
 
 import {
-  BrowserConnectOptions,
+  type BrowserConnectOptions,
   _connectToCdpBrowser,
 } from './BrowserConnector.js';
-import {ConnectionTransport} from './ConnectionTransport.js';
-import {CustomQueryHandler, customQueryHandlers} from './CustomQueryHandler.js';
+import {type ConnectionTransport} from './ConnectionTransport.js';
+import {
+  type CustomQueryHandler,
+  customQueryHandlers,
+} from './CustomQueryHandler.js';
 
 /**
  * Settings that are common to the Puppeteer class, regardless of environment.

--- a/packages/puppeteer-core/src/common/SecurityDetails.ts
+++ b/packages/puppeteer-core/src/common/SecurityDetails.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 /**
  * The SecurityDetails class represents the security details of a

--- a/packages/puppeteer-core/src/common/Target.ts
+++ b/packages/puppeteer-core/src/common/Target.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
-import {CDPSession} from '../api/CDPSession.js';
-import {Page, PageEvent} from '../api/Page.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type Page, PageEvent} from '../api/Page.js';
 import {Target, TargetType} from '../api/Target.js';
 import {Deferred} from '../util/Deferred.js';
 
 import {CdpCDPSession} from './CDPSession.js';
 import {CdpPage} from './Page.js';
-import {Viewport} from './PuppeteerViewport.js';
-import {TargetManager} from './TargetManager.js';
-import {TaskQueue} from './TaskQueue.js';
+import {type Viewport} from './PuppeteerViewport.js';
+import {type TargetManager} from './TargetManager.js';
+import {type TaskQueue} from './TaskQueue.js';
 import {debugError} from './util.js';
 import {WebWorker} from './WebWorker.js';
 

--- a/packages/puppeteer-core/src/common/TargetManager.ts
+++ b/packages/puppeteer-core/src/common/TargetManager.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 
-import {EventEmitter, EventType} from './EventEmitter.js';
-import {CdpTarget} from './Target.js';
+import {type EventEmitter, type EventType} from './EventEmitter.js';
+import {type CdpTarget} from './Target.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/TextQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/TextQueryHandler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {QueryHandler, QuerySelectorAll} from './QueryHandler.js';
+import {QueryHandler, type QuerySelectorAll} from './QueryHandler.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/Tracing.ts
+++ b/packages/puppeteer-core/src/common/Tracing.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {CDPSession} from '../api/CDPSession.js';
+import {type CDPSession} from '../api/CDPSession.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {ElementHandle} from '../api/ElementHandle.js';
-import {JSHandle} from '../api/JSHandle.js';
-import {Realm} from '../api/Realm.js';
+import {type ElementHandle} from '../api/ElementHandle.js';
+import {type JSHandle} from '../api/JSHandle.js';
+import {type Realm} from '../api/Realm.js';
 import type {Poller} from '../injected/Poller.js';
 import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
@@ -24,7 +24,7 @@ import {stringifyFunction} from '../util/Function.js';
 
 import {TimeoutError} from './Errors.js';
 import {LazyArg} from './LazyArg.js';
-import {HandleFor} from './types.js';
+import {type HandleFor} from './types.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/WebWorker.ts
+++ b/packages/puppeteer-core/src/common/WebWorker.ts
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CDPSession} from '../api/CDPSession.js';
-import {Realm} from '../api/Realm.js';
+import {type CDPSession} from '../api/CDPSession.js';
+import {type Realm} from '../api/Realm.js';
 
-import {ConsoleMessageType} from './ConsoleMessage.js';
-import {EventEmitter, EventType} from './EventEmitter.js';
+import {type ConsoleMessageType} from './ConsoleMessage.js';
+import {EventEmitter, type EventType} from './EventEmitter.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
 import {TimeoutSettings} from './TimeoutSettings.js';
-import {EvaluateFunc, HandleFor} from './types.js';
+import {type EvaluateFunc, type HandleFor} from './types.js';
 import {debugError, withSourcePuppeteerURLIfNone} from './util.js';
 
 /**

--- a/packages/puppeteer-core/src/common/XPathQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/XPathQueryHandler.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {QueryHandler, QuerySelectorAll} from './QueryHandler.js';
+import {QueryHandler, type QuerySelectorAll} from './QueryHandler.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/common/bidi/BidiOverCdp.ts
@@ -15,13 +15,13 @@
  */
 
 import * as BidiMapper from 'chromium-bidi/lib/cjs/bidiMapper/bidiMapper.js';
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
-import {CDPEvents, CDPSession} from '../../api/CDPSession.js';
-import {Connection as CdpConnection} from '../Connection.js';
+import {type CDPEvents, type CDPSession} from '../../api/CDPSession.js';
+import {type Connection as CdpConnection} from '../Connection.js';
 import {TargetCloseError} from '../Errors.js';
-import {Handler} from '../EventEmitter.js';
+import {type Handler} from '../EventEmitter.js';
 
 import {BidiConnection} from './Connection.js';
 

--- a/packages/puppeteer-core/src/common/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/common/bidi/Browser.ts
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-import {ChildProcess} from 'child_process';
+import {type ChildProcess} from 'child_process';
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {
   Browser,
-  BrowserCloseCallback,
-  BrowserContextOptions,
+  type BrowserCloseCallback,
+  type BrowserContextOptions,
   BrowserEvent,
 } from '../../api/Browser.js';
 import {BrowserContextEvent} from '../../api/BrowserContext.js';
-import {Page} from '../../api/Page.js';
-import {Target} from '../../api/Target.js';
-import {Handler} from '../EventEmitter.js';
-import {Viewport} from '../PuppeteerViewport.js';
+import {type Page} from '../../api/Page.js';
+import {type Target} from '../../api/Target.js';
+import {type Handler} from '../EventEmitter.js';
+import {type Viewport} from '../PuppeteerViewport.js';
 
 import {BidiBrowserContext} from './BrowserContext.js';
 import {BrowsingContext, BrowsingContextEvent} from './BrowsingContext.js';
-import {BidiConnection} from './Connection.js';
+import {type BidiConnection} from './Connection.js';
 import {
   BiDiBrowserTarget,
   BiDiBrowsingContextTarget,
   BiDiPageTarget,
-  BidiTarget,
+  type BidiTarget,
 } from './Target.js';
 import {debugError} from './utils.js';
 

--- a/packages/puppeteer-core/src/common/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/common/bidi/BrowserContext.ts
@@ -17,13 +17,13 @@
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {BrowserContext} from '../../api/BrowserContext.js';
-import {Page} from '../../api/Page.js';
-import {Target} from '../../api/Target.js';
-import {Viewport} from '../PuppeteerViewport.js';
+import {type Page} from '../../api/Page.js';
+import {type Target} from '../../api/Target.js';
+import {type Viewport} from '../PuppeteerViewport.js';
 
-import {BidiBrowser} from './Browser.js';
-import {BidiConnection} from './Connection.js';
-import {BidiPage} from './Page.js';
+import {type BidiBrowser} from './Browser.js';
+import {type BidiConnection} from './Connection.js';
+import {type BidiPage} from './Page.js';
 
 interface BrowserContextOptions {
   defaultViewport: Viewport | null;

--- a/packages/puppeteer-core/src/common/bidi/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/common/bidi/BrowsingContext.ts
@@ -1,17 +1,17 @@
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import ProtocolMapping from 'devtools-protocol/types/protocol-mapping.js';
+import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping.js';
 
 import {CDPSession} from '../../api/CDPSession.js';
-import {WaitForOptions} from '../../api/Page.js';
+import {type WaitForOptions} from '../../api/Page.js';
 import {assert} from '../../util/assert.js';
 import {Deferred} from '../../util/Deferred.js';
-import {Connection as CdpConnection} from '../Connection.js';
+import {type Connection as CdpConnection} from '../Connection.js';
 import {ProtocolError, TargetCloseError, TimeoutError} from '../Errors.js';
-import {EventType} from '../EventEmitter.js';
-import {PuppeteerLifeCycleEvent} from '../LifecycleWatcher.js';
+import {type EventType} from '../EventEmitter.js';
+import {type PuppeteerLifeCycleEvent} from '../LifecycleWatcher.js';
 import {setPageContent, waitWithTimeout} from '../util.js';
 
-import {BidiConnection} from './Connection.js';
+import {type BidiConnection} from './Connection.js';
 import {Realm} from './Realm.js';
 import {debugError} from './utils.js';
 

--- a/packages/puppeteer-core/src/common/bidi/Connection.test.ts
+++ b/packages/puppeteer-core/src/common/bidi/Connection.test.ts
@@ -18,7 +18,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {ConnectionTransport} from '../ConnectionTransport.js';
+import {type ConnectionTransport} from '../ConnectionTransport.js';
 
 import {BidiConnection} from './Connection.js';
 

--- a/packages/puppeteer-core/src/common/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/common/bidi/Connection.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {CallbackRegistry} from '../Connection.js';
-import {ConnectionTransport} from '../ConnectionTransport.js';
+import {type ConnectionTransport} from '../ConnectionTransport.js';
 import {debug} from '../Debug.js';
 import {EventEmitter} from '../EventEmitter.js';
 
-import {BrowsingContext, cdpSessions} from './BrowsingContext.js';
+import {type BrowsingContext, cdpSessions} from './BrowsingContext.js';
 import {debugError} from './utils.js';
 
 const debugProtocolSend = debug('puppeteer:webDriverBiDi:SEND ►');

--- a/packages/puppeteer-core/src/common/bidi/Dialog.ts
+++ b/packages/puppeteer-core/src/common/bidi/Dialog.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {Dialog} from '../../api/Dialog.js';
 
-import {BrowsingContext} from './BrowsingContext.js';
+import {type BrowsingContext} from './BrowsingContext.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/common/bidi/ElementHandle.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {AutofillData, ElementHandle} from '../../api/ElementHandle.js';
+import {type AutofillData, ElementHandle} from '../../api/ElementHandle.js';
 import {throwIfDisposed} from '../../util/decorators.js';
 
-import {BidiFrame} from './Frame.js';
+import {type BidiFrame} from './Frame.js';
 import {BidiJSHandle} from './JSHandle.js';
-import {Realm} from './Realm.js';
-import {Sandbox} from './Sandbox.js';
+import {type Realm} from './Realm.js';
+import {type Sandbox} from './Sandbox.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/EmulationManager.ts
+++ b/packages/puppeteer-core/src/common/bidi/EmulationManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {BrowsingContext} from './BrowsingContext.js';
+import {type BrowsingContext} from './BrowsingContext.js';
 
 interface Viewport {
   width: number;

--- a/packages/puppeteer-core/src/common/bidi/ExposedFunction.ts
+++ b/packages/puppeteer-core/src/common/bidi/ExposedFunction.ts
@@ -19,10 +19,10 @@ import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import {assert} from '../../util/assert.js';
 import {Deferred} from '../../util/Deferred.js';
 import {interpolateFunction, stringifyFunction} from '../../util/Function.js';
-import {Awaitable, FlattenHandle} from '../types.js';
+import {type Awaitable, type FlattenHandle} from '../types.js';
 
-import {BidiConnection} from './Connection.js';
-import {BidiFrame} from './Frame.js';
+import {type BidiConnection} from './Connection.js';
+import {type BidiFrame} from './Frame.js';
 import {BidiSerializer} from './Serializer.js';
 import {debugError} from './utils.js';
 

--- a/packages/puppeteer-core/src/common/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/common/bidi/Frame.ts
@@ -16,28 +16,28 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {CDPSession} from '../../api/CDPSession.js';
+import {type CDPSession} from '../../api/CDPSession.js';
 import {Frame, throwIfDetached} from '../../api/Frame.js';
 import {Deferred} from '../../util/Deferred.js';
 import {UTILITY_WORLD_NAME} from '../FrameManager.js';
-import {PuppeteerLifeCycleEvent} from '../LifecycleWatcher.js';
-import {TimeoutSettings} from '../TimeoutSettings.js';
-import {Awaitable} from '../types.js';
+import {type PuppeteerLifeCycleEvent} from '../LifecycleWatcher.js';
+import {type TimeoutSettings} from '../TimeoutSettings.js';
+import {type Awaitable} from '../types.js';
 import {waitForEvent} from '../util.js';
 
 import {
-  BrowsingContext,
+  type BrowsingContext,
   getWaitUntilSingle,
   lifeCycleToSubscribedEvent,
 } from './BrowsingContext.js';
 import {ExposeableFunction} from './ExposedFunction.js';
-import {BidiHTTPResponse} from './HTTPResponse.js';
-import {BidiPage} from './Page.js';
+import {type BidiHTTPResponse} from './HTTPResponse.js';
+import {type BidiPage} from './Page.js';
 import {
   MAIN_SANDBOX,
   PUPPETEER_SANDBOX,
   Sandbox,
-  SandboxChart,
+  type SandboxChart,
 } from './Sandbox.js';
 
 /**

--- a/packages/puppeteer-core/src/common/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/common/bidi/HTTPRequest.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {Frame} from '../../api/Frame.js';
-import {HTTPRequest, ResourceType} from '../../api/HTTPRequest.js';
+import {type Frame} from '../../api/Frame.js';
+import {HTTPRequest, type ResourceType} from '../../api/HTTPRequest.js';
 
-import {BidiHTTPResponse} from './HTTPResponse.js';
+import {type BidiHTTPResponse} from './HTTPResponse.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/common/bidi/HTTPResponse.ts
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import Protocol from 'devtools-protocol';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type Protocol from 'devtools-protocol';
 
-import {Frame} from '../../api/Frame.js';
+import {type Frame} from '../../api/Frame.js';
 import {
   HTTPResponse as HTTPResponse,
-  RemoteAddress,
+  type RemoteAddress,
 } from '../../api/HTTPResponse.js';
 
-import {BidiHTTPRequest} from './HTTPRequest.js';
+import {type BidiHTTPRequest} from './HTTPRequest.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/Input.ts
+++ b/packages/puppeteer-core/src/common/bidi/Input.ts
@@ -16,23 +16,23 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {Point} from '../../api/ElementHandle.js';
+import {type Point} from '../../api/ElementHandle.js';
 import {
   Keyboard as BaseKeyboard,
   Mouse as BaseMouse,
   Touchscreen as BaseTouchscreen,
-  KeyDownOptions,
-  KeyPressOptions,
-  KeyboardTypeOptions,
+  type KeyDownOptions,
+  type KeyPressOptions,
+  type KeyboardTypeOptions,
   MouseButton,
-  MouseClickOptions,
-  MouseMoveOptions,
-  MouseOptions,
-  MouseWheelOptions,
+  type MouseClickOptions,
+  type MouseMoveOptions,
+  type MouseOptions,
+  type MouseWheelOptions,
 } from '../../api/Input.js';
-import {KeyInput} from '../USKeyboardLayout.js';
+import {type KeyInput} from '../USKeyboardLayout.js';
 
-import {BrowsingContext} from './BrowsingContext.js';
+import {type BrowsingContext} from './BrowsingContext.js';
 
 const enum InputId {
   Mouse = '__puppeteer_mouse',

--- a/packages/puppeteer-core/src/common/bidi/JSHandle.ts
+++ b/packages/puppeteer-core/src/common/bidi/JSHandle.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import Protocol from 'devtools-protocol';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type Protocol from 'devtools-protocol';
 
-import {ElementHandle} from '../../api/ElementHandle.js';
+import {type ElementHandle} from '../../api/ElementHandle.js';
 import {JSHandle} from '../../api/JSHandle.js';
 
-import {Realm} from './Realm.js';
-import {Sandbox} from './Sandbox.js';
+import {type Realm} from './Realm.js';
+import {type Sandbox} from './Sandbox.js';
 import {BidiSerializer} from './Serializer.js';
 import {releaseReference} from './utils.js';
 

--- a/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
+++ b/packages/puppeteer-core/src/common/bidi/NetworkManager.ts
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {EventEmitter, EventSubscription, EventType} from '../EventEmitter.js';
+import {
+  EventEmitter,
+  EventSubscription,
+  type EventType,
+} from '../EventEmitter.js';
 import {NetworkManagerEvent} from '../NetworkManager.js';
 
-import {BidiConnection} from './Connection.js';
-import {BidiFrame} from './Frame.js';
+import {type BidiConnection} from './Connection.js';
+import {type BidiFrame} from './Frame.js';
 import {BidiHTTPRequest} from './HTTPRequest.js';
 import {BidiHTTPResponse} from './HTTPResponse.js';
-import {BidiPage} from './Page.js';
+import {type BidiPage} from './Page.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/Page.ts
+++ b/packages/puppeteer-core/src/common/bidi/Page.ts
@@ -16,34 +16,37 @@
 
 import type {Readable} from 'stream';
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import Protocol from 'devtools-protocol';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type Protocol from 'devtools-protocol';
 
-import {CDPSession} from '../../api/CDPSession.js';
+import {type CDPSession} from '../../api/CDPSession.js';
 import {
-  GeolocationOptions,
-  MediaFeature,
-  NewDocumentScriptEvaluation,
+  type GeolocationOptions,
+  type MediaFeature,
+  type NewDocumentScriptEvaluation,
   Page,
   PageEvent,
-  ScreenshotOptions,
-  WaitForOptions,
+  type ScreenshotOptions,
+  type WaitForOptions,
 } from '../../api/Page.js';
 import {assert} from '../../util/assert.js';
 import {Deferred} from '../../util/Deferred.js';
 import {Accessibility} from '../Accessibility.js';
-import {ConsoleMessage, ConsoleMessageLocation} from '../ConsoleMessage.js';
+import {
+  ConsoleMessage,
+  type ConsoleMessageLocation,
+} from '../ConsoleMessage.js';
 import {Coverage} from '../Coverage.js';
 import {EmulationManager as CdpEmulationManager} from '../EmulationManager.js';
 import {TargetCloseError} from '../Errors.js';
-import {Handler} from '../EventEmitter.js';
+import {type Handler} from '../EventEmitter.js';
 import {FrameTree} from '../FrameTree.js';
 import {NetworkManagerEvent} from '../NetworkManager.js';
-import {PDFOptions} from '../PDFOptions.js';
-import {Viewport} from '../PuppeteerViewport.js';
+import {type PDFOptions} from '../PDFOptions.js';
+import {type Viewport} from '../PuppeteerViewport.js';
 import {TimeoutSettings} from '../TimeoutSettings.js';
 import {Tracing} from '../Tracing.js';
-import {Awaitable} from '../types.js';
+import {type Awaitable} from '../types.js';
 import {
   debugError,
   evaluationString,
@@ -53,19 +56,19 @@ import {
   waitWithTimeout,
 } from '../util.js';
 
-import {BidiBrowser} from './Browser.js';
-import {BidiBrowserContext} from './BrowserContext.js';
+import {type BidiBrowser} from './Browser.js';
+import {type BidiBrowserContext} from './BrowserContext.js';
 import {
-  BrowsingContext,
+  type BrowsingContext,
   BrowsingContextEvent,
   CdpSessionWrapper,
 } from './BrowsingContext.js';
-import {BidiConnection} from './Connection.js';
+import {type BidiConnection} from './Connection.js';
 import {BidiDialog} from './Dialog.js';
 import {EmulationManager} from './EmulationManager.js';
 import {BidiFrame} from './Frame.js';
-import {BidiHTTPRequest} from './HTTPRequest.js';
-import {BidiHTTPResponse} from './HTTPResponse.js';
+import {type BidiHTTPRequest} from './HTTPRequest.js';
+import {type BidiHTTPResponse} from './HTTPResponse.js';
 import {Keyboard, Mouse, Touchscreen} from './Input.js';
 import {BidiNetworkManager} from './NetworkManager.js';
 import {createBidiHandle} from './Realm.js';

--- a/packages/puppeteer-core/src/common/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/common/bidi/Realm.ts
@@ -1,20 +1,20 @@
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import PuppeteerUtil from '../../injected/injected.js';
+import type PuppeteerUtil from '../../injected/injected.js';
 import {stringifyFunction} from '../../util/Function.js';
-import {EventEmitter, EventType} from '../EventEmitter.js';
+import {EventEmitter, type EventType} from '../EventEmitter.js';
 import {scriptInjector} from '../ScriptInjector.js';
-import {EvaluateFunc, HandleFor} from '../types.js';
+import {type EvaluateFunc, type HandleFor} from '../types.js';
 import {
   PuppeteerURL,
   getSourcePuppeteerURLIfAvailable,
   isString,
 } from '../util.js';
 
-import {BidiConnection} from './Connection.js';
+import {type BidiConnection} from './Connection.js';
 import {BidiElementHandle} from './ElementHandle.js';
 import {BidiJSHandle} from './JSHandle.js';
-import {Sandbox} from './Sandbox.js';
+import {type Sandbox} from './Sandbox.js';
 import {BidiSerializer} from './Serializer.js';
 import {createEvaluationError} from './utils.js';
 

--- a/packages/puppeteer-core/src/common/bidi/Sandbox.ts
+++ b/packages/puppeteer-core/src/common/bidi/Sandbox.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import {JSHandle} from '../../api/JSHandle.js';
+import {type JSHandle} from '../../api/JSHandle.js';
 import {Realm} from '../../api/Realm.js';
-import {TimeoutSettings} from '../TimeoutSettings.js';
-import {EvaluateFunc, HandleFor} from '../types.js';
+import {type TimeoutSettings} from '../TimeoutSettings.js';
+import {type EvaluateFunc, type HandleFor} from '../types.js';
 import {withSourcePuppeteerURLIfNone} from '../util.js';
 
-import {BrowsingContext} from './BrowsingContext.js';
-import {BidiFrame} from './Frame.js';
-import {Realm as BidiRealm} from './Realm.js';
+import {type BrowsingContext} from './BrowsingContext.js';
+import {type BidiFrame} from './Frame.js';
+import {type Realm as BidiRealm} from './Realm.js';
 /**
  * A unique key for {@link SandboxChart} to denote the default world.
  * Realms are automatically created in the default sandbox.

--- a/packages/puppeteer-core/src/common/bidi/Serializer.ts
+++ b/packages/puppeteer-core/src/common/bidi/Serializer.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {LazyArg} from '../LazyArg.js';
 import {debugError, isDate, isPlainObject, isRegExp} from '../util.js';
 
 import {BidiElementHandle} from './ElementHandle.js';
 import {BidiJSHandle} from './JSHandle.js';
-import {Sandbox} from './Sandbox.js';
+import {type Sandbox} from './Sandbox.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/bidi/Target.ts
+++ b/packages/puppeteer-core/src/common/bidi/Target.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {CDPSession} from '../../api/CDPSession.js';
+import {type CDPSession} from '../../api/CDPSession.js';
 import {Target, TargetType} from '../../api/Target.js';
 import type {WebWorker} from '../WebWorker.js';
 
-import {BidiBrowser} from './Browser.js';
-import {BidiBrowserContext} from './BrowserContext.js';
-import {BrowsingContext, CdpSessionWrapper} from './BrowsingContext.js';
+import {type BidiBrowser} from './Browser.js';
+import {type BidiBrowserContext} from './BrowserContext.js';
+import {type BrowsingContext, CdpSessionWrapper} from './BrowsingContext.js';
 import {BidiPage} from './Page.js';
 
 /**

--- a/packages/puppeteer-core/src/common/bidi/utils.ts
+++ b/packages/puppeteer-core/src/common/bidi/utils.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {debug} from '../Debug.js';
 import {PuppeteerURL} from '../util.js';
 
-import {Realm} from './Realm.js';
+import {type Realm} from './Realm.js';
 import {BidiSerializer} from './Serializer.js';
 
 /**

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -18,11 +18,16 @@ import type {Readable} from 'stream';
 
 import type {Protocol} from 'devtools-protocol';
 
-import {map, NEVER, Observable, timer} from '../../third_party/rxjs/rxjs.js';
+import {
+  map,
+  NEVER,
+  timer,
+  type Observable,
+} from '../../third_party/rxjs/rxjs.js';
 import type {CDPSession} from '../api/CDPSession.js';
 import type {ElementHandle} from '../api/ElementHandle.js';
 import type {JSHandle} from '../api/JSHandle.js';
-import {Page} from '../api/Page.js';
+import {type Page} from '../api/Page.js';
 import {isNode} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
@@ -32,9 +37,9 @@ import {debug} from './Debug.js';
 import {CdpElementHandle} from './ElementHandle.js';
 import {TimeoutError} from './Errors.js';
 import {EventSubscription} from './EventEmitter.js';
-import {IsolatedWorld} from './IsolatedWorld.js';
+import {type IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
-import {Awaitable} from './types.js';
+import {type Awaitable} from './types.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/injected/PQuerySelector.ts
+++ b/packages/puppeteer-core/src/injected/PQuerySelector.ts
@@ -20,13 +20,13 @@ import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {ariaQuerySelectorAll} from './ARIAQuerySelector.js';
 import {customQuerySelectors} from './CustomQuerySelector.js';
 import {
-  ComplexPSelector,
-  ComplexPSelectorList,
-  CompoundPSelector,
-  CSSSelector,
+  type ComplexPSelector,
+  type ComplexPSelectorList,
+  type CompoundPSelector,
+  type CSSSelector,
   parsePSelectors,
   PCombinator,
-  PPseudoSelector,
+  type PPseudoSelector,
 } from './PSelectorParser.js';
 import {textQuerySelectorAll} from './TextQuerySelector.js';
 import {pierce, pierceAll} from './util.js';

--- a/packages/puppeteer-core/src/injected/PSelectorParser.ts
+++ b/packages/puppeteer-core/src/injected/PSelectorParser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Token, tokenize, TOKENS, stringify} from 'parsel-js';
+import {type Token, tokenize, TOKENS, stringify} from 'parsel-js';
 
 export type CSSSelector = string;
 export interface PPseudoSelector {

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -23,18 +23,18 @@ import {
   ChromeReleaseChannel as BrowsersChromeReleaseChannel,
 } from '@puppeteer/browsers';
 
-import {Browser} from '../api/Browser.js';
+import {type Browser} from '../api/Browser.js';
 import {debugError} from '../common/util.js';
 import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {
-  BrowserLaunchArgumentOptions,
-  ChromeReleaseChannel,
-  PuppeteerNodeLaunchOptions,
+  type BrowserLaunchArgumentOptions,
+  type ChromeReleaseChannel,
+  type PuppeteerNodeLaunchOptions,
 } from './LaunchOptions.js';
-import {ProductLauncher, ResolvedLaunchArgs} from './ProductLauncher.js';
-import {PuppeteerNode} from './PuppeteerNode.js';
+import {ProductLauncher, type ResolvedLaunchArgs} from './ProductLauncher.js';
+import {type PuppeteerNode} from './PuppeteerNode.js';
 import {rm} from './util/fs.js';
 
 /**

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -31,11 +31,11 @@ import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 
 import {
-  BrowserLaunchArgumentOptions,
-  PuppeteerNodeLaunchOptions,
+  type BrowserLaunchArgumentOptions,
+  type PuppeteerNodeLaunchOptions,
 } from './LaunchOptions.js';
-import {ProductLauncher, ResolvedLaunchArgs} from './ProductLauncher.js';
-import {PuppeteerNode} from './PuppeteerNode.js';
+import {ProductLauncher, type ResolvedLaunchArgs} from './ProductLauncher.js';
+import {type PuppeteerNode} from './PuppeteerNode.js';
 import {rm} from './util/fs.js';
 
 /**

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {BrowserConnectOptions} from '../common/BrowserConnector.js';
-import {Product} from '../common/Product.js';
+import {type BrowserConnectOptions} from '../common/BrowserConnector.js';
+import {type Product} from '../common/Product.js';
 
 /**
  * Launcher options that only apply to Chrome.

--- a/packages/puppeteer-core/src/node/PipeTransport.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ConnectionTransport} from '../common/ConnectionTransport.js';
+import {type ConnectionTransport} from '../common/ConnectionTransport.js';
 import {EventSubscription} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -26,22 +26,22 @@ import {
   computeExecutablePath,
 } from '@puppeteer/browsers';
 
-import {Browser, BrowserCloseCallback} from '../api/Browser.js';
+import {type Browser, type BrowserCloseCallback} from '../api/Browser.js';
 import {CdpBrowser} from '../common/Browser.js';
 import {Connection} from '../common/Connection.js';
 import {TimeoutError} from '../common/Errors.js';
 import {NodeWebSocketTransport as WebSocketTransport} from '../common/NodeWebSocketTransport.js';
-import {Product} from '../common/Product.js';
-import {Viewport} from '../common/PuppeteerViewport.js';
+import {type Product} from '../common/Product.js';
+import {type Viewport} from '../common/PuppeteerViewport.js';
 import {debugError} from '../common/util.js';
 
 import {
-  BrowserLaunchArgumentOptions,
-  ChromeReleaseChannel,
-  PuppeteerNodeLaunchOptions,
+  type BrowserLaunchArgumentOptions,
+  type ChromeReleaseChannel,
+  type PuppeteerNodeLaunchOptions,
 } from './LaunchOptions.js';
 import {PipeTransport} from './PipeTransport.js';
-import {PuppeteerNode} from './PuppeteerNode.js';
+import {type PuppeteerNode} from './PuppeteerNode.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -22,13 +22,13 @@ import {
   uninstall,
 } from '@puppeteer/browsers';
 
-import {Browser} from '../api/Browser.js';
-import {BrowserConnectOptions} from '../common/BrowserConnector.js';
-import {Configuration} from '../common/Configuration.js';
-import {Product} from '../common/Product.js';
+import {type Browser} from '../api/Browser.js';
+import {type BrowserConnectOptions} from '../common/BrowserConnector.js';
+import {type Configuration} from '../common/Configuration.js';
+import {type Product} from '../common/Product.js';
 import {
-  CommonPuppeteerSettings,
-  ConnectOptions,
+  type CommonPuppeteerSettings,
+  type ConnectOptions,
   Puppeteer,
 } from '../common/Puppeteer.js';
 import {PUPPETEER_REVISIONS} from '../revisions.js';
@@ -36,11 +36,11 @@ import {PUPPETEER_REVISIONS} from '../revisions.js';
 import {ChromeLauncher} from './ChromeLauncher.js';
 import {FirefoxLauncher} from './FirefoxLauncher.js';
 import {
-  BrowserLaunchArgumentOptions,
-  ChromeReleaseChannel,
-  LaunchOptions,
+  type BrowserLaunchArgumentOptions,
+  type ChromeReleaseChannel,
+  type LaunchOptions,
 } from './LaunchOptions.js';
-import {ProductLauncher} from './ProductLauncher.js';
+import {type ProductLauncher} from './ProductLauncher.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/util/AsyncIterableUtil.ts
+++ b/packages/puppeteer-core/src/util/AsyncIterableUtil.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {AwaitableIterable} from '../common/types.js';
+import {type AwaitableIterable} from '../common/types.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/util/decorators.ts
+++ b/packages/puppeteer-core/src/util/decorators.ts
@@ -15,7 +15,7 @@
  */
 
 import {Symbol} from '../../third_party/disposablestack/disposablestack.js';
-import {Disposed, Moveable} from '../common/types.js';
+import {type Disposed, type Moveable} from '../common/types.js';
 
 const instances = new WeakSet<object>();
 

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -18,7 +18,7 @@ import {homedir} from 'os';
 import {join} from 'path';
 
 import {cosmiconfigSync} from 'cosmiconfig';
-import {Configuration, Product} from 'puppeteer-core';
+import {type Configuration, type Product} from 'puppeteer-core';
 
 /**
  * @internal

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -21,7 +21,7 @@ import {
   makeProgressCallback,
   detectBrowserPlatform,
 } from '@puppeteer/browsers';
-import {Product} from 'puppeteer-core';
+import {type Product} from 'puppeteer-core';
 import {PUPPETEER_REVISIONS} from 'puppeteer-core/internal/revisions.js';
 
 import {getConfiguration} from '../getConfiguration.js';

--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -18,23 +18,23 @@ import assert from 'assert';
 import {readFile, readFileSync} from 'fs';
 import {
   createServer as createHttpServer,
-  IncomingMessage,
-  RequestListener,
-  Server as HttpServer,
-  ServerResponse,
+  type IncomingMessage,
+  type RequestListener,
+  type Server as HttpServer,
+  type ServerResponse,
 } from 'http';
 import {
   createServer as createHttpsServer,
-  Server as HttpsServer,
-  ServerOptions as HttpsServerOptions,
+  type Server as HttpsServer,
+  type ServerOptions as HttpsServerOptions,
 } from 'https';
-import {AddressInfo} from 'net';
+import {type AddressInfo} from 'net';
 import {join} from 'path';
-import {Duplex} from 'stream';
+import {type Duplex} from 'stream';
 import {gzip} from 'zlib';
 
 import {getType as getMimeType} from 'mime';
-import {Server as WebSocketServer, WebSocket} from 'ws';
+import {Server as WebSocketServer, type WebSocket} from 'ws';
 
 interface Subscriber {
   resolve: (msg: IncomingMessage) => void;

--- a/test-d/CommonEventEmitter.test-d.ts
+++ b/test-d/CommonEventEmitter.test-d.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import {EventEmitter as NodeEventEmitter} from 'node:events';
 
-import {CommonEventEmitter, EventEmitter, EventType} from 'puppeteer';
+import {
+  type CommonEventEmitter,
+  type EventEmitter,
+  type EventType,
+} from 'puppeteer';
 import {expectAssignable} from 'tsd';
 
 declare const emitter: EventEmitter<Record<EventType, any>>;

--- a/test-d/ElementHandle.test-d.ts
+++ b/test-d/ElementHandle.test-d.ts
@@ -1,4 +1,4 @@
-import {ElementHandle} from 'puppeteer';
+import {type ElementHandle} from 'puppeteer';
 import {expectNotType, expectType} from 'tsd';
 
 declare const handle: ElementHandle;

--- a/test-d/JSHandle.test-d.ts
+++ b/test-d/JSHandle.test-d.ts
@@ -1,4 +1,4 @@
-import {ElementHandle, JSHandle} from 'puppeteer';
+import {type ElementHandle, type JSHandle} from 'puppeteer';
 import {expectNotAssignable, expectNotType, expectType} from 'tsd';
 
 declare const handle: JSHandle;

--- a/test-d/puppeteer.test-d.ts
+++ b/test-d/puppeteer.test-d.ts
@@ -1,8 +1,8 @@
 import puppeteer, {
-  connect,
-  defaultArgs,
-  executablePath,
-  launch,
+  type connect,
+  type defaultArgs,
+  type executablePath,
+  type launch,
 } from 'puppeteer';
 import {expectType} from 'tsd';
 

--- a/test/src/TargetManager.spec.ts
+++ b/test/src/TargetManager.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import expect from 'expect';
-import {CdpBrowser} from 'puppeteer-core/internal/common/Browser.js';
+import {type CdpBrowser} from 'puppeteer-core/internal/common/Browser.js';
 
 import {getTestState, launch} from './mocha-utils.js';
 import {attachFrame} from './utils.js';

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -17,7 +17,7 @@
 import assert from 'assert';
 
 import expect from 'expect';
-import {SerializedAXNode} from 'puppeteer-core/internal/common/Accessibility.js';
+import {type SerializedAXNode} from 'puppeteer-core/internal/common/Accessibility.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/chromiumonly.spec.ts
+++ b/test/src/chromiumonly.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {IncomingMessage} from 'http';
+import {type IncomingMessage} from 'http';
 
 import expect from 'expect';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';

--- a/test/src/frame.spec.ts
+++ b/test/src/frame.spec.ts
@@ -16,7 +16,7 @@
 
 import expect from 'expect';
 import {CDPSession} from 'puppeteer-core/internal/api/CDPSession.js';
-import {Frame} from 'puppeteer-core/internal/api/Frame.js';
+import {type Frame} from 'puppeteer-core/internal/api/Frame.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {

--- a/test/src/headful.spec.ts
+++ b/test/src/headful.spec.ts
@@ -20,7 +20,7 @@ import path from 'path';
 
 import expect from 'expect';
 import {CDPSessionEvent} from 'puppeteer-core/internal/api/CDPSession.js';
-import {PuppeteerLaunchOptions} from 'puppeteer-core/internal/node/PuppeteerNode.js';
+import {type PuppeteerLaunchOptions} from 'puppeteer-core/internal/node/PuppeteerNode.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 
 import {getTestState, isHeadless, launch} from './mocha-utils.js';

--- a/test/src/idle_override.spec.ts
+++ b/test/src/idle_override.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import expect from 'expect';
-import {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
-import {Page} from 'puppeteer-core/internal/api/Page.js';
+import {type ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+import {type Page} from 'puppeteer-core/internal/api/Page.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/ignorehttpserrors.spec.ts
+++ b/test/src/ignorehttpserrors.spec.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {TLSSocket} from 'tls';
+import {type TLSSocket} from 'tls';
 
 import expect from 'expect';
-import {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
+import {type HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
 import {launch} from './mocha-utils.js';
 

--- a/test/src/keyboard.spec.ts
+++ b/test/src/keyboard.spec.ts
@@ -17,7 +17,7 @@
 import os from 'os';
 
 import expect from 'expect';
-import {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+import {type KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {attachFrame} from './utils.js';

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -18,11 +18,11 @@ import fs from 'fs';
 import {mkdtemp, readFile, writeFile} from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import {TLSSocket} from 'tls';
+import {type TLSSocket} from 'tls';
 
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';
-import {Page} from 'puppeteer-core/internal/api/Page.js';
+import {type Page} from 'puppeteer-core/internal/api/Page.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 import sinon from 'sinon';
 

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -18,20 +18,20 @@ import fs from 'fs';
 import path from 'path';
 
 import {TestServer} from '@pptr/testserver';
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 import expect from 'expect';
-import * as Mocha from 'mocha';
+import type * as Mocha from 'mocha';
 import puppeteer from 'puppeteer/lib/cjs/puppeteer/puppeteer.js';
-import {Browser} from 'puppeteer-core/internal/api/Browser.js';
-import {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
-import {Page} from 'puppeteer-core/internal/api/Page.js';
+import {type Browser} from 'puppeteer-core/internal/api/Browser.js';
+import {type BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
+import {type Page} from 'puppeteer-core/internal/api/Page.js';
 import {
   setLogCapture,
   getCapturedLogs,
 } from 'puppeteer-core/internal/common/Debug.js';
 import {
-  PuppeteerLaunchOptions,
-  PuppeteerNode,
+  type PuppeteerLaunchOptions,
+  type PuppeteerNode,
 } from 'puppeteer-core/internal/node/PuppeteerNode.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';

--- a/test/src/mouse.spec.ts
+++ b/test/src/mouse.spec.ts
@@ -17,8 +17,8 @@ import os from 'os';
 
 import expect from 'expect';
 import {MouseButton} from 'puppeteer-core/internal/api/Input.js';
-import {Page} from 'puppeteer-core/internal/api/Page.js';
-import {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+import {type Page} from 'puppeteer-core/internal/api/Page.js';
+import {type KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {ServerResponse} from 'http';
+import {type ServerResponse} from 'http';
 
 import expect from 'expect';
-import {Frame, TimeoutError} from 'puppeteer';
-import {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
+import {type Frame, TimeoutError} from 'puppeteer';
+import {type HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -15,12 +15,12 @@
  */
 
 import fs from 'fs';
-import {ServerResponse} from 'http';
+import {type ServerResponse} from 'http';
 import path from 'path';
 
 import expect from 'expect';
-import {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
-import {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
+import {type HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
+import {type HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
 import {getTestState, launch, setupTestBrowserHooks} from './mocha-utils.js';
 import {attachFrame, isFavicon, waitEvent} from './utils.js';

--- a/test/src/oopif.spec.ts
+++ b/test/src/oopif.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import expect from 'expect';
-import {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
-import {CdpTarget} from 'puppeteer-core/internal/common/Target.js';
+import {type BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
+import {type CdpTarget} from 'puppeteer-core/internal/common/Target.js';
 
 import {describeWithDebugLogs, getTestState, launch} from './mocha-utils.js';
 import {attachFrame, detachFrame, navigateFrame} from './utils.js';

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -15,15 +15,15 @@
  */
 import assert from 'assert';
 import fs from 'fs';
-import {ServerResponse} from 'http';
+import {type ServerResponse} from 'http';
 import path from 'path';
 
 import expect from 'expect';
 import {KnownDevices, TimeoutError} from 'puppeteer';
 import {CDPSession} from 'puppeteer-core/internal/api/CDPSession.js';
-import {Metrics, Page} from 'puppeteer-core/internal/api/Page.js';
-import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
-import {CdpPage} from 'puppeteer-core/internal/common/Page.js';
+import {type Metrics, type Page} from 'puppeteer-core/internal/api/Page.js';
+import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import {type CdpPage} from 'puppeteer-core/internal/common/Page.js';
 import sinon from 'sinon';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';

--- a/test/src/proxy.spec.ts
+++ b/test/src/proxy.spec.ts
@@ -19,7 +19,7 @@ import type {Server, IncomingMessage, ServerResponse} from 'http';
 import type {AddressInfo} from 'net';
 import os from 'os';
 
-import {TestServer} from '@pptr/testserver';
+import {type TestServer} from '@pptr/testserver';
 import expect from 'expect';
 
 import {getTestState, launch} from './mocha-utils.js';

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -17,7 +17,7 @@ import assert from 'assert';
 
 import expect from 'expect';
 import {Puppeteer} from 'puppeteer-core';
-import {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+import {type ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -19,11 +19,11 @@ import path from 'path';
 
 import expect from 'expect';
 import {
-  ActionResult,
-  HTTPRequest,
+  type ActionResult,
+  type HTTPRequest,
   InterceptResolutionAction,
 } from 'puppeteer-core/internal/api/HTTPRequest.js';
-import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {isFavicon, waitEvent} from './utils.js';

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -18,8 +18,8 @@ import fs from 'fs';
 import path from 'path';
 
 import expect from 'expect';
-import {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
-import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import {type HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
+import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {isFavicon, waitEvent} from './utils.js';

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {ServerResponse} from 'http';
+import {type ServerResponse} from 'http';
 
 import expect from 'expect';
-import {Target, TimeoutError} from 'puppeteer';
-import {Page} from 'puppeteer-core/internal/api/Page.js';
+import {type Target, TimeoutError} from 'puppeteer';
+import {type Page} from 'puppeteer-core/internal/api/Page.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {waitEvent} from './utils.js';

--- a/test/src/touchscreen.spec.ts
+++ b/test/src/touchscreen.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import expect from 'expect';
-import {KnownDevices, BoundingBox} from 'puppeteer';
+import {KnownDevices, type BoundingBox} from 'puppeteer';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -17,9 +17,9 @@
 import path from 'path';
 
 import expect from 'expect';
-import {Frame} from 'puppeteer-core/internal/api/Frame.js';
-import {Page} from 'puppeteer-core/internal/api/Page.js';
-import {EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
+import {type Frame} from 'puppeteer-core/internal/api/Frame.js';
+import {type Page} from 'puppeteer-core/internal/api/Page.js';
+import {type EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';
 
 import {compare} from './golden-utils.js';

--- a/test/src/worker.spec.ts
+++ b/test/src/worker.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import expect from 'expect';
-import {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
-import {WebWorker} from 'puppeteer-core/internal/common/WebWorker.js';
+import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import {type WebWorker} from 'puppeteer-core/internal/common/WebWorker.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {waitEvent} from './utils.js';

--- a/tools/internal/custom_markdown_documenter.ts
+++ b/tools/internal/custom_markdown_documenter.ts
@@ -23,7 +23,7 @@
 
 import * as path from 'path';
 
-import {DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig';
+import {type DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig';
 import {CustomMarkdownEmitter} from '@microsoft/api-documenter/lib/markdown/CustomMarkdownEmitter';
 import {CustomDocNodes} from '@microsoft/api-documenter/lib/nodes/CustomDocNodeKind';
 import {DocEmphasisSpan} from '@microsoft/api-documenter/lib/nodes/DocEmphasisSpan';
@@ -34,7 +34,7 @@ import {DocTableCell} from '@microsoft/api-documenter/lib/nodes/DocTableCell';
 import {DocTableRow} from '@microsoft/api-documenter/lib/nodes/DocTableRow';
 import {MarkdownDocumenterAccessor} from '@microsoft/api-documenter/lib/plugin/MarkdownDocumenterAccessor';
 import {
-  IMarkdownDocumenterFeatureOnBeforeWritePageArgs,
+  type IMarkdownDocumenterFeatureOnBeforeWritePageArgs,
   MarkdownDocumenterFeatureContext,
 } from '@microsoft/api-documenter/lib/plugin/MarkdownDocumenterFeature';
 import {PluginLoader} from '@microsoft/api-documenter/lib/plugin/PluginLoader';
@@ -43,15 +43,15 @@ import {
   ApiClass,
   ApiDeclaredItem,
   ApiDocumentedItem,
-  ApiEnum,
+  type ApiEnum,
   ApiInitializerMixin,
   ApiInterface,
-  ApiItem,
+  type ApiItem,
   ApiItemKind,
-  ApiModel,
-  ApiNamespace,
+  type ApiModel,
+  type ApiNamespace,
   ApiOptionalMixin,
-  ApiPackage,
+  type ApiPackage,
   ApiParameterListMixin,
   ApiPropertyItem,
   ApiProtectedMixin,
@@ -60,26 +60,26 @@ import {
   ApiReturnTypeMixin,
   ApiStaticMixin,
   ApiTypeAlias,
-  Excerpt,
-  ExcerptToken,
+  type Excerpt,
+  type ExcerptToken,
   ExcerptTokenKind,
-  IResolveDeclarationReferenceResult,
+  type IResolveDeclarationReferenceResult,
   ReleaseTag,
 } from '@microsoft/api-extractor-model';
 import {
-  DocBlock,
+  type DocBlock,
   DocCodeSpan,
-  DocComment,
+  type DocComment,
   DocFencedCode,
   DocLinkTag,
-  DocNodeContainer,
+  type DocNodeContainer,
   DocNodeKind,
   DocParagraph,
   DocPlainText,
   DocSection,
   StandardTags,
   StringBuilder,
-  TSDocConfiguration,
+  type TSDocConfiguration,
 } from '@microsoft/tsdoc';
 import {
   FileSystem,

--- a/tools/internal/job.ts
+++ b/tools/internal/job.ts
@@ -1,5 +1,5 @@
 import {createHash} from 'crypto';
-import {existsSync, Stats} from 'fs';
+import {existsSync, type Stats} from 'fs';
 import {mkdir, readFile, stat, writeFile} from 'fs/promises';
 import {tmpdir} from 'os';
 import {dirname, join} from 'path';

--- a/tools/mochaRunner/src/main.ts
+++ b/tools/mochaRunner/src/main.ts
@@ -16,18 +16,18 @@
 
 import {randomUUID} from 'crypto';
 import fs from 'fs';
-import {spawn, SpawnOptions} from 'node:child_process';
+import {spawn, type SpawnOptions} from 'node:child_process';
 import os from 'os';
 import path from 'path';
 
 import {
-  TestExpectation,
-  MochaResults,
+  type TestExpectation,
+  type MochaResults,
   zTestSuiteFile,
   zPlatform,
-  TestSuite,
-  TestSuiteFile,
-  Platform,
+  type TestSuite,
+  type TestSuiteFile,
+  type Platform,
 } from './types.js';
 import {
   extendProcessEnv,
@@ -36,7 +36,7 @@ import {
   filterByParameters,
   getExpectationUpdates,
   printSuggestions,
-  RecommendedExpectation,
+  type RecommendedExpectation,
   writeJSON,
 } from './utils.js';
 

--- a/tools/mochaRunner/src/test.ts
+++ b/tools/mochaRunner/src/test.ts
@@ -16,7 +16,7 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'node:test';
 
-import {Platform, TestExpectation} from './types.js';
+import {type Platform, type TestExpectation} from './types.js';
 import {
   filterByParameters,
   getTestResultForFailure,

--- a/tools/mochaRunner/src/types.ts
+++ b/tools/mochaRunner/src/types.ts
@@ -16,7 +16,7 @@
 
 import {z} from 'zod';
 
-import {RecommendedExpectation} from './utils.js';
+import {type RecommendedExpectation} from './utils.js';
 
 export const zPlatform = z.enum(['win32', 'linux', 'darwin']);
 

--- a/tools/mochaRunner/src/utils.ts
+++ b/tools/mochaRunner/src/utils.ts
@@ -18,10 +18,10 @@ import fs from 'fs';
 import path from 'path';
 
 import {
-  MochaTestResult,
-  TestExpectation,
-  MochaResults,
-  TestResult,
+  type MochaTestResult,
+  type TestExpectation,
+  type MochaResults,
+  type TestResult,
 } from './types.js';
 
 export function extendProcessEnv(envs: object[]): NodeJS.ProcessEnv {


### PR DESCRIPTION
This ensures type-only imports do not taint the dependency tree during runtime resolution.