### PR TITLE
chore: remove extra event listener

### DIFF
--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -352,7 +352,6 @@ export class CdpPage extends Page {
       this.#workers.set(session.id(), worker);
       this.emit(PageEvent.WorkerCreated, worker);
     }
-    session.on(CDPSessionEvent.Ready, this.#onAttachedToTarget);
   };
 
   async #initialize(): Promise<void> {


### PR DESCRIPTION
`onAttachedToTarget` is already a `Ready` listener ([see](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/cdp/Page.ts#L323)).I don't see  a reason to add the same listener again.