### PR TITLE
fix: update file chooser events

### DIFF
--- a/docs/api/puppeteer.filechooser.cancel.md
+++ b/docs/api/puppeteer.filechooser.cancel.md
@@ -10,10 +10,10 @@ Closes the file chooser without selecting any files.
 
 ```typescript
 class FileChooser {
-  cancel(): void;
+  cancel(): Promise<void>;
 }
 ```
 
 **Returns:**
 
-void
+Promise&lt;void&gt;

--- a/packages/puppeteer-core/src/common/FileChooser.ts
+++ b/packages/puppeteer-core/src/common/FileChooser.ts
@@ -87,11 +87,16 @@ export class FileChooser {
   /**
    * Closes the file chooser without selecting any files.
    */
-  cancel(): void {
+  async cancel(): Promise<void> {
     assert(
       !this.#handled,
       'Cannot cancel FileChooser which is already handled!'
     );
     this.#handled = true;
+    // XXX: These events should converted to trusted events. Perhaps do this
+    // in `DOM.setFileInputFiles`?
+    await this.#element.evaluate(element => {
+      element.dispatchEvent(new Event('cancel', {bubbles: true}));
+    });
   }
 }

--- a/test/src/input.spec.ts
+++ b/test/src/input.spec.ts
@@ -358,7 +358,7 @@ describe('input tests', function () {
       let error!: Error;
 
       try {
-        fileChooser.cancel();
+        await fileChooser.cancel();
       } catch (error_) {
         error = error_ as Error;
       }


### PR DESCRIPTION
This PR

 - adds `composed` to the input event since this is what occurs in the browser.
 - dispatches the `cancel` event when the chooser is canceled.