### PR TITLE
chore: remove `file:` deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,6 @@
       "devDependencies": {
         "@actions/core": "1.10.1",
         "@microsoft/api-extractor": "7.39.1",
-        "@pptr/testserver": "file:packages/testserver",
-        "@puppeteer/docgen": "file:tools/docgen",
         "@types/mocha": "10.0.6",
         "@types/node": "20.8.4",
         "@types/semver": "7.5.6",
@@ -45,7 +43,6 @@
         "mocha": "10.2.0",
         "npm-run-all": "4.1.5",
         "prettier": "3.1.1",
-        "puppeteer": "file:packages/puppeteer",
         "semver": "7.5.4",
         "sinon": "17.0.1",
         "source-map-support": "0.5.21",
@@ -11162,13 +11159,10 @@
       "name": "@puppeteer-test/test",
       "version": "latest",
       "dependencies": {
-        "@pptr/testserver": "file:../packages/testserver",
         "diff": "5.1.0",
         "jpeg-js": "0.4.4",
         "pixelmatch": "5.3.0",
-        "pngjs": "7.0.0",
-        "puppeteer": "file:../packages/puppeteer",
-        "puppeteer-core": "file:../packages/puppeteer-core"
+        "pngjs": "7.0.0"
       },
       "devDependencies": {
         "@types/diff": "5.0.9",
@@ -11248,7 +11242,6 @@
       "dependencies": {
         "c8": "9.0.0",
         "glob": "10.3.10",
-        "puppeteer-core": "file:../../packages/puppeteer-core",
         "zod": "3.22.4"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "build": "wireit",
+    "build:tools": "wireit",
     "check": "npm run check --workspaces --if-present && run-p check:*",
     "check:pinned-deps": "tsx tools/ensure-pinned-deps",
     "clean": "npm run clean --workspaces --if-present",
@@ -49,6 +50,15 @@
         "./packages/testserver:build",
         "./test:build",
         "./test/installation:build"
+      ]
+    },
+    "build:tools": {
+      "dependencies": [
+        "./tools/docgen:build",
+        "./tools/doctest:build",
+        "./tools/mocha-runner:build",
+        "./tools/eslint:build",
+        "./packages/testserver:build"
       ]
     },
     "docs": {
@@ -123,8 +133,6 @@
   "devDependencies": {
     "@actions/core": "1.10.1",
     "@microsoft/api-extractor": "7.39.1",
-    "@pptr/testserver": "file:packages/testserver",
-    "@puppeteer/docgen": "file:tools/docgen",
     "@types/mocha": "10.0.6",
     "@types/node": "20.8.4",
     "@types/semver": "7.5.6",
@@ -150,7 +158,6 @@
     "mocha": "10.2.0",
     "npm-run-all": "4.1.5",
     "prettier": "3.1.1",
-    "puppeteer": "file:packages/puppeteer",
     "semver": "7.5.4",
     "sinon": "17.0.1",
     "source-map-support": "0.5.21",

--- a/test/package.json
+++ b/test/package.json
@@ -24,13 +24,10 @@
     }
   },
   "dependencies": {
-    "@pptr/testserver": "file:../packages/testserver",
     "diff": "5.1.0",
     "jpeg-js": "0.4.4",
     "pixelmatch": "5.3.0",
-    "pngjs": "7.0.0",
-    "puppeteer-core": "file:../packages/puppeteer-core",
-    "puppeteer": "file:../packages/puppeteer"
+    "pngjs": "7.0.0"
   },
   "devDependencies": {
     "@types/diff": "5.0.9",

--- a/tools/mocha-runner/package.json
+++ b/tools/mocha-runner/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "c8": "9.0.0",
     "glob": "10.3.10",
-    "puppeteer-core": "file:../../packages/puppeteer-core",
     "zod": "3.22.4"
   }
 }


### PR DESCRIPTION
We should not need this as the packages that are defined in the workspace get symlinked at the top level `node_modules`.
https://docs.npmjs.com/cli/v10/using-npm/workspaces