### PR TITLE
docs: add note about unlisted versions to Chromium Support page

### DIFF
--- a/docs/chromium-support.md
+++ b/docs/chromium-support.md
@@ -1,6 +1,6 @@
 # Chromium Support
 
-The following versions of Chromium are supported, mapped to Puppeteer version:
+The following versions of Chromium are supported, mapped to Puppeteer version. This list is automatically updated when the version of Chromium changes in a given release of Puppeteer. If an exact matching version of Puppeteer isn't listed, the supported version of Chromium is that for the immediately prior version of Puppeteer:
 
 <!-- version-start -->
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?** Documentation

**Did you add tests for your changes?** N/A

**If relevant, did you update the documentation?** Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The current version of Puppeteer is v21.6.0 but it isn't listed at https://pptr.dev/chromium-support so it isn't clear what version of Chromium is supported. In this situation, a reader doesn't know if they should be using the previous version of Puppeteer's Chromium version, or if the documentation is outdated.  This PR aims to explain the content of the page and which version of Chromium to use when a Puppeteer version isn't present.

**Does this PR introduce a breaking change?** No

**Other information**
