### PR TITLE
refactor: remove extra variable on onTargetInfoChanged

### DIFF
--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -284,9 +284,6 @@ export class ChromeTargetManager
       target._initializedDeferred.value() === InitializationStatus.SUCCESS;
 
     if (isPageTargetBecomingPrimary(target, event.targetInfo)) {
-      const target = this.#attachedTargetsByTargetId.get(
-        event.targetInfo.targetId
-      );
       const session = target?._session();
       assert(
         session,


### PR DESCRIPTION
We are declaring this same variable using the same source a few [lines above](https://github.com/kblok/puppeteer/blob/remove-extra-variable/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts#L276-L277).

As this piece of code is synchronous. I don't think that there is something that can modify `attachedTargetsByTargetId` between these few lines.