### PR TITLE
chore: remove redundant type-check

### DIFF
--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -371,11 +371,7 @@ export class ChromeTargetManager
       this.#attachedTargetsBySessionId.set(session.id(), target);
     }
 
-    if (parentSession instanceof CDPSession) {
-      parentSession.emit(CDPSessionEvent.Ready, session);
-    } else {
-      parentSession.emit(CDPSessionEvent.Ready, session);
-    }
+    parentSession.emit(CDPSessionEvent.Ready, session);
 
     this.#targetsIdsForInit.delete(target._targetId);
     if (!isExistingTarget) {

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -146,14 +146,14 @@ export class CdpTarget extends Target {
 
   override browser(): Browser {
     if (!this.#browserContext) {
-      throw new Error('browserContext is not initialised');
+      throw new Error('browserContext is not initialized');
     }
     return this.#browserContext.browser();
   }
 
   override browserContext(): BrowserContext {
     if (!this.#browserContext) {
-      throw new Error('browserContext is not initialised');
+      throw new Error('browserContext is not initialized');
     }
     return this.#browserContext;
   }


### PR DESCRIPTION
Both the `CDPSession` and the `Connection` extend `EventEmitter<CDPSessionEvents>`. There is no need for a type check here.

And some typos :)