### PR TITLE
docs: update link to `third_party/README.md`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -234,7 +234,7 @@ A barrier for introducing new installation dependencies is especially high:
 
 There are additional considerations for dependencies that are environment
 agonistic. See the
-[`third_party/README.md`](https://github.com/puppeteer/puppeteer/blob/main/third_party/README.md)
+[`third_party/README.md`](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/third_party/README.md)
 for details.
 
 ## Testing tips


### PR DESCRIPTION
**PR Summary**:
PR simply updates the location of the `third_party/README.md` file which was moved in PR #9023.
> `third_party/README.md` -> `packages/puppeteer-core/third_party/README.md`