### PR TITLE
docs: Install and build before running examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Running the examples
 
-Assuming you have a checkout of the Puppeteer repo and have run npm i (or yarn) to install the dependencies, the examples can be run from the root folder like so:
+Assuming you have a checkout of the Puppeteer repo and have run `npm i` (or `yarn`) to install the dependencies, and `npm run build` (or `yarn run build`) to build the project, the examples can be run from the root folder like so:
 
 ```bash
 NODE_PATH=../ node examples/search.js


### PR DESCRIPTION
Closes gh-11211.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

I'm changing the docs for the examples to state that you have to build the project before running them.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes. I ran

```
git clone git@github.com:puppeteer/puppeteer.git
cd puppeteer
npm i
npm run build
NODE_PATH=../ node examples/search.js
```

on my MacBook, and the example runs successfully.

**If relevant, did you update the documentation?**

Yes.

**Summary**

This updates `examples/README.md` to say that you have to build the project before running an example.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
