### PR TITLE
docs: fix typo in guides evaluate-javascript

### DIFF
--- a/docs/guides/evaluate-javascript.md
+++ b/docs/guides/evaluate-javascript.md
@@ -98,7 +98,7 @@ const three = await page.evaluate(
 );
 ```
 
-The arguments can primitive values or `JSHandle`s.
+The arguments can be primitive values or `JSHandle`s.
 
 :::note
 


### PR DESCRIPTION
There was a missing word in that last sentence.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fix typo in documentation.

**Did you add tests for your changes?**
n/a

**If relevant, did you update the documentation?**
Yep

**Summary**

Just fixing a typo.


**Does this PR introduce a breaking change?**
no

**Other information**
Thanks for the great repo.