### PR TITLE
ci: turn off coverage by default

### DIFF
--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -52,7 +52,7 @@ const {
   .scriptName('@puppeteer/mocha-runner')
   .option('coverage', {
     boolean: true,
-    default: true,
+    default: false,
   })
   .option('suggestions', {
     boolean: true,


### PR DESCRIPTION
With sharding is not useful and recent version of c8 cause failures.