### PR TITLE
chore: add a deflake utility

### DIFF
--- a/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
@@ -20,10 +20,15 @@ import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js'
 
 import type {CDPEvents, CDPSession} from '../api/CDPSession.js';
 import type {Connection as CdpConnection} from '../cdp/Connection.js';
+import {debug} from '../common/Debug.js';
 import {TargetCloseError} from '../common/Errors.js';
 import type {Handler} from '../common/EventEmitter.js';
 
 import {BidiConnection} from './Connection.js';
+
+const bidiServerLogger = (prefix: string, ...args: unknown[]): void => {
+  debug(`bidi:${prefix}`)(args);
+};
 
 /**
  * @internal
@@ -54,7 +59,9 @@ export async function connectBidiOverCdp(
   const bidiServer = await BidiMapper.BidiServer.createAndStart(
     transportBiDi,
     cdpConnectionAdapter,
-    ''
+    '',
+    undefined,
+    bidiServerLogger
   );
   return pptrBiDiConnection;
 }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -26,6 +26,11 @@ module.exports = {
             selector:
               'MemberExpression[object.name="puppeteer"][property.name="launch"]',
           },
+          {
+            message: 'Unexpected debugging mocha test.',
+            selector:
+              'CallExpression[callee.object.name="it"] > MemberExpression > Identifier[name="deflake"], CallExpression[callee.object.name="it"] > MemberExpression > Identifier[name="deflakeOnly"]',
+          },
         ],
       },
     },

--- a/test/package.json
+++ b/test/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "puppeteer-core": "file:../packages/puppeteer-core",
     "puppeteer": "file:../packages/puppeteer"
   }
 }

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -26,12 +26,7 @@ import type {Page} from 'puppeteer-core/internal/api/Page.js';
 import {rmSync} from 'puppeteer-core/internal/node/util/fs.js';
 import sinon from 'sinon';
 
-import {
-  getTestState,
-  isHeadless,
-  itOnlyRegularInstall,
-  launch,
-} from './mocha-utils.js';
+import {getTestState, isHeadless, launch} from './mocha-utils.js';
 import {dumpFrames, waitEvent} from './utils.js';
 
 const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
@@ -601,7 +596,7 @@ describe('Launcher specs', function () {
     });
 
     describe('Puppeteer.launch', function () {
-      itOnlyRegularInstall('should be able to launch Chrome', async () => {
+      it('should be able to launch Chrome', async () => {
         const {browser, close} = await launch({product: 'chrome'});
         try {
           const userAgent = await browser.userAgent();
@@ -875,7 +870,7 @@ describe('Launcher specs', function () {
       });
     });
     describe('Puppeteer.executablePath', function () {
-      itOnlyRegularInstall('should work', async () => {
+      it('should work', async () => {
         const {puppeteer} = await getTestState({
           skipLaunch: true,
         });

--- a/test/src/oopif.spec.ts
+++ b/test/src/oopif.spec.ts
@@ -18,10 +18,10 @@ import expect from 'expect';
 import type {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
 import type {CdpTarget} from 'puppeteer-core/internal/cdp/Target.js';
 
-import {describeWithDebugLogs, getTestState, launch} from './mocha-utils.js';
+import {getTestState, launch} from './mocha-utils.js';
 import {attachFrame, detachFrame, navigateFrame} from './utils.js';
 
-describeWithDebugLogs('OOPIF', function () {
+describe('OOPIF', function () {
   /* We use a special browser for this test as we need the --site-per-process flag */
   let state: Awaited<ReturnType<typeof launch>>;
 

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -246,6 +246,7 @@ describe('Target', function () {
     expect(targetChanged).toBe(false);
     context.off('targetchanged', listener);
   });
+
   it('should not crash while redirecting if original request was missed', async () => {
     const {page, server, context} = await getTestState();
 
@@ -268,11 +269,12 @@ describe('Target', function () {
       {timeout: 3000}
     );
     const newPage = (await target.page())!;
+    const loadEvent = waitEvent(newPage, 'load');
     // Issue a redirect.
     serverResponse.writeHead(302, {location: '/injectedstyle.css'});
     serverResponse.end();
     // Wait for the new page to load.
-    await waitEvent(newPage, 'load');
+    await loadEvent;
     // Cleanup.
     await newPage.close();
   });

--- a/tools/mocha-runner/README.md
+++ b/tools/mocha-runner/README.md
@@ -71,3 +71,33 @@ Examples:
 Currently, expectations are updated manually. The test runner outputs the
 suggested changes to the expectation file if the test run does not match
 expectations.
+
+## Debugging flaky test
+
+### Utility functions:
+
+| Utility                  | Params                          | Description                                                                       |
+| ------------------------ | ------------------------------- | --------------------------------------------------------------------------------- |
+| `describe.withDebugLogs` | `(title, <DescribeBody>)`       | Capture and print debug logs for each test that failed                            |
+| `it.deflake`             | `(repeat, title, <itFunction>)` | Reruns the test N number of times and print the debug logs if for the failed runs |
+| `it.deflakeOnly`         | `(repeat, title, <itFunction>)` | Same as `it.deflake` but runs only this specific test                             |
+
+### With Environment variable
+
+Run the test with the following environment variable to wrap it around `describe.withDebugLogs`. Example:
+
+```bash
+PUPPETEER_DEFLAKE_TESTS="[navigation.spec] navigation Page.goto should navigate to empty page with networkidle0" npm run test:chrome:headless
+```
+
+It also works with [patterns](#1--this-is-my-header) just like `TestExpectations.json`
+
+```bash
+PUPPETEER_DEFLAKE_TESTS="[navigation.spec] *" npm run test:chrome:headless
+```
+
+By default the test is rerun 100 times, but you can control this as well:
+
+```bash
+PUPPETEER_DEFLAKE_RETRIES=1000 PUPPETEER_DEFLAKE_TESTS="[navigation.spec] *" npm run test:chrome:headless
+```

--- a/tools/mocha-runner/package.json
+++ b/tools/mocha-runner/package.json
@@ -29,5 +29,8 @@
         "build"
       ]
     }
+  },
+  "dependencies": {
+    "puppeteer-core": "file:../../packages/puppeteer-core"
   }
 }

--- a/tools/mocha-runner/src/interface.ts
+++ b/tools/mocha-runner/src/interface.ts
@@ -16,6 +16,10 @@
 
 import Mocha from 'mocha';
 import commonInterface from 'mocha/lib/interfaces/common';
+import {
+  setLogCapture,
+  getCapturedLogs,
+} from 'puppeteer-core/internal/common/Debug.js';
 
 import {testIdMatchesExpectationPattern} from './utils.js';
 
@@ -28,6 +32,10 @@ const skippedTests: Array<{testIdPattern: string; skip: true}> = process.env[
   ? JSON.parse(process.env['PUPPETEER_SKIPPED_TEST_CONFIG'])
   : [];
 
+const deflakeRetries = Number(process.env['PUPPETEER_DEFLAKE_RETRIES'] ?? 100);
+const deflakeTestPattern: string | undefined =
+  process.env['PUPPETEER_DEFLAKE_TESTS'];
+
 function shouldSkipTest(test: Mocha.Test): boolean {
   // TODO: more efficient lookup.
   const definition = skippedTests.find(skippedTest => {
@@ -39,8 +47,26 @@ function shouldSkipTest(test: Mocha.Test): boolean {
   return false;
 }
 
+function shouldDeflakeTest(test: Mocha.Test): boolean {
+  if (deflakeTestPattern) {
+    // TODO: cache if we have seen it already
+    return testIdMatchesExpectationPattern(test, deflakeTestPattern);
+  }
+  return false;
+}
+
+function dumpLogsIfFail(this: Mocha.Context) {
+  if (this.currentTest?.state === 'failed') {
+    console.log(
+      `\n"${this.currentTest.fullTitle()}" failed. Here is a debug log:`
+    );
+    console.log(getCapturedLogs().join('\n') + '\n');
+  }
+  setLogCapture(false);
+}
+
 function customBDDInterface(suite: Mocha.Suite) {
-  const suites = [suite];
+  const suites: [Mocha.Suite] = [suite];
 
   suite.on(
     Mocha.Suite.constants.EVENT_FILE_PRE_REQUIRE,
@@ -78,12 +104,25 @@ function customBDDInterface(suite: Mocha.Suite) {
         });
       };
 
+      describe.withDebugLogs = function (
+        description: string,
+        body: (this: Mocha.Suite) => void
+      ): void {
+        context['describe']('with Debug Logs', () => {
+          context['beforeEach'](() => {
+            setLogCapture(true);
+          });
+          context['afterEach'](dumpLogsIfFail);
+          context['describe'](description, body);
+        });
+      };
+
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       context['describe'] = describe;
 
       function it(title: string, fn: Mocha.TestFunction, itOnly = false) {
-        const suite = suites[0]!;
+        const suite = suites[0]! as Mocha.Suite;
         const test = new Mocha.Test(title, suite.isPending() ? undefined : fn);
         test.file = file;
         test.parent = suite;
@@ -95,8 +134,22 @@ function customBDDInterface(suite: Mocha.Suite) {
             return child === suite;
           })
         );
+        if (shouldDeflakeTest(test)) {
+          const deflakeSuit = Mocha.Suite.create(suite, 'with Debug Logs');
+          test.parent = deflakeSuit;
+          deflakeSuit.file = file;
+          deflakeSuit.parent = suite;
 
-        if (shouldSkipTest(test) && !(itOnly || describeOnly)) {
+          deflakeSuit.beforeEach(function () {
+            setLogCapture(true);
+          });
+          deflakeSuit.afterEach(dumpLogsIfFail);
+          for (let i = 0; i < deflakeRetries; i++) {
+            deflakeSuit.addTest(test.clone());
+          }
+
+          return test;
+        } else if (!(itOnly || describeOnly) && shouldSkipTest(test)) {
           const test = new Mocha.Test(title);
           test.file = file;
           suite.addTest(test);
@@ -110,13 +163,31 @@ function customBDDInterface(suite: Mocha.Suite) {
       it.only = function (title: string, fn: Mocha.TestFunction) {
         return common.test.only(
           mocha,
-          (context['it'] as typeof it)(title, fn, true)
+          (context['it'] as unknown as typeof it)(title, fn, true)
         );
       };
 
       it.skip = function (title: string) {
         return context['it'](title);
       };
+
+      function wrapDeflake(
+        func: Function
+      ): (repeats: number, title: string, fn: Mocha.AsyncFunc) => void {
+        return (repeats: number, title: string, fn: Mocha.AsyncFunc): void => {
+          (context['describe'] as unknown as typeof describe).withDebugLogs(
+            'with Debug Logs',
+            () => {
+              for (let i = 1; i <= repeats; i++) {
+                func(`${i}/${title}`, fn);
+              }
+            }
+          );
+        };
+      }
+
+      it.deflake = wrapDeflake(it);
+      it.deflakeOnly = wrapDeflake(it.only);
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error


### PR DESCRIPTION
Provide an easy way to wrap a test and get its logs, tooling added to prevent submitting it to `main`. 
Also adds Logger to BiDi server.