### PR TITLE
ci: optimize installation tests and inspect code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           rm $diff_file
 
   check-changes:
-    needs: inspect-code
     uses: ./.github/workflows/changed-packages.yml
     with:
       check-mergeable-state: true

--- a/test/installation/src/puppeteer-firefox.spec.ts
+++ b/test/installation/src/puppeteer-firefox.spec.ts
@@ -17,31 +17,36 @@
 import assert from 'assert';
 import {readdir} from 'fs/promises';
 import {join} from 'path';
+import {platform} from 'os';
 
 import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';
 
-describe('`puppeteer` with Firefox', () => {
-  configureSandbox({
-    dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
-    env: cwd => {
-      return {
-        PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
-        PUPPETEER_PRODUCT: 'firefox',
-      };
-    },
-  });
+// Skipping this test on Windows as windows runners are much slower.
+(platform() === 'win32' ? describe.skip : describe)(
+  '`puppeteer` with Firefox',
+  () => {
+    configureSandbox({
+      dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
+      env: cwd => {
+        return {
+          PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
+          PUPPETEER_PRODUCT: 'firefox',
+        };
+      },
+    });
 
-  it('evaluates CommonJS', async function () {
-    const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
-    assert.equal(files.length, 1);
-    assert.equal(files[0], 'firefox');
-    const script = await readAsset('puppeteer-core', 'requires.cjs');
-    await this.runScript(script, 'cjs');
-  });
+    it('evaluates CommonJS', async function () {
+      const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
+      assert.equal(files.length, 1);
+      assert.equal(files[0], 'firefox');
+      const script = await readAsset('puppeteer-core', 'requires.cjs');
+      await this.runScript(script, 'cjs');
+    });
 
-  it('evaluates ES modules', async function () {
-    const script = await readAsset('puppeteer-core', 'imports.js');
-    await this.runScript(script, 'mjs');
-  });
-});
+    it('evaluates ES modules', async function () {
+      const script = await readAsset('puppeteer-core', 'imports.js');
+      await this.runScript(script, 'mjs');
+    });
+  }
+);

--- a/test/installation/src/puppeteer-firefox.spec.ts
+++ b/test/installation/src/puppeteer-firefox.spec.ts
@@ -16,8 +16,8 @@
 
 import assert from 'assert';
 import {readdir} from 'fs/promises';
-import {join} from 'path';
 import {platform} from 'os';
+import {join} from 'path';
 
 import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';

--- a/test/installation/src/puppeteer-typescript.spec.ts
+++ b/test/installation/src/puppeteer-typescript.spec.ts
@@ -15,8 +15,8 @@
  */
 
 import {readFile, writeFile} from 'fs/promises';
-import {join} from 'path';
 import {platform} from 'os';
+import {join} from 'path';
 
 import {configureSandbox} from './sandbox.js';
 import {execFile, readAsset} from './util.js';

--- a/test/installation/src/puppeteer-typescript.spec.ts
+++ b/test/installation/src/puppeteer-typescript.spec.ts
@@ -16,39 +16,44 @@
 
 import {readFile, writeFile} from 'fs/promises';
 import {join} from 'path';
+import {platform} from 'os';
 
 import {configureSandbox} from './sandbox.js';
 import {execFile, readAsset} from './util.js';
 
-describe('`puppeteer` with TypeScript', () => {
-  configureSandbox({
-    dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
-    devDependencies: ['typescript@4.7.4', '@types/node@16.3.3'],
-    env: cwd => {
-      return {
-        PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
-      };
-    },
-  });
+// Skipping this test on Windows as windows runners are much slower.
+(platform() === 'win32' ? describe.skip : describe)(
+  '`puppeteer` with TypeScript',
+  () => {
+    configureSandbox({
+      dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
+      devDependencies: ['typescript@4.7.4', '@types/node@16.3.3'],
+      env: cwd => {
+        return {
+          PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
+        };
+      },
+    });
 
-  it('should work', async function () {
-    // Write a Webpack configuration.
-    await writeFile(
-      join(this.sandbox, 'tsconfig.json'),
-      await readAsset('puppeteer', 'tsconfig.json')
-    );
+    it('should work', async function () {
+      // Write a Webpack configuration.
+      await writeFile(
+        join(this.sandbox, 'tsconfig.json'),
+        await readAsset('puppeteer', 'tsconfig.json')
+      );
 
-    // Write the source code.
-    await writeFile(
-      join(this.sandbox, 'index.ts'),
-      await readAsset('puppeteer', 'basic.ts')
-    );
+      // Write the source code.
+      await writeFile(
+        join(this.sandbox, 'index.ts'),
+        await readAsset('puppeteer', 'basic.ts')
+      );
 
-    // Compile.
-    await execFile('npx', ['tsc'], {cwd: this.sandbox, shell: true});
+      // Compile.
+      await execFile('npx', ['tsc'], {cwd: this.sandbox, shell: true});
 
-    const script = await readFile(join(this.sandbox, 'index.js'), 'utf-8');
+      const script = await readFile(join(this.sandbox, 'index.js'), 'utf-8');
 
-    await this.runScript(script, 'cjs');
-  });
-});
+      await this.runScript(script, 'cjs');
+    });
+  }
+);

--- a/test/installation/src/puppeteer.spec.ts
+++ b/test/installation/src/puppeteer.spec.ts
@@ -17,8 +17,8 @@
 import assert from 'assert';
 import {readdirSync} from 'fs';
 import {readdir} from 'fs/promises';
-import {join} from 'path';
 import {platform} from 'os';
+import {join} from 'path';
 
 import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';

--- a/test/installation/src/puppeteer.spec.ts
+++ b/test/installation/src/puppeteer.spec.ts
@@ -18,6 +18,7 @@ import assert from 'assert';
 import {readdirSync} from 'fs';
 import {readdir} from 'fs/promises';
 import {join} from 'path';
+import {platform} from 'os';
 
 import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';
@@ -46,57 +47,65 @@ describe('`puppeteer`', () => {
   });
 });
 
-describe('`puppeteer` with PUPPETEER_DOWNLOAD_PATH', () => {
-  configureSandbox({
-    dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
-    env: cwd => {
-      return {
-        PUPPETEER_DOWNLOAD_PATH: join(cwd, '.cache', 'puppeteer'),
-      };
-    },
-  });
+// Skipping this test on Windows as windows runners are much slower.
+(platform() === 'win32' ? describe.skip : describe)(
+  '`puppeteer` with PUPPETEER_DOWNLOAD_PATH',
+  () => {
+    configureSandbox({
+      dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
+      env: cwd => {
+        return {
+          PUPPETEER_DOWNLOAD_PATH: join(cwd, '.cache', 'puppeteer'),
+        };
+      },
+    });
 
-  it('evaluates', async function () {
-    const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
-    assert.equal(files.length, 1);
-    assert.equal(files[0], 'chrome');
+    it('evaluates', async function () {
+      const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
+      assert.equal(files.length, 1);
+      assert.equal(files[0], 'chrome');
 
-    const script = await readAsset('puppeteer', 'basic.js');
-    await this.runScript(script, 'mjs');
-  });
-});
+      const script = await readAsset('puppeteer', 'basic.js');
+      await this.runScript(script, 'mjs');
+    });
+  }
+);
 
-describe('`puppeteer` clears cache', () => {
-  configureSandbox({
-    dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
-    env: cwd => {
-      return {
-        PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
-      };
-    },
-  });
+// Skipping this test on Windows as windows runners are much slower.
+(platform() === 'win32' ? describe.skip : describe)(
+  '`puppeteer` clears cache',
+  () => {
+    configureSandbox({
+      dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
+      env: cwd => {
+        return {
+          PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
+        };
+      },
+    });
 
-  it('evaluates', async function () {
-    assert.equal(
-      readdirSync(join(this.sandbox, '.cache', 'puppeteer', 'chrome')).length,
-      1
-    );
+    it('evaluates', async function () {
+      assert.equal(
+        readdirSync(join(this.sandbox, '.cache', 'puppeteer', 'chrome')).length,
+        1
+      );
 
-    await this.runScript(
-      await readAsset('puppeteer', 'installCanary.js'),
-      'mjs'
-    );
+      await this.runScript(
+        await readAsset('puppeteer', 'installCanary.js'),
+        'mjs'
+      );
 
-    assert.equal(
-      readdirSync(join(this.sandbox, '.cache', 'puppeteer', 'chrome')).length,
-      2
-    );
+      assert.equal(
+        readdirSync(join(this.sandbox, '.cache', 'puppeteer', 'chrome')).length,
+        2
+      );
 
-    await this.runScript(await readAsset('puppeteer', 'trimCache.js'), 'mjs');
+      await this.runScript(await readAsset('puppeteer', 'trimCache.js'), 'mjs');
 
-    assert.equal(
-      readdirSync(join(this.sandbox, '.cache', 'puppeteer', 'chrome')).length,
-      1
-    );
-  });
-});
+      assert.equal(
+        readdirSync(join(this.sandbox, '.cache', 'puppeteer', 'chrome')).length,
+        1
+      );
+    });
+  }
+);

--- a/test/installation/src/sandbox.ts
+++ b/test/installation/src/sandbox.ts
@@ -72,6 +72,7 @@ declare module 'mocha' {
  */
 export const configureSandbox = (options: SandboxOptions): void => {
   before(async function (): Promise<void> {
+    console.time('before');
     const sandbox = await mkdtemp(join(tmpdir(), 'puppeteer-'));
     const dependencies = (options.dependencies ?? []).map(module => {
       switch (module) {
@@ -125,13 +126,16 @@ export const configureSandbox = (options: SandboxOptions): void => {
       await writeFile(script, content);
       await execFile('node', [script], {cwd: sandbox, env});
     };
+    console.timeEnd('before');
   });
 
   after(async function () {
+    console.time('after');
     if (!process.env['KEEP_SANDBOX']) {
       await rm(this.sandbox, {recursive: true, force: true, maxRetries: 5});
     } else {
       console.log('sandbox saved in', this.sandbox);
     }
+    console.timeEnd('after');
   });
 };


### PR DESCRIPTION
- skips some non-essential installation tests for Windows (the slowest platform to run these tests on). Reduces run time from 10m to ~6min.
- adds always-on time logging to before/after hooks in installation tests.
- allows inspect code to run in parallel to the tests.
