### PR TITLE
test: replace usages of webkit-scrollbar with scrollbar-width

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3377,12 +3377,6 @@
     "expectations": ["FAIL", "PASS"]
   },
   {
-    "testIdPattern": "[screenshot.spec] Screenshots ElementHandle.screenshot should capture full element when larger than viewport",
-    "platforms": ["win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[screenshot.spec] Screenshots ElementHandle.screenshot should work for an element with an offset",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -3413,64 +3407,10 @@
     "expectations": ["FAIL", "PASS"]
   },
   {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should clip rect",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should clip rect",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL", "PASS"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should return base64",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should return base64",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL", "PASS"]
-  },
-  {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots without captureBeyondViewport",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should take fullPage screenshots without captureBeyondViewport",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL", "PASS"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[stacktrace.spec] Stack trace should work for none error objects",
@@ -3841,12 +3781,6 @@
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome", "headful"],
     "expectations": ["FAIL", "PASS"]
-  },
-  {
-    "testIdPattern": "[screenshot.spec] Screenshots ElementHandle.screenshot should capture full element when larger than viewport",
-    "platforms": ["darwin", "win32"],
-    "parameters": ["firefox", "headless", "webDriverBiDi"],
-    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[screenshot.spec] Screenshots ElementHandle.screenshot should work for an element with an offset",

--- a/test/assets/frames/nested-frames.html
+++ b/test/assets/frames/nested-frames.html
@@ -1,4 +1,8 @@
 <style>
+:root {
+  scrollbar-width: none;
+}
+
 body {
     display: flex;
 }
@@ -6,9 +10,6 @@ body {
 body iframe {
     flex-grow: 1;
     flex-shrink: 1;
-}
-::-webkit-scrollbar{
-    display: none;
 }
 </style>
 <script>

--- a/test/assets/grid.html
+++ b/test/assets/grid.html
@@ -28,6 +28,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 <style>
 
+:root {
+  scrollbar-width: none;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -45,8 +49,3 @@ body {
     box-sizing: border-box;
     border: 1px solid darkgray;
 }
-
-::-webkit-scrollbar {
-    display: none;
-}
-</style>

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -232,14 +232,14 @@ describe('Screenshots', function () {
       await page.setContent(`
           something above
           <style>
+          :root {
+            scrollbar-width: none;
+          }
           div.to-screenshot {
             border: 1px solid blue;
             width: 600px;
             height: 600px;
             margin-left: 50px;
-          }
-          ::-webkit-scrollbar{
-            display: none;
           }
           </style>
           <div class="to-screenshot"></div>


### PR DESCRIPTION
`webkit-scrollbar` is not cross-browser compatible, but `scrollbar-width` is. Given that Chrome since version 121 supports it we can replace the usages.

Nearly all the screenshot tests were affected by this and should now work on non-retina displays.