### PR TITLE
chore: remove "module" from @puppeteer/browsers

### DIFF
--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - name: Install dependencies Firefox
-        run: node ./node_modules/puppeteer/install.js
+        run: node ./node_modules/puppeteer/install.mjs
         env:
           PUPPETEER_PRODUCT: firefox
       - name: Verify issue

--- a/package-lock.json
+++ b/package-lock.json
@@ -11015,6 +11015,7 @@
       "license": "Apache-2.0"
     },
     "tools/mocha-runner": {
+      "name": "@puppeteer/mocha-runner",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "bin": {

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -8,15 +8,12 @@
     "clean": "../../tools/clean.js",
     "test": "wireit"
   },
+  "type": "commonjs",
   "bin": "lib/cjs/main-cli.js",
   "main": "./lib/cjs/main.js",
-  "module": "./lib/esm/main.js",
-  "type": "commonjs",
   "exports": {
-    ".": {
-      "import": "./lib/esm/main.js",
-      "require": "./lib/cjs/main.js"
-    }
+    "import": "./lib/esm/main.js",
+    "require": "./lib/cjs/main.js"
   },
   "wireit": {
     "build": {

--- a/packages/puppeteer/install.mjs
+++ b/packages/puppeteer/install.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Copyright 2017 Google Inc. All rights reserved.
  *
@@ -24,20 +26,18 @@
  * necessary.
  */
 
-const fs = require('fs');
-const path = require('path');
-
-// Need to ensure TS is compiled before loading the installer
-if (!fs.existsSync(path.join(__dirname, 'lib'))) {
-  console.warn(
-    'Skipping browser installation because the Puppeteer build is not available. Run `npm install` again after you have re-built Puppeteer.'
-  );
-  process.exit(0);
-}
-
 try {
-  const {downloadBrowser} = require('puppeteer/internal/node/install.js');
+  const {downloadBrowser} = await (async () => {
+    try {
+      return await import('puppeteer/internal/node/install.js');
+    } catch {
+      console.warn(
+        'Skipping browser installation because the Puppeteer build is not available. Run `npm install` again after you have re-built Puppeteer.'
+      );
+      process.exit(0);
+    }
+  })();
   downloadBrowser();
-} catch (err) {
-  console.warn('Browser download failed', err);
+} catch (error) {
+  console.warn('Browser download failed', error);
 }

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -37,7 +37,7 @@
     "build:docs": "wireit",
     "build": "wireit",
     "clean": "../../tools/clean.js",
-    "postinstall": "node install.js",
+    "postinstall": "node install.mjs",
     "prepack": "wireit"
   },
   "wireit": {
@@ -111,7 +111,7 @@
   "files": [
     "lib",
     "src",
-    "install.js",
+    "install.mjs",
     "!*.test.js",
     "!*.test.d.ts",
     "!*.test.js.map",


### PR DESCRIPTION
`module` is obselete; `exports` takes care of import resolution.