### PR TITLE
test: skip mouse reset tests

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -837,7 +837,7 @@
     "testIdPattern": "[mouse.spec] Mouse should reset properly",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp"],
-    "expectations": ["FAIL", "TIMEOUT"]
+    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation \"after each\" hook for \"should work with both domcontentloaded and load\"",


### PR DESCRIPTION
Context menu in Firefox blocks further actions.