### PR TITLE
fix!: make console warn level compatible with WebDriver BiDi

### DIFF
--- a/docs/api/puppeteer.consolemessagetype.md
+++ b/docs/api/puppeteer.consolemessagetype.md
@@ -14,7 +14,7 @@ export type ConsoleMessageType =
   | 'debug'
   | 'info'
   | 'error'
-  | 'warning'
+  | 'warn'
   | 'dir'
   | 'dirxml'
   | 'table'

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -33,6 +33,7 @@ import {Coverage} from '../cdp/Coverage.js';
 import {EmulationManager as CdpEmulationManager} from '../cdp/EmulationManager.js';
 import {FrameTree} from '../cdp/FrameTree.js';
 import {Tracing} from '../cdp/Tracing.js';
+import type {ConsoleMessageType} from '../common/ConsoleMessage.js';
 import {
   ConsoleMessage,
   type ConsoleMessageLocation,
@@ -408,7 +409,7 @@ export class BidiPage extends Page {
       this.emit(
         PageEvent.Console,
         new ConsoleMessage(
-          event.method as any,
+          event.method as ConsoleMessageType,
           text,
           args,
           getStackTraceLocations(event.stackTrace)

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -8,7 +8,6 @@ import type {Protocol} from 'devtools-protocol';
 import type {CDPSession} from '../api/CDPSession.js';
 import type {Realm} from '../api/Realm.js';
 import {WebWorker} from '../api/WebWorker.js';
-import type {ConsoleMessageType} from '../common/ConsoleMessage.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError} from '../common/util.js';
 
@@ -20,7 +19,7 @@ import {CdpJSHandle} from './JSHandle.js';
  * @internal
  */
 export type ConsoleAPICalledCallback = (
-  eventType: ConsoleMessageType,
+  eventType: string,
   handles: CdpJSHandle[],
   trace?: Protocol.Runtime.StackTrace
 ) => void;

--- a/packages/puppeteer-core/src/common/ConsoleMessage.ts
+++ b/packages/puppeteer-core/src/common/ConsoleMessage.ts
@@ -35,7 +35,7 @@ export type ConsoleMessageType =
   | 'debug'
   | 'info'
   | 'error'
-  | 'warning'
+  | 'warn'
   | 'dir'
   | 'dirxml'
   | 'table'

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -922,7 +922,7 @@
     "testIdPattern": "[page.spec] Page Page.Events.Console should work for different console API calls with logging functions",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[page.spec] Page Page.Events.error should throw when page crashes",

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -445,7 +445,7 @@ describe('Page', function () {
         messages.map(msg => {
           return msg.type();
         })
-      ).toEqual(['trace', 'dir', 'warning', 'error', 'log']);
+      ).toEqual(['trace', 'dir', 'warn', 'error', 'log']);
       expect(
         messages.map(msg => {
           return msg.text();


### PR DESCRIPTION
In CDP the console.warn resulted in a warning level, whereas HTML and WebDriver BiDi spec use `warn` to denote this level. To migrate, if you used ConsoleMessageType and checked for `warning`, check for `warn` instead.