### PR TITLE
fix: remove CDP-specific preferences from defaults for Firefox

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -220,12 +220,6 @@ function defaultProfilePreferences(
     // Make sure opening about:addons will not hit the network
     'extensions.webservice.discoverURL': `http://${server}/dummy/discoveryURL`,
 
-    // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
-    'fission.bfcacheInParent': false,
-
-    // Force all web content to use a single content process
-    'fission.webContentIsolationStrategy': 0,
-
     // Allow the application to have focus even it runs in the background
     'focusmanager.testmode': true,
     // Disable useragent updates

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -113,7 +113,18 @@ export class FirefoxLauncher extends ProductLauncher {
 
     await createProfile(SupportedBrowsers.FIREFOX, {
       path: userDataDir,
-      preferences: extraPrefsFirefox,
+      preferences: {
+        ...extraPrefsFirefox,
+        ...(options.protocol === 'cdp'
+          ? {
+              // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
+              'fission.bfcacheInParent': false,
+
+              // Force all web content to use a single content process
+              'fission.webContentIsolationStrategy': 0,
+            }
+          : {}),
+      },
     });
 
     let firefoxExecutable: string;

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -119,11 +119,14 @@ export class FirefoxLauncher extends ProductLauncher {
           ? {
               // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
               'fission.bfcacheInParent': false,
-
-              // Force all web content to use a single content process
-              'fission.webContentIsolationStrategy': 0,
             }
           : {}),
+        // Force all web content to use a single content process. TODO: remove
+        // this once Firefox supports mouse event dispatch from the main frame
+        // context. Once this happens, webContentIsolationStrategy should only
+        // be set for CDP. See
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1773393
+        'fission.webContentIsolationStrategy': 0,
       },
     });
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1497,7 +1497,7 @@
     "testIdPattern": "[click.spec] Page.click should click the button with fixed position inside an iframe",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[click.spec] Page.click should click the button with fixed position inside an iframe",
@@ -1893,7 +1893,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should report different frame instance when frame re-attaches",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should report frame from-inside shadow DOM",
@@ -1959,7 +1959,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame.evaluate should throw for detached frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"]
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame.executionContext should work",
@@ -2766,10 +2766,22 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[oopif.spec] OOPIF clickablePoint, boundingBox, boxModel should work for elements inside OOPIFs",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[oopif.spec] OOPIF should keep track of a frames OOP state",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["PASS"]
+  },
+  {
+    "testIdPattern": "[oopif.spec] OOPIF should provide access to elements",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[oopif.spec] OOPIF should support lazy OOP frames",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1497,7 +1497,7 @@
     "testIdPattern": "[click.spec] Page.click should click the button with fixed position inside an iframe",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[click.spec] Page.click should click the button with fixed position inside an iframe",
@@ -1893,7 +1893,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should report different frame instance when frame re-attaches",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should report frame from-inside shadow DOM",
@@ -1959,7 +1959,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame.evaluate should throw for detached frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame.executionContext should work",
@@ -2769,7 +2769,7 @@
     "testIdPattern": "[oopif.spec] OOPIF clickablePoint, boundingBox, boxModel should work for elements inside OOPIFs",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[oopif.spec] OOPIF should keep track of a frames OOP state",
@@ -2781,7 +2781,7 @@
     "testIdPattern": "[oopif.spec] OOPIF should provide access to elements",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[oopif.spec] OOPIF should support lazy OOP frames",


### PR DESCRIPTION
Closes #11474