### PR TITLE
chore: removing unused Firefox pref browser.safebrowsing.passwords.enabled

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -130,7 +130,6 @@ function defaultProfilePreferences(
     'browser.safebrowsing.blockedURIs.enabled': false,
     'browser.safebrowsing.downloads.enabled': false,
     'browser.safebrowsing.malware.enabled': false,
-    'browser.safebrowsing.passwords.enabled': false,
     'browser.safebrowsing.phishing.enabled': false,
 
     // Disable updates to search engines.


### PR DESCRIPTION
Closes #11291
