### PR TITLE
docs: use link with placeholder

### DIFF
--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -402,7 +402,9 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * {@link Page.setUserAgent}.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract userAgent(): Promise<string>;
 

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -166,7 +166,9 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
    * are not listed here will be automatically denied.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract overridePermissions(
     origin: string,
@@ -188,7 +190,9 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract clearPermissionOverrides(): Promise<void>;
 

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -964,7 +964,9 @@ export abstract class ElementHandle<
    * absolute.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract uploadFile(
     this: ElementHandle<HTMLInputElement>,

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -313,7 +313,9 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
    * `false`.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract isOOPFrame(): boolean;
 
@@ -352,7 +354,9 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
    * calling {@link HTTPResponse.status}.
    *
    * @privateRemarks BiDi
-   * Partial support
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
    *
    * - `referer` not supported
    * - `referrerPolicy` not supported
@@ -1206,7 +1210,9 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    *
    * @internal
    */

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -132,7 +132,9 @@ export abstract class HTTPRequest {
    * @experimental
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract get client(): CDPSession;
 
@@ -152,7 +154,9 @@ export abstract class HTTPRequest {
    * `respond()` aren't called).
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract continueRequestOverrides(): ContinueRequestOverrides;
 
@@ -161,7 +165,9 @@ export abstract class HTTPRequest {
    * interception is allowed to respond (ie, `abort()` is not called).
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract responseForRequest(): Partial<ResponseForRequest> | null;
 
@@ -169,7 +175,9 @@ export abstract class HTTPRequest {
    * The most recent reason for aborting the request
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract abortErrorReason(): Protocol.Network.ErrorReason | null;
 
@@ -185,7 +193,9 @@ export abstract class HTTPRequest {
    * `disabled`, `none`, or `already-handled`.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract interceptResolutionState(): InterceptResolutionState;
 
@@ -194,7 +204,9 @@ export abstract class HTTPRequest {
    * `false` otherwise.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract isInterceptResolutionHandled(): boolean;
 
@@ -213,7 +225,9 @@ export abstract class HTTPRequest {
    * the request interception.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract finalizeInterceptions(): Promise<void>;
 
@@ -311,7 +325,9 @@ export abstract class HTTPRequest {
    * failure text if the request fails.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract failure(): {errorText: string} | null;
 
@@ -345,7 +361,9 @@ export abstract class HTTPRequest {
    * immediately.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract continue(
     overrides?: ContinueRequestOverrides,
@@ -385,7 +403,9 @@ export abstract class HTTPRequest {
    * immediately.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract respond(
     response: Partial<ResponseForRequest>,
@@ -406,7 +426,9 @@ export abstract class HTTPRequest {
    * immediately.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract abort(errorCode?: ErrorCode, priority?: number): Promise<void>;
 }

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -83,7 +83,9 @@ export abstract class HTTPResponse {
    * secure connection, or `null` otherwise.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract securityDetails(): SecurityDetails | null;
 
@@ -96,7 +98,9 @@ export abstract class HTTPResponse {
    * Promise which resolves to a buffer with response body.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract buffer(): Promise<Buffer>;
 
@@ -136,7 +140,9 @@ export abstract class HTTPResponse {
    * True if the response was served by a service worker.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract fromServiceWorker(): boolean;
 

--- a/packages/puppeteer-core/src/api/Input.ts
+++ b/packages/puppeteer-core/src/api/Input.ts
@@ -437,7 +437,9 @@ export abstract class Mouse {
    * @param target - point to drag to
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract drag(start: Point, target: Point): Promise<Protocol.Input.DragData>;
 
@@ -447,7 +449,9 @@ export abstract class Mouse {
    * @param data - drag data containing items and operations mask
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract dragEnter(
     target: Point,
@@ -460,7 +464,9 @@ export abstract class Mouse {
    * @param data - drag data containing items and operations mask
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract dragOver(
     target: Point,
@@ -473,7 +479,9 @@ export abstract class Mouse {
    * @param data - drag data containing items and operations mask
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract drop(target: Point, data: Protocol.Input.DragData): Promise<void>;
 
@@ -486,7 +494,9 @@ export abstract class Mouse {
    * Defaults to 0.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract dragAndDrop(
     start: Point,

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1049,6 +1049,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param selector - A `selector` to query page for
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors | selector}
    * to query page for.
+   *
+   * @privateRemarks BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * - ARIA selector not supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   async $<Selector extends string>(
     selector: Selector
@@ -1062,6 +1071,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @remarks
    * Shortcut for {@link Frame.$$ | Page.mainFrame().$$(selector) }.
    * @param selector - A `selector` to query page for
+   *
+   * @privateRemarks BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * - ARIA selector not supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   async $$<Selector extends string>(
     selector: Selector
@@ -1235,6 +1253,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @returns The result of calling `pageFunction`. If it returns an element it
    * is wrapped in an {@link ElementHandle}, else the raw value itself is
    * returned.
+   *
+   * @privateRemarks BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * - ARIA selector not supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   async $eval<
     Selector extends string,
@@ -1313,6 +1340,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @returns The result of calling `pageFunction`. If it returns an element it
    * is wrapped in an {@link ElementHandle}, else the raw value itself is
    * returned.
+   *
+   * @privateRemarks BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * - ARIA selector not supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   async $$eval<
     Selector extends string,

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -422,7 +422,9 @@ export const enum PageEvent {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   Popup = 'popup',
   /**
@@ -468,7 +470,9 @@ export const enum PageEvent {
    * is spawned by the page.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   WorkerCreated = 'workercreated',
   /**
@@ -477,7 +481,9 @@ export const enum PageEvent {
    * is destroyed by the page.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   WorkerDestroyed = 'workerdestroyed',
 }
@@ -620,7 +626,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * `true` if the service worker are being bypassed, `false` otherwise.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract isServiceWorkerBypassed(): boolean;
 
@@ -632,7 +640,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * {@link Page.mouse}).
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract isDragInterceptionEnabled(): boolean;
 
@@ -640,8 +650,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * `true` if the page has JavaScript enabled, `false` otherwise.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Support for BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract isJavaScriptEnabled(): boolean;
 
@@ -729,7 +742,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract waitForFileChooser(
     options?: WaitTimeoutOptions
@@ -749,7 +764,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract setGeolocation(options: GeolocationOptions): Promise<void>;
 
@@ -780,8 +799,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * Creates a Chrome Devtools Protocol session attached to the page.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported By BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract createCDPSession(): Promise<CDPSession>;
 
@@ -824,7 +846,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * This does not contain ServiceWorkers
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract workers(): WebWorker[];
 
@@ -865,7 +889,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param value - Whether to enable request interception.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setRequestInterception(value: boolean): Promise<void>;
 
@@ -875,7 +901,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param bypass - Whether to bypass service worker and load from network.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setBypassServiceWorker(bypass: boolean): Promise<void>;
 
@@ -887,7 +915,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * {@link Page.mouse}).
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setDragInterception(enabled: boolean): Promise<void>;
 
@@ -899,7 +929,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param enabled - When `true`, enables offline mode for the page.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setOfflineMode(enabled: boolean): Promise<void>;
 
@@ -931,7 +963,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * emulation.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract emulateNetworkConditions(
     networkConditions: NetworkConditions | null
@@ -1130,8 +1164,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * this prototype.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported with BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract queryObjects<Prototype>(
     prototypeHandle: JSHandle<Prototype>
@@ -1312,13 +1349,17 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * URL. If URLs are specified, only cookies for those URLs are returned.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract cookies(...urls: string[]): Promise<Protocol.Network.Cookie[]>;
 
   /**
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract deleteCookie(
     ...cookies: Protocol.Network.DeleteCookiesRequest[]
@@ -1332,7 +1373,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setCookie(...cookies: Protocol.Network.CookieParam[]): Promise<void>;
 
@@ -1463,7 +1506,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * To disable authentication, pass `null`.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract authenticate(credentials: Credentials): Promise<void>;
 
@@ -1488,7 +1533,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * with every request. All header values must be strings.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setExtraHTTPHeaders(headers: Record<string, string>): Promise<void>;
 
@@ -1499,7 +1546,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @returns Promise which resolves when the user agent is set.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract setUserAgent(
     userAgent: string,
@@ -1543,7 +1592,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * in seconds since an arbitrary point in the past.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract metrics(): Promise<Metrics>;
 
@@ -1849,7 +1900,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *   more than 2 network connections for at least `500` ms.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract goBack(options?: WaitForOptions): Promise<HTTPResponse | null>;
 
@@ -1880,7 +1933,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *   more than 2 network connections for at least `500` ms.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract goForward(options?: WaitForOptions): Promise<HTTPResponse | null>;
 
@@ -1920,7 +1975,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   async emulate(device: Device): Promise<void> {
     await Promise.all([
@@ -1936,8 +1993,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * It will take full effect on the next navigation.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported Bidi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract setJavaScriptEnabled(enabled: boolean): Promise<void>;
 
@@ -1950,8 +2010,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * before navigating to the domain.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract setBypassCSP(enabled: boolean): Promise<void>;
 
@@ -1981,8 +2044,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract emulateMediaType(type?: string): Promise<void>;
 
@@ -1991,8 +2057,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param factor - slowdown factor (1 is no throttle, 2 is 2x slowdown, etc).
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported By BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract emulateCPUThrottling(factor: number | null): Promise<void>;
 
@@ -2058,8 +2127,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported By BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract emulateMediaFeatures(features?: MediaFeature[]): Promise<void>;
 
@@ -2070,8 +2142,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * `null` disables timezone emulation.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract emulateTimezone(timezoneId?: string): Promise<void>;
 
@@ -2095,8 +2170,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param overrides - Mock idle state. If not set, clears idle overrides
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract emulateIdleState(overrides?: {
     isUserActive: boolean;
@@ -2132,8 +2210,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param type - the type of deficiency to simulate, or `'none'` to reset.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract emulateVisionDeficiency(
     type?: Protocol.Emulation.SetEmulatedVisionDeficiencyRequest['type']
@@ -2164,9 +2245,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * set the isMobile or hasTouch properties.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Full support by BiDi+
-   * Partial support by BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * #TODO: List unsupported?
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract setViewport(viewport: Viewport): Promise<void>;
 
@@ -2292,8 +2377,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @defaultValue `true`
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract setCacheEnabled(enabled?: boolean): Promise<void>;
 
@@ -2354,8 +2442,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @experimental
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
-   * Supported by BiDi+
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   async screencast(
     options: Readonly<ScreencastOptions> = {}
@@ -2499,7 +2590,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param options - Configures screenshot behavior.
    *
    * @privateRemarks BiDi
-   * Partial support by BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * #TODO: List unsupported?
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   async screenshot(
     options: Readonly<ScreenshotOptions> & {encoding: 'base64'}
@@ -2665,7 +2762,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param options - options for generating the PDF.
    *
    * @privateRemarks BiDi
-   * Partial support by BiDi
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * #TODO: List unsupported?
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
    */
   abstract createPDFStream(options?: PDFOptions): Promise<Readable>;
 
@@ -2802,7 +2905,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * Shortcut for {@link Frame.tap | page.mainFrame().tap(selector)}.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   tap(selector: string): Promise<void> {
     return this.mainFrame().tap(selector);
@@ -2916,8 +3021,11 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *   by using the {@link Page.setDefaultTimeout} method.
    *
    * @privateRemarks BiDi
-   * Partial support -
-   * ARIA selector not supported
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Partial support
+   *
+   * - ARIA selector not supported
    */
   async waitForSelector<Selector extends string>(
     selector: Selector,
@@ -3076,7 +3184,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract waitForDevicePrompt(
     options?: WaitTimeoutOptions

--- a/packages/puppeteer-core/src/api/Target.ts
+++ b/packages/puppeteer-core/src/api/Target.ts
@@ -72,7 +72,9 @@ export abstract class Target {
    * Creates a Chrome Devtools Protocol session attached to the target.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract createCDPSession(): Promise<CDPSession>;
 
@@ -99,7 +101,9 @@ export abstract class Target {
    * Get the target that opened this target. Top-level targets return `null`.
    *
    * @privateRemarks BiDi
-   * Not supported when using protocol `webDriverBiDi`
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+   *
+   * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
    */
   abstract opener(): Target | undefined;
 }

--- a/packages/puppeteer-core/src/cdp/Accessibility.ts
+++ b/packages/puppeteer-core/src/cdp/Accessibility.ts
@@ -130,7 +130,9 @@ export interface SnapshotOptions {
  *
  * @privateRemarks BiDi
  * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+ *
  * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+ *
  * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
  *
  * @public

--- a/packages/puppeteer-core/src/cdp/Accessibility.ts
+++ b/packages/puppeteer-core/src/cdp/Accessibility.ts
@@ -129,8 +129,9 @@ export interface SnapshotOptions {
  * the "interesting" nodes of the tree.
  *
  * @privateRemarks BiDi
- * Not supported when using protocol `webDriverBiDi`
- * Support for BiDi+
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
  *
  * @public
  */

--- a/packages/puppeteer-core/src/cdp/Coverage.ts
+++ b/packages/puppeteer-core/src/cdp/Coverage.ts
@@ -124,8 +124,11 @@ export interface CSSCoverageOptions {
  * ```
  *
  * @privateRemarks BiDi
- * Not supported when using protocol `webDriverBiDi`
- * Support for BiDi+
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
+ *
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
+ *
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
  *
  * @public
  */

--- a/packages/puppeteer-core/src/cdp/Tracing.ts
+++ b/packages/puppeteer-core/src/cdp/Tracing.ts
@@ -46,11 +46,11 @@ export interface TracingOptions {
  * ```
  *
  * @privateRemarks BiDi
- * {@link http://example.com | CDP}: Supported
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | CDP}: Supported
  *
- * {@link http://example.com | BiDi}: Unsupported
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi}: Unsupported
  *
- * {@link http://example.com | BiDi+}: Supported
+ * {@link PROTOCOL_GET_STARTED_LINK_TEMPLATE | BiDi+}: Supported
  *
  * @public
  */

--- a/packages/puppeteer-core/src/cdp/Tracing.ts
+++ b/packages/puppeteer-core/src/cdp/Tracing.ts
@@ -46,8 +46,11 @@ export interface TracingOptions {
  * ```
  *
  * @privateRemarks BiDi
- * Not supported when using protocol `webDriverBiDi`
- * Support for BiDi+
+ * {@link http://example.com | CDP}: Supported
+ *
+ * {@link http://example.com | BiDi}: Unsupported
+ *
+ * {@link http://example.com | BiDi+}: Supported
  *
  * @public
  */


### PR DESCRIPTION
Note: Locally this will look very broken due to TsDoc not knowing how to handle the `PLACEHOLDER`.
But due to them all being behind `@privateRemarks` they will be stripped  from Public releases.