### PR TITLE
chore: implement `Puppeteer.connect` for BiDi over CDP browser

### DIFF
--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -18,6 +18,7 @@ import type {
   IsPageTargetCallback,
   TargetFilterCallback,
 } from '../api/Browser.js';
+import type {BidiBrowser} from '../bidi/Browser.js';
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {getFetch} from '../common/fetch.js';
 import {debugError} from '../common/util.js';
@@ -29,6 +30,7 @@ import {isErrorLike} from '../util/ErrorLike.js';
 import {CdpBrowser} from './Browser.js';
 import {Connection} from './Connection.js';
 import type {ConnectOptions} from './ConnectOptions.js';
+
 /**
  * Generic browser options that can be passed when launching any browser or when
  * connecting to an existing browser instance.
@@ -79,7 +81,7 @@ const getWebSocketTransportClass = async () => {
 
 /**
  * Users should never call this directly; it's called when calling
- * `puppeteer.connect`.
+ * `puppeteer.connect` with `protocol: 'cdp'`.
  *
  * @internal
  */
@@ -87,49 +89,13 @@ export async function _connectToCdpBrowser(
   options: BrowserConnectOptions & ConnectOptions
 ): Promise<CdpBrowser> {
   const {
-    browserWSEndpoint,
-    browserURL,
     ignoreHTTPSErrors = false,
     defaultViewport = {width: 800, height: 600},
-    transport,
-    headers = {},
-    slowMo = 0,
     targetFilter,
     _isPageTarget: isPageTarget,
-    protocolTimeout,
   } = options;
 
-  assert(
-    Number(!!browserWSEndpoint) + Number(!!browserURL) + Number(!!transport) ===
-      1,
-    'Exactly one of browserWSEndpoint, browserURL or transport must be passed to puppeteer.connect'
-  );
-
-  let connection!: Connection;
-  if (transport) {
-    connection = new Connection('', transport, slowMo, protocolTimeout);
-  } else if (browserWSEndpoint) {
-    const WebSocketClass = await getWebSocketTransportClass();
-    const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(browserWSEndpoint, headers);
-    connection = new Connection(
-      browserWSEndpoint,
-      connectionTransport,
-      slowMo,
-      protocolTimeout
-    );
-  } else if (browserURL) {
-    const connectionURL = await getWSEndpoint(browserURL);
-    const WebSocketClass = await getWebSocketTransportClass();
-    const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(connectionURL);
-    connection = new Connection(
-      connectionURL,
-      connectionTransport,
-      slowMo,
-      protocolTimeout
-    );
-  }
+  const connection = await getCdpConnection(options);
   const version = await connection.send('Browser.getVersion');
 
   const product = version.product.toLowerCase().includes('firefox')
@@ -155,6 +121,16 @@ export async function _connectToCdpBrowser(
   return browser;
 }
 
+/**
+ * Users should never call this directly; it's called when calling
+ * `puppeteer.connect` with `protocol: 'webDriverBiDi'`.
+ *
+ * @internal
+ */
+export async function _connectToBiDiOverCdpBrowser(): Promise<BidiBrowser> {
+  throw new Error('Not implemented');
+}
+
 async function getWSEndpoint(browserURL: string): Promise<string> {
   const endpointURL = new URL('/json/version', browserURL);
 
@@ -176,4 +152,52 @@ async function getWSEndpoint(browserURL: string): Promise<string> {
     }
     throw error;
   }
+}
+
+/**
+ * Returns a CDP connection for the given options.
+ */
+async function getCdpConnection(
+  options: BrowserConnectOptions & ConnectOptions
+): Promise<Connection> {
+  const {
+    browserWSEndpoint,
+    browserURL,
+    transport,
+    headers = {},
+    slowMo = 0,
+    protocolTimeout,
+  } = options;
+
+  assert(
+    Number(!!browserWSEndpoint) + Number(!!browserURL) + Number(!!transport) ===
+      1,
+    'Exactly one of browserWSEndpoint, browserURL or transport must be passed to puppeteer.connect'
+  );
+
+  if (transport) {
+    return new Connection('', transport, slowMo, protocolTimeout);
+  } else if (browserWSEndpoint) {
+    const WebSocketClass = await getWebSocketTransportClass();
+    const connectionTransport: ConnectionTransport =
+      await WebSocketClass.create(browserWSEndpoint, headers);
+    return new Connection(
+      browserWSEndpoint,
+      connectionTransport,
+      slowMo,
+      protocolTimeout
+    );
+  } else if (browserURL) {
+    const connectionURL = await getWSEndpoint(browserURL);
+    const WebSocketClass = await getWebSocketTransportClass();
+    const connectionTransport: ConnectionTransport =
+      await WebSocketClass.create(connectionURL);
+    return new Connection(
+      connectionURL,
+      connectionTransport,
+      slowMo,
+      protocolTimeout
+    );
+  }
+  throw new Error('Invalid connection options');
 }

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -98,8 +98,8 @@ export async function _connectToCdpBrowser(
   } = options;
 
   const connection = await getCdpConnection(options);
-  const version = await connection.send('Browser.getVersion');
 
+  const version = await connection.send('Browser.getVersion');
   const product = version.product.toLowerCase().includes('firefox')
     ? 'firefox'
     : 'chrome';
@@ -136,6 +136,12 @@ export async function _connectToBiDiOverCdpBrowser(
     options;
 
   const connection = await getCdpConnection(options);
+
+  const version = await connection.send('Browser.getVersion');
+  if (version.product.toLowerCase().includes('firefox')) {
+    throw new Error('Firefox is not supported in BiDi over CDP mode.');
+  }
+
   // TODO: use other options too.
   const BiDi = await import(/* webpackIgnore: true */ '../bidi/bidi.js');
   const bidiConnection = await BiDi.connectBidiOverCdp(connection);

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -148,8 +148,7 @@ export async function _connectToBiDiOverCdpBrowser(
   const bidiBrowser = await BiDi.BidiBrowser.create({
     connection: bidiConnection,
     closeCallback: () => {
-      // TODO: implement proper closing.
-      throw new Error('Not implemented yet');
+      return connection.send('Browser.close').catch(debugError);
     },
     process: undefined,
     defaultViewport: defaultViewport,

--- a/packages/puppeteer-core/src/common/Puppeteer.ts
+++ b/packages/puppeteer-core/src/common/Puppeteer.ts
@@ -132,7 +132,7 @@ export class Puppeteer {
    */
   connect(options: ConnectOptions): Promise<Browser> {
     if (options.protocol === 'webDriverBiDi') {
-      return _connectToBiDiOverCdpBrowser();
+      return _connectToBiDiOverCdpBrowser(options);
     } else {
       return _connectToCdpBrowser(options);
     }

--- a/packages/puppeteer-core/src/common/Puppeteer.ts
+++ b/packages/puppeteer-core/src/common/Puppeteer.ts
@@ -15,7 +15,10 @@
  */
 
 import type {Browser} from '../api/Browser.js';
-import {_connectToCdpBrowser} from '../cdp/BrowserConnector.js';
+import {
+  _connectToBiDiOverCdpBrowser,
+  _connectToCdpBrowser,
+} from '../cdp/BrowserConnector.js';
 import type {ConnectOptions} from '../cdp/ConnectOptions.js';
 
 import {
@@ -129,7 +132,7 @@ export class Puppeteer {
    */
   connect(options: ConnectOptions): Promise<Browser> {
     if (options.protocol === 'webDriverBiDi') {
-      throw new Error('Not implemented');
+      return _connectToBiDiOverCdpBrowser();
     } else {
       return _connectToCdpBrowser(options);
     }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -384,12 +384,6 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[browser.spec] Browser specs Browser.process should not return child_process for remote browser",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[browser.spec] Browser specs Browser.process should return child_process instance",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -639,13 +639,13 @@
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["TIMEOUT"]
+    "expectations": ["FAIL", "TIMEOUT"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject waitForSelector when browser closes",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["TIMEOUT"]
+    "expectations": ["FAIL", "TIMEOUT"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath returns executablePath for channel",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2022,12 +2022,6 @@
     "expectations": ["SKIP"]
   },
   {
-    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
-    "platforms": ["linux"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to close remote browser",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -639,13 +639,13 @@
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL", "PASS"]
+    "expectations": ["TIMEOUT"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject waitForSelector when browser closes",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL", "PASS"]
+    "expectations": ["TIMEOUT"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.executablePath returns executablePath for channel",
@@ -2025,19 +2025,19 @@
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to close remote browser",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to connect multiple times to the same browser",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to connect to a browser with no page targets",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to connect to a browser with no page targets",
@@ -2055,7 +2055,7 @@
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to connect to the same page simultaneously",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to reconnect to a disconnected browser",
@@ -2067,7 +2067,7 @@
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support ignoreHTTPSErrors option",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["SKIP"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support targetFilter option",
@@ -3605,6 +3605,12 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "headful", "webDriverBiDi"],
     "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
+    "platforms": ["linux"],
+    "parameters": ["cdp", "firefox", "headful"],
+    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation \"after all\" hook in \"navigation\"",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2022,6 +2022,12 @@
     "expectations": ["SKIP"]
   },
   {
+    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
+    "platforms": ["linux"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to close remote browser",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
@@ -3605,12 +3611,6 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "headful", "webDriverBiDi"],
     "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Browser.disconnect should reject navigation when browser closes",
-    "platforms": ["linux"],
-    "parameters": ["cdp", "firefox", "headful"],
-    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation \"after all\" hook in \"navigation\"",


### PR DESCRIPTION
Implementing Puppeteer.connect for pure BiDi is out of scope of this PR