### PR TITLE
fix: wrap error if extracting fails for any reason

### DIFF
--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -161,6 +161,10 @@ export async function install(
     try {
       debugTime('extract');
       await unpackArchive(archivePath, outputPath);
+    } catch (err) {
+      const error = new Error('Failed to unpack browser from archive!');
+      error.cause = err;
+      throw error;
     } finally {
       debugTimeEnd('extract');
     }


### PR DESCRIPTION
Better error handling when the unpacking fails, this may be do to corrupted download.