### PR TITLE
refactor!: remove duplicate type names

### DIFF
--- a/docs/guides/locators.md
+++ b/docs/guides/locators.md
@@ -160,7 +160,7 @@ Currently, locators support a single event that notifies you when the locator is
 let willClick = false;
 await page
   .locator('button')
-  .on(LocatorEmittedEvents.Action, () => {
+  .on(LocatorEvent.Action, () => {
     willClick = true;
   })
   .click();

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -165,13 +165,6 @@ export const enum BrowserEvent {
   TargetDiscovered = 'targetdiscovered',
 }
 
-export {
-  /**
-   * @deprecated Use {@link BrowserEvent}.
-   */
-  BrowserEvent as BrowserEmittedEvents,
-};
-
 /**
  * @public
  */

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -38,13 +38,6 @@ export const enum BrowserContextEvent {
   TargetDestroyed = 'targetdestroyed',
 }
 
-export {
-  /**
-   * @deprecated Use {@link BrowserContextEvent}
-   */
-  BrowserContextEvent as BrowserContextEmittedEvents,
-};
-
 /**
  * @public
  */

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -484,15 +484,6 @@ export const enum PageEvent {
   WorkerDestroyed = 'workerdestroyed',
 }
 
-export {
-  /**
-   * All the events that a page instance may emit.
-   *
-   * @deprecated Use {@link PageEvent}.
-   */
-  PageEvent as PageEmittedEvents,
-};
-
 /**
  * Denotes the objects received by callback functions for page events.
  *
@@ -522,13 +513,6 @@ export interface PageEvents extends Record<EventType, unknown> {
   [PageEvent.WorkerCreated]: WebWorker;
   [PageEvent.WorkerDestroyed]: WebWorker;
 }
-
-export type {
-  /**
-   * @deprecated Use {@link PageEvents}.
-   */
-  PageEvents as PageEventObject,
-};
 
 /**
  * @public

--- a/packages/puppeteer-core/src/api/locators/locators.ts
+++ b/packages/puppeteer-core/src/api/locators/locators.ts
@@ -109,24 +109,14 @@ export enum LocatorEvent {
    */
   Action = 'action',
 }
-export {
-  /**
-   * @deprecated Use {@link LocatorEvent}.
-   */
-  LocatorEvent as LocatorEmittedEvents,
-};
+
 /**
  * @public
  */
 export interface LocatorEvents extends Record<EventType, unknown> {
   [LocatorEvent.Action]: undefined;
 }
-export type {
-  /**
-   * @deprecated Use {@link LocatorEvents}.
-   */
-  LocatorEvents as LocatorEventObject,
-};
+
 /**
  * Locators describe a strategy of locating objects and performing an action on
  * them. If the action fails because the object is not ready for the action, the


### PR DESCRIPTION
Removes deprecated Event type names.
 To continue using these export please rename them as follows:
`BrowserEmittedEvents` -> `BrowserEvent` ;
`BrowserContextEmittedEvents` -> `BrowserContextEvent` ;
`PageEmittedEvents` -> `PageEvent` ;
`PageEventObject` -> `PageEvents` ;
`LocatorEmittedEvents` -> `LocatorEvent` ;
`LocatorEventObject` -> `LocatorEvents` ;