### PR TITLE
fix: get port from created server

### DIFF
--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -8,7 +8,7 @@
     "dev:test": "npm run test --watch",
     "dev": "npm run build --watch",
     "sandbox:test": "node tools/sandbox.js --test",
-    "sandbox": "node tools/sandbox.js",
+    "sandbox": "node tools/sandbox.mjs",
     "test": "wireit",
     "test:smoke": "wireit"
   },
@@ -24,7 +24,8 @@
       ],
       "output": [
         "lib/**",
-        "test/build/**"
+        "test/build/**",
+        "*.tsbuildinfo"
       ]
     },
     "test": {

--- a/packages/ng-schematics/src/schematics/ng-add/files/common/e2e/tests/utils.ts.template
+++ b/packages/ng-schematics/src/schematics/ng-add/files/common/e2e/tests/utils.ts.template
@@ -3,7 +3,7 @@ import {before, beforeEach, after, afterEach} from 'node:test';
 <% } %>
 import * as puppeteer from 'puppeteer';
 
-const baseUrl = '<%= baseUrl %>';
+const baseUrl = process.env['baseUrl'] ?? '<%= baseUrl %>';
 let browser: puppeteer.Browser;
 let page: puppeteer.Page;
 

--- a/packages/ng-schematics/tools/sandbox.mjs
+++ b/packages/ng-schematics/tools/sandbox.mjs
@@ -199,7 +199,7 @@ async function main() {
   });
 
   if (isShell) {
-    await runNgSchematicsSandbox(getOptions()).catch(error => {
+    await runNgSchematicsSandbox(options).catch(error => {
       console.log('Something went wrong');
       console.error(error);
     });


### PR DESCRIPTION
When lunching the Angular server if the port is in use the App will ask if you want to use another port. If you press Yes `@puppeteer/ng-schematics` need to find about the new `baseUrl` rather than the default one.