### PR TITLE
chore: use `-Xf` instead of `-Xdf`

### DIFF
--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build:docs": "wireit",
     "build": "wireit",
-    "clean": "git clean -Xdf -e '!node_modules' .",
+    "clean": "git clean -Xf -e '!node_modules' .",
     "test": "wireit"
   },
   "bin": "lib/cjs/main-cli.js",

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -4,7 +4,7 @@
   "description": "Puppeteer Angular schematics",
   "scripts": {
     "build": "wireit",
-    "clean": "git clean -Xdf -e '!node_modules' .",
+    "clean": "git clean -Xf -e '!node_modules' .",
     "dev:test": "npm run test --watch",
     "dev": "npm run build --watch",
     "sandbox:test": "node tools/sandbox.js --test",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -37,7 +37,7 @@
     "build:docs": "wireit",
     "build": "wireit",
     "check": "tsx tools/ensure-correct-devtools-protocol-package",
-    "clean": "git clean -Xdf -e '!node_modules' .",
+    "clean": "git clean -Xf -e '!node_modules' .",
     "prepack": "wireit",
     "unit": "wireit"
   },

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build:docs": "wireit",
     "build": "wireit",
-    "clean": "git clean -Xdf -e '!node_modules' .",
+    "clean": "git clean -Xf -e '!node_modules' .",
     "postinstall": "node install.js",
     "prepack": "wireit"
   },

--- a/packages/testserver/package.json
+++ b/packages/testserver/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "wireit",
-    "clean": "git clean -Xdf -e '!node_modules' ."
+    "clean": "git clean -Xf -e '!node_modules' ."
   },
   "wireit": {
     "build": {

--- a/test/installation/package.json
+++ b/test/installation/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "wireit",
-    "clean": "git clean -Xdf -e '!node_modules' .",
+    "clean": "git clean -Xf -e '!node_modules' .",
     "test": "mocha"
   },
   "wireit": {

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "wireit",
-    "clean": "git clean -Xdf -e '!node_modules' ."
+    "clean": "git clean -Xf -e '!node_modules' ."
   },
   "wireit": {
     "build": {


### PR DESCRIPTION
The `-d` flag causes subdirectories in node_modules to also be deleted.