### PR TITLE
fix: avoid structuredClone for Node 16

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2277,7 +2277,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
   ): Promise<Buffer | string> {
     await this.bringToFront();
 
-    const options = structuredClone(userOptions) as ScreenshotOptions;
+    // TODO: use structuredClone after Node 16 support is dropped.«
+    const options = {
+      ...userOptions,
+      clip: userOptions.clip
+        ? {
+            ...userOptions.clip,
+          }
+        : undefined,
+    } as ScreenshotOptions;
     if (options.type === undefined && options.path !== undefined) {
       const filePath = options.path;
       // Note we cannot use Node.js here due to browser compatability.


### PR DESCRIPTION
Although we drop Node 16 support soon, we should keep the code compatible with Node 16 due to semver.

Closes #11004