### PR TITLE
refactor: use RxJS for waitForTarget

### DIFF
--- a/docs/api/puppeteer.browsercontext.waitfortarget.md
+++ b/docs/api/puppeteer.browsercontext.waitfortarget.md
@@ -14,9 +14,7 @@ This will look all open [browser contexts](./puppeteer.browsercontext.md).
 class BrowserContext {
   abstract waitForTarget(
     predicate: (x: Target) => boolean | Promise<boolean>,
-    options?: {
-      timeout?: number;
-    }
+    options?: WaitForTargetOptions
   ): Promise<Target>;
 }
 ```
@@ -26,7 +24,7 @@ class BrowserContext {
 | Parameter | Type                                                                         | Description  |
 | --------- | ---------------------------------------------------------------------------- | ------------ |
 | predicate | (x: [Target](./puppeteer.target.md)) =&gt; boolean \| Promise&lt;boolean&gt; |              |
-| options   | { timeout?: number; }                                                        | _(Optional)_ |
+| options   | [WaitForTargetOptions](./puppeteer.waitfortargetoptions.md)                  | _(Optional)_ |
 
 **Returns:**
 

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -18,7 +18,7 @@ import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import {asyncDisposeSymbol, disposeSymbol} from '../util/disposable.js';
 
-import type {Browser, Permission} from './Browser.js';
+import type {Browser, Permission, WaitForTargetOptions} from './Browser.js';
 import type {Page} from './Page.js';
 import type {Target} from './Target.js';
 
@@ -128,7 +128,7 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
    */
   abstract waitForTarget(
     predicate: (x: Target) => boolean | Promise<boolean>,
-    options?: {timeout?: number}
+    options?: WaitForTargetOptions
   ): Promise<Target>;
 
   /**

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -16,6 +16,7 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
+import type {WaitForTargetOptions} from '../api/Browser.js';
 import {BrowserContext} from '../api/BrowserContext.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
@@ -58,7 +59,7 @@ export class BidiBrowserContext extends BrowserContext {
 
   override waitForTarget(
     predicate: (x: Target) => boolean | Promise<boolean>,
-    options: {timeout?: number} = {}
+    options: WaitForTargetOptions = {}
   ): Promise<Target> {
     return this.#browser.waitForTarget(target => {
       return target.browserContext() === this && predicate(target);

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -288,8 +288,9 @@ export class BidiConnection extends EventEmitter<BidiEvents> {
       return;
     }
     this.#closed = true;
-    this.#transport.onmessage = undefined;
-    this.#transport.onclose = undefined;
+    // Both may still be invoked and produce errors
+    this.#transport.onmessage = () => {};
+    this.#transport.onclose = () => {};
 
     this.#callbacks.clear();
   }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -27,6 +27,7 @@ import {
   type IsPageTargetCallback,
   type Permission,
   type TargetFilterCallback,
+  type WaitForTargetOptions,
 } from '../api/Browser.js';
 import {BrowserContext, BrowserContextEvent} from '../api/BrowserContext.js';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
@@ -453,7 +454,7 @@ export class CdpBrowserContext extends BrowserContext {
 
   override waitForTarget(
     predicate: (x: Target) => boolean | Promise<boolean>,
-    options: {timeout?: number} = {}
+    options: WaitForTargetOptions = {}
   ): Promise<Target> {
     return this.#browser.waitForTarget(target => {
       return target.browserContext() === this && predicate(target);


### PR DESCRIPTION
This implementation works with `CDP` but there seems to be some issue with `BiDi` where even though we have `3000` ms timeout it never gets triggered.

The issue above is related to how BiDi mapper implementation waits for 2 events (`requestWillBeSend` and `requestWillBeSentExtraInfo`, or `responseRecivedEvent` which never comes).