### PR TITLE
refactor!: use ReadableStreams

### DIFF
--- a/docs/api/puppeteer.page.createpdfstream.md
+++ b/docs/api/puppeteer.page.createpdfstream.md
@@ -10,7 +10,9 @@ Generates a PDF of the page with the `print` CSS media type.
 
 ```typescript
 class Page {
-  abstract createPDFStream(options?: PDFOptions): Promise<Readable>;
+  abstract createPDFStream(
+    options?: PDFOptions
+  ): Promise<ReadableStream<Uint8Array>>;
 }
 ```
 
@@ -22,7 +24,7 @@ class Page {
 
 **Returns:**
 
-Promise&lt;Readable&gt;
+Promise&lt;ReadableStream&lt;Uint8Array&gt;&gt;
 
 ## Remarks
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Readable} from 'stream';
-
 import type {Protocol} from 'devtools-protocol';
 
 import {
@@ -2574,7 +2572,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust | `-webkit-print-color-adjust`}
    * property to force rendering of exact colors.
    */
-  abstract createPDFStream(options?: PDFOptions): Promise<Readable>;
+  abstract createPDFStream(
+    options?: PDFOptions
+  ): Promise<ReadableStream<Uint8Array>>;
 
   /**
    * {@inheritDoc Page.createPDFStream}

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Readable} from 'stream';
-
 import type {Protocol} from 'devtools-protocol';
 
 import {firstValueFrom, from, raceWith} from '../../third_party/rxjs/rxjs.js';
@@ -1105,7 +1103,9 @@ export class CdpPage extends Page {
     return data;
   }
 
-  override async createPDFStream(options: PDFOptions = {}): Promise<Readable> {
+  override async createPDFStream(
+    options: PDFOptions = {}
+  ): Promise<ReadableStream<Uint8Array>> {
     const {timeout: ms = this._timeoutSettings.timeout()} = options;
     const {
       landscape,

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -1964,9 +1964,15 @@ describe('Page', function () {
 
       const stream = await page.createPDFStream();
       let size = 0;
-      for await (const chunk of stream) {
-        size += chunk.length;
+      const reader = stream.getReader();
+      while (true) {
+        const {done, value} = await reader.read();
+        if (done) {
+          break;
+        }
+        size += value.length;
       }
+
       expect(size).toBeGreaterThan(0);
     });
 


### PR DESCRIPTION
Affected APIs - [createPDFStream](https://pptr.dev/api/puppeteer.page.createpdfstream) 
Migrating from [Node's Readable](https://nodejs.org/api/stream.html#class-streamreadable) to [ReadableStream](https://nodejs.org/api/stream.html#class-streamreadable).
Please refer to the ReadableStream documentation and update accordingly.
In most cases you would want to:
```ts
const stream = await page.createPDFStream()
const reader = stream.getReader();
while (true) {
      const {done, value} = await reader.read();
      if (done) {
        break;
      }
      buffers.push(value);
    }
}
```