### PR TITLE
chore: for Firefox keep preference "browser.tabs.closeWindowWithLastTab" disabled for CDP

### DIFF
--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -45,6 +45,8 @@ export class FirefoxLauncher extends ProductLauncher {
       ...(protocol === 'webDriverBiDi'
         ? {}
         : {
+            // Do not close the window when the last tab gets closed
+            'browser.tabs.closeWindowWithLastTab': false,
             // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
             'fission.bfcacheInParent': false,
           }),


### PR DESCRIPTION
Upstream version of the patch for https://phabricator.services.mozilla.com/D200073.

We have to keep this preference disabled for CDP given that it looks complicated to fix. For BiDi (and classic) we have to remove it because it won't allow closing the last tab of any open (not the last) window.

@OrKoN can you please review? Thanks.