### PR TITLE
refactor: unify tab target handling in page

### DIFF
--- a/packages/puppeteer-core/src/cdp/CDPSession.ts
+++ b/packages/puppeteer-core/src/cdp/CDPSession.ts
@@ -68,7 +68,8 @@ export class CdpCDPSession extends CDPSession {
 
   override parentSession(): CDPSession | undefined {
     if (!this.#parentSessionId) {
-      return;
+      // To make it work in Firefox that does not have parent (tab) sessions.
+      return this;
     }
     const parent = this.#connection?.session(this.#parentSessionId);
     return parent ?? undefined;

--- a/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
@@ -22,6 +22,7 @@ import {EventEmitter} from '../common/EventEmitter.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 
+import type {CdpCDPSession} from './CDPSession.js';
 import type {Connection} from './Connection.js';
 import type {CdpTarget} from './Target.js';
 import {
@@ -205,6 +206,7 @@ export class FirefoxTargetManager
 
     assert(target, `Target ${targetInfo.targetId} is missing`);
 
+    (session as CdpCDPSession)._setTarget(target);
     this.setupAttachmentListeners(session);
 
     this.#availableTargetsBySessionId.set(

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -1206,7 +1206,7 @@ export class CdpPage extends Page {
       await connection.send('Target.closeTarget', {
         targetId: this.#primaryTarget._targetId,
       });
-      await this.#primaryTarget._isClosedDeferred.valueOrThrow();
+      await this.#tabTarget._isClosedDeferred.valueOrThrow();
     }
   }
 


### PR DESCRIPTION
This PR renamed `#client` to `#primaryTargetClient` and moves event handlers that belong to the tab to the tabTargetClient