### PR TITLE
fix!: remove viewport resizing from ElementHandle.screenshot

### DIFF
--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -17,15 +17,10 @@ import type {
   NodeFor,
 } from '../common/types.js';
 import type {KeyInput} from '../common/USKeyboardLayout.js';
-import {
-  debugError,
-  isString,
-  withSourcePuppeteerURLIfNone,
-} from '../common/util.js';
+import {isString, withSourcePuppeteerURLIfNone} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
-import {AsyncDisposableStack} from '../util/disposable.js';
 
 import {_isElementHandle} from './ElementHandleSymbol.js';
 import type {
@@ -1345,30 +1340,6 @@ export abstract class ElementHandle<
     let clip = await this.#nonEmptyVisibleBoundingBox();
 
     const page = this.frame.page();
-
-    // If the element is larger than the viewport, `captureBeyondViewport` will
-    // _not_ affect element rendering, so we need to adjust the viewport to
-    // properly render the element.
-    const viewport = page.viewport() ?? {
-      width: clip.width,
-      height: clip.height,
-    };
-    await using stack = new AsyncDisposableStack();
-    if (clip.width > viewport.width || clip.height > viewport.height) {
-      await this.frame.page().setViewport({
-        ...viewport,
-        width: Math.max(viewport.width, Math.ceil(clip.width)),
-        height: Math.max(viewport.height, Math.ceil(clip.height)),
-      });
-
-      stack.defer(async () => {
-        try {
-          await this.frame.page().setViewport(viewport);
-        } catch (error) {
-          debugError(error);
-        }
-      });
-    }
 
     // Only scroll the element into view if the user wants it.
     if (scrollIntoView) {


### PR DESCRIPTION
Viewport resizing was previously done to fix issues related to hidden elements within `overflow: hidden` containers or viewport-sized iframes.

This PR removes this logic since this use-case is better handled by either:

 - explicitly setting the viewport to the element size using `page.setViewport({clip: await element.boundingBox()});` (this declaratively implies the element being screenshotted is dependent on the viewport size), or
 - changing the element's state for testing to ensure the element is visible.

The latter depends on your codebase. For example, if the element is hidden in a `overflow: hidden` container, just `page.evaluate` away the `overflow: hidden`.
