### PR TITLE
chore: add memory debugging to mocha runner

### DIFF
--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -169,6 +169,21 @@ export const setupTestBrowserHooks = (): void => {
       // if browser is not found
     }
   });
+
+  after(() => {
+    if (typeof gc !== 'undefined') {
+      gc();
+      const memory = process.memoryUsage();
+      console.log('Memory stats:');
+      for (const key of Object.keys(memory)) {
+        console.log(
+          key,
+          // @ts-expect-error TS cannot the key type.
+          `${Math.round(((memory[key] / 1024 / 1024) * 100) / 100)} MB`
+        );
+      }
+    }
+  });
 };
 
 export const getTestState = async (

--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -46,6 +46,7 @@ const {
   minTests,
   shard,
   reporter,
+  printMemory,
 } = yargs(hideBin(process.argv))
   .parserConfiguration({'unknown-options-as-args': true})
   .scriptName('@puppeteer/mocha-runner')
@@ -81,6 +82,10 @@ const {
   .option('reporter', {
     string: true,
     requiresArg: true,
+  })
+  .option('print-memory', {
+    boolean: true,
+    default: false,
   })
   .parseSync();
 
@@ -196,6 +201,10 @@ async function main() {
         '-n',
         'trace-warnings',
       ];
+
+      if (printMemory) {
+        args.push('-n', 'expose-gc');
+      }
 
       const specPattern = 'test/build/**/*.spec.js';
       const specs = globSync(specPattern, {


### PR DESCRIPTION
The argument `--print-memory` would expose GC to the node program, which in turn, will be used to print memory stats after each test suite.