### PR TITLE
chore: update unsupported to return `never`

### DIFF
--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -168,7 +168,7 @@ export class BidiBrowser extends Browser {
     }
   }
 
-  override userAgent(): Promise<string> {
+  override userAgent(): never {
     throw new UnsupportedOperation();
   }
 

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -126,11 +126,11 @@ export class BidiBrowserContext extends BrowserContext {
     return !this.#isDefault;
   }
 
-  override overridePermissions(): Promise<void> {
+  override overridePermissions(): never {
     throw new UnsupportedOperation();
   }
 
-  override clearPermissionOverrides(): Promise<void> {
+  override clearPermissionOverrides(): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/bidi/ElementHandle.ts
@@ -91,7 +91,7 @@ export class BidiElementHandle<
     return null;
   }
 
-  override uploadFile(this: ElementHandle<HTMLInputElement>): Promise<void> {
+  override uploadFile(this: ElementHandle<HTMLInputElement>): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -38,7 +38,6 @@ import {UnsupportedOperation} from '../common/Errors.js';
 import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import type {Awaitable} from '../common/types.js';
 import {UTILITY_WORLD_NAME, setPageContent, timeout} from '../common/util.js';
-import type {DeviceRequestPrompt} from '../puppeteer-core.js';
 import {Deferred} from '../util/Deferred.js';
 import {disposeSymbol} from '../util/disposable.js';
 
@@ -111,7 +110,7 @@ export class BidiFrame extends Frame {
     return this.#page;
   }
 
-  override isOOPFrame(): boolean {
+  override isOOPFrame(): never {
     throw new UnsupportedOperation();
   }
 
@@ -233,7 +232,7 @@ export class BidiFrame extends Frame {
     return this.#page.getNavigationResponse(response?.result.navigation);
   }
 
-  override waitForDevicePrompt(): Promise<DeviceRequestPrompt> {
+  override waitForDevicePrompt(): never {
     throw new UnsupportedOperation();
   }
 

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import type {Protocol} from 'devtools-protocol';
 
-import type {CDPSession} from '../api/CDPSession.js';
 import type {Frame} from '../api/Frame.js';
 import type {
   ContinueRequestOverrides,
-  InterceptResolutionState,
   ResponseForRequest,
 } from '../api/HTTPRequest.js';
 import {HTTPRequest, type ResourceType} from '../api/HTTPRequest.js';
@@ -72,7 +69,7 @@ export class BidiHTTPRequest extends HTTPRequest {
     }
   }
 
-  override get client(): CDPSession {
+  override get client(): never {
     throw new UnsupportedOperation();
   }
 
@@ -123,48 +120,46 @@ export class BidiHTTPRequest extends HTTPRequest {
     return this.#frame;
   }
 
-  override continueRequestOverrides(): ContinueRequestOverrides {
+  override continueRequestOverrides(): never {
     throw new UnsupportedOperation();
   }
 
-  override async continue(
-    _overrides: ContinueRequestOverrides = {}
-  ): Promise<void> {
+  override continue(_overrides: ContinueRequestOverrides = {}): never {
     throw new UnsupportedOperation();
   }
 
-  override responseForRequest(): Partial<ResponseForRequest> {
+  override responseForRequest(): never {
     throw new UnsupportedOperation();
   }
 
-  override abortErrorReason(): Protocol.Network.ErrorReason | null {
+  override abortErrorReason(): never {
     throw new UnsupportedOperation();
   }
 
-  override interceptResolutionState(): InterceptResolutionState {
+  override interceptResolutionState(): never {
     throw new UnsupportedOperation();
   }
 
-  override isInterceptResolutionHandled(): boolean {
+  override isInterceptResolutionHandled(): never {
     throw new UnsupportedOperation();
   }
 
-  override async finalizeInterceptions(): Promise<void> {
+  override finalizeInterceptions(): never {
     throw new UnsupportedOperation();
   }
 
-  override abort(): Promise<void> {
+  override abort(): never {
     throw new UnsupportedOperation();
   }
 
   override respond(
     _response: Partial<ResponseForRequest>,
     _priority?: number
-  ): Promise<void> {
+  ): never {
     throw new UnsupportedOperation();
   }
 
-  override failure(): {errorText: string} | null {
+  override failure(): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -22,7 +22,6 @@ import {
   type RemoteAddress,
 } from '../api/HTTPResponse.js';
 import {UnsupportedOperation} from '../common/Errors.js';
-import type {SecurityDetails} from '../common/SecurityDetails.js';
 
 import type {BidiHTTPRequest} from './HTTPRequest.js';
 
@@ -108,11 +107,11 @@ export class BidiHTTPResponse extends HTTPResponse {
     return false;
   }
 
-  override securityDetails(): SecurityDetails | null {
+  override securityDetails(): never {
     throw new UnsupportedOperation();
   }
 
-  override buffer(): Promise<Buffer> {
+  override buffer(): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/Input.ts
+++ b/packages/puppeteer-core/src/bidi/Input.ts
@@ -15,7 +15,6 @@
  */
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
-import type Protocol from 'devtools-protocol';
 
 import type {Point} from '../api/ElementHandle.js';
 import {
@@ -630,23 +629,23 @@ export class BidiMouse extends Mouse {
     });
   }
 
-  override drag(): Promise<Protocol.Input.DragData> {
+  override drag(): never {
     throw new UnsupportedOperation();
   }
 
-  override dragOver(): Promise<void> {
+  override dragOver(): never {
     throw new UnsupportedOperation();
   }
 
-  override dragEnter(): Promise<void> {
+  override dragEnter(): never {
     throw new UnsupportedOperation();
   }
 
-  override drop(): Promise<void> {
+  override drop(): never {
     throw new UnsupportedOperation();
   }
 
-  override dragAndDrop(): Promise<void> {
+  override dragAndDrop(): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -30,7 +30,6 @@ import {
 } from '../../third_party/rxjs/rxjs.js';
 import type {CDPSession} from '../api/CDPSession.js';
 import type {WaitForOptions} from '../api/Frame.js';
-import type {Metrics} from '../api/Page.js';
 import {
   Page,
   PageEvent,
@@ -39,20 +38,17 @@ import {
   type NewDocumentScriptEvaluation,
   type ScreenshotOptions,
 } from '../api/Page.js';
-import type {Target} from '../api/Target.js';
 import {Accessibility} from '../cdp/Accessibility.js';
 import {Coverage} from '../cdp/Coverage.js';
 import {EmulationManager as CdpEmulationManager} from '../cdp/EmulationManager.js';
 import {FrameTree} from '../cdp/FrameTree.js';
 import {Tracing} from '../cdp/Tracing.js';
-import type {WebWorker} from '../cdp/WebWorker.js';
 import {
   ConsoleMessage,
   type ConsoleMessageLocation,
 } from '../common/ConsoleMessage.js';
 import {TargetCloseError, UnsupportedOperation} from '../common/Errors.js';
 import type {Handler} from '../common/EventEmitter.js';
-import type {FileChooser} from '../common/FileChooser.js';
 import {NetworkManagerEvent} from '../common/NetworkManagerEvents.js';
 import type {PDFOptions} from '../common/PDFOptions.js';
 import type {Awaitable} from '../common/types.js';
@@ -65,7 +61,6 @@ import {
   waitForHTTP,
 } from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
-import type {DeviceRequestPrompt, HTTPResponse} from '../puppeteer-core.js';
 import {assert} from '../util/assert.js';
 import {Deferred} from '../util/Deferred.js';
 import {disposeSymbol} from '../util/disposable.js';
@@ -828,80 +823,80 @@ export class BidiPage extends Page {
     });
   }
 
-  override isServiceWorkerBypassed(): boolean {
+  override isServiceWorkerBypassed(): never {
     throw new UnsupportedOperation();
   }
 
-  override target(): Target {
+  override target(): never {
     throw new UnsupportedOperation();
   }
 
-  override waitForFileChooser(): Promise<FileChooser> {
+  override waitForFileChooser(): never {
     throw new UnsupportedOperation();
   }
 
-  override workers(): WebWorker[] {
+  override workers(): never {
     throw new UnsupportedOperation();
   }
 
-  override setRequestInterception(): Promise<void> {
+  override setRequestInterception(): never {
     throw new UnsupportedOperation();
   }
 
-  override setDragInterception(): Promise<void> {
+  override setDragInterception(): never {
     throw new UnsupportedOperation();
   }
 
-  override setBypassServiceWorker(): Promise<void> {
+  override setBypassServiceWorker(): never {
     throw new UnsupportedOperation();
   }
 
-  override setOfflineMode(): Promise<void> {
+  override setOfflineMode(): never {
     throw new UnsupportedOperation();
   }
 
-  override emulateNetworkConditions(): Promise<void> {
+  override emulateNetworkConditions(): never {
     throw new UnsupportedOperation();
   }
 
-  override cookies(): Promise<Protocol.Network.Cookie[]> {
+  override cookies(): never {
     throw new UnsupportedOperation();
   }
 
-  override setCookie(): Promise<void> {
+  override setCookie(): never {
     throw new UnsupportedOperation();
   }
 
-  override deleteCookie(): Promise<void> {
+  override deleteCookie(): never {
     throw new UnsupportedOperation();
   }
 
-  override removeExposedFunction(): Promise<void> {
+  override removeExposedFunction(): never {
     // TODO: Quick win?
     throw new UnsupportedOperation();
   }
 
-  override authenticate(): Promise<void> {
+  override authenticate(): never {
     throw new UnsupportedOperation();
   }
 
-  override setExtraHTTPHeaders(): Promise<void> {
+  override setExtraHTTPHeaders(): never {
     throw new UnsupportedOperation();
   }
 
-  override metrics(): Promise<Metrics> {
+  override metrics(): never {
     throw new UnsupportedOperation();
   }
 
-  override goBack(): Promise<HTTPResponse | null> {
+  override goBack(): never {
     throw new UnsupportedOperation();
   }
 
-  override goForward(): Promise<HTTPResponse | null> {
+  override goForward(): never {
     throw new UnsupportedOperation();
   }
 
-  override waitForDevicePrompt(): Promise<DeviceRequestPrompt> {
+  override waitForDevicePrompt(): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/Target.ts
+++ b/packages/puppeteer-core/src/bidi/Target.ts
@@ -26,7 +26,7 @@ import {BidiPage} from './Page.js';
 /**
  * @internal
  */
-export class BidiTarget extends Target {
+export abstract class BidiTarget extends Target {
   protected _browserContext: BidiBrowserContext;
 
   constructor(browserContext: BidiBrowserContext) {
@@ -50,19 +50,11 @@ export class BidiTarget extends Target {
     return this._browserContext;
   }
 
-  override opener(): Target | undefined {
-    throw new UnsupportedOperation();
-  }
-
-  override url(): string {
+  override opener(): never {
     throw new UnsupportedOperation();
   }
 
   override createCDPSession(): Promise<CDPSession> {
-    throw new UnsupportedOperation();
-  }
-
-  override type(): TargetType {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -349,7 +349,7 @@ export class CdpFrame extends Frame {
     this.worlds[PUPPETEER_WORLD][disposeSymbol]();
   }
 
-  exposeFunction(): Promise<void> {
+  exposeFunction(): never {
     throw new UnsupportedOperation();
   }
 }


### PR DESCRIPTION
Not Perfect but at least better support for TypeScript if you import the classes directly.
Example: 
![image](https://github.com/puppeteer/puppeteer/assets/34244704/dddfdcff-5d18-48ba-9895-3138c66e49f3)
