### PR TITLE
chore: fail fast waitForSelector BiDi

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -28,15 +28,17 @@ import {
   raceWith,
 } from '../../third_party/rxjs/rxjs.js';
 import type {CDPSession} from '../api/CDPSession.js';
+import type {ElementHandle} from '../api/ElementHandle.js';
 import {
   Frame,
   type GoToOptions,
   type WaitForOptions,
   throwIfDetached,
 } from '../api/Frame.js';
+import type {WaitForSelectorOptions} from '../api/Page.js';
 import {UnsupportedOperation} from '../common/Errors.js';
 import type {TimeoutSettings} from '../common/TimeoutSettings.js';
-import type {Awaitable} from '../common/types.js';
+import type {Awaitable, NodeFor} from '../common/types.js';
 import {UTILITY_WORLD_NAME, setPageContent, timeout} from '../common/util.js';
 import {Deferred} from '../util/Deferred.js';
 import {disposeSymbol} from '../util/disposable.js';
@@ -269,5 +271,18 @@ export class BidiFrame extends Frame {
       this.#exposedFunctions.delete(name);
       throw error;
     }
+  }
+
+  override waitForSelector<Selector extends string>(
+    selector: Selector,
+    options?: WaitForSelectorOptions
+  ): Promise<ElementHandle<NodeFor<Selector>> | null> {
+    if (selector.startsWith('aria')) {
+      throw new UnsupportedOperation(
+        'ARIA selector is not supported for BiDi!'
+      );
+    }
+
+    return super.waitForSelector(selector, options);
   }
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -357,25 +357,25 @@
     "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler waitForSelector (aria) should have an error message specifically for awaiting an element to be hidden",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler waitForSelector (aria) should have correct stack trace for timeout",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler waitForSelector (aria) should respect timeout",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler waitForSelector (aria) should throw when frame is detached",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[autofill.spec] *",


### PR DESCRIPTION
The makes a few test fail, but now you don't get an `TimeoutError`, which would be confusing.