### PR TITLE
Update/Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,13 @@ USER pptruser
 
 WORKDIR /home/pptruser
 
-COPY puppeteer-browsers-latest.tgz puppeteer-latest.tgz puppeteer-core-latest.tgz ./
+# Files don't exist and seem to be unneccesary
+# COPY puppeteer-browsers-latest.tgz puppeteer-latest.tgz puppeteer-core-latest.tgz ./
 
 # Install @puppeteer/browsers, puppeteer and puppeteer-core into /home/pptruser/node_modules.
-RUN npm i ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz \
-    && rm ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz \
+#RUN npm i ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz \
+#    && rm ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz \
+RUN npm i puppeteer \
     && (node -e "require('child_process').execSync(require('puppeteer').executablePath() + ' --credits', {stdio: 'inherit'})" > THIRD_PARTY_NOTICES)
 
 CMD ["google-chrome-stable"]


### PR DESCRIPTION
Ignore missing files on the `COPY` line
use `npm i puppeteer` to install instead of the missing local files.

**What kind of change does this PR introduce?**

Allows to build docker container without the 3 files that seem to be missing, and appear to be unnecessary(?)
The files: puppeteer-browsers-latest.tgz puppeteer-latest.tgz puppeteer-core-latest.tgz

**Did you add tests for your changes?**
No. But the already-existing `docker/test/smoke-test.js` returns without error

**If relevant, did you update the documentation?**
Shouldn't be needed

**Summary**
I was unable to build the docker container locally without the 3 files that are missing from the COPY line in the Dockerfile.  I realized those files don't need to exist as puppeteer is available for installation from npm directly -- even the latest version (at time of writing, version 21.3.1)

I am not sure if there is any open issues for this. TBH I didn't check.

**Does this PR introduce a breaking change?**
None that I'm aware of.


**Other information**
None

Thank you for your consideration