### PR TITLE
chore: add @typescript-eslint/no-import-type-side-effects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -227,13 +227,11 @@ module.exports = {
         // This is more performant; see https://v8.dev/blog/fast-async.
         '@typescript-eslint/return-await': ['error', 'always'],
         // This optimizes the dependency tracking for type-only files.
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          {
-            disallowTypeAnnotations: false,
-            fixStyle: 'inline-type-imports',
-          },
-        ],
+        '@typescript-eslint/consistent-type-imports': 'error',
+        // So type-only exports get elided.
+        '@typescript-eslint/consistent-type-exports': 'error',
+        // Don't want to trigger unintended side-effects.
+        '@typescript-eslint/no-import-type-side-effects': 'error',
       },
       overrides: [
         {

--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -24,10 +24,10 @@ import {
   BrowserPlatform,
   BrowserTag,
   ChromeReleaseChannel,
-  ProfileOptions,
+  type ProfileOptions,
 } from './types.js';
 
-export {ProfileOptions};
+export type {ProfileOptions};
 
 export const downloadUrls = {
   [Browser.CHROMEDRIVER]: chromedriver.resolveDownloadUrl,

--- a/packages/browsers/src/main.ts
+++ b/packages/browsers/src/main.ts
@@ -14,35 +14,39 @@
  * limitations under the License.
  */
 
+export type {
+  LaunchOptions,
+  ComputeExecutablePathOptions as Options,
+  SystemOptions,
+} from './launch.js';
 export {
   launch,
   computeExecutablePath,
   computeSystemExecutablePath,
   TimeoutError,
-  LaunchOptions,
-  ComputeExecutablePathOptions as Options,
-  SystemOptions,
   CDP_WEBSOCKET_ENDPOINT_REGEX,
   WEBDRIVER_BIDI_WEBSOCKET_ENDPOINT_REGEX,
   Process,
 } from './launch.js';
+export type {
+  InstallOptions,
+  GetInstalledBrowsersOptions,
+  UninstallOptions,
+} from './install.js';
 export {
   install,
   getInstalledBrowsers,
   canDownload,
   uninstall,
-  InstallOptions,
-  GetInstalledBrowsersOptions,
-  UninstallOptions,
 } from './install.js';
 export {detectBrowserPlatform} from './detectPlatform.js';
+export type {ProfileOptions} from './browser-data/browser-data.js';
 export {
   resolveBuildId,
   Browser,
   BrowserPlatform,
   ChromeReleaseChannel,
   createProfile,
-  ProfileOptions,
 } from './browser-data/browser-data.js';
 export {CLI, makeProgressCallback} from './CLI.js';
 export {Cache, InstalledBrowser} from './Cache.js';

--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -7,11 +7,11 @@ import {
   targetFromTargetString,
   type BuilderRun,
 } from '@angular-devkit/architect';
-import {type JsonObject} from '@angular-devkit/core';
+import type {JsonObject} from '@angular-devkit/core';
 
 import {TestRunner} from '../../schematics/utils/types.js';
 
-import {type PuppeteerBuilderOptions} from './types.js';
+import type {PuppeteerBuilderOptions} from './types.js';
 
 const terminalStyles = {
   cyan: '\u001b[36;1m',

--- a/packages/ng-schematics/src/builders/puppeteer/types.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/types.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type JsonObject} from '@angular-devkit/core';
+import type {JsonObject} from '@angular-devkit/core';
 
-import {type TestRunner} from '../../schematics/utils/types.js';
+import type {TestRunner} from '../../schematics/utils/types.js';
 
 export interface PuppeteerBuilderOptions extends JsonObject {
   testRunner: TestRunner;

--- a/packages/ng-schematics/src/schematics/utils/files.ts
+++ b/packages/ng-schematics/src/schematics/utils/files.ts
@@ -28,7 +28,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 
-import {type AngularProject, type TestRunner} from './types.js';
+import type {AngularProject, TestRunner} from './types.js';
 
 export interface FilesOptions {
   options: {

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -16,7 +16,7 @@
 
 import {get} from 'https';
 
-import {type Tree} from '@angular-devkit/schematics';
+import type {Tree} from '@angular-devkit/schematics';
 
 import {getNgCommandName} from './files.js';
 import {

--- a/packages/ng-schematics/test/src/utils.ts
+++ b/packages/ng-schematics/test/src/utils.ts
@@ -1,7 +1,7 @@
 import https from 'https';
 import {join} from 'path';
 
-import {type JsonObject} from '@angular-devkit/core';
+import type {JsonObject} from '@angular-devkit/core';
 import {
   SchematicTestRunner,
   type UnitTestTree,

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type ChildProcess} from 'child_process';
+import type {ChildProcess} from 'child_process';
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {debugError, waitWithTimeout} from '../common/util.js';

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -19,7 +19,7 @@ import {debugError} from '../common/util.js';
 import {asyncDisposeSymbol, disposeSymbol} from '../util/disposable.js';
 
 import type {Browser, Permission} from './Browser.js';
-import {type Page} from './Page.js';
+import type {Page} from './Page.js';
 import type {Target} from './Target.js';
 
 /**

--- a/packages/puppeteer-core/src/api/Dialog.ts
+++ b/packages/puppeteer-core/src/api/Dialog.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {assert} from '../util/assert.js';
 

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -14,31 +14,31 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type Frame} from '../api/Frame.js';
+import type {Frame} from '../api/Frame.js';
 import {getQueryHandlerAndSelector} from '../common/GetQueryHandler.js';
 import {LazyArg} from '../common/LazyArg.js';
-import {
-  type ElementFor,
-  type EvaluateFuncWith,
-  type HandleFor,
-  type HandleOr,
-  type NodeFor,
+import type {
+  ElementFor,
+  EvaluateFuncWith,
+  HandleFor,
+  HandleOr,
+  NodeFor,
 } from '../common/types.js';
-import {type KeyInput} from '../common/USKeyboardLayout.js';
+import type {KeyInput} from '../common/USKeyboardLayout.js';
 import {isString, withSourcePuppeteerURLIfNone} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
-import {
-  type KeyboardTypeOptions,
-  type KeyPressOptions,
-  type MouseClickOptions,
+import type {
+  KeyboardTypeOptions,
+  KeyPressOptions,
+  MouseClickOptions,
 } from './Input.js';
 import {JSHandle} from './JSHandle.js';
-import {type ScreenshotOptions, type WaitForSelectorOptions} from './Page.js';
+import type {ScreenshotOptions, WaitForSelectorOptions} from './Page.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/Environment.ts
+++ b/packages/puppeteer-core/src/api/Environment.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {type CDPSession} from './CDPSession.js';
-import {type Realm} from './Realm.js';
+import type {CDPSession} from './CDPSession.js';
+import type {Realm} from './Realm.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -16,26 +16,26 @@
 
 import type Protocol from 'devtools-protocol';
 
-import {type ClickOptions, type ElementHandle} from '../api/ElementHandle.js';
-import {type HTTPResponse} from '../api/HTTPResponse.js';
-import {
-  type Page,
-  type WaitForSelectorOptions,
-  type WaitTimeoutOptions,
+import type {ClickOptions, ElementHandle} from '../api/ElementHandle.js';
+import type {HTTPResponse} from '../api/HTTPResponse.js';
+import type {
+  Page,
+  WaitForSelectorOptions,
+  WaitTimeoutOptions,
 } from '../api/Page.js';
-import {type DeviceRequestPrompt} from '../cdp/DeviceRequestPrompt.js';
-import {type IsolatedWorldChart} from '../cdp/IsolatedWorld.js';
-import {type PuppeteerLifeCycleEvent} from '../cdp/LifecycleWatcher.js';
+import type {DeviceRequestPrompt} from '../cdp/DeviceRequestPrompt.js';
+import type {IsolatedWorldChart} from '../cdp/IsolatedWorld.js';
+import type {PuppeteerLifeCycleEvent} from '../cdp/LifecycleWatcher.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {getQueryHandlerAndSelector} from '../common/GetQueryHandler.js';
 import {transposeIterableHandle} from '../common/HandleIterator.js';
 import {LazyArg} from '../common/LazyArg.js';
-import {
-  type Awaitable,
-  type EvaluateFunc,
-  type EvaluateFuncWith,
-  type HandleFor,
-  type NodeFor,
+import type {
+  Awaitable,
+  EvaluateFunc,
+  EvaluateFuncWith,
+  HandleFor,
+  NodeFor,
 } from '../common/types.js';
 import {
   getPageContent,
@@ -45,14 +45,14 @@ import {
 import {assert} from '../util/assert.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
-import {type CDPSession} from './CDPSession.js';
-import {type KeyboardTypeOptions} from './Input.js';
+import type {CDPSession} from './CDPSession.js';
+import type {KeyboardTypeOptions} from './Input.js';
 import {
   FunctionLocator,
   type Locator,
   NodeLocator,
 } from './locators/locators.js';
-import {type Realm} from './Realm.js';
+import type {Realm} from './Realm.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from './CDPSession.js';
-import {type Frame} from './Frame.js';
-import {type HTTPResponse} from './HTTPResponse.js';
+import type {CDPSession} from './CDPSession.js';
+import type {Frame} from './Frame.js';
+import type {HTTPResponse} from './HTTPResponse.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -16,10 +16,10 @@
 
 import type Protocol from 'devtools-protocol';
 
-import {type SecurityDetails} from '../common/SecurityDetails.js';
+import type {SecurityDetails} from '../common/SecurityDetails.js';
 
-import {type Frame} from './Frame.js';
-import {type HTTPRequest} from './HTTPRequest.js';
+import type {Frame} from './Frame.js';
+import type {HTTPRequest} from './HTTPRequest.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/Input.ts
+++ b/packages/puppeteer-core/src/api/Input.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type KeyInput} from '../common/USKeyboardLayout.js';
+import type {KeyInput} from '../common/USKeyboardLayout.js';
 
-import {type Point} from './ElementHandle.js';
+import type {Point} from './ElementHandle.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/JSHandle.ts
+++ b/packages/puppeteer-core/src/api/JSHandle.ts
@@ -16,17 +16,13 @@
 
 import type Protocol from 'devtools-protocol';
 
-import {
-  type EvaluateFuncWith,
-  type HandleFor,
-  type HandleOr,
-} from '../common/types.js';
+import type {EvaluateFuncWith, HandleFor, HandleOr} from '../common/types.js';
 import {debugError, withSourcePuppeteerURLIfNone} from '../common/util.js';
 import {moveable, throwIfDisposed} from '../util/decorators.js';
 import {disposeSymbol, asyncDisposeSymbol} from '../util/disposable.js';
 
-import {type ElementHandle} from './ElementHandle.js';
-import {type Realm} from './Realm.js';
+import type {ElementHandle} from './ElementHandle.js';
+import type {Realm} from './Realm.js';
 
 /**
  * Represents a reference to a JavaScript object. Instances can be created using

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -16,7 +16,7 @@
 
 import type {Readable} from 'stream';
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {
   delay,
@@ -39,7 +39,7 @@ import type {HTTPResponse} from '../api/HTTPResponse.js';
 import type {BidiNetworkManager} from '../bidi/NetworkManager.js';
 import type {Accessibility} from '../cdp/Accessibility.js';
 import type {Coverage} from '../cdp/Coverage.js';
-import {type DeviceRequestPrompt} from '../cdp/DeviceRequestPrompt.js';
+import type {DeviceRequestPrompt} from '../cdp/DeviceRequestPrompt.js';
 import {
   NetworkManagerEvent,
   type NetworkManager as CdpNetworkManager,
@@ -49,7 +49,7 @@ import {
 import type {Tracing} from '../cdp/Tracing.js';
 import type {WebWorker} from '../cdp/WebWorker.js';
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
-import {type Device} from '../common/Device.js';
+import type {Device} from '../common/Device.js';
 import {TargetCloseError} from '../common/Errors.js';
 import {
   EventEmitter,
@@ -82,7 +82,7 @@ import {
 import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {guarded} from '../util/decorators.js';
-import {type Deferred} from '../util/Deferred.js';
+import type {Deferred} from '../util/Deferred.js';
 import {
   AsyncDisposableStack,
   asyncDisposeSymbol,
@@ -102,11 +102,11 @@ import type {
   GoToOptions,
   WaitForOptions,
 } from './Frame.js';
-import {
-  type Keyboard,
-  type KeyboardTypeOptions,
-  type Mouse,
-  type Touchscreen,
+import type {
+  Keyboard,
+  KeyboardTypeOptions,
+  Mouse,
+  Touchscreen,
 } from './Input.js';
 import type {JSHandle} from './JSHandle.js';
 import {
@@ -481,7 +481,7 @@ export interface PageEvents extends Record<EventType, unknown> {
   [PageEvent.WorkerDestroyed]: WebWorker;
 }
 
-export {
+export type {
   /**
    * @deprecated Use {@link PageEvents}.
    */

--- a/packages/puppeteer-core/src/api/Realm.ts
+++ b/packages/puppeteer-core/src/api/Realm.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import {type TimeoutSettings} from '../common/TimeoutSettings.js';
-import {
-  type EvaluateFunc,
-  type HandleFor,
-  type InnerLazyParams,
+import type {TimeoutSettings} from '../common/TimeoutSettings.js';
+import type {
+  EvaluateFunc,
+  HandleFor,
+  InnerLazyParams,
 } from '../common/types.js';
 import {TaskManager, WaitTask} from '../common/WaitTask.js';
 import {disposeSymbol} from '../util/disposable.js';
 
-import {type ElementHandle} from './ElementHandle.js';
-import {type Environment} from './Environment.js';
-import {type JSHandle} from './JSHandle.js';
+import type {ElementHandle} from './ElementHandle.js';
+import type {Environment} from './Environment.js';
+import type {JSHandle} from './JSHandle.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/api/Target.ts
+++ b/packages/puppeteer-core/src/api/Target.ts
@@ -16,10 +16,10 @@
 
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
-import {type Page} from '../api/Page.js';
-import {type WebWorker} from '../cdp/WebWorker.js';
+import type {Page} from '../api/Page.js';
+import type {WebWorker} from '../cdp/WebWorker.js';
 
-import {type CDPSession} from './CDPSession.js';
+import type {CDPSession} from './CDPSession.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/locators/DelegatedLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/DelegatedLocator.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {type Observable} from '../../../third_party/rxjs/rxjs.js';
-import {type HandleFor} from '../../common/types.js';
+import type {Observable} from '../../../third_party/rxjs/rxjs.js';
+import type {HandleFor} from '../../common/types.js';
 
 import {Locator, type VisibilityOption} from './locators.js';
 

--- a/packages/puppeteer-core/src/api/locators/FilteredLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/FilteredLocator.ts
@@ -22,10 +22,10 @@ import {
   mergeMap,
   throwIfEmpty,
 } from '../../../third_party/rxjs/rxjs.js';
-import {type Awaitable, type HandleFor} from '../../common/types.js';
+import type {Awaitable, HandleFor} from '../../common/types.js';
 
 import {DelegatedLocator} from './DelegatedLocator.js';
-import {type ActionOptions, type Locator} from './locators.js';
+import type {ActionOptions, Locator} from './locators.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/locators/FunctionLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/FunctionLocator.ts
@@ -20,9 +20,9 @@ import {
   from,
   throwIfEmpty,
 } from '../../../third_party/rxjs/rxjs.js';
-import {type Awaitable, type HandleFor} from '../../common/types.js';
-import {type Frame} from '../Frame.js';
-import {type Page} from '../Page.js';
+import type {Awaitable, HandleFor} from '../../common/types.js';
+import type {Frame} from '../Frame.js';
+import type {Page} from '../Page.js';
 
 import {type ActionOptions, Locator} from './locators.js';
 

--- a/packages/puppeteer-core/src/api/locators/Locator.ts
+++ b/packages/puppeteer-core/src/api/locators/Locator.ts
@@ -38,12 +38,12 @@ import {
   tap,
 } from '../../../third_party/rxjs/rxjs.js';
 import {EventEmitter, type EventType} from '../../common/EventEmitter.js';
-import {type HandleFor} from '../../common/types.js';
+import type {HandleFor} from '../../common/types.js';
 import {debugError, timeout} from '../../common/util.js';
-import {
-  type BoundingBox,
-  type ClickOptions,
-  type ElementHandle,
+import type {
+  BoundingBox,
+  ClickOptions,
+  ElementHandle,
 } from '../ElementHandle.js';
 
 import {
@@ -155,7 +155,7 @@ export interface LocatorEvents extends Record<EventType, unknown> {
   [LocatorEvent.Action]: undefined;
 }
 
-export {
+export type {
   /**
    * @deprecated Use {@link LocatorEvents}.
    */

--- a/packages/puppeteer-core/src/api/locators/MappedLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/MappedLocator.ts
@@ -19,7 +19,7 @@ import {
   from,
   mergeMap,
 } from '../../../third_party/rxjs/rxjs.js';
-import {type Awaitable, type HandleFor} from '../../common/types.js';
+import type {Awaitable, HandleFor} from '../../common/types.js';
 
 import {
   type ActionOptions,

--- a/packages/puppeteer-core/src/api/locators/NodeLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/NodeLocator.ts
@@ -26,9 +26,9 @@ import {
   retry,
   throwIfEmpty,
 } from '../../../third_party/rxjs/rxjs.js';
-import {type HandleFor, type NodeFor} from '../../common/types.js';
-import {type Frame} from '../Frame.js';
-import {type Page} from '../Page.js';
+import type {HandleFor, NodeFor} from '../../common/types.js';
+import type {Frame} from '../Frame.js';
+import type {Page} from '../Page.js';
 
 import {type ActionOptions, Locator, RETRY_DELAY} from './locators.js';
 

--- a/packages/puppeteer-core/src/api/locators/RaceLocator.ts
+++ b/packages/puppeteer-core/src/api/locators/RaceLocator.ts
@@ -15,7 +15,7 @@
  */
 
 import {type Observable, race} from '../../../third_party/rxjs/rxjs.js';
-import {type HandleFor} from '../../common/types.js';
+import type {HandleFor} from '../../common/types.js';
 
 import {type ActionOptions, Locator} from './locators.js';
 

--- a/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
@@ -18,10 +18,10 @@ import * as BidiMapper from 'chromium-bidi/lib/cjs/bidiMapper/bidiMapper.js';
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
-import {type CDPEvents, type CDPSession} from '../api/CDPSession.js';
-import {type Connection as CdpConnection} from '../cdp/Connection.js';
+import type {CDPEvents, CDPSession} from '../api/CDPSession.js';
+import type {Connection as CdpConnection} from '../cdp/Connection.js';
 import {TargetCloseError} from '../common/Errors.js';
-import {type Handler} from '../common/EventEmitter.js';
+import type {Handler} from '../common/EventEmitter.js';
 
 import {BidiConnection} from './Connection.js';
 

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-import {type ChildProcess} from 'child_process';
+import type {ChildProcess} from 'child_process';
 
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {
   Browser,
+  BrowserEvent,
   type BrowserCloseCallback,
   type BrowserContextOptions,
-  BrowserEvent,
 } from '../api/Browser.js';
 import {BrowserContextEvent} from '../api/BrowserContext.js';
-import {type Page} from '../api/Page.js';
-import {type Target} from '../api/Target.js';
-import {type Handler} from '../common/EventEmitter.js';
+import type {Page} from '../api/Page.js';
+import type {Target} from '../api/Target.js';
+import type {Handler} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 
 import {BidiBrowserContext} from './BrowserContext.js';
 import {BrowsingContext, BrowsingContextEvent} from './BrowsingContext.js';
-import {type BidiConnection} from './Connection.js';
+import type {BidiConnection} from './Connection.js';
 import {
   BiDiBrowserTarget,
   BiDiBrowsingContextTarget,

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -17,13 +17,13 @@
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {BrowserContext} from '../api/BrowserContext.js';
-import {type Page} from '../api/Page.js';
-import {type Target} from '../api/Target.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Page} from '../api/Page.js';
+import type {Target} from '../api/Target.js';
+import type {Viewport} from '../common/Viewport.js';
 
-import {type BidiBrowser} from './Browser.js';
-import {type BidiConnection} from './Connection.js';
-import {type BidiPage} from './Page.js';
+import type {BidiBrowser} from './Browser.js';
+import type {BidiConnection} from './Connection.js';
+import type {BidiPage} from './Page.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowsingContext.ts
@@ -2,15 +2,15 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping.js';
 
 import {CDPSession} from '../api/CDPSession.js';
-import {type Connection as CdpConnection} from '../cdp/Connection.js';
-import {type PuppeteerLifeCycleEvent} from '../cdp/LifecycleWatcher.js';
+import type {Connection as CdpConnection} from '../cdp/Connection.js';
+import type {PuppeteerLifeCycleEvent} from '../cdp/LifecycleWatcher.js';
 import {TargetCloseError} from '../common/Errors.js';
-import {type EventType} from '../common/EventEmitter.js';
+import type {EventType} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {type BidiConnection} from './Connection.js';
+import type {BidiConnection} from './Connection.js';
 import {BidiRealm} from './Realm.js';
 
 /**

--- a/packages/puppeteer-core/src/bidi/Connection.test.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.test.ts
@@ -18,7 +18,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {type ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 
 import {BidiConnection} from './Connection.js';
 

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -17,7 +17,7 @@
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {CallbackRegistry} from '../cdp/Connection.js';
-import {type ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {debug} from '../common/Debug.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';

--- a/packages/puppeteer-core/src/bidi/Dialog.ts
+++ b/packages/puppeteer-core/src/bidi/Dialog.ts
@@ -18,7 +18,7 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {Dialog} from '../api/Dialog.js';
 
-import {type BrowsingContext} from './BrowsingContext.js';
+import type {BrowsingContext} from './BrowsingContext.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/bidi/ElementHandle.ts
@@ -19,10 +19,10 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import {type AutofillData, ElementHandle} from '../api/ElementHandle.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
-import {type BidiFrame} from './Frame.js';
+import type {BidiFrame} from './Frame.js';
 import {BidiJSHandle} from './JSHandle.js';
-import {type BidiRealm} from './Realm.js';
-import {type Sandbox} from './Sandbox.js';
+import type {BidiRealm} from './Realm.js';
+import type {Sandbox} from './Sandbox.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/EmulationManager.ts
+++ b/packages/puppeteer-core/src/bidi/EmulationManager.ts
@@ -15,7 +15,7 @@
  */
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {type BrowsingContext} from './BrowsingContext.js';
+import type {BrowsingContext} from './BrowsingContext.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/ExposedFunction.ts
+++ b/packages/puppeteer-core/src/bidi/ExposedFunction.ts
@@ -16,14 +16,14 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {type Awaitable, type FlattenHandle} from '../common/types.js';
+import type {Awaitable, FlattenHandle} from '../common/types.js';
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {interpolateFunction, stringifyFunction} from '../util/Function.js';
 
-import {type BidiConnection} from './Connection.js';
-import {type BidiFrame} from './Frame.js';
+import type {BidiConnection} from './Connection.js';
+import type {BidiFrame} from './Frame.js';
 import {BidiSerializer} from './Serializer.js';
 
 type SendArgsChannel<Args> = (value: [id: number, args: Args]) => void;

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -25,17 +25,17 @@ import {
   raceWith,
   switchMap,
 } from '../../third_party/rxjs/rxjs.js';
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {
   Frame,
   type GoToOptions,
   type WaitForOptions,
   throwIfDetached,
 } from '../api/Frame.js';
-import {type PuppeteerLifeCycleEvent} from '../cdp/LifecycleWatcher.js';
+import type {PuppeteerLifeCycleEvent} from '../cdp/LifecycleWatcher.js';
 import {ProtocolError, TimeoutError} from '../common/Errors.js';
-import {type TimeoutSettings} from '../common/TimeoutSettings.js';
-import {type Awaitable} from '../common/types.js';
+import type {TimeoutSettings} from '../common/TimeoutSettings.js';
+import type {Awaitable} from '../common/types.js';
 import {
   UTILITY_WORLD_NAME,
   setPageContent,
@@ -51,8 +51,8 @@ import {
   type BrowsingContext,
 } from './BrowsingContext.js';
 import {ExposeableFunction} from './ExposedFunction.js';
-import {type BidiHTTPResponse} from './HTTPResponse.js';
-import {type BidiPage} from './Page.js';
+import type {BidiHTTPResponse} from './HTTPResponse.js';
+import type {BidiPage} from './Page.js';
 import {
   MAIN_SANDBOX,
   PUPPETEER_SANDBOX,

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -15,10 +15,10 @@
  */
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {type Frame} from '../api/Frame.js';
+import type {Frame} from '../api/Frame.js';
 import {HTTPRequest, type ResourceType} from '../api/HTTPRequest.js';
 
-import {type BidiHTTPResponse} from './HTTPResponse.js';
+import type {BidiHTTPResponse} from './HTTPResponse.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -16,13 +16,13 @@
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type Protocol from 'devtools-protocol';
 
-import {type Frame} from '../api/Frame.js';
+import type {Frame} from '../api/Frame.js';
 import {
   HTTPResponse as HTTPResponse,
   type RemoteAddress,
 } from '../api/HTTPResponse.js';
 
-import {type BidiHTTPRequest} from './HTTPRequest.js';
+import type {BidiHTTPRequest} from './HTTPRequest.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/Input.ts
+++ b/packages/puppeteer-core/src/bidi/Input.ts
@@ -16,7 +16,7 @@
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {type Point} from '../api/ElementHandle.js';
+import type {Point} from '../api/ElementHandle.js';
 import {
   Keyboard,
   Mouse,
@@ -30,10 +30,10 @@ import {
   type MouseOptions,
   type MouseWheelOptions,
 } from '../api/Input.js';
-import {type KeyInput} from '../common/USKeyboardLayout.js';
+import type {KeyInput} from '../common/USKeyboardLayout.js';
 
-import {type BrowsingContext} from './BrowsingContext.js';
-import {type BidiPage} from './Page.js';
+import type {BrowsingContext} from './BrowsingContext.js';
+import type {BidiPage} from './Page.js';
 
 const enum InputId {
   Mouse = '__puppeteer_mouse',

--- a/packages/puppeteer-core/src/bidi/JSHandle.ts
+++ b/packages/puppeteer-core/src/bidi/JSHandle.ts
@@ -16,11 +16,11 @@
 
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
-import {type ElementHandle} from '../api/ElementHandle.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';
 
-import {type BidiRealm} from './Realm.js';
-import {type Sandbox} from './Sandbox.js';
+import type {BidiRealm} from './Realm.js';
+import type {Sandbox} from './Sandbox.js';
 import {BidiSerializer} from './Serializer.js';
 import {releaseReference} from './util.js';
 

--- a/packages/puppeteer-core/src/bidi/NetworkManager.ts
+++ b/packages/puppeteer-core/src/bidi/NetworkManager.ts
@@ -24,11 +24,11 @@ import {
 } from '../common/EventEmitter.js';
 import {DisposableStack} from '../util/disposable.js';
 
-import {type BidiConnection} from './Connection.js';
-import {type BidiFrame} from './Frame.js';
+import type {BidiConnection} from './Connection.js';
+import type {BidiFrame} from './Frame.js';
 import {BidiHTTPRequest} from './HTTPRequest.js';
 import {BidiHTTPResponse} from './HTTPResponse.js';
-import {type BidiPage} from './Page.js';
+import type {BidiPage} from './Page.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -19,8 +19,8 @@ import type {Readable} from 'stream';
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type Protocol from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type WaitForOptions} from '../api/Frame.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {WaitForOptions} from '../api/Frame.js';
 import {
   Page,
   PageEvent,
@@ -44,10 +44,10 @@ import {
   TargetCloseError,
   TimeoutError,
 } from '../common/Errors.js';
-import {type Handler} from '../common/EventEmitter.js';
-import {type PDFOptions} from '../common/PDFOptions.js';
+import type {Handler} from '../common/EventEmitter.js';
+import type {PDFOptions} from '../common/PDFOptions.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
-import {type Awaitable} from '../common/types.js';
+import type {Awaitable} from '../common/types.js';
 import {
   debugError,
   evaluationString,
@@ -56,28 +56,28 @@ import {
   waitForEvent,
   waitWithTimeout,
 } from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {disposeSymbol} from '../util/disposable.js';
 
-import {type BidiBrowser} from './Browser.js';
-import {type BidiBrowserContext} from './BrowserContext.js';
+import type {BidiBrowser} from './Browser.js';
+import type {BidiBrowserContext} from './BrowserContext.js';
 import {
   BrowsingContextEvent,
   CdpSessionWrapper,
   getWaitUntilSingle,
   type BrowsingContext,
 } from './BrowsingContext.js';
-import {type BidiConnection} from './Connection.js';
+import type {BidiConnection} from './Connection.js';
 import {BidiDialog} from './Dialog.js';
 import {BidiElementHandle} from './ElementHandle.js';
 import {EmulationManager} from './EmulationManager.js';
 import {BidiFrame, lifeCycleToReadinessState} from './Frame.js';
-import {type BidiHTTPRequest} from './HTTPRequest.js';
-import {type BidiHTTPResponse} from './HTTPResponse.js';
+import type {BidiHTTPRequest} from './HTTPRequest.js';
+import type {BidiHTTPResponse} from './HTTPResponse.js';
 import {BidiKeyboard, BidiMouse, BidiTouchscreen} from './Input.js';
-import {type BidiJSHandle} from './JSHandle.js';
+import type {BidiJSHandle} from './JSHandle.js';
 import {BidiNetworkManager} from './NetworkManager.js';
 import {createBidiHandle} from './Realm.js';
 import {BidiSerializer} from './Serializer.js';

--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -2,7 +2,7 @@ import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {scriptInjector} from '../common/ScriptInjector.js';
-import {type EvaluateFunc, type HandleFor} from '../common/types.js';
+import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {
   PuppeteerURL,
   SOURCE_URL_REGEX,
@@ -14,10 +14,10 @@ import type PuppeteerUtil from '../injected/injected.js';
 import {disposeSymbol} from '../util/disposable.js';
 import {stringifyFunction} from '../util/Function.js';
 
-import {type BidiConnection} from './Connection.js';
+import type {BidiConnection} from './Connection.js';
 import {BidiElementHandle} from './ElementHandle.js';
 import {BidiJSHandle} from './JSHandle.js';
-import {type Sandbox} from './Sandbox.js';
+import type {Sandbox} from './Sandbox.js';
 import {BidiSerializer} from './Serializer.js';
 import {createEvaluationError} from './util.js';
 

--- a/packages/puppeteer-core/src/bidi/Sandbox.ts
+++ b/packages/puppeteer-core/src/bidi/Sandbox.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import {type JSHandle} from '../api/JSHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
 import {Realm} from '../api/Realm.js';
-import {type TimeoutSettings} from '../common/TimeoutSettings.js';
-import {type EvaluateFunc, type HandleFor} from '../common/types.js';
+import type {TimeoutSettings} from '../common/TimeoutSettings.js';
+import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {withSourcePuppeteerURLIfNone} from '../common/util.js';
 
-import {type BrowsingContext} from './BrowsingContext.js';
+import type {BrowsingContext} from './BrowsingContext.js';
 import {BidiElementHandle} from './ElementHandle.js';
-import {type BidiFrame} from './Frame.js';
-import {type BidiRealm as BidiRealm} from './Realm.js';
+import type {BidiFrame} from './Frame.js';
+import type {BidiRealm as BidiRealm} from './Realm.js';
 /**
  * A unique key for {@link SandboxChart} to denote the default world.
  * Realms are automatically created in the default sandbox.

--- a/packages/puppeteer-core/src/bidi/Serializer.ts
+++ b/packages/puppeteer-core/src/bidi/Serializer.ts
@@ -21,7 +21,7 @@ import {debugError, isDate, isPlainObject, isRegExp} from '../common/util.js';
 
 import {BidiElementHandle} from './ElementHandle.js';
 import {BidiJSHandle} from './JSHandle.js';
-import {type Sandbox} from './Sandbox.js';
+import type {Sandbox} from './Sandbox.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/bidi/Target.ts
+++ b/packages/puppeteer-core/src/bidi/Target.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {Target, TargetType} from '../api/Target.js';
 
-import {type BidiBrowser} from './Browser.js';
-import {type BidiBrowserContext} from './BrowserContext.js';
+import type {BidiBrowser} from './Browser.js';
+import type {BidiBrowserContext} from './BrowserContext.js';
 import {type BrowsingContext, CdpSessionWrapper} from './BrowsingContext.js';
 import {BidiPage} from './Page.js';
 

--- a/packages/puppeteer-core/src/bidi/util.ts
+++ b/packages/puppeteer-core/src/bidi/util.ts
@@ -18,7 +18,7 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {PuppeteerURL, debugError} from '../common/util.js';
 
-import {type BidiRealm} from './Realm.js';
+import type {BidiRealm} from './Realm.js';
 import {BidiSerializer} from './Serializer.js';
 
 /**

--- a/packages/puppeteer-core/src/cdp/Accessibility.ts
+++ b/packages/puppeteer-core/src/cdp/Accessibility.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type ElementHandle} from '../api/ElementHandle.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
 
 /**
  * Represents a Node and the properties of it that are relevant to Accessibility.

--- a/packages/puppeteer-core/src/cdp/AriaQueryHandler.ts
+++ b/packages/puppeteer-core/src/cdp/AriaQueryHandler.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type ElementHandle} from '../api/ElementHandle.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
 import {QueryHandler, type QuerySelector} from '../common/QueryHandler.js';
-import {type AwaitableIterable} from '../common/types.js';
+import type {AwaitableIterable} from '../common/types.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 

--- a/packages/puppeteer-core/src/cdp/Binding.ts
+++ b/packages/puppeteer-core/src/cdp/Binding.ts
@@ -3,7 +3,7 @@ import {debugError} from '../common/util.js';
 import {DisposableStack} from '../util/disposable.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
-import {type ExecutionContext} from './ExecutionContext.js';
+import type {ExecutionContext} from './ExecutionContext.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type ChildProcess} from 'child_process';
+import type {ChildProcess} from 'child_process';
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {
   Browser as BrowserBase,
@@ -30,14 +30,14 @@ import {
 } from '../api/Browser.js';
 import {BrowserContext, BrowserContextEvent} from '../api/BrowserContext.js';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
-import {type Page} from '../api/Page.js';
-import {type Target} from '../api/Target.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Page} from '../api/Page.js';
+import type {Target} from '../api/Target.js';
+import type {Viewport} from '../common/Viewport.js';
 import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {ChromeTargetManager} from './ChromeTargetManager.js';
-import {type Connection} from './Connection.js';
+import type {Connection} from './Connection.js';
 import {FirefoxTargetManager} from './FirefoxTargetManager.js';
 import {
   DevToolsTarget,

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  type IsPageTargetCallback,
-  type TargetFilterCallback,
+import type {
+  IsPageTargetCallback,
+  TargetFilterCallback,
 } from '../api/Browser.js';
-import {type ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {getFetch} from '../common/fetch.js';
 import {debugError} from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 import {isNode} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {isErrorLike} from '../util/ErrorLike.js';

--- a/packages/puppeteer-core/src/cdp/CDPSession.ts
+++ b/packages/puppeteer-core/src/cdp/CDPSession.ts
@@ -1,4 +1,4 @@
-import {type ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
 import {
   type CDPEvents,
@@ -13,7 +13,7 @@ import {
   type Connection,
   createProtocolErrorMessage,
 } from './Connection.js';
-import {type CdpTarget} from './Target.js';
+import type {CdpTarget} from './Target.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type TargetFilterCallback} from '../api/Browser.js';
+import type {TargetFilterCallback} from '../api/Browser.js';
 import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {TargetType} from '../api/Target.js';
 import {EventEmitter} from '../common/EventEmitter.js';
@@ -24,8 +24,8 @@ import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {type CdpCDPSession} from './CDPSession.js';
-import {type Connection} from './Connection.js';
+import type {CdpCDPSession} from './CDPSession.js';
+import type {Connection} from './Connection.js';
 import {CdpTarget, InitializationStatus} from './Target.js';
 import {
   type TargetFactory,

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
-import {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+import type {Protocol} from 'devtools-protocol';
+import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
 import {
-  type CDPSession,
   CDPSessionEvent,
+  type CDPSession,
   type CDPSessionEvents,
 } from '../api/CDPSession.js';
-import {ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {debug} from '../common/Debug.js';
 import {ProtocolError, TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
@@ -37,7 +37,7 @@ const debugProtocolReceive = debug('puppeteer:protocol:RECV ◀');
 /**
  * @public
  */
-export {ConnectionTransport, ProtocolMapping};
+export type {ConnectionTransport, ProtocolMapping};
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/Coverage.ts
+++ b/packages/puppeteer-core/src/cdp/Coverage.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {EventSubscription} from '../common/EventEmitter.js';
 import {debugError, PuppeteerURL} from '../common/util.js';
 import {assert} from '../util/assert.js';

--- a/packages/puppeteer-core/src/cdp/DeviceRequestPrompt.test.ts
+++ b/packages/puppeteer-core/src/cdp/DeviceRequestPrompt.test.ts
@@ -18,7 +18,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {type CDPSessionEvents} from '../api/CDPSession.js';
+import type {CDPSessionEvents} from '../api/CDPSession.js';
 import {TimeoutError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';

--- a/packages/puppeteer-core/src/cdp/DeviceRequestPrompt.ts
+++ b/packages/puppeteer-core/src/cdp/DeviceRequestPrompt.ts
@@ -16,9 +16,9 @@
 
 import type Protocol from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type WaitTimeoutOptions} from '../api/Page.js';
-import {type TimeoutSettings} from '../common/TimeoutSettings.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {WaitTimeoutOptions} from '../api/Page.js';
+import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 

--- a/packages/puppeteer-core/src/cdp/Dialog.ts
+++ b/packages/puppeteer-core/src/cdp/Dialog.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {Dialog} from '../api/Dialog.js';
 
 /**

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type Path from 'path';
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {Protocol} from 'devtools-protocol';
+
+import type {CDPSession} from '../api/CDPSession.js';
 import {ElementHandle, type AutofillData} from '../api/ElementHandle.js';
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
-import {type CdpFrame} from './Frame.js';
-import {type FrameManager} from './FrameManager.js';
-import {type IsolatedWorld} from './IsolatedWorld.js';
+import type {CdpFrame} from './Frame.js';
+import type {FrameManager} from './FrameManager.js';
+import type {IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
 
 /**
@@ -113,7 +115,7 @@ export class CdpElementHandle<
     );
 
     // Locate all files and confirm that they exist.
-    let path: typeof import('path');
+    let path: typeof Path;
     try {
       path = await import('path');
     } catch (error) {

--- a/packages/puppeteer-core/src/cdp/EmulationManager.ts
+++ b/packages/puppeteer-core/src/cdp/EmulationManager.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
-import {type GeolocationOptions, type MediaFeature} from '../api/Page.js';
+import type {GeolocationOptions, MediaFeature} from '../api/Page.js';
 import {debugError} from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {invokeAtMostOnceForArguments} from '../util/decorators.js';
 import {isErrorLike} from '../util/ErrorLike.js';

--- a/packages/puppeteer-core/src/cdp/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/cdp/ExecutionContext.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import type {ElementHandle} from '../api/ElementHandle.js';
-import {type JSHandle} from '../api/JSHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
 import {LazyArg} from '../common/LazyArg.js';
 import {scriptInjector} from '../common/ScriptInjector.js';
-import {type EvaluateFunc, type HandleFor} from '../common/types.js';
+import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {
   PuppeteerURL,
   SOURCE_URL_REGEX,
@@ -39,7 +39,7 @@ import {stringifyFunction} from '../util/Function.js';
 import {ARIAQueryHandler} from './AriaQueryHandler.js';
 import {Binding} from './Binding.js';
 import {CdpElementHandle} from './ElementHandle.js';
-import {type IsolatedWorld} from './IsolatedWorld.js';
+import type {IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
 
 /**

--- a/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type TargetFilterCallback} from '../api/Browser.js';
+import type {TargetFilterCallback} from '../api/Browser.js';
 import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {type Connection} from './Connection.js';
-import {type CdpTarget} from './Target.js';
+import type {Connection} from './Connection.js';
+import type {CdpTarget} from './Target.js';
 import {
   type TargetFactory,
   TargetManagerEvent,

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {Frame, FrameEvent, throwIfDetached} from '../api/Frame.js';
-import {type HTTPResponse} from '../api/HTTPResponse.js';
-import {type Page, type WaitTimeoutOptions} from '../api/Page.js';
+import type {HTTPResponse} from '../api/HTTPResponse.js';
+import type {Page, WaitTimeoutOptions} from '../api/Page.js';
 import {setPageContent} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {disposeSymbol} from '../util/disposable.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 
-import {
-  type DeviceRequestPrompt,
-  type DeviceRequestPromptManager,
+import type {
+  DeviceRequestPrompt,
+  DeviceRequestPromptManager,
 } from './DeviceRequestPrompt.js';
-import {type FrameManager} from './FrameManager.js';
+import type {FrameManager} from './FrameManager.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import {

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {FrameEvent} from '../api/Frame.js';
-import {type Page} from '../api/Page.js';
+import type {Page} from '../api/Page.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
-import {type TimeoutSettings} from '../common/TimeoutSettings.js';
+import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError, PuppeteerURL, UTILITY_WORLD_NAME} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
@@ -33,10 +33,10 @@ import {DeviceRequestPromptManager} from './DeviceRequestPrompt.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {CdpFrame} from './Frame.js';
 import {FrameTree} from './FrameTree.js';
-import {type IsolatedWorld} from './IsolatedWorld.js';
+import type {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import {NetworkManager} from './NetworkManager.js';
-import {type CdpTarget} from './Target.js';
+import type {CdpTarget} from './Target.js';
 
 /**
  * We use symbols to prevent external parties listening to these events.

--- a/packages/puppeteer-core/src/cdp/FrameTree.ts
+++ b/packages/puppeteer-core/src/cdp/FrameTree.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type Frame} from '../api/Frame.js';
+import type {Frame} from '../api/Frame.js';
 import {Deferred} from '../util/Deferred.js';
 
 /**

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type Frame} from '../api/Frame.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {Frame} from '../api/Frame.js';
 import {
   type ContinueRequestOverrides,
   type ErrorCode,
@@ -28,8 +28,8 @@ import {
   type ResponseForRequest,
   STATUS_TEXTS,
 } from '../api/HTTPRequest.js';
-import {type HTTPResponse} from '../api/HTTPResponse.js';
-import {type ProtocolError} from '../common/Errors.js';
+import type {HTTPResponse} from '../api/HTTPResponse.js';
+import type {ProtocolError} from '../common/Errors.js';
 import {debugError, isString} from '../common/util.js';
 import {assert} from '../util/assert.js';
 

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type Frame} from '../api/Frame.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {Frame} from '../api/Frame.js';
 import {HTTPResponse, type RemoteAddress} from '../api/HTTPResponse.js';
 import {ProtocolError} from '../common/Errors.js';
 import {SecurityDetails} from '../common/SecurityDetails.js';
 import {Deferred} from '../util/Deferred.js';
 
-import {type CdpHTTPRequest} from './HTTPRequest.js';
+import type {CdpHTTPRequest} from './HTTPRequest.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/Input.ts
+++ b/packages/puppeteer-core/src/cdp/Input.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type Point} from '../api/ElementHandle.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {Point} from '../api/ElementHandle.js';
 import {
   Keyboard,
   type KeyDownOptions,

--- a/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type JSHandle} from '../api/JSHandle.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {JSHandle} from '../api/JSHandle.js';
 import {Realm} from '../api/Realm.js';
-import {type TimeoutSettings} from '../common/TimeoutSettings.js';
-import {
-  type BindingPayload,
-  type EvaluateFunc,
-  type HandleFor,
-} from '../common/types.js';
+import type {TimeoutSettings} from '../common/TimeoutSettings.js';
+import type {BindingPayload, EvaluateFunc, HandleFor} from '../common/types.js';
 import {
   addPageBinding,
   debugError,
@@ -34,11 +30,11 @@ import {Deferred} from '../util/Deferred.js';
 import {disposeSymbol} from '../util/disposable.js';
 import {Mutex} from '../util/Mutex.js';
 
-import {type Binding} from './Binding.js';
+import type {Binding} from './Binding.js';
 import {type ExecutionContext, createCdpHandle} from './ExecutionContext.js';
 import {CdpFrame} from './Frame.js';
-import {type MAIN_WORLD, type PUPPETEER_WORLD} from './IsolatedWorlds.js';
-import {type WebWorker} from './WebWorker.js';
+import type {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
+import type {WebWorker} from './WebWorker.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/JSHandle.ts
+++ b/packages/puppeteer-core/src/cdp/JSHandle.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {JSHandle} from '../api/JSHandle.js';
 import {valueFromRemoteObject} from '../common/util.js';
 
 import type {CdpElementHandle} from './ElementHandle.js';
 import {releaseObject} from './ExecutionContext.js';
-import {type IsolatedWorld} from './IsolatedWorld.js';
+import type {IsolatedWorld} from './IsolatedWorld.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/cdp/LifecycleWatcher.ts
@@ -17,16 +17,16 @@
 import type Protocol from 'devtools-protocol';
 
 import {type Frame, FrameEvent} from '../api/Frame.js';
-import {type HTTPResponse} from '../api/HTTPResponse.js';
-import {type TimeoutError} from '../common/Errors.js';
+import type {HTTPResponse} from '../api/HTTPResponse.js';
+import type {TimeoutError} from '../common/Errors.js';
 import {EventSubscription} from '../common/EventEmitter.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {DisposableStack} from '../util/disposable.js';
 
-import {type CdpFrame} from './Frame.js';
+import type {CdpFrame} from './Frame.js';
 import {FrameManagerEvent} from './FrameManager.js';
-import {type CdpHTTPRequest} from './HTTPRequest.js';
+import type {CdpHTTPRequest} from './HTTPRequest.js';
 import {type NetworkManager, NetworkManagerEvent} from './NetworkManager.js';
 
 /**

--- a/packages/puppeteer-core/src/cdp/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkEventManager.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CdpHTTPRequest} from './HTTPRequest.js';
+import type {CdpHTTPRequest} from './HTTPRequest.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -18,12 +18,12 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {type CDPSessionEvents} from '../api/CDPSession.js';
-import {type HTTPRequest} from '../api/HTTPRequest.js';
-import {type HTTPResponse} from '../api/HTTPResponse.js';
+import type {CDPSessionEvents} from '../api/CDPSession.js';
+import type {HTTPRequest} from '../api/HTTPRequest.js';
+import type {HTTPResponse} from '../api/HTTPResponse.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 
-import {type CdpFrame} from './Frame.js';
+import type {CdpFrame} from './Frame.js';
 import {NetworkManager, NetworkManagerEvent} from './NetworkManager.js';
 
 // TODO: develop a helper to generate fake network events for attributes that

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -16,16 +16,16 @@
 
 import type {Readable} from 'stream';
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type Browser} from '../api/Browser.js';
+import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
-import {type ElementHandle} from '../api/ElementHandle.js';
-import {type Frame, type WaitForOptions} from '../api/Frame.js';
-import {type HTTPRequest} from '../api/HTTPRequest.js';
-import {type HTTPResponse} from '../api/HTTPResponse.js';
-import {type JSHandle} from '../api/JSHandle.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
+import type {Frame, WaitForOptions} from '../api/Frame.js';
+import type {HTTPRequest} from '../api/HTTPRequest.js';
+import type {HTTPResponse} from '../api/HTTPResponse.js';
+import type {JSHandle} from '../api/JSHandle.js';
 import {
   Page,
   PageEvent,
@@ -43,9 +43,9 @@ import {
 } from '../common/ConsoleMessage.js';
 import {TargetCloseError} from '../common/Errors.js';
 import {FileChooser} from '../common/FileChooser.js';
-import {type PDFOptions} from '../common/PDFOptions.js';
+import type {PDFOptions} from '../common/PDFOptions.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
-import {type BindingPayload, type HandleFor} from '../common/types.js';
+import type {BindingPayload, HandleFor} from '../common/types.js';
 import {
   createClientError,
   debugError,
@@ -59,7 +59,7 @@ import {
   waitForEvent,
   waitWithTimeout,
 } from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {AsyncDisposableStack} from '../util/disposable.js';
@@ -70,12 +70,12 @@ import {Binding} from './Binding.js';
 import {CdpCDPSession} from './CDPSession.js';
 import {isTargetClosedError} from './Connection.js';
 import {Coverage} from './Coverage.js';
-import {type DeviceRequestPrompt} from './DeviceRequestPrompt.js';
+import type {DeviceRequestPrompt} from './DeviceRequestPrompt.js';
 import {CdpDialog} from './Dialog.js';
 import {EmulationManager} from './EmulationManager.js';
 import {createCdpHandle, releaseObject} from './ExecutionContext.js';
 import {FirefoxTargetManager} from './FirefoxTargetManager.js';
-import {type CdpFrame} from './Frame.js';
+import type {CdpFrame} from './Frame.js';
 import {FrameManager, FrameManagerEvent} from './FrameManager.js';
 import {CdpKeyboard, CdpMouse, CdpTouchscreen} from './Input.js';
 import {MAIN_WORLD} from './IsolatedWorlds.js';
@@ -84,7 +84,7 @@ import {
   type Credentials,
   type NetworkConditions,
 } from './NetworkManager.js';
-import {type CdpTarget} from './Target.js';
+import type {CdpTarget} from './Target.js';
 import {TargetManagerEvent} from './TargetManager.js';
 import {Tracing} from './Tracing.js';
 import {WebWorker} from './WebWorker.js';

--- a/packages/puppeteer-core/src/cdp/PredefinedNetworkConditions.ts
+++ b/packages/puppeteer-core/src/cdp/PredefinedNetworkConditions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type NetworkConditions} from './NetworkManager.js';
+import type {NetworkConditions} from './NetworkManager.js';
 
 /**
  * A list of network conditions to be used with

--- a/packages/puppeteer-core/src/cdp/Puppeteer.ts
+++ b/packages/puppeteer-core/src/cdp/Puppeteer.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {type Browser} from '../api/Browser.js';
-import {type ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {Browser} from '../api/Browser.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {
   type CustomQueryHandler,
   customQueryHandlers,

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import type {Browser} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {PageEvent, type Page} from '../api/Page.js';
 import {Target, TargetType} from '../api/Target.js';
 import {debugError} from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 import {Deferred} from '../util/Deferred.js';
 
 import {CdpCDPSession} from './CDPSession.js';
 import {CdpPage} from './Page.js';
-import {type TargetManager} from './TargetManager.js';
+import type {TargetManager} from './TargetManager.js';
 import {WebWorker} from './WebWorker.js';
 
 /**

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type EventEmitter, type EventType} from '../common/EventEmitter.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {EventEmitter, EventType} from '../common/EventEmitter.js';
 
-import {type CdpTarget} from './Target.js';
+import type {CdpTarget} from './Target.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/Tracing.ts
+++ b/packages/puppeteer-core/src/cdp/Tracing.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type CDPSession} from '../api/CDPSession.js';
+import type {CDPSession} from '../api/CDPSession.js';
 import {
   getReadableAsBuffer,
   getReadableFromProtocolStream,

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CDPSession} from '../api/CDPSession.js';
-import {type Realm} from '../api/Realm.js';
-import {type ConsoleMessageType} from '../common/ConsoleMessage.js';
+import type {CDPSession} from '../api/CDPSession.js';
+import type {Realm} from '../api/Realm.js';
+import type {ConsoleMessageType} from '../common/ConsoleMessage.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
-import {type EvaluateFunc, type HandleFor} from '../common/types.js';
+import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {debugError, withSourcePuppeteerURLIfNone} from '../common/util.js';
 
 import {ExecutionContext} from './ExecutionContext.js';

--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type ConnectionTransport} from './ConnectionTransport.js';
+import type {ConnectionTransport} from './ConnectionTransport.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/Configuration.ts
+++ b/packages/puppeteer-core/src/common/Configuration.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type Product} from './Product.js';
+import type {Product} from './Product.js';
 
 /**
  * Defines experiment options for Puppeteer.

--- a/packages/puppeteer-core/src/common/ConsoleMessage.ts
+++ b/packages/puppeteer-core/src/common/ConsoleMessage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type JSHandle} from '../api/JSHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/Debug.ts
+++ b/packages/puppeteer-core/src/common/Debug.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type Debug from 'debug';
+
 import {isNode} from '../environment.js';
 
 declare global {
@@ -24,11 +26,11 @@ declare global {
 /**
  * @internal
  */
-let debugModule: typeof import('debug') | null = null;
+let debugModule: typeof Debug | null = null;
 /**
  * @internal
  */
-export async function importDebug(): Promise<typeof import('debug')> {
+export async function importDebug(): Promise<typeof Debug> {
   if (!debugModule) {
     debugModule = (await import('debug')).default;
   }

--- a/packages/puppeteer-core/src/common/Device.ts
+++ b/packages/puppeteer-core/src/common/Device.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type Viewport} from './Viewport.js';
+import type {Viewport} from './Viewport.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/EventEmitter.ts
+++ b/packages/puppeteer-core/src/common/EventEmitter.ts
@@ -21,7 +21,7 @@ import mitt, {
 } from '../../third_party/mitt/index.js';
 import {disposeSymbol} from '../util/disposable.js';
 
-export {
+export type {
   /**
    * @public
    */

--- a/packages/puppeteer-core/src/common/FileChooser.ts
+++ b/packages/puppeteer-core/src/common/FileChooser.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type ElementHandle} from '../api/ElementHandle.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
 import {assert} from '../util/assert.js';
 
 /**

--- a/packages/puppeteer-core/src/common/HandleIterator.ts
+++ b/packages/puppeteer-core/src/common/HandleIterator.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {type JSHandle} from '../api/JSHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
 import {DisposableStack, disposeSymbol} from '../util/disposable.js';
 
-import {type AwaitableIterable, type HandleFor} from './types.js';
+import type {AwaitableIterable, HandleFor} from './types.js';
 
 const DEFAULT_BATCH_SIZE = 20;
 

--- a/packages/puppeteer-core/src/common/LazyArg.ts
+++ b/packages/puppeteer-core/src/common/LazyArg.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type JSHandle} from '../api/JSHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
 import type PuppeteerUtil from '../injected/injected.js';
 
 /**

--- a/packages/puppeteer-core/src/common/SecurityDetails.ts
+++ b/packages/puppeteer-core/src/common/SecurityDetails.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 /**
  * The SecurityDetails class represents the security details of a

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {type ElementHandle} from '../api/ElementHandle.js';
-import {type JSHandle} from '../api/JSHandle.js';
-import {type Realm} from '../api/Realm.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
+import type {JSHandle} from '../api/JSHandle.js';
+import type {Realm} from '../api/Realm.js';
 import type {Poller} from '../injected/Poller.js';
 import {Deferred} from '../util/Deferred.js';
 import {isErrorLike} from '../util/ErrorLike.js';
@@ -24,7 +24,7 @@ import {stringifyFunction} from '../util/Function.js';
 
 import {TimeoutError} from './Errors.js';
 import {LazyArg} from './LazyArg.js';
-import {type HandleFor} from './types.js';
+import type {HandleFor} from './types.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type FS from 'fs/promises';
 import type {Readable} from 'stream';
 
 import type {Protocol} from 'devtools-protocol';
@@ -25,7 +26,7 @@ import {
   type Observable,
 } from '../../third_party/rxjs/rxjs.js';
 import type {CDPSession} from '../api/CDPSession.js';
-import {type Page} from '../api/Page.js';
+import type {Page} from '../api/Page.js';
 import {isNode} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
@@ -34,7 +35,7 @@ import {isErrorLike} from '../util/ErrorLike.js';
 import {debug} from './Debug.js';
 import {TimeoutError} from './Errors.js';
 import {EventSubscription} from './EventEmitter.js';
-import {type Awaitable} from './types.js';
+import type {Awaitable} from './types.js';
 
 /**
  * @internal
@@ -455,13 +456,11 @@ export async function waitWithTimeout<T>(
 /**
  * @internal
  */
-let fs: typeof import('fs/promises') | null = null;
+let fs: typeof FS | null = null;
 /**
  * @internal
  */
-export async function importFSPromises(): Promise<
-  typeof import('fs/promises')
-> {
+export async function importFSPromises(): Promise<typeof FS> {
   if (!fs) {
     try {
       fs = await import('fs/promises');

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -23,18 +23,18 @@ import {
   ChromeReleaseChannel as BrowsersChromeReleaseChannel,
 } from '@puppeteer/browsers';
 
-import {type Browser} from '../api/Browser.js';
+import type {Browser} from '../api/Browser.js';
 import {debugError} from '../common/util.js';
 import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
-import {
-  type BrowserLaunchArgumentOptions,
-  type ChromeReleaseChannel,
-  type PuppeteerNodeLaunchOptions,
+import type {
+  BrowserLaunchArgumentOptions,
+  ChromeReleaseChannel,
+  PuppeteerNodeLaunchOptions,
 } from './LaunchOptions.js';
 import {ProductLauncher, type ResolvedLaunchArgs} from './ProductLauncher.js';
-import {type PuppeteerNode} from './PuppeteerNode.js';
+import type {PuppeteerNode} from './PuppeteerNode.js';
 import {rm} from './util/fs.js';
 
 /**

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -30,12 +30,12 @@ import {
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 
-import {
-  type BrowserLaunchArgumentOptions,
-  type PuppeteerNodeLaunchOptions,
+import type {
+  BrowserLaunchArgumentOptions,
+  PuppeteerNodeLaunchOptions,
 } from './LaunchOptions.js';
 import {ProductLauncher, type ResolvedLaunchArgs} from './ProductLauncher.js';
-import {type PuppeteerNode} from './PuppeteerNode.js';
+import type {PuppeteerNode} from './PuppeteerNode.js';
 import {rm} from './util/fs.js';
 
 /**

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {type BrowserConnectOptions} from '../cdp/BrowserConnector.js';
-import {type Product} from '../common/Product.js';
+import type {BrowserConnectOptions} from '../cdp/BrowserConnector.js';
+import type {Product} from '../common/Product.js';
 
 /**
  * Launcher options that only apply to Chrome.

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
@@ -15,7 +15,7 @@
  */
 import NodeWebSocket from 'ws';
 
-import {type ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {packageVersion} from '../generated/version.js';
 
 /**

--- a/packages/puppeteer-core/src/node/PipeTransport.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type ConnectionTransport} from '../common/ConnectionTransport.js';
+import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {EventSubscription} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -26,22 +26,22 @@ import {
   computeExecutablePath,
 } from '@puppeteer/browsers';
 
-import {type Browser, type BrowserCloseCallback} from '../api/Browser.js';
+import type {Browser, BrowserCloseCallback} from '../api/Browser.js';
 import {CdpBrowser} from '../cdp/Browser.js';
 import {Connection} from '../cdp/Connection.js';
 import {TimeoutError} from '../common/Errors.js';
-import {type Product} from '../common/Product.js';
+import type {Product} from '../common/Product.js';
 import {debugError} from '../common/util.js';
-import {type Viewport} from '../common/Viewport.js';
+import type {Viewport} from '../common/Viewport.js';
 
-import {
-  type BrowserLaunchArgumentOptions,
-  type ChromeReleaseChannel,
-  type PuppeteerNodeLaunchOptions,
+import type {
+  BrowserLaunchArgumentOptions,
+  ChromeReleaseChannel,
+  PuppeteerNodeLaunchOptions,
 } from './LaunchOptions.js';
 import {NodeWebSocketTransport as WebSocketTransport} from './NodeWebSocketTransport.js';
 import {PipeTransport} from './PipeTransport.js';
-import {type PuppeteerNode} from './PuppeteerNode.js';
+import type {PuppeteerNode} from './PuppeteerNode.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -22,25 +22,25 @@ import {
   uninstall,
 } from '@puppeteer/browsers';
 
-import {type Browser} from '../api/Browser.js';
-import {type BrowserConnectOptions} from '../cdp/BrowserConnector.js';
+import type {Browser} from '../api/Browser.js';
+import type {BrowserConnectOptions} from '../cdp/BrowserConnector.js';
 import {
   type CommonPuppeteerSettings,
   type ConnectOptions,
   Puppeteer,
 } from '../cdp/Puppeteer.js';
-import {type Configuration} from '../common/Configuration.js';
-import {type Product} from '../common/Product.js';
+import type {Configuration} from '../common/Configuration.js';
+import type {Product} from '../common/Product.js';
 import {PUPPETEER_REVISIONS} from '../revisions.js';
 
 import {ChromeLauncher} from './ChromeLauncher.js';
 import {FirefoxLauncher} from './FirefoxLauncher.js';
-import {
-  type BrowserLaunchArgumentOptions,
-  type ChromeReleaseChannel,
-  type LaunchOptions,
+import type {
+  BrowserLaunchArgumentOptions,
+  ChromeReleaseChannel,
+  LaunchOptions,
 } from './LaunchOptions.js';
-import {type ProductLauncher} from './ProductLauncher.js';
+import type {ProductLauncher} from './ProductLauncher.js';
 
 /**
  * @public

--- a/packages/puppeteer-core/src/puppeteer-core.ts
+++ b/packages/puppeteer-core/src/puppeteer-core.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export {Protocol} from 'devtools-protocol';
+export type {Protocol} from 'devtools-protocol';
 
 export * from './api/api.js';
 export * from './cdp/cdp.js';

--- a/packages/puppeteer-core/src/util/AsyncIterableUtil.ts
+++ b/packages/puppeteer-core/src/util/AsyncIterableUtil.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type AwaitableIterable} from '../common/types.js';
+import type {AwaitableIterable} from '../common/types.js';
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/util/decorators.ts
+++ b/packages/puppeteer-core/src/util/decorators.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {type Disposed, type Moveable} from '../common/types.js';
+import type {Disposed, Moveable} from '../common/types.js';
 
 import {asyncDisposeSymbol, disposeSymbol} from './disposable.js';
 import {Mutex} from './Mutex.js';

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -18,7 +18,7 @@ import {homedir} from 'os';
 import {join} from 'path';
 
 import {cosmiconfigSync} from 'cosmiconfig';
-import {type Configuration, type Product} from 'puppeteer-core';
+import type {Configuration, Product} from 'puppeteer-core';
 
 /**
  * @internal

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -21,7 +21,7 @@ import {
   makeProgressCallback,
   detectBrowserPlatform,
 } from '@puppeteer/browsers';
-import {type Product} from 'puppeteer-core';
+import type {Product} from 'puppeteer-core';
 import {PUPPETEER_REVISIONS} from 'puppeteer-core/internal/revisions.js';
 
 import {getConfiguration} from '../getConfiguration.js';

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export {Protocol} from 'puppeteer-core';
+export type {Protocol} from 'puppeteer-core';
 
 export * from 'puppeteer-core/internal/puppeteer-core.js';
 

--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -28,9 +28,9 @@ import {
   type Server as HttpsServer,
   type ServerOptions as HttpsServerOptions,
 } from 'https';
-import {type AddressInfo} from 'net';
+import type {AddressInfo} from 'net';
 import {join} from 'path';
-import {type Duplex} from 'stream';
+import type {Duplex} from 'stream';
 import {gzip} from 'zlib';
 
 import {getType as getMimeType} from 'mime';

--- a/test-d/CommonEventEmitter.test-d.ts
+++ b/test-d/CommonEventEmitter.test-d.ts
@@ -3,11 +3,7 @@ import {EventEmitter as NodeEventEmitter} from 'node:events';
 
 import {expectAssignable} from 'tsd';
 
-import {
-  type CommonEventEmitter,
-  type EventEmitter,
-  type EventType,
-} from 'puppeteer';
+import type {CommonEventEmitter, EventEmitter, EventType} from 'puppeteer';
 
 declare const emitter: EventEmitter<Record<EventType, any>>;
 

--- a/test-d/ElementHandle.test-d.ts
+++ b/test-d/ElementHandle.test-d.ts
@@ -1,6 +1,6 @@
 import {expectNotType, expectType} from 'tsd';
 
-import {type ElementHandle} from 'puppeteer';
+import type {ElementHandle} from 'puppeteer';
 
 declare const handle: ElementHandle;
 

--- a/test-d/JSHandle.test-d.ts
+++ b/test-d/JSHandle.test-d.ts
@@ -1,6 +1,6 @@
 import {expectNotAssignable, expectNotType, expectType} from 'tsd';
 
-import {type ElementHandle, type JSHandle} from 'puppeteer';
+import type {ElementHandle, JSHandle} from 'puppeteer';
 
 declare const handle: JSHandle;
 

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -17,7 +17,7 @@
 import assert from 'assert';
 
 import expect from 'expect';
-import {type SerializedAXNode} from 'puppeteer-core/internal/cdp/Accessibility.js';
+import type {SerializedAXNode} from 'puppeteer-core/internal/cdp/Accessibility.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import expect from 'expect';
-import {type CdpBrowser} from 'puppeteer-core/internal/cdp/Browser.js';
+import type {CdpBrowser} from 'puppeteer-core/internal/cdp/Browser.js';
 
 import {getTestState, launch} from '../mocha-utils.js';
 import {attachFrame} from '../utils.js';

--- a/test/src/chromiumonly.spec.ts
+++ b/test/src/chromiumonly.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type IncomingMessage} from 'http';
+import type {IncomingMessage} from 'http';
 
 import expect from 'expect';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';

--- a/test/src/frame.spec.ts
+++ b/test/src/frame.spec.ts
@@ -16,7 +16,7 @@
 
 import expect from 'expect';
 import {CDPSession} from 'puppeteer-core/internal/api/CDPSession.js';
-import {type Frame} from 'puppeteer-core/internal/api/Frame.js';
+import type {Frame} from 'puppeteer-core/internal/api/Frame.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {

--- a/test/src/headful.spec.ts
+++ b/test/src/headful.spec.ts
@@ -20,7 +20,7 @@ import path from 'path';
 
 import expect from 'expect';
 import {CDPSessionEvent} from 'puppeteer-core/internal/api/CDPSession.js';
-import {type PuppeteerLaunchOptions} from 'puppeteer-core/internal/node/PuppeteerNode.js';
+import type {PuppeteerLaunchOptions} from 'puppeteer-core/internal/node/PuppeteerNode.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 
 import {getTestState, isHeadless, launch} from './mocha-utils.js';

--- a/test/src/idle_override.spec.ts
+++ b/test/src/idle_override.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import expect from 'expect';
-import {type ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
-import {type Page} from 'puppeteer-core/internal/api/Page.js';
+import type {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/ignorehttpserrors.spec.ts
+++ b/test/src/ignorehttpserrors.spec.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import {type TLSSocket} from 'tls';
+import type {TLSSocket} from 'tls';
 
 import expect from 'expect';
-import {type HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
+import type {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
 import {launch} from './mocha-utils.js';
 

--- a/test/src/keyboard.spec.ts
+++ b/test/src/keyboard.spec.ts
@@ -17,7 +17,7 @@
 import os from 'os';
 
 import expect from 'expect';
-import {type KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+import type {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {attachFrame} from './utils.js';

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -18,11 +18,11 @@ import fs from 'fs';
 import {mkdtemp, readFile, writeFile} from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import {type TLSSocket} from 'tls';
+import type {TLSSocket} from 'tls';
 
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';
-import {type Page} from 'puppeteer-core/internal/api/Page.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 import sinon from 'sinon';
 

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -18,20 +18,20 @@ import fs from 'fs';
 import path from 'path';
 
 import {TestServer} from '@pptr/testserver';
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 import expect from 'expect';
 import type * as Mocha from 'mocha';
 import puppeteer from 'puppeteer/lib/cjs/puppeteer/puppeteer.js';
-import {type Browser} from 'puppeteer-core/internal/api/Browser.js';
-import {type BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
-import {type Page} from 'puppeteer-core/internal/api/Page.js';
+import type {Browser} from 'puppeteer-core/internal/api/Browser.js';
+import type {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
 import {
   setLogCapture,
   getCapturedLogs,
 } from 'puppeteer-core/internal/common/Debug.js';
-import {
-  type PuppeteerLaunchOptions,
-  type PuppeteerNode,
+import type {
+  PuppeteerLaunchOptions,
+  PuppeteerNode,
 } from 'puppeteer-core/internal/node/PuppeteerNode.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';

--- a/test/src/mouse.spec.ts
+++ b/test/src/mouse.spec.ts
@@ -17,8 +17,8 @@ import os from 'os';
 
 import expect from 'expect';
 import {MouseButton} from 'puppeteer-core/internal/api/Input.js';
-import {type Page} from 'puppeteer-core/internal/api/Page.js';
-import {type KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
+import type {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {type ServerResponse} from 'http';
+import type {ServerResponse} from 'http';
 
 import expect from 'expect';
 import {type Frame, TimeoutError} from 'puppeteer';
-import {type HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
+import type {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -15,12 +15,12 @@
  */
 
 import fs from 'fs';
-import {type ServerResponse} from 'http';
+import type {ServerResponse} from 'http';
 import path from 'path';
 
 import expect from 'expect';
-import {type HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
-import {type HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
+import type {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
+import type {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
 import {getTestState, launch, setupTestBrowserHooks} from './mocha-utils.js';
 import {attachFrame, isFavicon, waitEvent} from './utils.js';

--- a/test/src/oopif.spec.ts
+++ b/test/src/oopif.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import expect from 'expect';
-import {type BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
-import {type CdpTarget} from 'puppeteer-core/internal/cdp/Target.js';
+import type {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
+import type {CdpTarget} from 'puppeteer-core/internal/cdp/Target.js';
 
 import {describeWithDebugLogs, getTestState, launch} from './mocha-utils.js';
 import {attachFrame, detachFrame, navigateFrame} from './utils.js';

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -15,15 +15,15 @@
  */
 import assert from 'assert';
 import fs from 'fs';
-import {type ServerResponse} from 'http';
+import type {ServerResponse} from 'http';
 import path from 'path';
 
 import expect from 'expect';
 import {KnownDevices, TimeoutError} from 'puppeteer';
 import {CDPSession} from 'puppeteer-core/internal/api/CDPSession.js';
-import {type Metrics, type Page} from 'puppeteer-core/internal/api/Page.js';
-import {type CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
-import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import type {Metrics, Page} from 'puppeteer-core/internal/api/Page.js';
+import type {CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
+import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 import sinon from 'sinon';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';

--- a/test/src/proxy.spec.ts
+++ b/test/src/proxy.spec.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import type {IncomingMessage, Server, ServerResponse} from 'http';
 import http from 'http';
-import type {Server, IncomingMessage, ServerResponse} from 'http';
 import type {AddressInfo} from 'net';
 import os from 'os';
 
-import {type TestServer} from '@pptr/testserver';
+import type {TestServer} from '@pptr/testserver';
 import expect from 'expect';
 
 import {getTestState, launch} from './mocha-utils.js';

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -17,7 +17,7 @@ import assert from 'assert';
 
 import expect from 'expect';
 import {Puppeteer} from 'puppeteer-core';
-import {type ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
+import type {ElementHandle} from 'puppeteer-core/internal/api/ElementHandle.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -23,7 +23,7 @@ import {
   type HTTPRequest,
   InterceptResolutionAction,
 } from 'puppeteer-core/internal/api/HTTPRequest.js';
-import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {isFavicon, waitEvent} from './utils.js';

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -18,8 +18,8 @@ import fs from 'fs';
 import path from 'path';
 
 import expect from 'expect';
-import {type HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
-import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import type {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';
+import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {isFavicon, waitEvent} from './utils.js';

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import {type ServerResponse} from 'http';
+import type {ServerResponse} from 'http';
 
 import expect from 'expect';
 import {type Target, TimeoutError} from 'puppeteer';
-import {type Page} from 'puppeteer-core/internal/api/Page.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {waitEvent} from './utils.js';

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -17,9 +17,9 @@
 import path from 'path';
 
 import expect from 'expect';
-import {type Frame} from 'puppeteer-core/internal/api/Frame.js';
-import {type Page} from 'puppeteer-core/internal/api/Page.js';
-import {type EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
+import type {Frame} from 'puppeteer-core/internal/api/Frame.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
+import type {EventEmitter} from 'puppeteer-core/internal/common/EventEmitter.js';
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';
 
 import {compare} from './golden-utils.js';

--- a/test/src/worker.spec.ts
+++ b/test/src/worker.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import expect from 'expect';
-import {type WebWorker} from 'puppeteer-core/internal/cdp/WebWorker.js';
-import {type ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import type {WebWorker} from 'puppeteer-core/internal/cdp/WebWorker.js';
+import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {waitEvent} from './utils.js';

--- a/tools/internal/custom_markdown_documenter.ts
+++ b/tools/internal/custom_markdown_documenter.ts
@@ -23,7 +23,7 @@
 
 import * as path from 'path';
 
-import {type DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig';
+import type {DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig';
 import {CustomMarkdownEmitter} from '@microsoft/api-documenter/lib/markdown/CustomMarkdownEmitter';
 import {CustomDocNodes} from '@microsoft/api-documenter/lib/nodes/CustomDocNodeKind';
 import {DocEmphasisSpan} from '@microsoft/api-documenter/lib/nodes/DocEmphasisSpan';

--- a/tools/mocha-runner/src/test.ts
+++ b/tools/mocha-runner/src/test.ts
@@ -16,7 +16,7 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'node:test';
 
-import {type Platform, type TestExpectation} from './types.js';
+import type {Platform, TestExpectation} from './types.js';
 import {
   filterByParameters,
   getTestResultForFailure,

--- a/tools/mocha-runner/src/types.ts
+++ b/tools/mocha-runner/src/types.ts
@@ -16,7 +16,7 @@
 
 import {z} from 'zod';
 
-import {type RecommendedExpectation} from './utils.js';
+import type {RecommendedExpectation} from './utils.js';
 
 export const zPlatform = z.enum(['win32', 'linux', 'darwin']);
 

--- a/tools/mocha-runner/src/utils.ts
+++ b/tools/mocha-runner/src/utils.ts
@@ -17,11 +17,11 @@
 import fs from 'fs';
 import path from 'path';
 
-import {
-  type MochaTestResult,
-  type TestExpectation,
-  type MochaResults,
-  type TestResult,
+import type {
+  MochaTestResult,
+  TestExpectation,
+  MochaResults,
+  TestResult,
 } from './types.js';
 
 export function extendProcessEnv(envs: object[]): NodeJS.ProcessEnv {


### PR DESCRIPTION
[`--verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) is being recommended for new code. This flag improves compatibility with other utilities such as ESBuild and SWC and also provides better semantics for type imports.

This PR updates the ESLint rules for this flag.