### PR TITLE
fix: add --disable-infobars

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -211,6 +211,7 @@ export class ChromeLauncher extends ProductLauncher {
       '--disable-extensions',
       '--disable-field-trial-config', // https://source.chromium.org/chromium/chromium/src/+/main:testing/variations/README.md
       '--disable-hang-monitor',
+      '--disable-infobars',
       '--disable-ipc-flooding-protection',
       '--disable-popup-blocking',
       '--disable-prompt-on-repost',


### PR DESCRIPTION
Closes #11013

It looks like the flag will be supported starting from M121 only for Chrome for Testing binaries https://chromium-review.googlesource.com/c/chromium/src/+/5012709