### PR TITLE
chore: use CdpPage instead of Page in CDP frames

### DIFF
--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -19,7 +19,7 @@ import type {Protocol} from 'devtools-protocol';
 import type {CDPSession} from '../api/CDPSession.js';
 import {Frame, FrameEvent, throwIfDetached} from '../api/Frame.js';
 import type {HTTPResponse} from '../api/HTTPResponse.js';
-import type {Page, WaitTimeoutOptions} from '../api/Page.js';
+import type {WaitTimeoutOptions} from '../api/Page.js';
 import {setPageContent} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
@@ -37,6 +37,7 @@ import {
   LifecycleWatcher,
   type PuppeteerLifeCycleEvent,
 } from './LifecycleWatcher.js';
+import type {CdpPage} from './Page.js';
 
 /**
  * @internal
@@ -112,7 +113,7 @@ export class CdpFrame extends Frame {
     }
   }
 
-  override page(): Page {
+  override page(): CdpPage {
     return this._frameManager.page();
   }
 

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -18,7 +18,6 @@ import type {Protocol} from 'devtools-protocol';
 
 import {type CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
 import {FrameEvent} from '../api/Frame.js';
-import type {Page} from '../api/Page.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError, PuppeteerURL, UTILITY_WORLD_NAME} from '../common/util.js';
@@ -36,6 +35,7 @@ import {FrameTree} from './FrameTree.js';
 import type {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import {NetworkManager} from './NetworkManager.js';
+import type {CdpPage} from './Page.js';
 import type {CdpTarget} from './Target.js';
 
 /**
@@ -77,7 +77,7 @@ const TIME_FOR_WAITING_FOR_SWAP = 100; // ms.
  * @internal
  */
 export class FrameManager extends EventEmitter<FrameManagerEvents> {
-  #page: Page;
+  #page: CdpPage;
   #networkManager: NetworkManager;
   #timeoutSettings: TimeoutSettings;
   #contextIdToContext = new Map<string, ExecutionContext>();
@@ -114,7 +114,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
 
   constructor(
     client: CDPSession,
-    page: Page,
+    page: CdpPage,
     ignoreHTTPSErrors: boolean,
     timeoutSettings: TimeoutSettings
   ) {
@@ -291,7 +291,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     return this.#contextIdToContext.get(`${session.id()}:${contextId}`);
   }
 
-  page(): Page {
+  page(): CdpPage {
     return this.#page;
   }
 


### PR DESCRIPTION
The purpose of this PR is to provide correct typings in anticipation of https://github.com/puppeteer/puppeteer/pull/11153, wherein we need access to the root frame.

Bug: #11072