### PR TITLE
chore: update expected bidi errors

### DIFF
--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -231,6 +231,15 @@ export class WaitTask<T = unknown> {
         return;
       }
 
+      // Errors coming from WebDriver BiDi. TODO: Adjust messages after
+      // https://github.com/w3c/webdriver-bidi/issues/540 is resolved.
+      if (
+        error.message.includes('no such handle') ||
+        error.message.includes("Actor 'MessageHandlerFrame' destroyed")
+      ) {
+        return;
+      }
+
       return error;
     }
 

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -221,21 +221,16 @@ export class WaitTask<T = unknown> {
 
       // We could have tried to evaluate in a context which was already
       // destroyed.
-      if (
-        error.message.includes('Cannot find context with specified id') ||
-        // Firefox BiDi Error, update one https://github.com/w3c/webdriver-bidi/issues/540 is resolved
-        error.message.includes(
-          "destroyed before query 'MessageHandlerFrameParent:sendCommand'"
-        )
-      ) {
+      if (error.message.includes('Cannot find context with specified id')) {
         return;
       }
 
       // Errors coming from WebDriver BiDi. TODO: Adjust messages after
       // https://github.com/w3c/webdriver-bidi/issues/540 is resolved.
       if (
-        error.message.includes('no such handle') ||
-        error.message.includes("Actor 'MessageHandlerFrame' destroyed")
+        error.message.includes(
+          "AbortError: Actor 'MessageHandlerFrame' destroyed"
+        )
       ) {
         return;
       }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3699,7 +3699,7 @@
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should survive cross-process navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should survive cross-process navigation",
@@ -3711,7 +3711,7 @@
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should survive navigations",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForFunction should work when resolved right before execution context disposal",
@@ -3765,7 +3765,7 @@
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should survive cross-process navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should survive cross-process navigation",


### PR DESCRIPTION
We can consider this errors coming from Firefox's BiDi implementation as errors that require rerunning the wait tasks. We need to replace it with the standard message once https://github.com/w3c/webdriver-bidi/issues/540 lands.