### PR TITLE
chore: remove updated but unused variable

### DIFF
--- a/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/FirefoxTargetManager.ts
@@ -63,11 +63,6 @@ export class FirefoxTargetManager
    * Tracks which sessions attach to which target.
    */
   #availableTargetsBySessionId = new Map<string, CdpTarget>();
-  /**
-   * If a target was filtered out by `targetFilterCallback`, we still receive
-   * events about it from CDP, but we don't forward them to the rest of Puppeteer.
-   */
-  #ignoredTargets = new Set<string>();
   #targetFilterCallback: TargetFilterCallback | undefined;
   #targetFactory: TargetFactory;
 
@@ -162,7 +157,6 @@ export class FirefoxTargetManager
 
     const target = this.#targetFactory(event.targetInfo, undefined);
     if (this.#targetFilterCallback && !this.#targetFilterCallback(target)) {
-      this.#ignoredTargets.add(event.targetInfo.targetId);
       this.#finishInitializationIfReady(event.targetInfo.targetId);
       return;
     }


### PR DESCRIPTION
I found that we are updating the `ignoredTargets` variable but never using its content. I don't know whether this PR is valid or if we need to use this list somewhere else.