### PR TITLE
test: update user context tests checking the number of user contexts

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1476,8 +1476,7 @@
     "testIdPattern": "[browsercontext.spec] BrowserContext should create new incognito context",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Fails because test assumes there is 1 user context initially, Firefox has 5"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[browsercontext.spec] BrowserContext should fire target events",
@@ -1496,8 +1495,7 @@
     "testIdPattern": "[browsercontext.spec] BrowserContext should have default context",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Fails because test assumes there is 1 user context initially, Firefox has 5"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[browsercontext.spec] BrowserContext should timeout waiting for a non-existent target",

--- a/test/src/browsercontext.spec.ts
+++ b/test/src/browsercontext.spec.ts
@@ -18,9 +18,13 @@ describe('BrowserContext', function () {
     const {browser} = await getTestState({
       skipContextCreation: true,
     });
-    expect(browser.browserContexts()).toHaveLength(1);
-    const defaultContext = browser.browserContexts()[0]!;
-    expect(defaultContext!.isIncognito()).toBe(false);
+
+    expect(browser.browserContexts().length).toBeGreaterThanOrEqual(1);
+    const defaultContext = browser.browserContexts().find(context => {
+      return !context.isIncognito();
+    });
+    expect(defaultContext).toBeDefined();
+
     let error!: Error;
     await defaultContext!.close().catch(error_ => {
       return (error = error_);
@@ -33,13 +37,14 @@ describe('BrowserContext', function () {
       skipContextCreation: true,
     });
 
-    expect(browser.browserContexts()).toHaveLength(1);
+    const contextCount = browser.browserContexts().length;
+    expect(contextCount).toBeGreaterThanOrEqual(1);
     const context = await browser.createBrowserContext();
     expect(context.isIncognito()).toBe(true);
-    expect(browser.browserContexts()).toHaveLength(2);
+    expect(browser.browserContexts()).toHaveLength(contextCount + 1);
     expect(browser.browserContexts().indexOf(context) !== -1).toBe(true);
     await context.close();
-    expect(browser.browserContexts()).toHaveLength(1);
+    expect(browser.browserContexts()).toHaveLength(contextCount);
   });
   it('should close all belonging targets once closing context', async () => {
     const {browser} = await getTestState({


### PR DESCRIPTION
@OrKoN Fixes the two tests asserting the number of user contexts. I don't think we have an easy way to only have the default container in Firefox at the moment, but if that sounds important we can also try to work on that on Firefox' side. Let me know