### PR TITLE
test: add a test for eval followed by a mouse event

### DIFF
--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -176,11 +176,13 @@ export class BidiRealm extends EventEmitter<Record<EventType, any>> {
         : `${functionDeclaration}\n${sourceUrlComment}\n`;
       responsePromise = this.connection.send('script.callFunction', {
         functionDeclaration,
-        arguments: await Promise.all(
-          args.map(arg => {
-            return BidiSerializer.serialize(sandbox, arg);
-          })
-        ),
+        arguments: args.length
+          ? await Promise.all(
+              args.map(arg => {
+                return BidiSerializer.serialize(sandbox, arg);
+              })
+            )
+          : [],
         target: this.target,
         resultOwnership,
         awaitPromise: true,

--- a/packages/puppeteer-core/src/cdp/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/cdp/ExecutionContext.ts
@@ -293,7 +293,9 @@ export class ExecutionContext {
       callFunctionOnPromise = this._client.send('Runtime.callFunctionOn', {
         functionDeclaration: functionDeclarationWithSourceUrl,
         executionContextId: this._contextId,
-        arguments: await Promise.all(args.map(convertArgument.bind(this))),
+        arguments: args.length
+          ? await Promise.all(args.map(convertArgument.bind(this)))
+          : [],
         returnByValue,
         awaitPromise: true,
         userGesture: true,

--- a/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
@@ -31,7 +31,7 @@ import {disposeSymbol} from '../util/disposable.js';
 import {Mutex} from '../util/Mutex.js';
 
 import type {Binding} from './Binding.js';
-import {type ExecutionContext, createCdpHandle} from './ExecutionContext.js';
+import {ExecutionContext, createCdpHandle} from './ExecutionContext.js';
 import type {CdpFrame} from './Frame.js';
 import type {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
 import type {WebWorker} from './WebWorker.js';
@@ -147,7 +147,10 @@ export class IsolatedWorld extends Realm {
       this.evaluate.name,
       pageFunction
     );
-    const context = await this.#executionContext();
+    let context = this.#context.value();
+    if (!context || !(context instanceof ExecutionContext)) {
+      context = await this.#executionContext();
+    }
     return await context.evaluate(pageFunction, ...args);
   }
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2874,6 +2874,12 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[page.spec] Page Page.close should reject all promises when page is closed",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["SKIP"]
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.close should run beforeunload if asked for",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/mouse.spec.ts
+++ b/test/src/mouse.spec.ts
@@ -458,4 +458,25 @@ describe('Mouse', function () {
       },
     ]);
   });
+
+  it('should evaluate before mouse event', async () => {
+    const {page, server} = await getTestState();
+
+    await page.goto(server.EMPTY_PAGE);
+    await page.goto(server.CROSS_PROCESS_PREFIX + '/input/button.html');
+
+    using button = await page.waitForSelector('button');
+
+    const point = await button!.clickablePoint();
+
+    const result = page.evaluate(() => {
+      return new Promise(resolve => {
+        document
+          .querySelector('button')
+          ?.addEventListener('click', resolve, {once: true});
+      });
+    });
+    await page.mouse.click(point?.x, point?.y);
+    await result;
+  });
 });


### PR DESCRIPTION
Previously users of Puppeteer could rely on the fact that evaluate calls will be scheduled synchronously. It looks like we regressed w.r.t. to this behavior after starting to await for contexts and lazy args.

This PR adds a test and recovers the previous order of execution for the cases when there are no arguments and the context is readily available. 

Issue https://github.com/puppeteer/puppeteer/issues/11507