### PR TITLE
feat: roll to Chrome 120.0.6099.109 (r1217362)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3388,9 +3388,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1203626",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
-      "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
+      "version": "0.0.1213968",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1213968.tgz",
+      "integrity": "sha512-o4n/beY+3CcZwFctYapjGelKptR4AuQT5gXS1Kvgbig+ArwkxK7f8wDVuD1wsoswiJWCwV6OK+Qb7vhNzNmABQ=="
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -10908,7 +10908,7 @@
         "chromium-bidi": "0.5.4",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1203626",
+        "devtools-protocol": "0.0.1213968",
         "ws": "8.16.0"
       },
       "devDependencies": {

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -122,7 +122,7 @@
     "chromium-bidi": "0.5.4",
     "cross-fetch": "4.0.0",
     "debug": "4.3.4",
-    "devtools-protocol": "0.0.1203626",
+    "devtools-protocol": "0.0.1213968",
     "ws": "8.16.0"
   },
   "devDependencies": {

--- a/packages/puppeteer-core/src/revisions.ts
+++ b/packages/puppeteer-core/src/revisions.ts
@@ -8,6 +8,6 @@
  * @internal
  */
 export const PUPPETEER_REVISIONS = Object.freeze({
-  chrome: '119.0.6045.105',
+  chrome: '120.0.6099.109',
   firefox: 'latest',
 });

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3321,12 +3321,26 @@
     "expectations": ["FAIL", "PASS"]
   },
   {
+    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should return base64",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "Remove with M121"
+  },
+  {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "Remove with M121"
+  },
+  {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots without captureBeyondViewport",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3349,6 +3363,13 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL", "PASS"]
+  },
+  {
+    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "Remove with M121"
   },
   {
     "testIdPattern": "[stacktrace.spec] Stack trace should work for none error objects",
@@ -3607,6 +3628,13 @@
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome", "new-headless"],
     "expectations": ["FAIL", "PASS"]
+  },
+  {
+    "testIdPattern": "[chromiumonly.spec] Chromium-Specific Launcher tests Puppeteer.launch |pipe| option should fire \"disconnected\" when closing with pipe",
+    "platforms": ["darwin"],
+    "parameters": ["cdp", "chrome", "new-headless"],
+    "expectations": ["FAIL"],
+    "comment": "Remove with M121"
   },
   {
     "testIdPattern": "[devtools.spec] DevTools should expose DevTools as a page",

--- a/versions.js
+++ b/versions.js
@@ -7,6 +7,7 @@
 const versionsPerRelease = new Map([
   // This is a mapping from Chrome version => Puppeteer version.
   // In Chrome roll patches, use `NEXT` for the Puppeteer version.
+  ['120.0.6099.109', 'NEXT'],
   ['119.0.6045.105', 'v21.5.0'],
   ['118.0.5993.70', 'v21.4.0'],
   ['117.0.5938.149', 'v21.3.7'],
@@ -60,7 +61,7 @@ const versionsPerRelease = new Map([
 ]);
 
 // Should not be more than 2 major versions behind Chrome Stable (https://chromestatus.com/roadmap).
-const lastMaintainedChromeVersion = '117.0.5938.149';
+const lastMaintainedChromeVersion = '118.0.5993.70';
 
 if (!versionsPerRelease.has(lastMaintainedChromeVersion)) {
   throw new Error(


### PR DESCRIPTION
Warning: M120 builds have an issue with screenshot capturing being flaky/producing slightly different results. This issue has been fixed in M121. See the list of tests affected in TestExpectations.json change for this PR.

Please upgrade directly to M121 whenever possible unless you want to do specific testing with M120.