### PR TITLE
fix: implement a fallback to download URLs provided by dashboard

### DIFF
--- a/packages/browsers/test/src/chrome/install.spec.ts
+++ b/packages/browsers/test/src/chrome/install.spec.ts
@@ -137,30 +137,21 @@ describe('Chrome install', () => {
     );
   });
 
-  it('throws on invalid URL', async function () {
+  it('falls back to the chrome-for-testing dashboard URLs if URL is not available', async function () {
     const expectedOutputPath = path.join(
       tmpDir,
       'chrome',
       `${BrowserPlatform.LINUX}-${testChromeBuildId}`
     );
     assert.strictEqual(fs.existsSync(expectedOutputPath), false);
-
-    async function installThatThrows(): Promise<unknown> {
-      try {
-        await install({
-          cacheDir: tmpDir,
-          browser: Browser.CHROME,
-          platform: BrowserPlatform.LINUX,
-          buildId: testChromeBuildId,
-          baseUrl: 'https://127.0.0.1',
-        });
-        return undefined;
-      } catch (err) {
-        return err;
-      }
-    }
-    assert.ok(await installThatThrows());
-    assert.strictEqual(fs.existsSync(expectedOutputPath), false);
+    await install({
+      cacheDir: tmpDir,
+      browser: Browser.CHROME,
+      platform: BrowserPlatform.LINUX,
+      buildId: testChromeBuildId,
+      baseUrl: 'https://127.0.0.1',
+    });
+    assert.strictEqual(fs.existsSync(expectedOutputPath), true);
   });
 
   describe('with proxy', () => {

--- a/packages/browsers/test/src/firefox/install.spec.ts
+++ b/packages/browsers/test/src/firefox/install.spec.ts
@@ -49,6 +49,32 @@ describe('Firefox install', () => {
     assert.ok(fs.existsSync(expectedOutputPath));
   });
 
+  it('throws on invalid URL', async function () {
+    const expectedOutputPath = path.join(
+      tmpDir,
+      'chrome',
+      `${BrowserPlatform.LINUX}-${testFirefoxBuildId}`
+    );
+    assert.strictEqual(fs.existsSync(expectedOutputPath), false);
+
+    async function installThatThrows(): Promise<unknown> {
+      try {
+        await install({
+          cacheDir: tmpDir,
+          browser: Browser.FIREFOX,
+          platform: BrowserPlatform.LINUX,
+          buildId: testFirefoxBuildId,
+          baseUrl: 'https://127.0.0.1',
+        });
+        return undefined;
+      } catch (err) {
+        return err;
+      }
+    }
+    assert.ok(await installThatThrows());
+    assert.strictEqual(fs.existsSync(expectedOutputPath), false);
+  });
+
   // install relies on the `hdiutil` utility on MacOS.
   // The utility is not available on other platforms.
   (os.platform() === 'darwin' ? it : it.skip)(


### PR DESCRIPTION
With this change, if the download for Chrome fails, the download will be attempted again using the download URL found at `https://googlechromelabs.github.io/chrome-for-testing/<buildId>.json` endpoint.

That would help to mitigate issues such as https://github.com/puppeteer/puppeteer/issues/11925 when the Chrome for Testing URLs are updated for new releases. Note that we still want to hard-code the URL scheme in `@puppeteer/browsers` by default to avoid making extra requests. 