### PR TITLE
fix: update TextQuerySelector cache on subtree update

### DIFF
--- a/packages/puppeteer-core/src/injected/TextContent.ts
+++ b/packages/puppeteer-core/src/injected/TextContent.ts
@@ -146,6 +146,7 @@ export const createTextContent = (root: Node): TextContent => {
       textChangeObserver.observe(root, {
         childList: true,
         characterData: true,
+        subtree: true,
       });
       observedNodes.add(root);
     }


### PR DESCRIPTION
Fix for: [[Bug]: invalid state of textContentCache after mutation in text-node](https://github.com/puppeteer/puppeteer/issues/11199)
