### PR TITLE
refactor!: change the way cookies are retrieved

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -7,6 +7,7 @@
 import type {Readable} from 'stream';
 
 import type {Protocol} from 'devtools-protocol';
+import net from 'net';
 
 import {
   concat,
@@ -1305,6 +1306,91 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * URL. If URLs are specified, only cookies for those URLs are returned.
    */
   abstract cookies(...urls: string[]): Promise<Protocol.Network.Cookie[]>;
+
+  static #testCookieUrlMatchHostname(cookie: Protocol.Network.Cookie, parsedUrl: URL): boolean {
+    // Check if domains match according to the spec:
+    //   A string domain-matches a given domain string if at least one of the
+    //   following conditions hold:
+    //   o  The domain string and the string are identical.  (Note that both
+    //      the domain string and the string will have been canonicalized to
+    //      lower case at this point.)
+    //   o  All of the following conditions hold:
+    //     *  The domain string is a suffix of the string.
+    //     *  The last character of the string that is not included in the
+    //        domain string is a %x2E (".") character.
+    //     *  The string is a host name (i.e., not an IP address).
+    // https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
+    const cookieDomain = cookie.domain.toLowerCase();
+    const urlHostname = parsedUrl.hostname.toLowerCase();
+    if (cookieDomain === urlHostname) {
+      // The domain string and the string are identical.
+      return true;
+    }
+    if (net.isIP(urlHostname)) {
+      // The string should be a host name (i.e., not an IP address).
+      return false;
+    }
+    if (!urlHostname.endsWith(cookieDomain)) {
+      // The domain string is a suffix of the string.
+      return false;
+    }
+    // The last character of the string that is not included in the domain string is a
+    // %x2E (".") character.
+    return urlHostname.endsWith("." + cookieDomain);
+  }
+
+  static #testCookieUrlMatchPath(cookie: Protocol.Network.Cookie, parsedUrl: URL): boolean {
+    // Check paths match according to the spec:
+    //   A request-path path-matches a given cookie-path if at least one of
+    //   the following conditions holds:
+    //   o  The cookie-path and the request-path are identical.
+    //   o  The cookie-path is a prefix of the request-path, and the last
+    //      character of the cookie-path is %x2F ("/").
+    //   o  The cookie-path is a prefix of the request-path, and the first
+    //      character of the request-path that is not included in the cookie-
+    //      path is a %x2F ("/") character.
+    // https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4
+    const uriPath = parsedUrl.pathname;
+    const cookiePath = cookie.path;
+
+    console.log("!!@@##", uriPath, cookiePath);
+
+    if (uriPath === cookiePath) {
+      // The cookie-path and the request-path are identical.
+      return true;
+    }
+    // * The cookie-path is a prefix of the request-path, and the last character of the
+    //   cookie-path is %x2F ("/").
+    // * The cookie-path is a prefix of the request-path, and the first character of the
+    //   request-path that is not included in the cookie-path is a %x2F ("/") character.
+    if (uriPath.startsWith(cookiePath)) {
+      // The cookie-path is a prefix of the request-path.
+      if (cookiePath.endsWith('/')) {
+        // The last character of the cookie-path is %x2F ("/").
+        return true;
+      }
+      if (uriPath[cookiePath.length] === '/') {
+        // The first character of the request-path that is not included in the cookie-path
+        // is a %x2F ("/") character.
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Checks the cookie matches the URL according to the spec:
+   * * https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
+   * * https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4
+   */
+  static testCookieUrlMatch(cookie: Protocol.Network.Cookie, url: string): boolean {
+    const parsedUrl = new URL(url);
+    console.assert(cookie!==undefined)
+    if(!this.#testCookieUrlMatchHostname(cookie, parsedUrl))
+      return false;
+    return this.#testCookieUrlMatchPath(cookie, parsedUrl);
+  }
+
 
   abstract deleteCookie(
     ...cookies: Protocol.Network.DeleteCookiesRequest[]

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1307,7 +1307,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    */
   abstract cookies(...urls: string[]): Promise<Protocol.Network.Cookie[]>;
 
-  static #testCookieUrlMatchHostname(
+  static #testUrlMatchCookieHostname(
     cookie: Protocol.Network.Cookie,
     parsedUrl: URL
   ): boolean {
@@ -1342,7 +1342,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
     return urlHostname.endsWith('.' + cookieDomain);
   }
 
-  static #testCookieUrlMatchPath(
+  static #testUrlMatchCookiePath(
     cookie: Protocol.Network.Cookie,
     parsedUrl: URL
   ): boolean {
@@ -1388,16 +1388,16 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * - https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
    * - https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4
    */
-  static testCookieUrlMatch(
+  static testUrlMatchCookie(
     cookie: Protocol.Network.Cookie,
     url: string
   ): boolean {
     const parsedUrl = new URL(url);
     console.assert(cookie !== undefined);
-    if (!this.#testCookieUrlMatchHostname(cookie, parsedUrl)) {
+    if (!this.#testUrlMatchCookieHostname(cookie, parsedUrl)) {
       return false;
     }
-    return this.#testCookieUrlMatchPath(cookie, parsedUrl);
+    return this.#testUrlMatchCookiePath(cookie, parsedUrl);
   }
 
   abstract deleteCookie(

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1383,6 +1383,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
   }
 
   /**
+   * @internal
    * Checks the cookie matches the URL according to the spec:
    *
    * - https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import net from 'net';
 import type {Readable} from 'stream';
 
 import type {Protocol} from 'devtools-protocol';
-import net from 'net';
 
 import {
   concat,
@@ -1307,7 +1307,10 @@ export abstract class Page extends EventEmitter<PageEvents> {
    */
   abstract cookies(...urls: string[]): Promise<Protocol.Network.Cookie[]>;
 
-  static #testCookieUrlMatchHostname(cookie: Protocol.Network.Cookie, parsedUrl: URL): boolean {
+  static #testCookieUrlMatchHostname(
+    cookie: Protocol.Network.Cookie,
+    parsedUrl: URL
+  ): boolean {
     // Check if domains match according to the spec:
     //   A string domain-matches a given domain string if at least one of the
     //   following conditions hold:
@@ -1336,10 +1339,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
     }
     // The last character of the string that is not included in the domain string is a
     // %x2E (".") character.
-    return urlHostname.endsWith("." + cookieDomain);
+    return urlHostname.endsWith('.' + cookieDomain);
   }
 
-  static #testCookieUrlMatchPath(cookie: Protocol.Network.Cookie, parsedUrl: URL): boolean {
+  static #testCookieUrlMatchPath(
+    cookie: Protocol.Network.Cookie,
+    parsedUrl: URL
+  ): boolean {
     // Check paths match according to the spec:
     //   A request-path path-matches a given cookie-path if at least one of
     //   the following conditions holds:
@@ -1353,7 +1359,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
     const uriPath = parsedUrl.pathname;
     const cookiePath = cookie.path;
 
-    console.log("!!@@##", uriPath, cookiePath);
+    console.log('!!@@##', uriPath, cookiePath);
 
     if (uriPath === cookiePath) {
       // The cookie-path and the request-path are identical.
@@ -1380,17 +1386,21 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
   /**
    * Checks the cookie matches the URL according to the spec:
-   * * https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
-   * * https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4
+   *
+   * - https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
+   * - https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4
    */
-  static testCookieUrlMatch(cookie: Protocol.Network.Cookie, url: string): boolean {
+  static testCookieUrlMatch(
+    cookie: Protocol.Network.Cookie,
+    url: string
+  ): boolean {
     const parsedUrl = new URL(url);
-    console.assert(cookie!==undefined)
-    if(!this.#testCookieUrlMatchHostname(cookie, parsedUrl))
+    console.assert(cookie !== undefined);
+    if (!this.#testCookieUrlMatchHostname(cookie, parsedUrl)) {
       return false;
+    }
     return this.#testCookieUrlMatchPath(cookie, parsedUrl);
   }
-
 
   abstract deleteCookie(
     ...cookies: Protocol.Network.DeleteCookiesRequest[]

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1359,8 +1359,6 @@ export abstract class Page extends EventEmitter<PageEvents> {
     const uriPath = parsedUrl.pathname;
     const cookiePath = cookie.path;
 
-    console.log('!!@@##', uriPath, cookiePath);
-
     if (uriPath === cookiePath) {
       // The cookie-path and the request-path are identical.
       return true;

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -582,7 +582,7 @@ export class CdpPage extends Page {
       })
     ).cookies.filter(c => {
       return requiredUrls.some(u => {
-        return Page.testCookieUrlMatch(c, u);
+        return Page.testUrlMatchCookie(c, u);
       });
     });
 

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -577,7 +577,11 @@ export class CdpPage extends Page {
   ): Promise<Protocol.Network.Cookie[]> {
     const originalCookies = (
       await this.#primaryTargetClient.send('Storage.getCookies', {})
-    ).cookies.filter(c => urls.some(u => Page.testCookieUrlMatch(c, u)));
+    ).cookies.filter(c => {
+      return urls.some(u => {
+        return Page.testCookieUrlMatch(c, u);
+      });
+    });
 
     const unsupportedCookieAttributes = ['priority'];
     const filterUnsupportedAttributes = (

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -576,10 +576,8 @@ export class CdpPage extends Page {
     ...urls: string[]
   ): Promise<Protocol.Network.Cookie[]> {
     const originalCookies = (
-      await this.#primaryTargetClient.send('Network.getCookies', {
-        urls: urls.length ? urls : [this.url()],
-      })
-    ).cookies;
+      await this.#primaryTargetClient.send('Storage.getCookies', {})
+    ).cookies.filter(c => urls.some(u => Page.testCookieUrlMatch(c, u)));
 
     const unsupportedCookieAttributes = ['priority'];
     const filterUnsupportedAttributes = (

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -575,10 +575,11 @@ export class CdpPage extends Page {
   override async cookies(
     ...urls: string[]
   ): Promise<Protocol.Network.Cookie[]> {
+    const requiredUrls = urls.length ? urls : [this.url()];
     const originalCookies = (
       await this.#primaryTargetClient.send('Storage.getCookies', {})
     ).cookies.filter(c => {
-      return urls.some(u => {
+      return requiredUrls.some(u => {
         return Page.testCookieUrlMatch(c, u);
       });
     });

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -577,7 +577,9 @@ export class CdpPage extends Page {
   ): Promise<Protocol.Network.Cookie[]> {
     const requiredUrls = urls.length ? urls : [this.url()];
     const originalCookies = (
-      await this.#primaryTargetClient.send('Storage.getCookies', {})
+      await this.#primaryTargetClient.send('Storage.getCookies', {
+        browserContextId: this.browserContext().id,
+      })
     ).cookies.filter(c => {
       return requiredUrls.some(u => {
         return Page.testCookieUrlMatch(c, u);

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -174,15 +174,13 @@ describe('Cookie specs', () => {
     it('should get cookies from subdomain', async () => {
       const {page, close} = await launch({});
       try {
-        await page.setCookie(
-          {
-            url: 'https://base_domain.com',
-            name: 'doggo',
-            value: 'woofs',
-          },
-        );
+        await page.setCookie({
+          url: 'https://base_domain.com',
+          name: 'doggo',
+          value: 'woofs',
+        });
         const cookies = await page.cookies(
-          'https://sub_domain.base_domain.com',
+          'https://sub_domain.base_domain.com'
         );
         await expectCookieEquals(cookies, [
           {
@@ -207,16 +205,14 @@ describe('Cookie specs', () => {
     it('should get cookies from nested path', async () => {
       const {page, close} = await launch({});
       try {
-        await page.setCookie(
-          {
-            url: 'https://foo.com',
-            path: '/some_path',
-            name: 'doggo',
-            value: 'woofs',
-          },
-        );
+        await page.setCookie({
+          url: 'https://foo.com',
+          path: '/some_path',
+          name: 'doggo',
+          value: 'woofs',
+        });
         const cookies = await page.cookies(
-          'https://foo.com/some_path/nested_path',
+          'https://foo.com/some_path/nested_path'
         );
         await expectCookieEquals(cookies, [
           {

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -182,22 +182,7 @@ describe('Cookie specs', () => {
         const cookies = await page.cookies(
           'https://sub_domain.base_domain.com'
         );
-        await expectCookieEquals(cookies, [
-          {
-            name: 'doggo',
-            value: 'woofs',
-            domain: 'base_domain.com',
-            path: '/',
-            sameParty: false,
-            expires: -1,
-            size: 10,
-            httpOnly: false,
-            secure: true,
-            session: true,
-            sourcePort: 443,
-            sourceScheme: 'Secure',
-          },
-        ]);
+        expect(cookies).toHaveLength(1);
       } finally {
         await close();
       }
@@ -214,22 +199,7 @@ describe('Cookie specs', () => {
         const cookies = await page.cookies(
           'https://foo.com/some_path/nested_path'
         );
-        await expectCookieEquals(cookies, [
-          {
-            name: 'doggo',
-            value: 'woofs',
-            domain: 'foo.com',
-            path: '/some_path',
-            sameParty: false,
-            expires: -1,
-            size: 10,
-            httpOnly: false,
-            secure: true,
-            session: true,
-            sourcePort: 443,
-            sourceScheme: 'Secure',
-          },
-        ]);
+        expect(cookies).toHaveLength(1);
       } finally {
         await close();
       }

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -171,6 +171,73 @@ describe('Cookie specs', () => {
         },
       ]);
     });
+    it('should get cookies from subdomain', async () => {
+      const {page, close} = await launch({});
+      try {
+        await page.setCookie(
+          {
+            url: 'https://base_domain.com',
+            name: 'doggo',
+            value: 'woofs',
+          },
+        );
+        const cookies = await page.cookies(
+          'https://sub_domain.base_domain.com',
+        );
+        await expectCookieEquals(cookies, [
+          {
+            name: 'doggo',
+            value: 'woofs',
+            domain: 'base_domain.com',
+            path: '/',
+            sameParty: false,
+            expires: -1,
+            size: 10,
+            httpOnly: false,
+            secure: true,
+            session: true,
+            sourcePort: 443,
+            sourceScheme: 'Secure',
+          },
+        ]);
+      } finally {
+        await close();
+      }
+    });
+    it('should get cookies from nested path', async () => {
+      const {page, close} = await launch({});
+      try {
+        await page.setCookie(
+          {
+            url: 'https://foo.com',
+            path: '/some_path',
+            name: 'doggo',
+            value: 'woofs',
+          },
+        );
+        const cookies = await page.cookies(
+          'https://foo.com/some_path/nested_path',
+        );
+        await expectCookieEquals(cookies, [
+          {
+            name: 'doggo',
+            value: 'woofs',
+            domain: 'foo.com',
+            path: '/some_path',
+            sameParty: false,
+            expires: -1,
+            size: 10,
+            httpOnly: false,
+            secure: true,
+            session: true,
+            sourcePort: 443,
+            sourceScheme: 'Secure',
+          },
+        ]);
+      } finally {
+        await close();
+      }
+    });
   });
   describe('Page.setCookie', function () {
     it('should work', async () => {


### PR DESCRIPTION
Currently, CDP method `network.getCookies` makes a part of filtering, but it is not guaranteed the returned cookies will actually be sent to the server, as it would depend on the request itself. It is not feasible to implement when WebDriver BiDi protocol is used. With this PR, the cookies will be filtered only based on the domain and path. The actual cookies sent to each specific domain can be retrieved via network request interception.
* https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.3
* https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.4

BREAKING CHANGE: the `Page.cookies()` method became less strict.