### PR TITLE
test: re-enable Firefox BiDi tests on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,10 +246,6 @@ jobs:
             suite: firefox-headful
           - os: macos-latest
             suite: firefox-headless
-          # Disabled due to https://bugzilla.mozilla.org/show_bug.cgi?id=1843550
-          # The first time the browsers launches it crashes.
-          - os: macos-latest
-            suite: firefox-bidi
           - os: windows-latest
             suite: firefox-headful
           - os: windows-latest

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2072,6 +2072,12 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[keyboard.spec] Keyboard should report shiftKey",
+    "platforms": ["darwin"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[keyboard.spec] Keyboard should send a character with sendCharacter",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -2357,7 +2363,7 @@
     "testIdPattern": "[navigation.spec] navigation Frame.waitForNavigation should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL", "PASS"]
+    "expectations": ["FAIL", "PASS", "TIMEOUT"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goBack should work with HistoryAPI",
@@ -3832,7 +3838,7 @@
   },
   {
     "testIdPattern": "[screenshot.spec] Screenshots ElementHandle.screenshot should capture full element when larger than viewport",
-    "platforms": ["win32"],
+    "platforms": ["darwin", "win32"],
     "parameters": ["firefox", "headless", "webDriverBiDi"],
     "expectations": ["FAIL"]
   },


### PR DESCRIPTION
For the [referenced bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1843550) it was mentioned that it is working again and that tests will be re-enabled. But this hasn't been done yet. With this patch the BiDi tests for Firefox will be re-enabled on MacOS.