### PR TITLE
refactor: move target checks to the api surface

### DIFF
--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -260,13 +260,6 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
   }
 
   /**
-   * @internal
-   */
-  get _targets(): Map<string, Target> {
-    throw new Error('Not implemented');
-  }
-
-  /**
    * Gets the associated
    * {@link https://nodejs.org/api/child_process.html#class-childprocess | ChildProcess}.
    *

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -91,10 +91,6 @@ export class CdpBrowser extends BrowserBase {
   #contexts = new Map<string, CdpBrowserContext>();
   #targetManager: TargetManager;
 
-  override get _targets(): Map<string, CdpTarget> {
-    return this.#targetManager.getAvailableTargets();
-  }
-
   constructor(
     product: 'chrome' | 'firefox' | undefined,
     connection: Connection,
@@ -314,8 +310,9 @@ export class CdpBrowser extends BrowserBase {
 
   #onAttachedToTarget = async (target: CdpTarget) => {
     if (
+      target._isTargetExposed() &&
       (await target._initializedDeferred.valueOrThrow()) ===
-      InitializationStatus.SUCCESS
+        InitializationStatus.SUCCESS
     ) {
       this.emit(BrowserEvent.TargetCreated, target);
       target.browserContext().emit(BrowserContextEvent.TargetCreated, target);
@@ -326,8 +323,9 @@ export class CdpBrowser extends BrowserBase {
     target._initializedDeferred.resolve(InitializationStatus.ABORTED);
     target._isClosedDeferred.resolve();
     if (
+      target._isTargetExposed() &&
       (await target._initializedDeferred.valueOrThrow()) ===
-      InitializationStatus.SUCCESS
+        InitializationStatus.SUCCESS
     ) {
       this.emit(BrowserEvent.TargetDestroyed, target);
       target.browserContext().emit(BrowserContextEvent.TargetDestroyed, target);
@@ -382,6 +380,7 @@ export class CdpBrowser extends BrowserBase {
       this.#targetManager.getAvailableTargets().values()
     ).filter(target => {
       return (
+        target._isTargetExposed() &&
         target._initializedDeferred.value() === InitializationStatus.SUCCESS
       );
     });

--- a/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
@@ -131,7 +131,7 @@ export class FirefoxTargetManager
     }
   }
 
-  getAvailableTargets(): Map<string, CdpTarget> {
+  getAvailableTargets(): ReadonlyMap<string, CdpTarget> {
     return this.#availableTargetsByTargetId;
   }
 

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -163,7 +163,11 @@ export class CdpTarget extends Target {
     if (!openerId) {
       return;
     }
-    return this.browser()._targets.get(openerId);
+    return this.browser()
+      .targets()
+      .find(target => {
+        return (target as CdpTarget)._targetId === openerId;
+      });
   }
 
   _targetInfoChanged(targetInfo: Protocol.Target.TargetInfo): void {
@@ -173,6 +177,10 @@ export class CdpTarget extends Target {
 
   _initialize(): void {
     this._initializedDeferred.resolve(InitializationStatus.SUCCESS);
+  }
+
+  _isTargetExposed(): boolean {
+    return this.type() !== TargetType.TAB && !this._subtype();
   }
 
   protected _checkIfInitialized(): void {

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -69,7 +69,7 @@ export interface TargetManagerEvents extends Record<EventType, unknown> {
  * @internal
  */
 export interface TargetManager extends EventEmitter<TargetManagerEvents> {
-  getAvailableTargets(): Map<string, CdpTarget>;
+  getAvailableTargets(): ReadonlyMap<string, CdpTarget>;
   initialize(): Promise<void>;
   dispose(): void;
 }

--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -53,18 +53,18 @@ describe('TargetManager', () => {
     const {server, context, browser} = state;
 
     const targetManager = browser._targetManager();
-    expect(targetManager.getAvailableTargets().size).toBe(2);
+    expect(targetManager.getAvailableTargets().size).toBe(3);
 
     expect(await context.pages()).toHaveLength(0);
-    expect(targetManager.getAvailableTargets().size).toBe(2);
+    expect(targetManager.getAvailableTargets().size).toBe(3);
 
     const page = await context.newPage();
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(3);
+    expect(targetManager.getAvailableTargets().size).toBe(5);
 
     await page.goto(server.EMPTY_PAGE);
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(3);
+    expect(targetManager.getAvailableTargets().size).toBe(5);
 
     // attach a local iframe.
     let framePromise = page.waitForFrame(frame => {
@@ -73,7 +73,7 @@ describe('TargetManager', () => {
     await attachFrame(page, 'frame1', server.EMPTY_PAGE);
     await framePromise;
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(3);
+    expect(targetManager.getAvailableTargets().size).toBe(5);
     expect(page.frames()).toHaveLength(2);
 
     // // attach a remote frame iframe.
@@ -87,7 +87,7 @@ describe('TargetManager', () => {
     );
     await framePromise;
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(4);
+    expect(targetManager.getAvailableTargets().size).toBe(6);
     expect(page.frames()).toHaveLength(3);
 
     framePromise = page.waitForFrame(frame => {
@@ -100,7 +100,7 @@ describe('TargetManager', () => {
     );
     await framePromise;
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(5);
+    expect(targetManager.getAvailableTargets().size).toBe(7);
     expect(page.frames()).toHaveLength(4);
   });
 });


### PR DESCRIPTION
The reason being that we need events from the target manager internally to know once the tab target is destroyed.

Also:
 - removes redundant getter to get targets.
 - mark the map returned by TargetManager as readonly.
