### PR TITLE
revert: refactor: adopt `core/UserContext` on `BidiBrowserContext`

### DIFF
--- a/packages/puppeteer-core/src/bidi/Target.ts
+++ b/packages/puppeteer-core/src/bidi/Target.ts
@@ -53,40 +53,13 @@ export abstract class BidiTarget extends Target {
 /**
  * @internal
  */
-export class BiDiBrowserTarget extends Target {
-  #browser: BidiBrowser;
-
-  constructor(browser: BidiBrowser) {
-    super();
-    this.#browser = browser;
-  }
-
+export class BiDiBrowserTarget extends BidiTarget {
   override url(): string {
     return '';
   }
 
   override type(): TargetType {
     return TargetType.BROWSER;
-  }
-
-  override asPage(): Promise<Page> {
-    throw new UnsupportedOperation();
-  }
-
-  override browser(): BidiBrowser {
-    return this.#browser;
-  }
-
-  override browserContext(): BidiBrowserContext {
-    return this.#browser.defaultBrowserContext();
-  }
-
-  override opener(): never {
-    throw new UnsupportedOperation();
-  }
-
-  override createCDPSession(): Promise<CDPSession> {
-    throw new UnsupportedOperation();
   }
 }
 

--- a/packages/puppeteer-core/src/bidi/core/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/core/Browser.ts
@@ -52,7 +52,7 @@ export class Browser extends EventEmitter<{
 
   // keep-sorted start
   #reason: string | undefined;
-  readonly #userContexts = new Map<string, UserContext>();
+  readonly #userContexts = new Map();
   readonly session: Session;
   // keep-sorted end
 
@@ -63,10 +63,7 @@ export class Browser extends EventEmitter<{
     this.session = session;
     // keep-sorted end
 
-    this.#userContexts.set(
-      UserContext.DEFAULT,
-      UserContext.create(this, UserContext.DEFAULT)
-    );
+    this.#userContexts.set('', UserContext.create(this, ''));
   }
 
   async #initialize() {
@@ -130,7 +127,7 @@ export class Browser extends EventEmitter<{
 
   get defaultUserContext(): UserContext {
     // SAFETY: A UserContext is always created for the default context.
-    return this.#userContexts.get(UserContext.DEFAULT)!;
+    return this.#userContexts.get('')!;
   }
 
   get userContexts(): Iterable<UserContext> {
@@ -190,21 +187,4 @@ export class Browser extends EventEmitter<{
       script,
     });
   }
-
-  async createUserContext(): Promise<UserContext> {
-    // TODO: implement incognito context https://github.com/w3c/webdriver-bidi/issues/289.
-    // TODO: Call `createUserContext` once available.
-    // Generating a monotonically increasing context id.
-    const context = `${++id}`;
-
-    const userContext = UserContext.create(this, context);
-    userContext.once('destroyed', () => {
-      this.#userContexts.delete(context);
-    });
-
-    this.#userContexts.set(userContext.id, userContext);
-    return userContext;
-  }
 }
-
-let id = 0;

--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -33,16 +33,7 @@ export class UserContext extends EventEmitter<{
     /** The new browsing context. */
     browsingContext: BrowsingContext;
   };
-  /**
-   * Emitted when the user context is destroyed.
-   */
-  destroyed: {
-    /** The user context that was destroyed. */
-    userContext: UserContext;
-  };
 }> {
-  static DEFAULT = 'default';
-
   static create(browser: Browser, id: string): UserContext {
     const context = new UserContext(browser, id);
     context.#initialize();
@@ -52,6 +43,8 @@ export class UserContext extends EventEmitter<{
   // keep-sorted start
   // Note these are only top-level contexts.
   readonly #browsingContexts = new Map<string, BrowsingContext>();
+  // @ts-expect-error -- TODO: This will be used once the WebDriver BiDi
+  // protocol supports it.
   readonly #id: string;
   readonly browser: Browser;
   // keep-sorted end
@@ -98,9 +91,6 @@ export class UserContext extends EventEmitter<{
   get browsingContexts(): Iterable<BrowsingContext> {
     return this.#browsingContexts.values();
   }
-  get id(): string {
-    return this.#id;
-  }
   // keep-sorted end
 
   async createBrowsingContext(
@@ -125,9 +115,11 @@ export class UserContext extends EventEmitter<{
     return browsingContext;
   }
 
-  async remove(): Promise<void> {
-    // TODO: Call `removeUserContext` once available.
-    this.emit('destroyed', {userContext: this});
-    this.removeAllListeners();
+  async close(): Promise<void> {
+    const promises = [];
+    for (const browsingContext of this.#browsingContexts.values()) {
+      promises.push(browsingContext.close());
+    }
+    await Promise.all(promises);
   }
 }


### PR DESCRIPTION
Reverts puppeteer/puppeteer#11714

Reason: after manually bisecting this PR seems to be the cause for a memory leak. Search for FATAL ERROR in https://github.com/puppeteer/ispuppeteerwebdriverbidiready/actions/runs/7622056774/job/20759443136

cc @jrandolf 