### PR TITLE
chore: update `mime`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12052,6 +12052,7 @@
         "@pptr/testserver": "file:../packages/testserver",
         "diff": "5.1.0",
         "jpeg-js": "0.4.4",
+        "mime": "4.0.0",
         "pixelmatch": "5.3.0",
         "pngjs": "7.0.0",
         "puppeteer": "file:../packages/puppeteer",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1564,9 +1564,9 @@
       "dev": true
     },
     "node_modules/@swc/core": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.99.tgz",
-      "integrity": "sha512-8O996RfuPC4ieb4zbYMfbyCU9k4gSOpyCNnr7qBQ+o7IEmh8JCV6B8wwu+fT/Om/6Lp34KJe1IpJ/24axKS6TQ==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.100.tgz",
+      "integrity": "sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.1",
@@ -1580,15 +1580,15 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.99",
-        "@swc/core-darwin-x64": "1.3.99",
-        "@swc/core-linux-arm64-gnu": "1.3.99",
-        "@swc/core-linux-arm64-musl": "1.3.99",
-        "@swc/core-linux-x64-gnu": "1.3.99",
-        "@swc/core-linux-x64-musl": "1.3.99",
-        "@swc/core-win32-arm64-msvc": "1.3.99",
-        "@swc/core-win32-ia32-msvc": "1.3.99",
-        "@swc/core-win32-x64-msvc": "1.3.99"
+        "@swc/core-darwin-arm64": "1.3.100",
+        "@swc/core-darwin-x64": "1.3.100",
+        "@swc/core-linux-arm64-gnu": "1.3.100",
+        "@swc/core-linux-arm64-musl": "1.3.100",
+        "@swc/core-linux-x64-gnu": "1.3.100",
+        "@swc/core-linux-x64-musl": "1.3.100",
+        "@swc/core-win32-arm64-msvc": "1.3.100",
+        "@swc/core-win32-ia32-msvc": "1.3.100",
+        "@swc/core-win32-x64-msvc": "1.3.100"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -1600,9 +1600,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.99.tgz",
-      "integrity": "sha512-Qj7Jct68q3ZKeuJrjPx7k8SxzWN6PqLh+VFxzA+KwLDpQDPzOlKRZwkIMzuFjLhITO4RHgSnXoDk/Syz0ZeN+Q==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.100.tgz",
+      "integrity": "sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==",
       "cpu": [
         "arm64"
       ],
@@ -1615,9 +1615,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.99.tgz",
-      "integrity": "sha512-wR7m9QVJjgiBu1PSOHy7s66uJPa45Kf9bZExXUL+JAa9OQxt5y+XVzr+n+F045VXQOwdGWplgPnWjgbUUHEVyw==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.100.tgz",
+      "integrity": "sha512-KF/MXrnH1nakm1wbt4XV8FS7kvqD9TGmVxeJ0U4bbvxXMvzeYUurzg3AJUTXYmXDhH/VXOYJE5N5RkwZZPs5iA==",
       "cpu": [
         "x64"
       ],
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.99.tgz",
-      "integrity": "sha512-gcGv1l5t0DScEONmw5OhdVmEI/o49HCe9Ik38zzH0NtDkc+PDYaCcXU5rvfZP2qJFaAAr8cua8iJcOunOSLmnA==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.100.tgz",
+      "integrity": "sha512-p8hikNnAEJrw5vHCtKiFT4hdlQxk1V7vqPmvUDgL/qe2menQDK/i12tbz7/3BEQ4UqUPnvwpmVn2d19RdEMNxw==",
       "cpu": [
         "arm64"
       ],
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.99.tgz",
-      "integrity": "sha512-XL1/eUsTO8BiKsWq9i3iWh7H99iPO61+9HYiWVKhSavknfj4Plbn+XyajDpxsauln5o8t+BRGitymtnAWJM4UQ==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.100.tgz",
+      "integrity": "sha512-BWx/0EeY89WC4q3AaIaBSGfQxkYxIlS3mX19dwy2FWJs/O+fMvF9oLk/CyJPOZzbp+1DjGeeoGFuDYpiNO91JA==",
       "cpu": [
         "arm64"
       ],
@@ -1660,9 +1660,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.99.tgz",
-      "integrity": "sha512-fGrXYE6DbTfGNIGQmBefYxSk3rp/1lgbD0nVg4rl4mfFRQPi7CgGhrrqSuqZ/ezXInUIgoCyvYGWFSwjLXt/Qg==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.100.tgz",
+      "integrity": "sha512-XUdGu3dxAkjsahLYnm8WijPfKebo+jHgHphDxaW0ovI6sTdmEGFDew7QzKZRlbYL2jRkUuuKuDGvD6lO5frmhA==",
       "cpu": [
         "x64"
       ],
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.99.tgz",
-      "integrity": "sha512-kvgZp/mqf3IJ806gUOL6gN6VU15+DfzM1Zv4Udn8GqgXiUAvbQehrtruid4Snn5pZTLj4PEpSCBbxgxK1jbssA==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.100.tgz",
+      "integrity": "sha512-PhoXKf+f0OaNW/GCuXjJ0/KfK9EJX7z2gko+7nVnEA0p3aaPtbP6cq1Ubbl6CMoPL+Ci3gZ7nYumDqXNc3CtLQ==",
       "cpu": [
         "x64"
       ],
@@ -1690,9 +1690,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.99.tgz",
-      "integrity": "sha512-yt8RtZ4W/QgFF+JUemOUQAkVW58cCST7mbfKFZ1v16w3pl3NcWd9OrtppFIXpbjU1rrUX2zp2R7HZZzZ2Zk/aQ==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.100.tgz",
+      "integrity": "sha512-PwLADZN6F9cXn4Jw52FeP/MCLVHm8vwouZZSOoOScDtihjY495SSjdPnlosMaRSR4wJQssGwiD/4MbpgQPqbAw==",
       "cpu": [
         "arm64"
       ],
@@ -1705,9 +1705,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.99.tgz",
-      "integrity": "sha512-62p5fWnOJR/rlbmbUIpQEVRconICy5KDScWVuJg1v3GPLBrmacjphyHiJC1mp6dYvvoEWCk/77c/jcQwlXrDXw==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.100.tgz",
+      "integrity": "sha512-0f6nicKSLlDKlyPRl2JEmkpBV4aeDfRQg6n8mPqgL7bliZIcDahG0ej+HxgNjZfS3e0yjDxsNRa6sAqWU2Z60A==",
       "cpu": [
         "ia32"
       ],
@@ -1720,9 +1720,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.99",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.99.tgz",
-      "integrity": "sha512-PdppWhkoS45VGdMBxvClVgF1hVjqamtvYd82Gab1i4IV45OSym2KinoDCKE1b6j3LwBLOn2J9fvChGSgGfDCHQ==",
+      "version": "1.3.100",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.100.tgz",
+      "integrity": "sha512-b7J0rPoMkRTa3XyUGt8PwCaIBuYWsL2DqbirrQKRESzgCvif5iNpqaM6kjIjI/5y5q1Ycv564CB51YDpiS8EtQ==",
       "cpu": [
         "x64"
       ],
@@ -7195,14 +7195,17 @@
       }
     },
     "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.0.tgz",
+      "integrity": "sha512-pzhgdeqU5pJ9t5WK9m4RT4GgGWqYJylxUf62Yb9datXRwdcw5MjiD1BYI5evF8AgTXN9gtKX3CFLvCUL5fAhEA==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/mimic-fn": {
@@ -12035,7 +12038,7 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "mime": "3.0.0",
+        "mime": "4.0.0",
         "ws": "8.14.2"
       },
       "devDependencies": {
@@ -12084,7 +12087,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/core": "1.3.99",
+        "@swc/core": "1.3.100",
         "acorn": "8.11.2",
         "doctrine": "3.0.0",
         "glob": "10.3.10",

--- a/packages/testserver/package.json
+++ b/packages/testserver/package.json
@@ -27,7 +27,7 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "dependencies": {
-    "mime": "3.0.0",
+    "mime": "4.0.0",
     "ws": "8.14.2"
   },
   "devDependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -27,6 +27,7 @@
     "@pptr/testserver": "file:../packages/testserver",
     "diff": "5.1.0",
     "jpeg-js": "0.4.4",
+    "mime": "4.0.0",
     "pixelmatch": "5.3.0",
     "pngjs": "7.0.0",
     "puppeteer-core": "file:../packages/puppeteer-core",

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -30,7 +30,7 @@ describe('Screenshots', function () {
       await page.setViewport({width: 500, height: 500});
       await page.goto(server.PREFIX + '/grid.html');
       const screenshot = await page.screenshot();
-      expect(screenshot).toBeGolden('screenshot-sanity.png');
+      await expect(screenshot).toBeGolden('screenshot-sanity.png');
     });
     it('should clip rect', async () => {
       const {page, server} = await getTestState();
@@ -45,7 +45,7 @@ describe('Screenshots', function () {
           height: 100,
         },
       });
-      expect(screenshot).toBeGolden('screenshot-clip-rect.png');
+      await expect(screenshot).toBeGolden('screenshot-clip-rect.png');
     });
     it('should use scale for clip', async () => {
       const {page, server} = await getTestState();
@@ -61,7 +61,7 @@ describe('Screenshots', function () {
           scale: 2,
         },
       });
-      expect(screenshot).toBeGolden('screenshot-clip-rect-scale2.png');
+      await expect(screenshot).toBeGolden('screenshot-clip-rect-scale2.png');
     });
     it('should get screenshot bigger than the viewport', async () => {
       const {page, server} = await getTestState();
@@ -75,7 +75,7 @@ describe('Screenshots', function () {
           height: 100,
         },
       });
-      expect(screenshot).toBeGolden('screenshot-offscreen-clip.png');
+      await expect(screenshot).toBeGolden('screenshot-offscreen-clip.png');
     });
     it('should clip clip bigger than the viewport without "captureBeyondViewport"', async () => {
       const {page, server} = await getTestState();
@@ -90,7 +90,7 @@ describe('Screenshots', function () {
           height: 100,
         },
       });
-      expect(screenshot).toBeGolden('screenshot-offscreen-clip-2.png');
+      await expect(screenshot).toBeGolden('screenshot-offscreen-clip-2.png');
     });
     it('should run in parallel', async () => {
       const {page, server} = await getTestState();
@@ -111,7 +111,7 @@ describe('Screenshots', function () {
         );
       }
       const screenshots = await Promise.all(promises);
-      expect(screenshots[1]).toBeGolden('grid-cell-1.png');
+      await expect(screenshots[1]).toBeGolden('grid-cell-1.png');
     });
     it('should take fullPage screenshots', async () => {
       const {page, server} = await getTestState();
@@ -121,7 +121,7 @@ describe('Screenshots', function () {
       const screenshot = await page.screenshot({
         fullPage: true,
       });
-      expect(screenshot).toBeGolden('screenshot-grid-fullpage.png');
+      await expect(screenshot).toBeGolden('screenshot-grid-fullpage.png');
     });
     it('should run in parallel in multiple pages', async () => {
       const {server, context} = await getTestState();
@@ -145,9 +145,12 @@ describe('Screenshots', function () {
         );
       }
       const screenshots = await Promise.all(promises);
-      for (let i = 0; i < N; ++i) {
-        expect(screenshots[i]).toBeGolden(`grid-cell-${i}.png`);
-      }
+      await Promise.all([
+        new Array(N).map((_, i) => {
+          return expect(screenshots[i]).toBeGolden(`grid-cell-${i}.png`);
+        }),
+      ]);
+
       await Promise.all(
         pages.map(page => {
           return page.close();
@@ -165,7 +168,7 @@ describe('Screenshots', function () {
           height: 11,
         },
       });
-      expect(screenshot).toBeGolden('screenshot-clip-odd-size.png');
+      await expect(screenshot).toBeGolden('screenshot-clip-odd-size.png');
     });
     it('should return base64', async () => {
       const {page, server} = await getTestState();
@@ -175,7 +178,7 @@ describe('Screenshots', function () {
       const screenshot = await page.screenshot({
         encoding: 'base64',
       });
-      expect(Buffer.from(screenshot, 'base64')).toBeGolden(
+      await expect(Buffer.from(screenshot, 'base64')).toBeGolden(
         'screenshot-sanity.png'
       );
     });
@@ -192,7 +195,9 @@ describe('Screenshots', function () {
       });
       using elementHandle = (await page.$('.box:nth-of-type(3)'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden('screenshot-element-bounding-box.png');
+      await expect(screenshot).toBeGolden(
+        'screenshot-element-bounding-box.png'
+      );
     });
     it('should work with a null viewport', async () => {
       const {server} = await getTestState({
@@ -233,7 +238,9 @@ describe('Screenshots', function () {
       `);
       using elementHandle = (await page.$('div'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden('screenshot-element-padding-border.png');
+      await expect(screenshot).toBeGolden(
+        'screenshot-element-padding-border.png'
+      );
     });
     it('should capture full element when larger than viewport', async () => {
       const {page} = await getTestState();
@@ -257,7 +264,7 @@ describe('Screenshots', function () {
         `);
       using elementHandle = (await page.$('div.to-screenshot'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden(
+      await expect(screenshot).toBeGolden(
         'screenshot-element-larger-than-viewport.png'
       );
 
@@ -293,7 +300,7 @@ describe('Screenshots', function () {
       `);
       using elementHandle = (await page.$('div.to-screenshot'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden(
+      await expect(screenshot).toBeGolden(
         'screenshot-element-scrolled-into-view.png'
       );
     });
@@ -310,7 +317,7 @@ describe('Screenshots', function () {
                                         transform: rotateZ(200deg);">&nbsp;</div>`);
       using elementHandle = (await page.$('div'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden('screenshot-element-rotate.png');
+      await expect(screenshot).toBeGolden('screenshot-element-rotate.png');
     });
     it('should fail to screenshot a detached element', async () => {
       const {page} = await getTestState();
@@ -345,7 +352,7 @@ describe('Screenshots', function () {
       );
       using elementHandle = (await page.$('div'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden('screenshot-element-fractional.png');
+      await expect(screenshot).toBeGolden('screenshot-element-fractional.png');
     });
     it('should work for an element with an offset', async () => {
       const {page} = await getTestState();
@@ -355,7 +362,9 @@ describe('Screenshots', function () {
       );
       using elementHandle = (await page.$('div'))!;
       const screenshot = await elementHandle.screenshot();
-      expect(screenshot).toBeGolden('screenshot-element-fractional-offset.png');
+      await expect(screenshot).toBeGolden(
+        'screenshot-element-fractional-offset.png'
+      );
     });
     it('should work with webp', async () => {
       const {page, server} = await getTestState();
@@ -377,7 +386,7 @@ describe('Screenshots', function () {
       await page.setViewport({width: 100, height: 100});
       await page.goto(server.EMPTY_PAGE);
       const screenshot = await page.screenshot({omitBackground: true});
-      expect(screenshot).toBeGolden('transparent.png');
+      await expect(screenshot).toBeGolden('transparent.png');
     });
     it('should render white background on jpeg file', async () => {
       const {page, server} = await getTestState();
@@ -388,7 +397,7 @@ describe('Screenshots', function () {
         omitBackground: true,
         type: 'jpeg',
       });
-      expect(screenshot).toBeGolden('white.jpg');
+      await expect(screenshot).toBeGolden('white.jpg');
     });
     it('should work in "fromSurface: false" mode', async () => {
       const {page, server} = await getTestState();

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -30,7 +30,7 @@ const PROJECT_ROOT = path.join(__dirname, '..', '..');
 
 declare module 'expect' {
   interface Matchers<R> {
-    toBeGolden(pathOrBuffer: string | Buffer): R;
+    toBeGolden(pathOrBuffer: string | Buffer): Promise<R>;
   }
 }
 
@@ -39,8 +39,8 @@ export const extendExpectWithToBeGolden = (
   outputDir: string
 ): void => {
   expect.extend({
-    toBeGolden: (testScreenshot: string | Buffer, goldenFilePath: string) => {
-      const result = compare(
+    async toBeGolden(testScreenshot: string | Buffer, goldenFilePath: string) {
+      const result = await compare(
         goldenDir,
         outputDir,
         testScreenshot,

--- a/tools/doctest/package.json
+++ b/tools/doctest/package.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "@swc/core": "1.3.99",
+    "@swc/core": "1.3.100",
     "acorn": "8.11.2",
     "doctrine": "3.0.0",
     "glob": "10.3.10",


### PR DESCRIPTION
Closes #11481

Due to the change to ESM only we need to do `await import` workaround.