### PR TITLE
ci: try to fix request timeouts

### DIFF
--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -66,6 +66,7 @@ export class TestServer {
   #csp = new Map<string, string>();
   #gzipRoutes = new Set<string>();
   #requestSubscribers = new Map<string, Subscriber>();
+  #requests = new Set<ServerResponse>();
 
   static async create(dirPath: string): Promise<TestServer> {
     let res!: (value: unknown) => void;
@@ -192,12 +193,20 @@ export class TestServer {
       subscriber.reject.call(undefined, error);
     }
     this.#requestSubscribers.clear();
+    for (const request of this.#requests.values()) {
+      if (!request.writableEnded) {
+        request.end();
+      }
+    }
+    this.#requests.clear();
   }
 
   #onRequest: RequestListener = (
     request: TestIncomingMessage,
     response
   ): void => {
+    this.#requests.add(response);
+
     request.on('error', (error: {code: string}) => {
       if (error.code === 'ECONNRESET') {
         response.end();


### PR DESCRIPTION
We have seen some BiDi Actions fail due to Request time out. 
This keeps track of the responses and if not completed resolves them so we don't have unhandled rejections.

https://github.com/puppeteer/puppeteer/actions/runs/6510435386/job/17684143579