### PR TITLE
feat: enable tab targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,6 @@ jobs:
           - chrome-headful
           - chrome-new-headless
           - chrome-bidi
-          - chrome-new-headless-tab
         shard:
           - 1/2
           - 2/2
@@ -159,10 +158,6 @@ jobs:
             suite: chrome-bidi
           - os: macos-latest
             suite: chrome-headful
-          - os: windows-latest
-            suite: chrome-new-headless-tab
-          - os: macos-latest
-            suite: chrome-new-headless-tab
     steps:
       - name: Check out repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test-types": "tsd -t packages/puppeteer",
     "test:chrome:headful": "wireit",
     "test:chrome:new-headless": "wireit",
-    "test:chrome:new-headless-tab": "wireit",
     "test:chrome:headless": "wireit",
     "test:chrome:bidi": "wireit",
     "test:chrome:bidi-local": "wireit",
@@ -75,9 +74,6 @@
     },
     "test:chrome:new-headless": {
       "command": "npm test -- --test-suite chrome-new-headless"
-    },
-    "test:chrome:new-headless-tab": {
-      "command": "npm test -- --test-suite chrome-new-headless-tab"
     },
     "test:chrome:bidi": {
       "command": "npm test -- --test-suite chrome-bidi"

--- a/packages/browsers/test/src/versions.ts
+++ b/packages/browsers/test/src/versions.ts
@@ -16,6 +16,6 @@
 
 export const testChromeBuildId = '113.0.5672.0';
 export const testChromiumBuildId = '1083080';
-export const testFirefoxBuildId = '119.0a1';
+export const testFirefoxBuildId = '120.0a1';
 export const testChromeDriverBuildId = '115.0.5763.0';
 export const testChromeHeadlessShellBuildId = '118.0.5950.0';

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -33,7 +33,6 @@ import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
 import type {Viewport} from '../common/Viewport.js';
-import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {ChromeTargetManager} from './ChromeTargetManager.js';
@@ -63,8 +62,7 @@ export class CdpBrowser extends BrowserBase {
     closeCallback?: BrowserCloseCallback,
     targetFilterCallback?: TargetFilterCallback,
     isPageTargetCallback?: IsPageTargetCallback,
-    waitForInitiallyDiscoveredTargets = true,
-    useTabTarget = USE_TAB_TARGET
+    waitForInitiallyDiscoveredTargets = true
   ): Promise<CdpBrowser> {
     const browser = new CdpBrowser(
       product,
@@ -76,8 +74,7 @@ export class CdpBrowser extends BrowserBase {
       closeCallback,
       targetFilterCallback,
       isPageTargetCallback,
-      waitForInitiallyDiscoveredTargets,
-      useTabTarget
+      waitForInitiallyDiscoveredTargets
     );
     await browser._attach();
     return browser;
@@ -107,8 +104,7 @@ export class CdpBrowser extends BrowserBase {
     closeCallback?: BrowserCloseCallback,
     targetFilterCallback?: TargetFilterCallback,
     isPageTargetCallback?: IsPageTargetCallback,
-    waitForInitiallyDiscoveredTargets = true,
-    useTabTarget = USE_TAB_TARGET
+    waitForInitiallyDiscoveredTargets = true
   ) {
     super();
     product = product || 'chrome';
@@ -134,8 +130,7 @@ export class CdpBrowser extends BrowserBase {
         connection,
         this.#createTarget,
         this.#targetFilterCallback,
-        waitForInitiallyDiscoveredTargets,
-        useTabTarget
+        waitForInitiallyDiscoveredTargets
       );
     }
     this.#defaultContext = new CdpBrowserContext(this.#connection, this);

--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -99,21 +99,16 @@ export class ChromeTargetManager
   #waitForInitiallyDiscoveredTargets = true;
 
   // TODO: remove the flag once the testing/rollout is done.
-  #tabMode: boolean;
   #discoveryFilter: Protocol.Target.FilterEntry[];
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
     targetFilterCallback?: TargetFilterCallback,
-    waitForInitiallyDiscoveredTargets = true,
-    useTabTarget = false
+    waitForInitiallyDiscoveredTargets = true
   ) {
     super();
-    this.#tabMode = useTabTarget;
-    this.#discoveryFilter = this.#tabMode
-      ? [{}]
-      : [{type: 'tab', exclude: true}, {}];
+    this.#discoveryFilter = [{}];
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;
@@ -166,15 +161,13 @@ export class ChromeTargetManager
       waitForDebuggerOnStart: true,
       flatten: true,
       autoAttach: true,
-      filter: this.#tabMode
-        ? [
-            {
-              type: 'page',
-              exclude: true,
-            },
-            ...this.#discoveryFilter,
-          ]
-        : this.#discoveryFilter,
+      filter: [
+        {
+          type: 'page',
+          exclude: true,
+        },
+        ...this.#discoveryFilter,
+      ],
     });
     this.#finishInitializationIfReady();
     await this.#initializeDeferred.valueOrThrow();

--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -98,8 +98,7 @@ export class ChromeTargetManager
   #targetsIdsForInit = new Set<string>();
   #waitForInitiallyDiscoveredTargets = true;
 
-  // TODO: remove the flag once the testing/rollout is done.
-  #discoveryFilter: Protocol.Target.FilterEntry[];
+  #discoveryFilter: Protocol.Target.FilterEntry[] = [{}];
 
   constructor(
     connection: Connection,
@@ -108,7 +107,6 @@ export class ChromeTargetManager
     waitForInitiallyDiscoveredTargets = true
   ) {
     super();
-    this.#discoveryFilter = [{}];
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -27,13 +27,3 @@ export const DEFERRED_PROMISE_DEBUG_TIMEOUT =
   typeof process.env['PUPPETEER_DEFERRED_PROMISE_DEBUG_TIMEOUT'] !== 'undefined'
     ? Number(process.env['PUPPETEER_DEFERRED_PROMISE_DEBUG_TIMEOUT'])
     : -1;
-
-/**
- * Only used for internal testing.
- *
- * @internal
- */
-export const USE_TAB_TARGET =
-  typeof process !== 'undefined'
-    ? process.env['PUPPETEER_INTERNAL_TAB_TARGET'] === 'true'
-    : false;

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -25,7 +25,6 @@ import {
 
 import type {Browser} from '../api/Browser.js';
 import {debugError} from '../common/util.js';
-import {USE_TAB_TARGET} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import type {
@@ -174,10 +173,6 @@ export class ChromeLauncher extends ProductLauncher {
       'MediaRouter',
       'OptimizationHints',
     ];
-
-    if (!USE_TAB_TARGET) {
-      disabledFeatures.push('Prerender2');
-    }
 
     const chromeArguments = [
       '--allow-pre-commit-input',

--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -19,12 +19,6 @@
       "expectedLineCoverage": 93
     },
     {
-      "id": "chrome-new-headless-tab",
-      "platforms": ["linux"],
-      "parameters": ["chrome", "new-headless", "cdp", "tabTarget"],
-      "expectedLineCoverage": 93
-    },
-    {
       "id": "firefox-headless",
       "platforms": ["linux", "darwin"],
       "parameters": ["firefox", "headless", "cdp"],
@@ -69,9 +63,6 @@
     "webDriverBiDi": {
       "PUPPETEER_PROTOCOL": "webDriverBiDi"
     },
-    "cdp": {},
-    "tabTarget": {
-      "PUPPETEER_INTERNAL_TAB_TARGET": "true"
-    }
+    "cdp": {}
   }
 }


### PR DESCRIPTION
[Tab target is a new type of target in CDP](https://docs.google.com/document/d/14aeiC_zga2SS0OXJd6eIFj8N0o5LGwUpuqa4L8NKoR4/edit) that reflects the architectural changes in Chromium that were needed for features such as bfcache, portals and prerendering.

Previously, the `page` targets were the top-level targets representing the entire tab. If you navigate to a new URL, the page target would remain the same. With the introduction of the `tab` target, it's not possible to have multiple page targets active within one tab. For example, one page would be the currently shown page and the other one would be a [prerendered](https://github.com/WICG/nav-speculation/) page. When the user navigates to the prerendered page, the secondary page becomes the primary and the primary page target gets destroyed (the process is called activation).

This change enables tab targets and allows testing Chrome features related to prerendering. Emulation and network manager domains should work with the prerendered targets. Some features like JS/CSS coverage might not work during the activation so you would need to disable prerendering to test those.

Use command line flags to disable prerendering in Chrome if you encounter issues. For example,
```
--disable-features=Prerender2
```
