### PR TITLE
fix: frameElement should work for framesets

### DIFF
--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -425,12 +425,12 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
       return null;
     }
     using list = await parentFrame.isolatedRealm().evaluateHandle(() => {
-      return document.querySelectorAll('iframe');
+      return document.querySelectorAll('iframe,frame');
     });
     for await (using iframe of transposeIterableHandle(list)) {
       const frame = await iframe.contentFrame();
-      if (frame._id === this._id) {
-        return iframe.move();
+      if (frame?._id === this._id) {
+        return (iframe as HandleFor<HTMLIFrameElement>).move();
       }
     }
     return null;

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -648,6 +648,13 @@
     "expectations": ["SKIP"]
   },
   {
+    "testIdPattern": "[frame.spec] Frame specs Frame Management should click elements in a frameset",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "New test for framesets. We probably do not want to support framesets in WebDriver BiDi in the long term."
+  },
+  {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should handle nested frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -2196,6 +2203,13 @@
     "expectations": ["SKIP"]
   },
   {
+    "testIdPattern": "[frame.spec] Frame specs Frame Management should click elements in a frameset",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "New test for framesets (does not seem to pass in Firefox CDP)."
+  },
+  {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should detach child frames on navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3550,7 +3564,8 @@
     "testIdPattern": "[oopif.spec] OOPIF should keep track of a frames OOP state",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["SKIP"],
+    "comment": "Failed previously and currently times out"
   },
   {
     "testIdPattern": "[oopif.spec] OOPIF should keep track of a frames OOP state",

--- a/test/src/frame.spec.ts
+++ b/test/src/frame.spec.ts
@@ -205,6 +205,18 @@ describe('Frame specs', function () {
       expect(detachedFrames).toHaveLength(4);
       expect(navigatedFrames).toHaveLength(1);
     });
+
+    it('should click elements in a frameset', async () => {
+      const {page, server} = await getTestState();
+      await page.goto(server.PREFIX + '/frames/frameset.html');
+      const frame = await page.waitForFrame(frame => {
+        return frame.url().endsWith('/frames/frame.html');
+      });
+      using div = await frame.waitForSelector('div');
+      expect(div).toBeTruthy();
+      await div?.click();
+    });
+
     it('should report frame from-inside shadow DOM', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
Although framesets are deprecated and browsers might stop supporting them, we still need to support them. This PR fixes a regression which only checked for iframe elements in the `Frame.frameElement()` method.

Closes #11827