### PR TITLE
fix: deprecate `Page.prototype.target`

### DIFF
--- a/docs/api/puppeteer.page.target.md
+++ b/docs/api/puppeteer.page.target.md
@@ -4,6 +4,10 @@ sidebar_label: Page.target
 
 # Page.target() method
 
+> Warning: This API is now obsolete.
+>
+> Use [Page.createCDPSession()](./puppeteer.page.createcdpsession.md) directly.
+
 A target this page was created from.
 
 #### Signature:

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -757,6 +757,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
   /**
    * A target this page was created from.
+   *
+   * @deprecated Use {@link Page.createCDPSession} directly.
    */
   abstract target(): Target;
 

--- a/test/src/browsercontext.spec.ts
+++ b/test/src/browsercontext.spec.ts
@@ -181,9 +181,9 @@ describe('BrowserContext', function () {
     });
 
     expect(context1.targets()).toHaveLength(1);
-    expect(context1.targets()[0]).toBe(page1.target());
+    expect(await context1.targets()[0]?.page()).toBe(page1);
     expect(context2.targets()).toHaveLength(1);
-    expect(context2.targets()[0]).toBe(page2.target());
+    expect(await context2.targets()[0]?.page()).toBe(page2);
 
     // Make sure pages don't share localstorage or cookies.
     expect(

--- a/test/src/oopif.spec.ts
+++ b/test/src/oopif.spec.ts
@@ -472,7 +472,7 @@ describe('OOPIF', function () {
     const {server, page} = state;
 
     // Setup our session listeners to observe OOPIF activity.
-    const session = await page.target().createCDPSession();
+    const session = await page.createCDPSession();
     const networkEvents: string[] = [];
     const otherSessions: CDPSession[] = [];
     await session.send('Target.setAutoAttach', {

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -583,14 +583,10 @@ describe('Page', function () {
         // 3. After that, remove the iframe.
         frame.remove();
       });
-      const popupTarget = page
-        .browserContext()
-        .targets()
-        .find(target => {
-          return target !== page.target();
-        })!;
-      // 4. Connect to the popup and make sure it doesn't throw.
-      await popupTarget.page();
+      // 4. The target should always be the last one.
+      const popupTarget = page.browserContext().targets().at(-1)!;
+      // 5. Connect to the popup and make sure it doesn't throw and is not the same page.
+      expect(await popupTarget.page()).not.toBe(page);
     });
   });
 

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -118,7 +118,7 @@ describe('request interception', function () {
       await page.goto(server.EMPTY_PAGE);
       await page.setRequestInterception(true);
 
-      const cdp = await page.target().createCDPSession();
+      const cdp = await page.createCDPSession();
       await cdp.send('DOM.enable');
       const urls: string[] = [];
       page.on('request', request => {


### PR DESCRIPTION
All methods on the `Target` instance obtained by `Page.prototype.target` are already on the `Page` class, so this getter is redundant.