### PR TITLE
chore: fix min Node 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11962,17 +11962,17 @@
       "devDependencies": {
         "@angular/cli": "^16.2.9",
         "@schematics/angular": "^16.2.9",
-        "@types/node": "^16.11.7",
+        "@types/node": "^16.18.61",
         "rxjs": "7.8.1"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=16.13.2"
       }
     },
     "packages/ng-schematics/node_modules/@types/node": {
-      "version": "16.18.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.60.tgz",
-      "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==",
+      "version": "16.18.61",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.61.tgz",
+      "integrity": "sha512-k0N7BqGhJoJzdh6MuQg1V1ragJiXTh8VUBAZTWjJ9cUq23SG0F0xavOwZbhiP4J3y20xd6jxKx+xNUhkMAi76Q==",
       "dev": true
     },
     "packages/puppeteer": {
@@ -11988,7 +11988,7 @@
         "@types/node": "18.17.15"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=16.13.2"
       }
     },
     "packages/puppeteer-core": {
@@ -12011,7 +12011,7 @@
         "rxjs": "7.8.1"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=16.13.2"
       }
     },
     "packages/puppeteer-core/node_modules/@types/node": {

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -45,7 +45,7 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.3.0"
+    "node": ">=16.13.2"
   },
   "dependencies": {
     "@angular-devkit/architect": "^0.1602.6",
@@ -53,7 +53,7 @@
     "@angular-devkit/schematics": "^16.2.6"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
+    "@types/node": "^16.18.61",
     "@schematics/angular": "^16.2.9",
     "@angular/cli": "^16.2.9",
     "rxjs": "7.8.1"

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/puppeteer/puppeteer/tree/main/packages/puppeteer-core"
   },
   "engines": {
-    "node": ">=16.3.0"
+    "node": ">=16.13.2"
   },
   "scripts": {
     "build:docs": "wireit",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/puppeteer/puppeteer/tree/main/packages/puppeteer"
   },
   "engines": {
-    "node": ">=16.3.0"
+    "node": ">=16.13.2"
   },
   "scripts": {
     "build:docs": "wireit",


### PR DESCRIPTION
Closes #11329

This is needed as we need [Class static initialization blocks](https://github.com/tc39/proposal-class-static-block)
We are using it for the decorators polyfilling. 
https://node.green/#ES2022-features-private-class-methods

Note: `@puppeteer/browser` should not need this as it has no decorators