### PR TITLE
feat: merge user-provided --{disable,enable}-features in args

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {getFeatures} from './ChromeLauncher.js';
+
+describe('getFeatures', () => {
+  it('returns an empty array when no options are provided', () => {
+    const result = getFeatures('--foo');
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when no options match the flag', () => {
+    const result = getFeatures('--foo', ['--bar', '--baz']);
+    expect(result).toEqual([]);
+  });
+
+  it('returns an array of values when options match the flag', () => {
+    const result = getFeatures('--foo', ['--foo=bar', '--foo=baz']);
+    expect(result).toEqual(['bar', 'baz']);
+  });
+
+  it('handles whitespace around the flag and value', () => {
+    const result = getFeatures('--foo', ['--foo bar', '--foo baz ']);
+    expect(result).toEqual(['bar', 'baz']);
+  });
+
+  it('handles equals sign around the flag and value', () => {
+    const result = getFeatures('--foo', ['--foo=bar', '--foo=baz ']);
+    expect(result).toEqual(['bar', 'baz']);
+  });
+});

--- a/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
@@ -35,9 +35,9 @@ describe('getFeatures', () => {
     expect(result).toEqual(['bar', 'baz']);
   });
 
-  it('handles whitespace around the flag and value', () => {
+  it('does not handle whitespace', () => {
     const result = getFeatures('--foo', ['--foo bar', '--foo baz ']);
-    expect(result).toEqual(['bar', 'baz']);
+    expect(result).toEqual([]);
   });
 
   it('handles equals sign around the flag and value', () => {

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -274,7 +274,8 @@ function convertPuppeteerChannelToBrowsersChannel(
 }
 
 /**
- * Extracts all features from the given command-line flag.
+ * Extracts all features from the given command-line flag
+ * (e.g. `--enable-features`, `--enable-features=`).
  *
  * Example input:
  * ["--enable-features=NetworkService,NetworkServiceInProcess", "--enable-features=Foo"]
@@ -285,10 +286,10 @@ function convertPuppeteerChannelToBrowsersChannel(
 export function getFeatures(flag: string, options: string[] = []): string[] {
   const opts = options
     .filter(s => {
-      return s.startsWith(flag);
+      return s.startsWith(flag.endsWith('=') ? flag : `${flag}=`);
     })
     .map(s => {
-      return s.split(new RegExp(`${flag}` + '[=\\s]*'))[1]!.trim();
+      return s.split(new RegExp(`${flag}` + '=\\s*'))[1]?.trim();
     });
   return opts.length === 0 ? [] : opts.join(',').split(',');
 }

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -166,6 +166,7 @@ export class ChromeLauncher extends ProductLauncher {
   override defaultArgs(options: BrowserLaunchArgumentOptions = {}): string[] {
     // See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
 
+    // Merge default disabled features with user-provided ones, if any.
     const disabledFeatures = [
       'Translate',
       // AcceptCHFrame disabled because of crbug.com/1348106.
@@ -174,9 +175,14 @@ export class ChromeLauncher extends ProductLauncher {
       'OptimizationHints',
       // https://crbug.com/1492053
       'ProcessPerSiteUpToMainFrameThreshold',
+      ...getFeatures('--disable-features', options.args),
     ];
 
-    const enabledFeatures = ['NetworkServiceInProcess2'];
+    // Merge default enabled features with user-provided ones, if any.
+    const enabledFeatures = [
+      'NetworkServiceInProcess2',
+      ...getFeatures('--enable-features', options.args),
+    ];
 
     const chromeArguments = [
       '--allow-pre-commit-input',
@@ -265,4 +271,24 @@ function convertPuppeteerChannelToBrowsersChannel(
     case 'chrome-canary':
       return BrowsersChromeReleaseChannel.CANARY;
   }
+}
+
+/**
+ * Extracts all features from the given command-line flag.
+ *
+ * Example input:
+ * ["--enable-features=NetworkService,NetworkServiceInProcess", "--enable-features=Foo"]
+ *
+ * Example output:
+ * ["NetworkService", "NetworkServiceInProcess", "Foo"]
+ */
+export function getFeatures(flag: string, options: string[] = []): string[] {
+  const opts = options
+    .filter(s => {
+      return s.startsWith(flag);
+    })
+    .map(s => {
+      return s.split(new RegExp(`${flag}` + '[=\\s]*'))[1]!.trim();
+    });
+  return opts.length === 0 ? [] : opts.join(',').split(',');
 }

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -286,12 +286,14 @@ function convertPuppeteerChannelToBrowsersChannel(
  * @internal
  */
 export function getFeatures(flag: string, options: string[] = []): string[] {
-  const opts = options
+  return options
     .filter(s => {
       return s.startsWith(flag.endsWith('=') ? flag : `${flag}=`);
     })
     .map(s => {
       return s.split(new RegExp(`${flag}` + '=\\s*'))[1]?.trim();
-    });
-  return opts.length === 0 ? [] : opts.join(',').split(',');
+    })
+    .filter(s => {
+      return s;
+    }) as string[];
 }

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -282,6 +282,8 @@ function convertPuppeteerChannelToBrowsersChannel(
  *
  * Example output:
  * ["NetworkService", "NetworkServiceInProcess", "Foo"]
+ *
+ * @internal
  */
 export function getFeatures(flag: string, options: string[] = []): string[] {
   const opts = options


### PR DESCRIPTION
Currently user-provided features are completely ignored in args, being overridden with default ones.

Bug: #11072