### PR TITLE
fix: handle missing detach events for restored bfcache targets

### DIFF
--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -24,6 +24,7 @@ import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
+import {type CdpCDPSession} from './CDPSession.js';
 import {type Connection} from './Connection.js';
 import {CdpTarget, InitializationStatus} from './Target.js';
 import {
@@ -358,10 +359,7 @@ export class ChromeTargetManager
     // `this.#connection.isAutoAttached(targetInfo.targetId)`. In the future, we
     // should determine if a target is auto-attached or not with the help of
     // CDP.
-    if (
-      targetInfo.type === 'service_worker' &&
-      this.#connection.isAutoAttached(targetInfo.targetId)
-    ) {
+    if (targetInfo.type === 'service_worker') {
       this.#finishInitializationIfReady(targetInfo.targetId);
       await silentDetach();
       if (this.#attachedTargetsByTargetId.has(targetInfo.targetId)) {
@@ -393,18 +391,16 @@ export class ChromeTargetManager
       return;
     }
 
-    if (!isExistingTarget) {
-      target._initialize();
-    }
-
     this.#setupAttachmentListeners(session);
 
     if (isExistingTarget) {
+      (session as CdpCDPSession)._setTarget(target);
       this.#attachedTargetsBySessionId.set(
         session.id(),
         this.#attachedTargetsByTargetId.get(targetInfo.targetId)!
       );
     } else {
+      target._initialize();
       this.#attachedTargetsByTargetId.set(targetInfo.targetId, target);
       this.#attachedTargetsBySessionId.set(session.id(), target);
     }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1398,6 +1398,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[bfcache.spec] BFCache can navigate to a BFCached page containing an OOPIF and a worker",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[browser.spec] Browser specs Browser.isConnected should set the browser connected state",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/assets/cached/bfcache/worker-iframe-container.html
+++ b/test/assets/cached/bfcache/worker-iframe-container.html
@@ -1,0 +1,11 @@
+<body>BFCached<a href="target.html">next</a></body>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    const iframe = document.createElement('iframe');
+    const url = new URL(location.href);
+    url.hostname = url.hostname === 'localhost' ? '127.0.0.1' : 'localhost';
+    url.pathname = '/cached/bfcache/worker-iframe.html';
+    iframe.src = url.toString();
+    document.body.appendChild(iframe);
+  }, false);
+</script>

--- a/test/assets/cached/bfcache/worker-iframe.html
+++ b/test/assets/cached/bfcache/worker-iframe.html
@@ -1,0 +1,3 @@
+<script>
+  const worker = new Worker('worker.mjs', {type: 'module'})
+</script>

--- a/test/assets/cached/bfcache/worker.mjs
+++ b/test/assets/cached/bfcache/worker.mjs
@@ -1,0 +1,1 @@
+console.log('HELLO');


### PR DESCRIPTION
Currently, if we navigate from a page with a worker in an OOPIF to another, we don't get a target detached event for the worker. The session and the target, therefore, continues to be registered as "attached" by Puppeteer. This leads to an issue when on going back to the same page the worker target is double attached. This behaviour is probably caused by the fact that the page is put into a bfcache instead of being actually destroyed. Probably, the correct behaviour from the CDP side would be to keep the client attached to the cached session instead of creating new sessions. Currently, this is not the case so I filed https://crbug.com/1485193.

Closes #10946 #10966