### PR TITLE
fix: add --disable-field-trial-config

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -209,7 +209,7 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',
-      `--disable-features=${disabledFeatures.join(',')}`,
+      '--disable-field-trial-config', // https://source.chromium.org/chromium/chromium/src/+/main:testing/variations/README.md
       '--disable-hang-monitor',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',
@@ -218,16 +218,14 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-search-engine-choice-screen',
       '--disable-sync',
       '--enable-automation',
-      // TODO(sadym): remove '--enable-blink-features=IdleDetection' once
-      // IdleDetection is turned on by default.
-      '--enable-blink-features=IdleDetection',
-      `--enable-features=${enabledFeatures.join(',')}`,
       '--export-tagged-pdf',
       '--force-color-profile=srgb',
       '--metrics-recording-only',
       '--no-first-run',
       '--password-store=basic',
       '--use-mock-keychain',
+      `--disable-features=${disabledFeatures.join(',')}`,
+      `--enable-features=${enabledFeatures.join(',')}`,
     ];
     const {
       devtools = false,


### PR DESCRIPTION
It would prevent any field trial experiments from
applying by default.

Drive-by: removed the IdleDetection flag which is shipping by default already https://chromestatus.com/feature/4590256452009984