### PR TITLE
Add path command to browsers cli

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -58,6 +58,16 @@ interface LaunchArgs {
   system: boolean;
 }
 
+interface PathArgs {
+  browser: {
+    name: Browser;
+    buildId: string;
+  };
+  path?: string;
+  platform?: BrowserPlatform;
+  system: boolean;
+}
+
 interface ClearArgs {
   path?: string;
 }
@@ -268,6 +278,37 @@ export class CLI {
             executablePath,
             detached: args.detached,
           });
+        }
+      )
+      .command(
+        'path',
+        'Print the path to the executable',
+        yargs => {
+          this.#defineBrowserParameter(yargs);
+          this.#definePlatformParameter(yargs);
+          this.#definePathParameter(yargs);
+          yargs.option('system', {
+            type: 'boolean',
+            desc: 'Search for a browser installed on the system instead of the cache folder.',
+            default: false,
+          });
+        },
+        async argv => {
+          const args = argv as unknown as PathArgs;
+          const executablePath = args.system
+            ? computeSystemExecutablePath({
+                browser: args.browser.name,
+                // TODO: throw an error if not a ChromeReleaseChannel is provided.
+                channel: args.browser.buildId as ChromeReleaseChannel,
+                platform: args.platform,
+              })
+            : computeExecutablePath({
+                browser: args.browser.name,
+                buildId: args.browser.buildId,
+                cacheDir: args.path ?? this.#cachePath,
+                platform: args.platform,
+              });
+          console.log(executablePath);
         }
       )
       .command(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Adds a new subcommand to the `browsers` cli to print the executable path.

Intended use is like to obtain the path to the executable that is installed. Here is an example for the Github Actions:

```
# Install chromedriver.
npx @puppeteer/browsers install chromedriver@stable

# Set CHROMEDRIVER env var.
printf "CHROMEDRIVER=%s\n" "$(npx @puppeteer/browsers path chromedriver@stable)" >>"$GITHUB_ENV"
```

**Did you add tests for your changes?**

- [ ] cli unit tests
- [ ] cli e2e tests (if any, idk yet)

**If relevant, did you update the documentation?**

No, not yet. I am not sure what to write manually, and what I can generate automatically.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Better than this:
```
CHROMEDRIVERS=(chromedriver/*/chromedriver-*/chromedriver)
printf "CHROMEDRIVER=%s\n" "${CHROMEDRIVERS[0]}" >>"$GITHUB_ENV"
```

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**

My first PR to puppeteer, help is welcome.