### PR TITLE
fix: improve reliability of exposeFunction

### DIFF
--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -96,6 +96,11 @@ export class CdpFrame extends Frame {
   updateClient(client: CDPSession, keepWorlds = false): void {
     this.#client = client;
     if (!keepWorlds) {
+      // Clear the current contexts on previous world instances.
+      if (this.worlds) {
+        this.worlds[MAIN_WORLD].clearContext();
+        this.worlds[PUPPETEER_WORLD].clearContext();
+      }
       this.worlds = {
         [MAIN_WORLD]: new IsolatedWorld(
           this,

--- a/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
@@ -93,6 +93,8 @@ export class IsolatedWorld extends Realm {
   }
 
   clearContext(): void {
+    // The message has to match the CDP message expected by the WaitTask class.
+    this.#context?.reject(new Error('Execution context was destroyed'));
     this.#context = Deferred.create();
     if ('clearDocumentHandle' in this.#frameOrWorker) {
       this.#frameOrWorker.clearDocumentHandle();

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -365,6 +365,13 @@ export function addPageBinding(type: string, name: string): void {
   // @ts-expect-error: In a different context.
   const callCdp = globalThis[name];
 
+  // Depending on the frame loading state either Runtime.evaluate or
+  // Page.addScriptToEvaluateOnNewDocument might succeed. Let's check that we
+  // don't re-wrap Puppeteer's binding.
+  if (callCdp[Symbol.toStringTag] === 'PuppeteerBinding') {
+    return;
+  }
+
   // We replace the CDP binding with a Puppeteer binding.
   Object.assign(globalThis, {
     [name](...args: unknown[]): Promise<unknown> {
@@ -404,6 +411,8 @@ export function addPageBinding(type: string, name: string): void {
       });
     },
   });
+  // @ts-expect-error: In a different context.
+  globalThis[name][Symbol.toStringTag] = 'PuppeteerBinding';
 }
 
 /**

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1045,6 +1045,13 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[page.spec] Page Page.exposeFunction should work with loading frames",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "Missing request interception"
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.pdf can print to PDF with accessible",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -3123,6 +3130,12 @@
   },
   {
     "testIdPattern": "[page.spec] Page Page.exposeFunction should work with complex objects",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["SKIP"]
+  },
+  {
+    "testIdPattern": "[page.spec] Page Page.exposeFunction should work with loading frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["SKIP"]


### PR DESCRIPTION
This PR adds the following fixes to the implementation of CDP's exposeFunction:

1) ensure a binding cannot be double-wrapped. This might happen during the loading of frames when there is a race condition between the client and the preload scripts.
2) ensure the context is cleared when a new world is created. If there were pending evaluate calls on the old context, they would hang forever. Rejecting the contexts make sure the call can be rejected to and the waiters can recover.
3) Skip installing functions into frames that have not started loading yet. There are some instances where a frame might never start loading (it's unclear how but I observed that on codepen.io examples). If they will start loading later, it should be handled by the preload scripts (it does not look like this works currently).
 
 Closes #8106