### PR TITLE
chore: flip test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -498,12 +498,6 @@
     "expectations": ["PASS"]
   },
   {
-    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should work for circular object",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should replace symbols with undefined",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp"],
@@ -511,6 +505,12 @@
   },
   {
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should return properly serialize objects with unknown type fields",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should work for circular object",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp"],
     "expectations": ["FAIL"]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -498,9 +498,9 @@
     "expectations": ["PASS"]
   },
   {
-    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should fail for circular object",
+    "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should work for circular object",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["cdp"],
     "expectations": ["FAIL"]
   },
   {

--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -324,16 +324,29 @@ describe('Evaluation specs', function () {
         promise: {},
       });
     });
-    it('should fail for circular object', async () => {
+    it('should work for circular object', async () => {
       const {page} = await getTestState();
 
       const result = await page.evaluate(() => {
-        const a: Record<string, unknown> = {};
+        const a: Record<string, unknown> = {
+          c: 5,
+          d: {
+            foo: 'bar',
+          },
+        };
         const b = {a};
         a['b'] = b;
         return a;
       });
-      expect(result).toBe(undefined);
+      expect(result).toMatchObject({
+        c: 5,
+        d: {
+          foo: 'bar',
+        },
+        b: {
+          a: undefined,
+        },
+      });
     });
     it('should accept a string', async () => {
       const {page} = await getTestState();


### PR DESCRIPTION
BiDi logic is more robust and can handle the `circular object`. While our Deserialize does not provide a way to express it in the output result it's much better then getting only `undefined`. 

CC @whimboo 