### PR TITLE
refactor: use internal event emitter for trusted events

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -60,7 +60,7 @@ export class BidiHTTPRequest extends HTTPRequest {
       this.#response = BidiHTTPResponse.from(data, this);
     });
 
-    this.#frame?.page().emit(PageEvent.Request, this);
+    this.#frame?.page().trustedEmitter.emit(PageEvent.Request, this);
   }
 
   override url(): string {

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -40,7 +40,7 @@ export class BidiHTTPResponse extends HTTPResponse {
   }
 
   #initialize() {
-    this.#request.frame()?.page().emit(PageEvent.Response, this);
+    this.#request.frame()?.page().trustedEmitter.emit(PageEvent.Response, this);
   }
 
   @invokeAtMostOnceForArguments

--- a/packages/puppeteer-core/src/bidi/core/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/core/Connection.ts
@@ -157,7 +157,4 @@ export interface Connection<Events extends BidiEvents = BidiEvents>
     method: T,
     params: Commands[T]['params']
   ): Promise<{result: Commands[T]['returnType']}>;
-
-  // This will pipe events into the provided emitter.
-  pipeTo<Events extends BidiEvents>(emitter: EventEmitter<Events>): void;
 }

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -8,7 +8,11 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {debugError} from '../../common/util.js';
-import {inertIfDisposed, throwIfDisposed} from '../../util/decorators.js';
+import {
+  bubble,
+  inertIfDisposed,
+  throwIfDisposed,
+} from '../../util/decorators.js';
 import {DisposableStack, disposeSymbol} from '../../util/disposable.js';
 
 import {Browser} from './Browser.js';
@@ -81,7 +85,8 @@ export class Session
   readonly #disposables = new DisposableStack();
   readonly #info: Bidi.Session.NewResult;
   readonly browser!: Browser;
-  readonly connection: Connection;
+  @bubble()
+  accessor connection: Connection;
   // keep-sorted end
 
   private constructor(connection: Connection, info: Bidi.Session.NewResult) {
@@ -93,8 +98,6 @@ export class Session
   }
 
   async #initialize(): Promise<void> {
-    this.connection.pipeTo(this);
-
     // SAFETY: We use `any` to allow assignment of the readonly property.
     (this as any).browser = await Browser.from(this);
 
@@ -123,10 +126,6 @@ export class Session
   private dispose(reason?: string): void {
     this.#reason = reason;
     this[disposeSymbol]();
-  }
-
-  pipeTo<Events extends BidiEvents>(emitter: EventEmitter<Events>): void {
-    this.connection.pipeTo(emitter);
   }
 
   /**

--- a/packages/puppeteer-core/src/util/decorators.test.ts
+++ b/packages/puppeteer-core/src/util/decorators.test.ts
@@ -9,7 +9,9 @@ import {describe, it} from 'node:test';
 import expect from 'expect';
 import sinon from 'sinon';
 
-import {invokeAtMostOnceForArguments} from './decorators.js';
+import {EventEmitter} from '../common/EventEmitter.js';
+
+import {bubble, invokeAtMostOnceForArguments} from './decorators.js';
 
 describe('decorators', function () {
   describe('invokeAtMostOnceForArguments', () => {
@@ -74,6 +76,50 @@ describe('decorators', function () {
       expect(() => {
         t.test(1);
       }).toThrow();
+    });
+  });
+
+  describe('bubble', () => {
+    it('should work', () => {
+      class Test extends EventEmitter<any> {
+        @bubble()
+        accessor field = new EventEmitter();
+      }
+
+      const t = new Test();
+      let a = false;
+      t.on('a', (value: boolean) => {
+        a = value;
+      });
+
+      t.field.emit('a', true);
+      expect(a).toBeTruthy();
+
+      // Set a new emitter.
+      t.field = new EventEmitter();
+      a = false;
+
+      t.field.emit('a', true);
+      expect(a).toBeTruthy();
+    });
+
+    it('should not bubble down', () => {
+      class Test extends EventEmitter<any> {
+        @bubble()
+        accessor field = new EventEmitter<any>();
+      }
+
+      const t = new Test();
+      let a = false;
+      t.field.on('a', (value: boolean) => {
+        a = value;
+      });
+
+      t.emit('a', true);
+      expect(a).toBeFalsy();
+
+      t.field.emit('a', true);
+      expect(a).toBeTruthy();
     });
   });
 });

--- a/packages/puppeteer-core/src/util/decorators.ts
+++ b/packages/puppeteer-core/src/util/decorators.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {EventType} from '../common/EventEmitter.js';
+import type {EventEmitter} from '../common/EventEmitter.js';
 import type {Disposed, Moveable} from '../common/types.js';
 
 import {asyncDisposeSymbol, disposeSymbol} from './disposable.js';
@@ -135,6 +137,70 @@ export function guarded<T extends object>(
       }
       await using _ = await mutex.acquire();
       return await target.call(this, ...args);
+    };
+  };
+}
+
+const bubbleHandlers = new WeakMap<object, Map<any, any>>();
+
+/**
+ * Event emitter fields marked with `bubble` will have their events bubble up
+ * the field owner.
+ */
+// The type is too complicated to type.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function bubble<T extends EventType[]>(events?: T) {
+  return <This extends EventEmitter<any>, Value extends EventEmitter<any>>(
+    {set, get}: ClassAccessorDecoratorTarget<This, Value>,
+    context: ClassAccessorDecoratorContext<This, Value>
+  ): ClassAccessorDecoratorResult<This, Value> => {
+    context.addInitializer(function () {
+      const handlers = bubbleHandlers.get(this) ?? new Map();
+      if (handlers.has(events)) {
+        return;
+      }
+
+      const handler =
+        events !== undefined
+          ? (type: EventType, event: unknown) => {
+              if (events.includes(type)) {
+                this.emit(type, event);
+              }
+            }
+          : (type: EventType, event: unknown) => {
+              this.emit(type, event);
+            };
+
+      handlers.set(events, handler);
+      bubbleHandlers.set(this, handlers);
+    });
+    return {
+      set(emitter) {
+        const handler = bubbleHandlers.get(this)!.get(events)!;
+
+        // In case we are re-setting.
+        const oldEmitter = get.call(this);
+        if (oldEmitter !== undefined) {
+          oldEmitter.off('*', handler);
+        }
+
+        if (emitter === undefined) {
+          return;
+        }
+        emitter.on('*', handler);
+        set.call(this, emitter);
+      },
+      // @ts-expect-error -- TypeScript incorrectly types init to require a
+      // return.
+      init(emitter) {
+        if (emitter === undefined) {
+          return;
+        }
+        const handler = bubbleHandlers.get(this)!.get(events)!;
+
+        emitter.on('*', handler);
+        return emitter;
+      },
     };
   };
 }


### PR DESCRIPTION
Currently Puppeteer uses its own events to handle business logic. This can cause problems if a malicious library user uses `removeAllListeners` on Puppeteer objects.

This PR fixes this by creating a separate event emitter on Puppeteer event objects that bubbles into its host. This allows us to distinguish between trusted and untrusted events and separate userland handlers from internal ones.