### PR TITLE
chore: implement improved `waitForNavigation`

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/Navigation.ts
+++ b/packages/puppeteer-core/src/bidi/core/Navigation.ts
@@ -26,31 +26,30 @@ export interface NavigationInfo {
 export class Navigation extends EventEmitter<{
   /** Emitted when navigation has a request associated with it. */
   request: Request;
-  /** Emitted when fragment navigation occurred. */
-  fragment: NavigationInfo;
   /** Emitted when navigation failed. */
   failed: NavigationInfo;
   /** Emitted when navigation was aborted. */
   aborted: NavigationInfo;
 }> {
-  static from(context: BrowsingContext): Navigation {
-    const navigation = new Navigation(context);
+  static from(context: BrowsingContext, url: string): Navigation {
+    const navigation = new Navigation(context, url);
     navigation.#initialize();
     return navigation;
   }
 
   // keep-sorted start
   #request: Request | undefined;
-  #navigation: Navigation | undefined;
   readonly #browsingContext: BrowsingContext;
   readonly #disposables = new DisposableStack();
   readonly #id = new Deferred<string | null>();
+  readonly #url: string;
   // keep-sorted end
 
-  private constructor(context: BrowsingContext) {
+  private constructor(context: BrowsingContext, url: string) {
     super();
     // keep-sorted start
     this.#browsingContext = context;
+    this.#url = url;
     // keep-sorted end
   }
 
@@ -84,35 +83,7 @@ export class Navigation extends EventEmitter<{
     const sessionEmitter = this.#disposables.use(
       new EventEmitter(this.#session)
     );
-    sessionEmitter.on('browsingContext.navigationStarted', info => {
-      if (
-        info.context !== this.#browsingContext.id ||
-        this.#navigation !== undefined
-      ) {
-        return;
-      }
-      this.#navigation = Navigation.from(this.#browsingContext);
-    });
-
-    for (const eventName of [
-      'browsingContext.domContentLoaded',
-      'browsingContext.load',
-    ] as const) {
-      sessionEmitter.on(eventName, info => {
-        if (
-          info.context !== this.#browsingContext.id ||
-          info.navigation === null ||
-          !this.#matches(info.navigation)
-        ) {
-          return;
-        }
-
-        this.dispose();
-      });
-    }
-
     for (const [eventName, event] of [
-      ['browsingContext.fragmentNavigated', 'fragment'],
       ['browsingContext.navigationFailed', 'failed'],
       ['browsingContext.navigationAborted', 'aborted'],
     ] as const) {
@@ -136,9 +107,6 @@ export class Navigation extends EventEmitter<{
   }
 
   #matches(navigation: string | null): boolean {
-    if (this.#navigation !== undefined && !this.#navigation.disposed) {
-      return false;
-    }
     if (!this.#id.resolved()) {
       this.#id.resolve(navigation);
       return true;
@@ -156,13 +124,13 @@ export class Navigation extends EventEmitter<{
   get request(): Request | undefined {
     return this.#request;
   }
-  get navigation(): Navigation | undefined {
-    return this.#navigation;
+  get url(): string {
+    return this.#url;
   }
   // keep-sorted end
 
   @inertIfDisposed
-  private dispose(): void {
+  dispose(): void {
     this[disposeSymbol]();
   }
 

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -105,19 +105,6 @@ export class Session
     browserEmitter.once('closed', ({reason}) => {
       this.dispose(reason);
     });
-
-    // TODO: Currently, some implementations do not emit navigationStarted event
-    // for fragment navigations (as per spec) and some do. This could emits a
-    // synthetic navigationStarted to work around this inconsistency.
-    const seen = new WeakSet();
-    this.on('browsingContext.fragmentNavigated', info => {
-      if (seen.has(info)) {
-        return;
-      }
-      seen.add(info);
-      this.emit('browsingContext.navigationStarted', info);
-      this.emit('browsingContext.fragmentNavigated', info);
-    });
   }
 
   // keep-sorted start block=yes

--- a/packages/puppeteer-core/third_party/rxjs/rxjs.ts
+++ b/packages/puppeteer-core/third_party/rxjs/rxjs.ts
@@ -14,7 +14,6 @@ export {
   first,
   firstValueFrom,
   forkJoin,
-  delayWhen,
   from,
   fromEvent,
   identity,

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2242,13 +2242,6 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[navigation.spec] navigation Page.goto should work when page calls history API in beforeunload",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "History navigation is breaking the Puppeteer expecation about navigation."
-  },
-  {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work with anchor navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "chrome-headless-shell"],


### PR DESCRIPTION
This PR implements a `waitForNavigation` that doesn't validate the expected flow and instead only cares about results.

 - It will wait for a response if it can.
 - It will wait for the first navigation (fragment or not).
 - It will wait for the completion condition (if available).
 - It will wait for other conditions when navigation is not fragment navigation.

This also modifies the `bidi/core` API to match the BiDi spec as defined.