### PR TITLE
test: fail `ignoreHTTPSErrors` faster

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2133,7 +2133,7 @@
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support ignoreHTTPSErrors option",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["SKIP"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support targetFilter option",

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -700,20 +700,16 @@ describe('Launcher specs', function () {
             protocol: browser.protocol,
           });
           const page = await remoteBrowser.newPage();
-          let error!: Error;
           const [serverRequest, response] = await Promise.all([
             httpsServer.waitForRequest('/empty.html'),
-            page.goto(httpsServer.EMPTY_PAGE).catch(error_ => {
-              return (error = error_);
-            }),
+            page.goto(httpsServer.EMPTY_PAGE),
           ]);
-          expect(error).toBeUndefined();
-          expect(response.ok()).toBe(true);
-          expect(response.securityDetails()).toBeTruthy();
+          expect(response!.ok()).toBe(true);
+          expect(response!.securityDetails()).toBeTruthy();
           const protocol = (serverRequest.socket as TLSSocket)
             .getProtocol()!
             .replace('v', ' ');
-          expect(response.securityDetails().protocol()).toBe(protocol);
+          expect(response!.securityDetails()!.protocol()).toBe(protocol);
           await page.close();
           await remoteBrowser.close();
         } finally {


### PR DESCRIPTION
When HTTS exception is raised, the `[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support ignoreHTTPSErrors option` hangs forever, as `httpsServer.waitForRequest` is never returned, and the test fails because of timeout, which masks the real problem and adds unnecessary test runtime.

Updated the test, so that it fails immediately after `page.goto` failed.