### PR TITLE
chore: remove `Page.prototype.target` from WebDriver BiDi

### DIFF
--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -144,7 +144,6 @@ export class BidiPage extends Page {
   #keyboard: BidiKeyboard;
   #browsingContext: BrowsingContext;
   #browserContext: BidiBrowserContext;
-  #target: BiDiPageTarget;
 
   _client(): CDPSession {
     return this.mainFrame().context().cdpSession;
@@ -152,13 +151,11 @@ export class BidiPage extends Page {
 
   constructor(
     browsingContext: BrowsingContext,
-    browserContext: BidiBrowserContext,
-    target: BiDiPageTarget
+    browserContext: BidiBrowserContext
   ) {
     super();
     this.#browsingContext = browsingContext;
     this.#browserContext = browserContext;
-    this.#target = target;
     this.#connection = browsingContext.connection;
 
     for (const [event, subscriber] of this.#browsingContextEvents) {
@@ -794,7 +791,7 @@ export class BidiPage extends Page {
   }
 
   override target(): BiDiPageTarget {
-    return this.#target;
+    throw new UnsupportedOperation();
   }
 
   override waitForFileChooser(): never {

--- a/packages/puppeteer-core/src/bidi/Target.ts
+++ b/packages/puppeteer-core/src/bidi/Target.ts
@@ -138,7 +138,7 @@ export class BiDiPageTarget extends BiDiBrowsingContextTarget {
   ) {
     super(browserContext, browsingContext);
 
-    this.#page = new BidiPage(browsingContext, browserContext, this);
+    this.#page = new BidiPage(browsingContext, browserContext);
   }
 
   override async page(): Promise<BidiPage> {

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -583,7 +583,7 @@ describe('Page', function () {
         // 3. After that, remove the iframe.
         frame.remove();
       });
-      // 4. The target should always be the last one.
+      // 4. The target will always be the last one.
       const popupTarget = page.browserContext().targets().at(-1)!;
       // 5. Connect to the popup and make sure it doesn't throw and is not the same page.
       expect(await popupTarget.page()).not.toBe(page);


### PR DESCRIPTION
Remove this method from BiDi while we have the chance.