### PR TITLE
fix: ignore unordered frames

### DIFF
--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -177,7 +177,9 @@ export class ScreenRecorder extends PassThrough {
         concatMap(([{timestamp: previousTimestamp, buffer}, {timestamp}]) => {
           return from(
             Array<Buffer>(
-              Math.round(DEFAULT_FPS * (timestamp - previousTimestamp))
+              Math.round(
+                DEFAULT_FPS * Math.max(timestamp - previousTimestamp, 0)
+              )
             ).fill(buffer)
           );
         }),


### PR DESCRIPTION
Fixed: https://github.com/puppeteer/puppeteer/issues/11279