### PR TITLE
ci: change matrix order

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
         suite:
           - chrome-headless
           - chrome-headful
@@ -28,6 +24,10 @@ jobs:
         shard:
           - 1-2
           - 2-2
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
         exclude:
           - os: windows-latest
             suite: chrome-bidi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,13 +21,13 @@ jobs:
           - chrome-headful
           - chrome-new-headless
           - chrome-bidi
-        shard:
-          - 1-2
-          - 2-2
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        shard:
+          - 1-2
+          - 2-2
         exclude:
           - os: windows-latest
             suite: chrome-bidi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
         suite:
           - chrome-headless
           - chrome-headful
@@ -152,6 +148,10 @@ jobs:
         shard:
           - 1-2
           - 2-2
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
         exclude:
           - os: windows-latest
             suite: chrome-bidi
@@ -228,10 +228,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
         suite:
           - firefox-bidi
           - firefox-headful
@@ -241,6 +237,10 @@ jobs:
           - 2-4
           - 3-4
           - 4-4
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         exclude:
           - os: macos-latest
             suite: firefox-headful
@@ -334,14 +334,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
         node:
           - 18
         pkg_manager:
           - npm
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - name: Download installation test
         uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,13 @@ jobs:
           - chrome-headful
           - chrome-new-headless
           - chrome-bidi
-        shard:
-          - 1-2
-          - 2-2
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        shard:
+          - 1-2
+          - 2-2
         exclude:
           - os: windows-latest
             suite: chrome-bidi
@@ -232,15 +232,15 @@ jobs:
           - firefox-bidi
           - firefox-headful
           - firefox-headless
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         shard:
           - 1-4
           - 2-4
           - 3-4
           - 4-4
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
         exclude:
           - os: macos-latest
             suite: firefox-headful


### PR DESCRIPTION
This changes the order of the matrix so that it should look like this

- chrome-new-headless (1-2) on ubuntu
- chrome-new-headless (1-2) on macOS
- chrome-new-headless (1-2) on Windows
- chrome-new-headless (2-2) on ubuntu
- chrome-new-headless (2-2) on macOS
- chrome-new-headless (2-2) on Windows

This will make it a little bit easier to spot when a group fails due to a change.