### PR TITLE
chore: use `redirectCount` for redirect detection in `bidi/core`

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -241,10 +241,11 @@ export class BrowsingContext extends EventEmitter<{
       if (event.context !== this.id) {
         return;
       }
-      // Means the request is a redirect. This is handled in Request.
-      if (this.#requests.has(event.request.request)) {
+      if (event.redirectCount !== 0) {
+        // Means the request is a redirect. This is handled in Request.
         return;
       }
+
       const request = Request.from(this, event);
       this.#requests.set(request.id, request);
       this.emit('request', {request});

--- a/packages/puppeteer-core/src/bidi/core/Request.ts
+++ b/packages/puppeteer-core/src/bidi/core/Request.ts
@@ -69,7 +69,7 @@ export class Request extends EventEmitter<{
       if (
         event.context !== this.#browsingContext.id ||
         event.request.request !== this.id ||
-        this.#redirect !== undefined
+        event.redirectCount !== this.#event.redirectCount + 1
       ) {
         return;
       }
@@ -80,7 +80,8 @@ export class Request extends EventEmitter<{
     sessionEmitter.on('network.fetchError', event => {
       if (
         event.context !== this.#browsingContext.id ||
-        event.request.request !== this.id
+        event.request.request !== this.id ||
+        this.#event.redirectCount !== event.redirectCount
       ) {
         return;
       }
@@ -91,7 +92,8 @@ export class Request extends EventEmitter<{
     sessionEmitter.on('network.responseCompleted', event => {
       if (
         event.context !== this.#browsingContext.id ||
-        event.request.request !== this.id
+        event.request.request !== this.id ||
+        this.#event.redirectCount !== event.redirectCount
       ) {
         return;
       }


### PR DESCRIPTION
Note we assume redirect `network.beforeRequestSent` happen in order. This is true for both Firefox and Chromium.