### PR TITLE
refactor: adopt `core/UserContext` on `BidiBrowserContext`

### DIFF
--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -27,6 +27,7 @@ import {BrowsingContext, BrowsingContextEvent} from './BrowsingContext.js';
 import type {BidiConnection} from './Connection.js';
 import type {Browser as BrowserCore} from './core/Browser.js';
 import {Session} from './core/Session.js';
+import type {UserContext} from './core/UserContext.js';
 import {
   BiDiBrowserTarget,
   BiDiBrowsingContextTarget,
@@ -95,9 +96,8 @@ export class BidiBrowser extends Browser {
   #closeCallback?: BrowserCloseCallback;
   #browserCore: BrowserCore;
   #defaultViewport: Viewport | null;
-  #defaultContext: BidiBrowserContext;
   #targets = new Map<string, BidiTarget>();
-  #contexts: BidiBrowserContext[] = [];
+  #browserContexts = new WeakMap<UserContext, BidiBrowserContext>();
   #browserTarget: BiDiBrowserTarget;
 
   #connectionEventHandlers = new Map<
@@ -111,25 +111,21 @@ export class BidiBrowser extends Browser {
     ['browsingContext.navigationStarted', this.#onContextNavigation.bind(this)],
   ]);
 
-  constructor(browserCore: BrowserCore, opts: BidiBrowserOptions) {
+  private constructor(browserCore: BrowserCore, opts: BidiBrowserOptions) {
     super();
     this.#process = opts.process;
     this.#closeCallback = opts.closeCallback;
     this.#browserCore = browserCore;
     this.#defaultViewport = opts.defaultViewport;
-    this.#defaultContext = new BidiBrowserContext(this, {
-      defaultViewport: this.#defaultViewport,
-      isDefault: true,
-    });
-    this.#browserTarget = new BiDiBrowserTarget(this.#defaultContext);
-    this.#contexts.push(this.#defaultContext);
+    this.#browserTarget = new BiDiBrowserTarget(this);
+    this.#createBrowserContext(this.#browserCore.defaultUserContext);
   }
 
   #initialize() {
     this.#browserCore.once('disconnected', () => {
       this.emit(BrowserEvent.Disconnected, undefined);
     });
-    this.#process?.once('close', async () => {
+    this.#process?.once('close', () => {
       this.#browserCore.dispose('Browser process exited.', true);
       this.connection.dispose();
     });
@@ -148,6 +144,14 @@ export class BidiBrowser extends Browser {
 
   override userAgent(): never {
     throw new UnsupportedOperation();
+  }
+
+  #createBrowserContext(userContext: UserContext) {
+    const browserContext = new BidiBrowserContext(this, userContext, {
+      defaultViewport: this.#defaultViewport,
+    });
+    this.#browserContexts.set(userContext, browserContext);
+    return browserContext;
   }
 
   #onContextDomLoaded(event: Bidi.BrowsingContext.Info) {
@@ -255,13 +259,8 @@ export class BidiBrowser extends Browser {
   override async createIncognitoBrowserContext(
     _options?: BrowserContextOptions
   ): Promise<BidiBrowserContext> {
-    // TODO: implement incognito context https://github.com/w3c/webdriver-bidi/issues/289.
-    const context = new BidiBrowserContext(this, {
-      defaultViewport: this.#defaultViewport,
-      isDefault: false,
-    });
-    this.#contexts.push(context);
-    return context;
+    const userContext = await this.#browserCore.createUserContext();
+    return this.#createBrowserContext(userContext);
   }
 
   override async version(): Promise<string> {
@@ -269,28 +268,17 @@ export class BidiBrowser extends Browser {
   }
 
   override browserContexts(): BidiBrowserContext[] {
-    // TODO: implement incognito context https://github.com/w3c/webdriver-bidi/issues/289.
-    return this.#contexts;
-  }
-
-  async _closeContext(browserContext: BidiBrowserContext): Promise<void> {
-    this.#contexts = this.#contexts.filter(c => {
-      return c !== browserContext;
+    return [...this.#browserCore.userContexts].map(context => {
+      return this.#browserContexts.get(context)!;
     });
-    for (const target of browserContext.targets()) {
-      const page = await target?.page();
-      await page?.close().catch(error => {
-        debugError(error);
-      });
-    }
   }
 
   override defaultBrowserContext(): BidiBrowserContext {
-    return this.#defaultContext;
+    return this.#browserContexts.get(this.#browserCore.defaultUserContext)!;
   }
 
   override newPage(): Promise<Page> {
-    return this.#defaultContext.newPage();
+    return this.defaultBrowserContext().newPage();
   }
 
   override targets(): Target[] {

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -11,10 +11,12 @@ import {BrowserContext} from '../api/BrowserContext.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
 import {UnsupportedOperation} from '../common/Errors.js';
+import {debugError} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
 
 import type {BidiBrowser} from './Browser.js';
 import type {BidiConnection} from './Connection.js';
+import {UserContext} from './core/UserContext.js';
 import type {BidiPage} from './Page.js';
 
 /**
@@ -22,7 +24,6 @@ import type {BidiPage} from './Page.js';
  */
 export interface BidiBrowserContextOptions {
   defaultViewport: Viewport | null;
-  isDefault: boolean;
 }
 
 /**
@@ -32,14 +33,18 @@ export class BidiBrowserContext extends BrowserContext {
   #browser: BidiBrowser;
   #connection: BidiConnection;
   #defaultViewport: Viewport | null;
-  #isDefault = false;
+  #userContext: UserContext;
 
-  constructor(browser: BidiBrowser, options: BidiBrowserContextOptions) {
+  constructor(
+    browser: BidiBrowser,
+    userContext: UserContext,
+    options: BidiBrowserContextOptions
+  ) {
     super();
     this.#browser = browser;
+    this.#userContext = userContext;
     this.#connection = this.#browser.connection;
     this.#defaultViewport = options.defaultViewport;
-    this.#isDefault = options.isDefault;
   }
 
   override targets(): Target[] {
@@ -90,11 +95,25 @@ export class BidiBrowserContext extends BrowserContext {
   }
 
   override async close(): Promise<void> {
-    if (this.#isDefault) {
+    if (!this.isIncognito()) {
       throw new Error('Default context cannot be closed!');
     }
 
-    await this.#browser._closeContext(this);
+    // TODO: Remove once we have adopted the new browsing contexts.
+    for (const target of this.targets()) {
+      const page = await target?.page();
+      try {
+        await page?.close();
+      } catch (error) {
+        debugError(error);
+      }
+    }
+
+    try {
+      await this.#userContext.remove();
+    } catch (error) {
+      debugError(error);
+    }
   }
 
   override browser(): BidiBrowser {
@@ -113,7 +132,7 @@ export class BidiBrowserContext extends BrowserContext {
   }
 
   override isIncognito(): boolean {
-    return !this.#isDefault;
+    return this.#userContext.id !== UserContext.DEFAULT;
   }
 
   override overridePermissions(): never {

--- a/packages/puppeteer-core/src/bidi/Target.ts
+++ b/packages/puppeteer-core/src/bidi/Target.ts
@@ -53,13 +53,40 @@ export abstract class BidiTarget extends Target {
 /**
  * @internal
  */
-export class BiDiBrowserTarget extends BidiTarget {
+export class BiDiBrowserTarget extends Target {
+  #browser: BidiBrowser;
+
+  constructor(browser: BidiBrowser) {
+    super();
+    this.#browser = browser;
+  }
+
   override url(): string {
     return '';
   }
 
   override type(): TargetType {
     return TargetType.BROWSER;
+  }
+
+  override asPage(): Promise<Page> {
+    throw new UnsupportedOperation();
+  }
+
+  override browser(): BidiBrowser {
+    return this.#browser;
+  }
+
+  override browserContext(): BidiBrowserContext {
+    return this.#browser.defaultBrowserContext();
+  }
+
+  override opener(): never {
+    throw new UnsupportedOperation();
+  }
+
+  override createCDPSession(): Promise<CDPSession> {
+    throw new UnsupportedOperation();
   }
 }
 

--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -43,6 +43,8 @@ export class UserContext extends EventEmitter<{
     reason: string;
   };
 }> {
+  static DEFAULT = 'default';
+
   static create(browser: Browser, id: string): UserContext {
     const context = new UserContext(browser, id);
     context.#initialize();
@@ -54,8 +56,6 @@ export class UserContext extends EventEmitter<{
   // Note these are only top-level contexts.
   readonly #browsingContexts = new Map<string, BrowsingContext>();
   readonly #disposables = new DisposableStack();
-  // @ts-expect-error -- TODO: This will be used once the WebDriver BiDi
-  // protocol supports it.
   readonly #id: string;
   readonly browser: Browser;
   // keep-sorted end
@@ -118,6 +118,9 @@ export class UserContext extends EventEmitter<{
   get disposed(): boolean {
     return this.closed;
   }
+  get id(): string {
+    return this.#id;
+  }
   // keep-sorted end
 
   @inertIfDisposed
@@ -156,13 +159,9 @@ export class UserContext extends EventEmitter<{
     // SAFETY: Disposal implies this exists.
     return context.#reason!;
   })
-  async close(): Promise<void> {
+  async remove(): Promise<void> {
     try {
-      const promises = [];
-      for (const browsingContext of this.#browsingContexts.values()) {
-        promises.push(browsingContext.close());
-      }
-      await Promise.all(promises);
+      // TODO: Call `removeUserContext` once available.
     } finally {
       this.dispose('User context already closed.');
     }


### PR DESCRIPTION
Reverts https://github.com/puppeteer/puppeteer/pull/11721

cc @OrKoN 