### PR TITLE
test: crash mocha if unhandled errors occur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@f3a3c79c553122e2fe5829eeac7d815326502903 # setup-github-actions-caching/v1
       - name: Build packages
         run: npm run build --workspace @puppeteer-test/test
       - name: Setup cache for Chrome binary
@@ -263,6 +265,8 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
+      # Set up GitHub Actions caching for Wireit.
+      - uses: google/wireit@f3a3c79c553122e2fe5829eeac7d815326502903 # setup-github-actions-caching/v1
       - name: Build packages
         run: npm run build --workspace @puppeteer-test/test
       - name: Setup cache for Firefox binary

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -27,4 +27,9 @@ module.exports = {
   parallel: !!process.env.PARALLEL,
   timeout: timeout,
   reporter: process.env.CI ? 'spec' : 'dot',
+  // This should make mocha crash on uncaught errors.
+  // See https://github.com/mochajs/mocha/blob/master/docs/index.md#--allow-uncaught.
+  allowUncaught: true,
+  // See https://github.com/mochajs/mocha/blob/master/docs/index.md#--async-only--a.
+  asyncOnly: true,
 };

--- a/test/src/elementhandle.spec.ts
+++ b/test/src/elementhandle.spec.ts
@@ -690,7 +690,7 @@ describe('ElementHandle specs', function () {
         Puppeteer.customQueryHandlerNames();
       expect(handlerNamesAfterUnregistering.includes('getById')).toBeFalsy();
     });
-    it('should throw with invalid query names', () => {
+    it('should throw with invalid query names', async () => {
       try {
         Puppeteer.registerCustomQueryHandler('1/2/3', {
           queryOne: () => {

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -249,10 +249,6 @@ if (
   );
 }
 
-process.on('unhandledRejection', reason => {
-  throw reason;
-});
-
 const browserNotClosedError = new Error(
   'A manually launched browser was not closed!'
 );


### PR DESCRIPTION
- enables allowUncaught which turns off attempts by mocha to catch uncaught errors and instead would cause the process crash.
- drive-by: turn on async only (not really needed but looks like there could be unhandled errors from promises created from sync tests).
- drive-by: enable wireit caching for ci.