### PR TITLE
fix: supress viewport errors for pages that do not support changing it

### DIFF
--- a/packages/puppeteer-core/src/cdp/EmulationManager.ts
+++ b/packages/puppeteer-core/src/cdp/EmulationManager.ts
@@ -267,13 +267,23 @@ export class EmulationManager {
     const hasTouch = viewport.hasTouch || false;
 
     await Promise.all([
-      client.send('Emulation.setDeviceMetricsOverride', {
-        mobile,
-        width,
-        height,
-        deviceScaleFactor,
-        screenOrientation,
-      }),
+      client
+        .send('Emulation.setDeviceMetricsOverride', {
+          mobile,
+          width,
+          height,
+          deviceScaleFactor,
+          screenOrientation,
+        })
+        .catch(err => {
+          if (
+            err.message.includes('Target does not support metrics override')
+          ) {
+            debugError(err);
+            return;
+          }
+          throw err;
+        }),
       client.send('Emulation.setTouchEmulationEnabled', {
         enabled: hasTouch,
       }),


### PR DESCRIPTION
Issue https://github.com/puppeteer/puppeteer/issues/11964