### PR TITLE
docs: add debug example for logging all but filtering just protocol messages

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -135,4 +135,7 @@ env DEBUG="puppeteer:*" env DEBUG_MAX_STRING_LENGTH=null node script.js
 
 # Protocol traffic can be rather noisy. This example filters out all Network domain messages
 env DEBUG="puppeteer:*" env DEBUG_COLORS=true node script.js 2>&1 | grep -v '"Network'
+
+# Filter out all protocol messages but keep all other logging
+env DEBUG="puppeteer:*,-puppeteer:protocol:*" node script.js
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?** Docs

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?** No, but tested in shell

**If relevant, did you update the documentation?** Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This adds an example for using just the `DEBUG` environment variable to filter out specific types of Puppeteer debugging messages. The other example on protocol network messages requires use of a separate command but this can be done natively.

**Does this PR introduce a breaking change?** No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
