### PR TITLE
test: update expectations for aborted request test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1068,7 +1068,7 @@
     "testIdPattern": "[page.spec] Page Page.waitForNetworkIdle should work with aborted requests",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
-    "expectations": ["SKIP"]
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[pdf.spec] Page.pdf *",


### PR DESCRIPTION
Once https://bugzilla.mozilla.org/show_bug.cgi?id=1877438 lands in Nightly, this test should pass for Firefox.

@OrKoN was it intended to also skip it on Chrome? The test seemed to pass when testing locally, but maybe it is flaky on your side?