### PR TITLE
Update reference to SKIP_CHROMIUM_DOWNLOAD env to SKIP_DOWNLOAD in troubleshooting docs page

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -361,7 +361,7 @@ RUN apt-get update \
 # Uncomment to skip the chromium download when installing puppeteer. If you do,
 # you'll need to launch puppeteer with:
 #     browser.launch({executablePath: 'google-chrome-stable'})
-# ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+# ENV PUPPETEER_SKIP_DOWNLOAD true
 
 # Install puppeteer so it's available in the container.
 RUN npm init -y &&  \


### PR DESCRIPTION
This PR updates the troubleshooting page which references the configuration environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `PUPPETEER_SKIP_DOWNLOAD` as the former variable has been made obsolete since this change here.

https://github.com/puppeteer/puppeteer/pull/10054/files#diff-38d209a9ccb2594d24d674a3c8f5ca4cb949466e78cb7b15d0114c998db9c2a4L50

