### PR TITLE
ci: fix ng-schematics version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "packages/puppeteer": "21.6.0",
   "packages/puppeteer-core": "21.6.0",
   "packages/testserver": "0.6.0",
-  "packages/ng-schematics": "0.5.3",
+  "packages/ng-schematics": "0.5.4",
   "packages/browsers": "1.9.0"
 }


### PR DESCRIPTION
There is a glitch in release-please config because it didn't update the version during the last release.

Issue https://github.com/puppeteer/puppeteer/issues/11521