### PR TITLE
chore: update frame tests

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -655,12 +655,6 @@
     "comment": "New test for framesets. We probably do not want to support framesets in WebDriver BiDi in the long term."
   },
   {
-    "testIdPattern": "[frame.spec] Frame specs Frame Management should handle nested frames",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should report frame.name()",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -2258,13 +2252,15 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should support lazy frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"]
+    "expectations": ["FAIL"],
+    "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1878166"
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should support lazy frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["FAIL"],
+    "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1878166"
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame.evaluate should throw for detached frames",

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -794,10 +794,10 @@ describe('Launcher specs', function () {
           })!;
           expect(dumpFrames(restoredPage.mainFrame())).toEqual([
             'http://localhost:<PORT>/frames/nested-frames.html',
-            '    http://localhost:<PORT>/frames/two-frames.html (2frames)',
-            '        http://localhost:<PORT>/frames/frame.html (uno)',
-            '        http://localhost:<PORT>/frames/frame.html (dos)',
-            '    http://localhost:<PORT>/frames/frame.html (aframe)',
+            '    http://localhost:<PORT>/frames/two-frames.html',
+            '        http://localhost:<PORT>/frames/frame.html',
+            '        http://localhost:<PORT>/frames/frame.html',
+            '    http://localhost:<PORT>/frames/frame.html',
           ]);
           expect(
             await restoredPage.evaluate(() => {

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -114,10 +114,7 @@ export async function navigateFrame(
 
 export const dumpFrames = (frame: Frame, indentation?: string): string[] => {
   indentation = indentation || '';
-  let description = frame.url().replace(/:\d{4,5}\//, ':<PORT>/');
-  if (frame.name()) {
-    description += ' (' + frame.name() + ')';
-  }
+  const description = frame.url().replace(/:\d{4,5}\//, ':<PORT>/');
   const result = [indentation + description];
   for (const child of frame.childFrames()) {
     result.push(...dumpFrames(child, '    ' + indentation));


### PR DESCRIPTION
This PR updates the frame tests to utilize a new condition waiter for destroyed contexts. Previously, we assumed navigation would destroy subframe contexts but this assumption does not always hold (e.g. the browser may destroy contexts after navigation to optimize the happy path).