### PR TITLE
ci: fix ci job for devtools

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -71,7 +71,6 @@ jobs:
         working-directory: devtools-frontend
         run: |
           puppeteer_pkgs=(../puppeteer-*.tgz)
-          tar -xf ${puppeteer_pkgs[0]} --strip-components 1 -C node_modules/puppeteer
           tar -xf ${puppeteer_pkgs[1]} --strip-components 1 -C node_modules/@puppeteer/browsers
           tar -xf ${puppeteer_pkgs[2]} --strip-components 1 -C node_modules/puppeteer-core
       - name: Generate targets


### PR DESCRIPTION
DevTools is using puppeteer-core now.