### PR TITLE
fix: do not pass --{enable,disable}-features twice when user-provided

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
@@ -17,7 +17,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {getFeatures} from './ChromeLauncher.js';
+import {getFeatures, removeMatching} from './ChromeLauncher.js';
 
 describe('getFeatures', () => {
   it('returns an empty array when no options are provided', () => {
@@ -43,5 +43,27 @@ describe('getFeatures', () => {
   it('handles equals sign around the flag and value', () => {
     const result = getFeatures('--foo', ['--foo=bar', '--foo=baz ']);
     expect(result).toEqual(['bar', 'baz']);
+  });
+});
+
+describe('removeMatching', () => {
+  it('empty', () => {
+    const a: string[] = [];
+    expect(removeMatching(a, /foo/)).toEqual([]);
+  });
+
+  it('with one match', () => {
+    const a: string[] = ['foo', 'bar'];
+    expect(removeMatching(a, /foo/)).toEqual(['bar']);
+  });
+
+  it('with multiple matches', () => {
+    const a: string[] = ['foo', 'fooz', 'bar'];
+    expect(removeMatching(a, /^foo/)).toEqual(['bar']);
+  });
+
+  it('with no matches', () => {
+    const a: string[] = ['foo', 'bar'];
+    expect(removeMatching(a, /baz/)).toEqual(['foo', 'bar']);
   });
 });

--- a/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.test.ts
@@ -17,7 +17,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {getFeatures, removeMatching} from './ChromeLauncher.js';
+import {getFeatures, removeMatchingFlags} from './ChromeLauncher.js';
 
 describe('getFeatures', () => {
   it('returns an empty array when no options are provided', () => {
@@ -46,24 +46,24 @@ describe('getFeatures', () => {
   });
 });
 
-describe('removeMatching', () => {
+describe('removeMatchingFlags', () => {
   it('empty', () => {
     const a: string[] = [];
-    expect(removeMatching(a, /foo/)).toEqual([]);
+    expect(removeMatchingFlags(a, '--foo')).toEqual([]);
   });
 
   it('with one match', () => {
-    const a: string[] = ['foo', 'bar'];
-    expect(removeMatching(a, /foo/)).toEqual(['bar']);
+    const a: string[] = ['--foo=1', '--bar=baz'];
+    expect(removeMatchingFlags(a, '--foo')).toEqual(['--bar=baz']);
   });
 
   it('with multiple matches', () => {
-    const a: string[] = ['foo', 'fooz', 'bar'];
-    expect(removeMatching(a, /^foo/)).toEqual(['bar']);
+    const a: string[] = ['--foo=1', '--foo=2', '--bar=baz'];
+    expect(removeMatchingFlags(a, '--foo')).toEqual(['--bar=baz']);
   });
 
   it('with no matches', () => {
-    const a: string[] = ['foo', 'bar'];
-    expect(removeMatching(a, /baz/)).toEqual(['foo', 'bar']);
+    const a: string[] = ['--foo=1', '--bar=baz'];
+    expect(removeMatchingFlags(a, '--baz')).toEqual(['--foo=1', '--bar=baz']);
   });
 });

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -171,7 +171,7 @@ export class ChromeLauncher extends ProductLauncher {
       options.args
     );
     if (options.args && userDisabledFeatures.length > 0) {
-      removeMatching(options.args, /^--disable-features=.*/);
+      removeMatchingFlags(options.args, '--disable-features');
     }
 
     // Merge default disabled features with user-provided ones, if any.
@@ -188,7 +188,7 @@ export class ChromeLauncher extends ProductLauncher {
 
     const userEnabledFeatures = getFeatures('--enable-features', options.args);
     if (options.args && userEnabledFeatures.length > 0) {
-      removeMatching(options.args, /^--enable-features=.*/);
+      removeMatchingFlags(options.args, '--enable-features');
     }
 
     // Merge default enabled features with user-provided ones, if any.
@@ -312,12 +312,13 @@ export function getFeatures(flag: string, options: string[] = []): string[] {
 }
 
 /**
- * Removes all elements in-place from the given array that match the given
- * regular expression.
+ * Removes all elements in-place from the given string array
+ * that match the given command-line flag.
  *
  * @internal
  */
-export function removeMatching(array: string[], regex: RegExp): string[] {
+export function removeMatchingFlags(array: string[], flag: string): string[] {
+  const regex = new RegExp(`^${flag}=.*`);
   let i = 0;
   while (i < array.length) {
     if (regex.test(array[i]!)) {

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -170,8 +170,8 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-features',
       options.args
     );
-    if (userDisabledFeatures.length > 0) {
-      removeMatching(options.args ?? [], /^--disable-features=.*/);
+    if (options.args && userDisabledFeatures.length > 0) {
+      removeMatching(options.args, /^--disable-features=.*/);
     }
 
     // Merge default disabled features with user-provided ones, if any.
@@ -187,8 +187,8 @@ export class ChromeLauncher extends ProductLauncher {
     ];
 
     const userEnabledFeatures = getFeatures('--enable-features', options.args);
-    if (userEnabledFeatures.length > 0) {
-      removeMatching(options.args ?? [], /^--enable-features=.*/);
+    if (options.args && userEnabledFeatures.length > 0) {
+      removeMatching(options.args, /^--enable-features=.*/);
     }
 
     // Merge default enabled features with user-provided ones, if any.

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -166,6 +166,14 @@ export class ChromeLauncher extends ProductLauncher {
   override defaultArgs(options: BrowserLaunchArgumentOptions = {}): string[] {
     // See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
 
+    const userDisabledFeatures = getFeatures(
+      '--disable-features',
+      options.args
+    );
+    if (userDisabledFeatures.length > 0) {
+      removeMatching(options.args ?? [], /^--disable-features=.*/);
+    }
+
     // Merge default disabled features with user-provided ones, if any.
     const disabledFeatures = [
       'Translate',
@@ -175,13 +183,18 @@ export class ChromeLauncher extends ProductLauncher {
       'OptimizationHints',
       // https://crbug.com/1492053
       'ProcessPerSiteUpToMainFrameThreshold',
-      ...getFeatures('--disable-features', options.args),
+      ...userDisabledFeatures,
     ];
+
+    const userEnabledFeatures = getFeatures('--enable-features', options.args);
+    if (userEnabledFeatures.length > 0) {
+      removeMatching(options.args ?? [], /^--enable-features=.*/);
+    }
 
     // Merge default enabled features with user-provided ones, if any.
     const enabledFeatures = [
       'NetworkServiceInProcess2',
-      ...getFeatures('--enable-features', options.args),
+      ...userEnabledFeatures,
     ];
 
     const chromeArguments = [
@@ -296,4 +309,22 @@ export function getFeatures(flag: string, options: string[] = []): string[] {
     .filter(s => {
       return s;
     }) as string[];
+}
+
+/**
+ * Removes all elements in-place from the given array that match the given
+ * regular expression.
+ *
+ * @internal
+ */
+export function removeMatching(array: string[], regex: RegExp): string[] {
+  let i = 0;
+  while (i < array.length) {
+    if (regex.test(array[i]!)) {
+      array.splice(i, 1);
+    } else {
+      i++;
+    }
+  }
+  return array;
 }


### PR DESCRIPTION
Currently, whenever the user provides:

    args: '--disable-features=TestDisableFeatures'

The --disable-features flag appears twice in chrome arguments.

Make it appear only once, by merging them.

Ditto for --enable-features.

Fixed: #11208