### PR TITLE
docs: update troubleshooting guide for Google Cloud Functions

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -515,7 +515,7 @@ The Node.js runtime of the
 comes with all system packages needed to run Headless Chrome.
 
 To use `puppeteer`, specify the module as a dependency in your `package.json`
-and then override the puppeteer cache directory by including a file named 
+and then override the puppeteer cache directory by including a file named
 `.puppeteerrc.cjs` at the root of your application with the contents:
 
 ```ts
@@ -530,10 +530,10 @@ module.exports = {
 ```
 
 > [!NOTE]  
-> Google App Engine caches your `node_modules` between builds. 
-> Specifying the Puppeteer cache as subdirectory of `node_modules` 
+> Google App Engine caches your `node_modules` between builds.
+> Specifying the Puppeteer cache as subdirectory of `node_modules`
 > mitigates an issue in which Puppeteer can't find the browser executable
-> due to `postinstall` not being run. 
+> due to `postinstall` not being run.
 
 ### Running Puppeteer on Google Cloud Functions
 
@@ -542,7 +542,7 @@ The Node.js runtime of
 comes with all system packages needed to run Headless Chrome.
 
 To use `puppeteer`, specify the module as a dependency in your `package.json`
-and then override the puppeteer cache directory by including a file named 
+and then override the puppeteer cache directory by including a file named
 `.puppeteerrc.cjs` at the root of your application with the contents:
 
 ```ts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -514,22 +514,51 @@ The Node.js runtime of the
 [App Engine standard environment](https://cloud.google.com/appengine/docs/standard/nodejs/)
 comes with all system packages needed to run Headless Chrome.
 
-To use `puppeteer`, simply list the module as a dependency in your
-`package.json` and deploy to Google App Engine. Read more about using
-`puppeteer` on App Engine by following
-[the official tutorial](https://cloud.google.com/appengine/docs/standard/nodejs/using-headless-chrome-with-puppeteer).
+To use `puppeteer`, specify the module as a dependency in your `package.json`
+and then override the puppeteer cache directory by including a file named 
+`.puppeteerrc.cjs` at the root of your application with the contents:
+
+```ts
+const {join} = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+  cacheDirectory: join(__dirname, 'node_modules', '.puppeteer_cache'),
+};
+```
+
+> [!NOTE]  
+> Google App Engine caches your `node_modules` between builds. Specifying the
+> puppeteer cache as subdirectory of `node_modules` mitigates an issue in which the
+> puppeteer install process does not run when the cache is hit.
 
 ### Running Puppeteer on Google Cloud Functions
 
-You can try running Puppeteer on
-[Google Cloud Functions](https://cloud.google.com/functions/docs/) but we have
-been getting reports that newest runtimes don't have all dependencies to run
-Chromium.
+The Node.js runtime of
+[Google Cloud Functions](https://cloud.google.com/functions/docs/)
+comes with all system packages needed to run Headless Chrome.
 
-If you encounter problems due to missing Chromium dependencies, consider using
-Google Cloud Run instead where you can provide a custom Dockerfile with all
-dependencies. Also, see our
-[official Docker image](https://github.com/puppeteer/puppeteer/pkgs/container/puppeteer).
+To use `puppeteer`, specify the module as a dependency in your `package.json`
+and then override the puppeteer cache directory by including a file named 
+`.puppeteerrc.cjs` at the root of your application with the contents:
+
+```ts
+const {join} = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+  cacheDirectory: join(__dirname, 'node_modules', '.puppeteer_cache'),
+};
+```
+
+> [!NOTE]  
+> Google Cloud Functions caches your `node_modules` between builds. Specifying the
+> puppeteer cache as subdirectory of `node_modules` mitigates an issue in which the
+> puppeteer install process does not run when the cache is hit.
 
 ### Running Puppeteer on Google Cloud Run
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -530,9 +530,10 @@ module.exports = {
 ```
 
 > [!NOTE]  
-> Google App Engine caches your `node_modules` between builds. Specifying the
-> puppeteer cache as subdirectory of `node_modules` mitigates an issue in which the
-> puppeteer install process does not run when the cache is hit.
+> Google App Engine caches your `node_modules` between builds. 
+> Specifying the Puppeteer cache as subdirectory of `node_modules` 
+> mitigates an issue in which Puppeteer can't find the browser executable
+> due to `postinstall` not being run. 
 
 ### Running Puppeteer on Google Cloud Functions
 


### PR DESCRIPTION
The Google App Engine and Google Cloud Functions runtimes both include all the necessary packages to run headless chrome, but there is an issue in which the puppeteer `postinstall` hook doesn't run when build re-uses cached `node_modules`. This commit updates the troubleshooting guide to help customers of these products use puppeteer.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

docs change

**Did you add tests for your changes?**

no, only docs

**Summary**

This change updates the troubleshooting guide to help Google Cloud customers who are trying to use puppeteer.

**Does this PR introduce a breaking change?**

No

**Other information**

I work on Google Cloud Functions. This update is a result of helping a customer debug their application.
