### PR TITLE
[WIP] Chrome's error line reporting is off-by-one in Chrome?

### DIFF
--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -1369,6 +1369,7 @@ describe('Page', function () {
         page.goto(server.PREFIX + '/error.html'),
       ]);
       expect(error.message).toContain('Fancy');
+      expect(error.stack).toContain('error.html:130');
     });
   });
 


### PR DESCRIPTION
Discovered via https://github.com/qunitjs/qunit where we integrate QUnit with grunt-contrib-qunit and verify how an uncaught error is reported.

Ref https://github.com/gruntjs/grunt-contrib-qunit/pull/204.
Ref https://github.com/qunitjs/qunit/commit/cb67c3976dcfe4a0fd55bac0c91f19cc5414b5de.

Examples:

* https://github.com/gruntjs/grunt-contrib-qunit/blob/v8.0.1/test/qunit_page_error.html#L16
  is now wrongly reported as line 15.
* https://github.com/qunitjs/qunit/blob/update-integration/test/integration/grunt-contrib-qunit/fail-uncaught.html#L16 is also wwrongly reported as line 15 instead of 16.

This broke between Puppeteer 9 and 21. I know that's a big gap. I don't have something more precise at the moment, and with workstations changing to ARM, and Puppeteer only recently supporting it, it's not particularly easy to narrow down.