### PR TITLE
test: add more e2e tests for device request prompt

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1644,13 +1644,13 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[device-request-prompt.spec] device request prompt can be opened",
+    "testIdPattern": "[device-request-prompt.spec] device request prompt can be cancelled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "headless"],
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[device-request-prompt.spec] device request prompt can be cancelled",
+    "testIdPattern": "[device-request-prompt.spec] device request prompt can be opened",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "headless"],
     "expectations": ["FAIL"]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1646,19 +1646,19 @@
   {
     "testIdPattern": "[device-request-prompt.spec] device request prompt can be opened",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless", "cdp"],
+    "parameters": ["chrome", "headless"],
     "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[device-request-prompt.spec] device request prompt can be cancelled",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless", "cdp"],
+    "parameters": ["chrome", "headless"],
     "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[device-request-prompt.spec] device request prompt waitForDevice does not crash",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless", "cdp"],
+    "parameters": ["chrome", "headless"],
     "expectations": ["FAIL"]
   },
   {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1644,22 +1644,10 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[device-request-prompt.spec] device request prompt can be cancelled",
+    "testIdPattern": "[device-request-prompt.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "headless"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[device-request-prompt.spec] device request prompt can be opened",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[device-request-prompt.spec] device request prompt waitForDevice does not crash",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless"],
-    "expectations": ["FAIL"]
+    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[dialog.spec] Page.Events.Dialog should allow accepting prompts",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1644,6 +1644,24 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[device-request-prompt.spec] device request prompt can be opened",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[device-request-prompt.spec] device request prompt can be cancelled",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[device-request-prompt.spec] device request prompt waitForDevice does not crash",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[dialog.spec] Page.Events.Dialog should allow accepting prompts",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -492,6 +492,12 @@
     "expectations": ["FAIL", "PASS"]
   },
   {
+    "testIdPattern": "[device-request-prompt.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[drag-and-drop.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -1642,12 +1648,6 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[device-request-prompt.spec] *",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless"],
-    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[dialog.spec] Page.Events.Dialog should allow accepting prompts",

--- a/test/assets/device-request.html
+++ b/test/assets/device-request.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Device request test</title>
+  </head>
+  <body>
+    <button onclick="clicked();" id="bluetooth">Device Request</button>
+    <script>
+      function clicked() {
+        navigator.bluetooth.requestDevice({acceptAllDevices: true})
+      }
+    </script>
+  </body>
+</html>

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -60,4 +60,50 @@ describe('device request prompt', function () {
       })
     ).rejects.toThrow(TimeoutError);
   });
+
+  it('can be opened', async function () {
+    this.timeout(1_000);
+
+    const {page, httpsServer} = state;
+
+    await page.goto(httpsServer.PREFIX + '/device-request.html');
+
+    await expect(
+      Promise.all([
+        page.waitForDevicePrompt({timeout: 100}),
+        page.click('#bluetooth'),
+      ])
+    ).resolves.toBeTruthy();
+  });
+
+  it('can be cancelled', async function () {
+    this.timeout(1_000);
+
+    const {page, httpsServer} = state;
+
+    await page.goto(httpsServer.PREFIX + '/device-request.html');
+
+    const [devicePrompt] = await Promise.all([
+      page.waitForDevicePrompt({timeout: 100}),
+      page.click('#bluetooth'),
+    ]);
+    expect(devicePrompt).toBeTruthy();
+    await expect(devicePrompt.cancel()).resolves.not.toThrow();
+  });
+
+  it('waitForDevice does not crash', async function () {
+    this.timeout(1_000);
+
+    const {page, httpsServer} = state;
+
+    await page.goto(httpsServer.PREFIX + '/device-request.html');
+
+    const [devicePrompt] = await Promise.all([
+      page.waitForDevicePrompt({timeout: 100}),
+      page.click('#bluetooth'),
+    ]);
+    await expect(
+      devicePrompt.waitForDevice(() => false, {timeout: 10})
+    ).rejects.toThrow(TimeoutError);
+  });
 });

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -19,6 +19,7 @@ import {TimeoutError} from 'puppeteer';
 import {launch} from './mocha-utils.js';
 
 describe('device request prompt', function () {
+  this.timeout(1_000);
   let state: Awaited<ReturnType<typeof launch>>;
 
   before(async () => {
@@ -48,8 +49,6 @@ describe('device request prompt', function () {
 
   // Bug: #11072
   it('does not crash', async function () {
-    this.timeout(1_000);
-
     const {page, httpsServer} = state;
 
     await page.goto(httpsServer.EMPTY_PAGE);
@@ -62,8 +61,6 @@ describe('device request prompt', function () {
   });
 
   it('can be opened', async function () {
-    this.timeout(1_000);
-
     const {page, httpsServer} = state;
 
     await page.goto(httpsServer.PREFIX + '/device-request.html');
@@ -77,8 +74,6 @@ describe('device request prompt', function () {
   });
 
   it('can be cancelled', async function () {
-    this.timeout(1_000);
-
     const {page, httpsServer} = state;
 
     await page.goto(httpsServer.PREFIX + '/device-request.html');
@@ -91,19 +86,19 @@ describe('device request prompt', function () {
     await expect(devicePrompt.cancel()).resolves.not.toThrow();
   });
 
-  it('waitForDevice does not crash', async function () {
-    this.timeout(1_000);
+  describe('waitForDevice', function () {
+    it('does not crash', async function () {
+      const {page, httpsServer} = state;
 
-    const {page, httpsServer} = state;
+      await page.goto(httpsServer.PREFIX + '/device-request.html');
 
-    await page.goto(httpsServer.PREFIX + '/device-request.html');
-
-    const [devicePrompt] = await Promise.all([
-      page.waitForDevicePrompt({timeout: 100}),
-      page.click('#bluetooth'),
-    ]);
-    await expect(
-      devicePrompt.waitForDevice(() => false, {timeout: 10})
-    ).rejects.toThrow(TimeoutError);
+      const [devicePrompt] = await Promise.all([
+        page.waitForDevicePrompt({timeout: 100}),
+        page.click('#bluetooth'),
+      ]);
+      await expect(
+        devicePrompt.waitForDevice(() => false, {timeout: 10})
+      ).rejects.toThrow(TimeoutError);
+    });
   });
 });

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -47,43 +47,45 @@ describe('device request prompt', function () {
     await state.context.close();
   });
 
-  // Bug: #11072
-  it('does not crash', async function () {
-    const {page, httpsServer} = state;
+  describe('waitForDevicePrompt', async function () {
+    // Bug: #11072
+    it('does not crash', async function () {
+      const {page, httpsServer} = state;
 
-    await page.goto(httpsServer.EMPTY_PAGE);
+      await page.goto(httpsServer.EMPTY_PAGE);
 
-    await expect(
-      page.waitForDevicePrompt({
-        timeout: 10,
-      })
-    ).rejects.toThrow(TimeoutError);
-  });
+      await expect(
+        page.waitForDevicePrompt({
+          timeout: 10,
+        })
+      ).rejects.toThrow(TimeoutError);
+    });
 
-  it('can be opened', async function () {
-    const {page, httpsServer} = state;
+    it('can be opened', async function () {
+      const {page, httpsServer} = state;
 
-    await page.goto(httpsServer.PREFIX + '/device-request.html');
+      await page.goto(httpsServer.PREFIX + '/device-request.html');
 
-    await expect(
-      Promise.all([
+      await expect(
+        Promise.all([
+          page.waitForDevicePrompt({timeout: 100}),
+          page.click('#bluetooth'),
+        ])
+      ).resolves.toBeTruthy();
+    });
+
+    it('can be cancelled', async function () {
+      const {page, httpsServer} = state;
+
+      await page.goto(httpsServer.PREFIX + '/device-request.html');
+
+      const [devicePrompt] = await Promise.all([
         page.waitForDevicePrompt({timeout: 100}),
         page.click('#bluetooth'),
-      ])
-    ).resolves.toBeTruthy();
-  });
-
-  it('can be cancelled', async function () {
-    const {page, httpsServer} = state;
-
-    await page.goto(httpsServer.PREFIX + '/device-request.html');
-
-    const [devicePrompt] = await Promise.all([
-      page.waitForDevicePrompt({timeout: 100}),
-      page.click('#bluetooth'),
-    ]);
-    expect(devicePrompt).toBeTruthy();
-    await expect(devicePrompt.cancel()).resolves.not.toThrow();
+      ]);
+      expect(devicePrompt).toBeTruthy();
+      await expect(devicePrompt.cancel()).resolves.not.toThrow();
+    });
   });
 
   describe('waitForDevice', function () {

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -26,7 +26,9 @@ describe('device request prompt', function () {
     this.timeout(10_000);
     state = await launch(
       {
-        args: ['--enable-features=WebBluetoothNewPermissionsBackend'],
+        args: [
+          '--enable-features=WebBluetoothNewPermissionsBackend,WebBluetooth',
+        ],
         ignoreHTTPSErrors: true,
       },
       {

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -23,6 +23,7 @@ describe('device request prompt', function () {
   let state: Awaited<ReturnType<typeof launch>>;
 
   before(async () => {
+    this.timeout(10_000);
     state = await launch(
       {
         args: ['--enable-features=WebBluetoothNewPermissionsBackend'],
@@ -67,10 +68,7 @@ describe('device request prompt', function () {
       await page.goto(httpsServer.PREFIX + '/device-request.html');
 
       await expect(
-        Promise.all([
-          page.waitForDevicePrompt({timeout: 100}),
-          page.click('#bluetooth'),
-        ])
+        Promise.all([page.waitForDevicePrompt(), page.click('#bluetooth')])
       ).resolves.toBeTruthy();
     });
 
@@ -80,7 +78,7 @@ describe('device request prompt', function () {
       await page.goto(httpsServer.PREFIX + '/device-request.html');
 
       const [devicePrompt] = await Promise.all([
-        page.waitForDevicePrompt({timeout: 100}),
+        page.waitForDevicePrompt(),
         page.click('#bluetooth'),
       ]);
       expect(devicePrompt).toBeTruthy();
@@ -95,7 +93,7 @@ describe('device request prompt', function () {
       await page.goto(httpsServer.PREFIX + '/device-request.html');
 
       const [devicePrompt] = await Promise.all([
-        page.waitForDevicePrompt({timeout: 100}),
+        page.waitForDevicePrompt(),
         page.click('#bluetooth'),
       ]);
       await expect(

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -22,7 +22,7 @@ describe('device request prompt', function () {
   this.timeout(1_000);
   let state: Awaited<ReturnType<typeof launch>>;
 
-  before(async () => {
+  before(async function () {
     this.timeout(10_000);
     state = await launch(
       {

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -97,7 +97,12 @@ describe('device request prompt', function () {
         page.click('#bluetooth'),
       ]);
       await expect(
-        devicePrompt.waitForDevice(() => false, {timeout: 10})
+        devicePrompt.waitForDevice(
+          () => {
+            return false;
+          },
+          {timeout: 10}
+        )
       ).rejects.toThrow(TimeoutError);
     });
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Adds some more basic e2e tests for `DeviceRequestPrompt`. These tests don't involve actual bluetooth connection scenarios since those would be hard to scaffold, but these will exercise more of the code to validate basic functioning and a couple error states. These e2e tests must be run headed since the bluetooth chooser will not launch on headless chrome instances.

**Did you add tests for your changes?**

It's all tests :)

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Building off of https://github.com/puppeteer/puppeteer/issues/11072 and https://github.com/puppeteer/puppeteer/pull/11159, this PR adds a few more e2e tests for `DeviceRequestPrompt` that can be run headed.

**Does this PR introduce a breaking change?**

Nope.

**Other information**
cc @thiagowfx 

Bug: https://github.com/puppeteer/puppeteer/issues/11189