### PR TITLE
chore(deps): Bump `chromium-bidi` to `0.5.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,12 +3006,12 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.4.tgz",
-      "integrity": "sha512-p9CdiHl0xNh4P7oVa44zXgJJw+pvnHXFDB+tVdo25xaPLgQDVf2kQO+TDxD2fp2Evqi7vs/vGRINMzl1qJrWiw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.6.tgz",
+      "integrity": "sha512-ber8smgoAs4EqSUHRb0I8fpx371ZmvsdQav8HRM9oO4fk5Ox16vQiNYXlsZkRj4FfvVL2dCef+zBFQixp+79CA==",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "9.0.0"
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -10388,9 +10388,9 @@
       }
     },
     "node_modules/urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -11311,7 +11311,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.4",
+        "chromium-bidi": "0.5.6",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1232444",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -119,7 +119,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "1.9.1",
-    "chromium-bidi": "0.5.4",
+    "chromium-bidi": "0.5.6",
     "cross-fetch": "4.0.0",
     "debug": "4.3.4",
     "devtools-protocol": "0.0.1232444",


### PR DESCRIPTION
Updates `chromium-bidi` from 0.5.4 to 0.5.6
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/GoogleChromeLabs/chromium-bidi/releases">chromium-bidi's releases</a>.</em></p>
<blockquote>
<h2>chromium-bidi: v0.5.6</h2>
<h2><a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.5...chromium-bidi-v0.5.6">0.5.6</a> (2024-01-29)</h2>
<h3>Features</h3>
<ul>
<li>add CPD specific field in cookies (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1759">#1759</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/d24584ac0d30f58306700d29d22db284a4f47f7a">d24584a</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li>handle headless errors when creating a target (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1757">#1757</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/cd7e772b39eb774c8f65e59b7047eafb419bea09">cd7e772</a>)</li>
</ul>
<h2>chromium-bidi: v0.5.5</h2>
<h2><a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.4...chromium-bidi-v0.5.5">0.5.5</a> (2024-01-25)</h2>
<h3>Features</h3>
<ul>
<li>allow not partitioned cookies (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1718">#1718</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/d54a4f186005fa0e3ea8e71a5929ca307c852f1d">d54a4f1</a>)</li>
<li>implement user contexts (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1715">#1715</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/b75def3778dc774d1bcee30f7029c6387568e960">b75def3</a>)</li>
<li>provide logs before Mapper is launched via NodeJS runner (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1737">#1737</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/0b278f30f9e46037bd9ec3d8d250457405ee7125">0b278f3</a>)</li>
<li>return all cookies for a given browsing context (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1746">#1746</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/456d9473a7cb3b58127b92c45a8cffcb992969ef">456d947</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/GoogleChromeLabs/chromium-bidi/blob/main/CHANGELOG.md">chromium-bidi's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.5...chromium-bidi-v0.5.6">0.5.6</a> (2024-01-29)</h2>
<h3>Features</h3>
<ul>
<li>add CPD specific field in cookies (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1759">#1759</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/d24584ac0d30f58306700d29d22db284a4f47f7a">d24584a</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li>handle headless errors when creating a target (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1757">#1757</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/cd7e772b39eb774c8f65e59b7047eafb419bea09">cd7e772</a>)</li>
</ul>
<h2><a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.4...chromium-bidi-v0.5.5">0.5.5</a> (2024-01-25)</h2>
<h3>Features</h3>
<ul>
<li>allow not partitioned cookies (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1718">#1718</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/d54a4f186005fa0e3ea8e71a5929ca307c852f1d">d54a4f1</a>)</li>
<li>implement user contexts (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1715">#1715</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/b75def3778dc774d1bcee30f7029c6387568e960">b75def3</a>)</li>
<li>provide logs before Mapper is launched via NodeJS runner (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1737">#1737</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/0b278f30f9e46037bd9ec3d8d250457405ee7125">0b278f3</a>)</li>
<li>return all cookies for a given browsing context (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1746">#1746</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/456d9473a7cb3b58127b92c45a8cffcb992969ef">456d947</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/3ad46532934c29c68a1043aae1c3faedd6fe55f4"><code>3ad4653</code></a> chore(main): release chromium-bidi 0.5.6 (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1758">#1758</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/a1e5f8fa1b068e63ec7b24eacb2c5462ad09a749"><code>a1e5f8f</code></a> build(deps): Bump wpt from <code>83ac63c</code> to <code>3c5b215</code> (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1763">#1763</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/6d09a82bb50cdc5b34481812ace58d9505a5efcb"><code>6d09a82</code></a> build: update cddlconv (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1761">#1761</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/d24584ac0d30f58306700d29d22db284a4f47f7a"><code>d24584a</code></a> feat: add CPD specific field in cookies (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1759">#1759</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/e273bf6000d5d3481a80afe87c1c65b3cef12177"><code>e273bf6</code></a> refactor: types + logic fix (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1760">#1760</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/cd7e772b39eb774c8f65e59b7047eafb419bea09"><code>cd7e772</code></a> fix: handle headless errors when creating a target (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1757">#1757</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/db34f89443517506ae1f9fbe882e6e317870ab03"><code>db34f89</code></a> build(deps): Bump wpt from <code>a8510ed</code> to <code>83ac63c</code> (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1756">#1756</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/455a1e720ab96c4d98a77417bd45f9d64a457c67"><code>455a1e7</code></a> ci: pin version to file (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1755">#1755</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/33cae112bfacc4cae3e56079e46dde7692bcbc73"><code>33cae11</code></a> build(deps): Bump the all group with 7 updates (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1754">#1754</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/1a6f173fbf4f8f2283e1a09c1e590067daa61e1d"><code>1a6f173</code></a> build(deps): Bump the all group with 3 updates (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1753">#1753</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.4...chromium-bidi-v0.5.6">compare view</a></li>
</ul>
</details>
<br />
