### PR TITLE
fix: Always set target for attached sessions

### DIFF
--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -32,6 +32,7 @@ import {
   TargetManagerEvent,
   type TargetManagerEvents,
 } from './TargetManager.js';
+import {CdpCDPSession} from './CDPSession.js';
 
 function isTargetExposed(target: CdpTarget): boolean {
   return target.type() !== TargetType.TAB && !target._subtype();
@@ -400,6 +401,10 @@ export class ChromeTargetManager
     this.#setupAttachmentListeners(session);
 
     if (isExistingTarget) {
+      if (session instanceof CdpCDPSession) {
+        session._setTarget(target);
+      }
+
       this.#attachedTargetsBySessionId.set(
         session.id(),
         this.#attachedTargetsByTargetId.get(targetInfo.targetId)!


### PR DESCRIPTION
In Lighthouse we are still getting uncaught exceptions "Target must exist" during our bfcache testing similar to https://github.com/puppeteer/puppeteer/issues/10892. Unfortunately I haven't created a minimum repro yet, here is what I do know:

- This happens for CDP sessions created on web worker targest
- The error is emitted because the session never has `_setTarget` called, this PR addresses that problem
- This happens as a result of the history navigation that restores from bfcache. Again similar to #10892 but the repro in that bug will not reproduce this.
  - Speculation: When the history navigation is performed, a new CDP session is created for the web worker. Since it's a bfcache restoration the target is the same but the session never has `_setTarget` called because we do not call into the target factory.

Please let me know if this needs more investigation.