### PR TITLE
test: implement workarounds for current state of WebDriver BiDi

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {Observable} from '../../third_party/rxjs/rxjs.js';
 import {
@@ -265,7 +265,14 @@ export class BidiFrame extends Frame {
   ): Promise<BidiHTTPResponse | null> {
     const [response] = await Promise.all([
       this.waitForNavigation(options),
-      this.browsingContext.navigate(url),
+      this.browsingContext.navigate(
+        url,
+        // Some implementations currently only report errors when the
+        // readiness=interactive. This also ensures that old frames have been
+        // removed.
+        // Related: https://bugzilla.mozilla.org/show_bug.cgi?id=1846601
+        Bidi.BrowsingContext.ReadinessState.Interactive
+      ),
     ]).catch(
       rewriteNavigationError(
         url,

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -107,7 +107,7 @@ export class Session
     });
 
     // TODO: Currently, some implementations do not emit navigationStarted event
-    // for fragement navigations (as per spec) and some do. This could emits a
+    // for fragment navigations (as per spec) and some do. This could emits a
     // synthetic navigationStarted to work around this inconsistency.
     const seen = new WeakSet();
     this.on('browsingContext.fragmentNavigated', info => {

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -106,7 +106,9 @@ export class Session
       this.dispose(reason);
     });
 
-    // TODO: Firefox-specific
+    // TODO: Currently, some implementations do not emit navigationStarted event
+    // for fragement navigations (as per spec) and some do. This could emits a
+    // synthetic navigationStarted to work around this inconsistency.
     const seen = new WeakSet();
     this.on('browsingContext.fragmentNavigated', info => {
       if (seen.has(info)) {

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -105,6 +105,17 @@ export class Session
     browserEmitter.once('closed', ({reason}) => {
       this.dispose(reason);
     });
+
+    // TODO: Firefox-specific
+    const seen = new WeakSet();
+    this.on('browsingContext.fragmentNavigated', info => {
+      if (seen.has(info)) {
+        return;
+      }
+      seen.add(info);
+      this.emit('browsingContext.navigationStarted', info);
+      this.emit('browsingContext.fragmentNavigated', info);
+    });
   }
 
   // keep-sorted start block=yes

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3100,7 +3100,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.goBack should work with HistoryAPI",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
+    "expectations": ["PASS"],
     "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
   },
   {
@@ -3243,7 +3243,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.goto should work with anchor navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
+    "expectations": ["PASS"],
     "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
   },
   {
@@ -3286,7 +3286,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with DOM history.back()/history.forward()",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
+    "expectations": ["PASS"],
     "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
   },
   {
@@ -3299,7 +3299,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with history.pushState()",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
+    "expectations": ["PASS"],
     "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
   },
   {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -823,13 +823,6 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating to bad SSL",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["SKIP"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
-  },
-  {
     "testIdPattern": "[navigation.spec] navigation Page.goto should send referer",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -2226,8 +2219,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should detach child frames on navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/659"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should report different frame instance when frame re-attaches",
@@ -2269,8 +2261,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should send \"framenavigated\" when navigating on anchor URLs",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should send events when frames are manipulated dynamically",
@@ -2288,8 +2279,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should support framesets",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/659"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should support lazy frames",
@@ -3100,29 +3090,37 @@
     "testIdPattern": "[navigation.spec] navigation Page.goBack should work with HistoryAPI",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"],
-    "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when main resources failed to load",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Timeout waiting for an error"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating and show the url at the error message",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Timeout waiting for an error: Firefox reports successful navigation, without waiting for redirects to finish. Then reports a network error for the successful navigaiton. And then browsingContext.domContentLoaded without a navigation ID. What is expected here?"
+    "expectations": ["PASS"]
+  },
+  {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating to bad SSL",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["PASS"]
+  },
+  {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating to bad SSL",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating to bad SSL after redirects",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Timeout waiting for an error"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when server returns 204",
@@ -3134,8 +3132,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when server returns 204",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Navigation ends without emitting any errors or load/contentloaded events"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should navigate to dataURL and fire dataURL requests",
@@ -3234,6 +3231,13 @@
     "expectations": ["FAIL"]
   },
   {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should work when page calls history API in beforeunload",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "History navigation is breaking the Puppeteer expecation about navigation."
+  },
+  {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work with anchor navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "chrome-headless-shell"],
@@ -3243,8 +3247,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.goto should work with anchor navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"],
-    "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work with subframes return 204",
@@ -3286,8 +3289,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with DOM history.back()/history.forward()",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"],
-    "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with history.pushState()",
@@ -3299,8 +3301,7 @@
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with history.pushState()",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["PASS"],
-    "comment": "browsingContext.navigationStarted event not emitted for fragment navigation"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with history.replaceState()",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2269,7 +2269,7 @@
     "testIdPattern": "[frame.spec] Frame specs Frame Management should send \"framenavigated\" when navigating on anchor URLs",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
+    "expectations": ["PASS"],
     "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
   },
   {
@@ -3108,21 +3108,21 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
+    "comment": "Timeout waiting for an error"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating and show the url at the error message",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
+    "comment": "Timeout waiting for an error: Firefox reports successful navigation, without waiting for redirects to finish. Then reports a network error for the successful navigaiton. And then browsingContext.domContentLoaded without a navigation ID. What is expected here?"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when navigating to bad SSL after redirects",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
+    "comment": "Timeout waiting for an error"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should fail when server returns 204",
@@ -3135,7 +3135,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "https://github.com/w3c/webdriver-bidi/issues/657"
+    "comment": "Navigation ends without emitting any errors or load/contentloaded events"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should navigate to dataURL and fire dataURL requests",
@@ -3542,7 +3542,8 @@
     "testIdPattern": "[network.spec] network Response.fromCache should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["FAIL"],
+    "comment": "Needs investigation, it looks like a bug in Puppeteer"
   },
   {
     "testIdPattern": "[network.spec] network Response.fromCache should work",
@@ -3681,8 +3682,7 @@
     "testIdPattern": "[oopif.spec] OOPIF should support frames within OOP iframes",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Fetch error"
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[oopif.spec] OOPIF should support lazy OOP frames",
@@ -3750,7 +3750,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "Fetch error"
+    "comment": "Chrome-specific test (uses DNS mapping); does not work with Firefox."
   },
   {
     "testIdPattern": "[page.spec] Page Page.addScriptTag should throw when added with content to the CSP page",

--- a/tools/sort-test-expectations.mjs
+++ b/tools/sort-test-expectations.mjs
@@ -43,6 +43,10 @@ testExpectations.forEach(item => {
   item.parameters.sort();
   item.expectations.sort();
   item.platforms.sort();
+  // Delete comments for PASS expectations. They are likely outdated.
+  if (item.expectations.length === 1 && item.expectations[0] === 'PASS') {
+    delete item.comment;
+  }
 });
 
 if (process.argv.includes('--lint')) {


### PR DESCRIPTION
- [x] [navigation.spec] navigation Page.goto should fail when navigating to bad SSL
- [x] [frame.spec] Frame specs Frame Management should detach child frames on navigation
- [x] [frame.spec] Frame specs Frame Management should send \"framenavigated\" when navigating on anchor URLs
- [x] [frame.spec] Frame specs Frame Management should support framesets
- [x] [navigation.spec] navigation Page.goBack should work with HistoryAPI
- [x] [navigation.spec] navigation Page.goto should fail when main resources failed to load
- [x] [navigation.spec] navigation Page.goto should fail when navigating and show the url at the error message
- [x] [navigation.spec] navigation Page.goto should fail when navigating to bad SSL after redirects
- [x] [navigation.spec] navigation Page.goto should fail when server returns 204
- [x] [navigation.spec] navigation Page.goto should work with anchor navigation
- [x] [navigation.spec] navigation Page.waitForNavigation should work with DOM history.back()/history.forward()
- [x] [navigation.spec] navigation Page.waitForNavigation should work with history.pushState()
- [ ] [network.spec] network Response.fromCache should work (was failing previously)
- [x] [oopif.spec] OOPIF should support frames within OOP iframes
- [ ] [oopif.spec] OOPIF should support lazy OOP frames (not supported yet in Firefox)
- [ ] [oopif.spec] OOPIF should wait for inner OOPIFs (uses Chrome-specific features)
- [ ] [navigation.spec] navigation Page.goto should work when page calls history API in beforeunload 

Closes https://github.com/puppeteer/puppeteer/issues/11913