### PR TITLE
test: update expectation for Page.removeScriptToEvaluateOnNewDocument

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -537,7 +537,7 @@
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.removeScriptToEvaluateOnNewDocument *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.removeScriptToEvaluateOnNewDocument *",


### PR DESCRIPTION
The test started to pass today.