### PR TITLE
docs: Fix Getting Started Usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ import puppeteer from 'puppeteer';
   await page.setViewport({width: 1080, height: 1024});
 
   // Type into search box
-  await page.type('.search-box__input', 'automate beyond recorder');
+  await page.type('.devsite-search-field', 'automate beyond recorder');
 
   // Wait and click on first result
-  const searchResultSelector = '.search-box__link';
+  const searchResultSelector = '.devsite-result-item-link';
   await page.waitForSelector(searchResultSelector);
   await page.click(searchResultSelector);
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,10 +156,10 @@ import puppeteer from 'puppeteer';
   await page.setViewport({width: 1080, height: 1024});
 
   // Type into search box
-  await page.type('.search-box__input', 'automate beyond recorder');
+  await page.type('.devsite-search-field', 'automate beyond recorder');
 
   // Wait and click on first result
-  const searchResultSelector = '.search-box__link';
+  const searchResultSelector = '.devsite-result-item-link';
   await page.waitForSelector(searchResultSelector);
   await page.click(searchResultSelector);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fixed getting started usage example due to developer.chrome.com class name change.

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

Yes

**Motivation**

Was getting puppeteer setup and following README but ran into the following error when running as is:

```
Error: No element found for selector: .search-box__input
```

After change:

```
The title of this blog post is "Customize and automate user flows beyond Chrome DevTools ...".
```

**Does this PR introduce a breaking change?**

Gosh I hope not!

**Other information**
