### PR TITLE
feat: implement `Browser.connected`

### DIFF
--- a/docs/api/puppeteer.browser.isconnected.md
+++ b/docs/api/puppeteer.browser.isconnected.md
@@ -4,13 +4,17 @@ sidebar_label: Browser.isConnected
 
 # Browser.isConnected() method
 
+> Warning: This API is now obsolete.
+>
+> Use [Browser.connected](./puppeteer.browser.connected.md).
+
 Whether Puppeteer is connected to this [browser](./puppeteer.browser.md).
 
 #### Signature:
 
 ```typescript
 class Browser {
-  abstract isConnected(): boolean;
+  isConnected(): boolean;
 }
 ```
 

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -54,6 +54,12 @@ const browser2 = await puppeteer.connect({browserWSEndpoint});
 await browser2.close();
 ```
 
+## Properties
+
+| Property  | Modifiers             | Type    | Description                                                               |
+| --------- | --------------------- | ------- | ------------------------------------------------------------------------- |
+| connected | <code>readonly</code> | boolean | Whether Puppeteer is connected to this [browser](./puppeteer.browser.md). |
+
 ## Methods
 
 | Method                                                                                         | Modifiers | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -475,8 +475,17 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
 
   /**
    * Whether Puppeteer is connected to this {@link Browser | browser}.
+   *
+   * @deprecated Use {@link Browser.connected}.
    */
-  abstract isConnected(): boolean;
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
+   * Whether Puppeteer is connected to this {@link Browser | browser}.
+   */
+  abstract get connected(): boolean;
 
   /** @internal */
   [Symbol.dispose](): void {

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -250,7 +250,7 @@ export class BidiBrowser extends Browser {
     await this.#closeCallback?.call(null);
   }
 
-  override isConnected(): boolean {
+  override get connected(): boolean {
     return !this.#connection.closed;
   }
 
@@ -274,10 +274,6 @@ export class BidiBrowser extends Browser {
     return `${this.#browserName}/${this.#browserVersion}`;
   }
 
-  /**
-   * Returns an array of all open browser contexts. In a newly created browser, this will
-   * return a single instance of {@link BidiBrowserContext}.
-   */
   override browserContexts(): BidiBrowserContext[] {
     // TODO: implement incognito context https://github.com/w3c/webdriver-bidi/issues/289.
     return this.#contexts;
@@ -295,9 +291,6 @@ export class BidiBrowser extends Browser {
     }
   }
 
-  /**
-   * Returns the default browser context. The default browser context cannot be closed.
-   */
   override defaultBrowserContext(): BidiBrowserContext {
     return this.#defaultContext;
   }


### PR DESCRIPTION
`Browser.isConnected` is being deprecated in favor of `Browser.connected` which coincides with other disposal APIs such as `disposed`.