### PR TITLE
Update Dockerfile to LTS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18@sha256:cd7fa8f136023f7500490e410ba70dd3982ccca21805264f2a260a3a97be7376
+FROM node:lts@sha256:cb7cd40ba6483f37f791e1aace576df449fc5f75332c19ff59e2c6064797160e
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chrome that Puppeteer


### PR DESCRIPTION
Always follow the latest LTS version
(Now Node 20)

**What kind of change does this PR introduce?**

To switch to use the real Node LTS version without changing code.
E.g. latest LTS version is now 20, in the codebase it is still 18.

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**

Use latest LTS version from Node as soon as possible.

**Does this PR introduce a breaking change?**

Should not break things, maybe in the future?

**Other information**

Let me know if you like this, or just use `node:20` 

closes: https://github.com/puppeteer/puppeteer/issues/11290