### PR TITLE
fix: add InlineTextBox as a non-element a11y role

### DIFF
--- a/packages/puppeteer-core/src/cdp/AriaQueryHandler.ts
+++ b/packages/puppeteer-core/src/cdp/AriaQueryHandler.ts
@@ -23,6 +23,8 @@ import type {AwaitableIterable} from '../common/types.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 
+const NON_ELEMENT_NODE_ROLES = new Set(['StaticText', 'InlineTextBox']);
+
 const queryAXTree = async (
   client: CDPSession,
   element: ElementHandle<Node>,
@@ -35,7 +37,7 @@ const queryAXTree = async (
     role,
   });
   return nodes.filter((node: Protocol.Accessibility.AXNode) => {
-    return !node.role || node.role.value !== 'StaticText';
+    return !node.role || !NON_ELEMENT_NODE_ROLES.has(node.role.value);
   });
 };
 


### PR DESCRIPTION
Changes that caused https://crbug.com/1492122 seem to enable InlineTextBox to be returned as a node for certain elements referencing a TextNode instead of an HTML element. We should filter those out in the same way as StaticText.