### PR TITLE
fix: remove the flag disabling bfcache

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -177,7 +177,6 @@ export class ChromeLauncher extends ProductLauncher {
 
     if (!USE_TAB_TARGET) {
       disabledFeatures.push('Prerender2');
-      disabledFeatures.push('BackForwardCache');
     }
 
     const chromeArguments = [

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1020,6 +1020,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[page.spec] Page Page.select should not throw when select causes navigation",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["PASS"]
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.select should respect event bubbling",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -3174,12 +3180,6 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[page.spec] Page Page.select should not throw when select causes navigation",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["PASS"]
-  },
-  {
     "testIdPattern": "[page.spec] Page Page.select should work when re-defining top-level Event class",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -3862,11 +3862,5 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "headless"],
     "expectations": ["FAIL", "PASS"]
-  },
-  {
-    "testIdPattern": "[coverage.spec] Coverage specs JSCoverage resetOnNavigation should report scripts across navigations when disabled",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "chrome", "new-headless", "tabTarget"],
-    "expectations": ["FAIL"]
   }
 ]

--- a/test/src/coverage.spec.ts
+++ b/test/src/coverage.spec.ts
@@ -165,6 +165,8 @@ describe('Coverage specs', function () {
 
         await page.coverage.startJSCoverage({resetOnNavigation: false});
         await page.goto(server.PREFIX + '/jscoverage/multiple.html');
+        // TODO: navigating too fast might loose JS coverage data in the browser.
+        await page.waitForNetworkIdle();
         await page.goto(server.EMPTY_PAGE);
         const coverage = await page.coverage.stopJSCoverage();
         expect(coverage).toHaveLength(2);


### PR DESCRIPTION
It is not strictly connected to the tab target feature and should already work.

Issue https://github.com/puppeteer/puppeteer/issues/8197