### PR TITLE
feat: implement permissions for WebDriver BiDi

### DIFF
--- a/docs/webdriver-bidi.md
+++ b/docs/webdriver-bidi.md
@@ -94,6 +94,11 @@ This is an exciting step towards a more unified and efficient cross-browser auto
   - Page.pdf (only `format`, `height`, `landscape`, `margin`, `pageRanges`, `printBackground`, `scale`, `width` are supported)
   - Page.createPDFStream (only `format`, `height`, `landscape`, `margin`, `pageRanges`, `printBackground`, `scale`, `width` are supported)
 
+- Permissions (Supported in Chrome only)
+
+  - BrowserContext.clearPermissionOverrides()
+  - BrowserContext.overridePermissions()
+
 ## Puppeteer features not yet supported over WebDriver BiDi
 
 - [Request interception](https://pptr.dev/guides/request-interception)
@@ -110,11 +115,6 @@ This is an exciting step towards a more unified and efficient cross-browser auto
   - HTTPRequest.respond()
   - HTTPRequest.responseForRequest()
   - Page.setRequestInterception()
-
-- Permissions
-
-  - BrowserContext.clearPermissionOverrides()
-  - BrowserContext.overridePermissions()
 
 - Various emulations (most are supported with Chrome)
 

--- a/packages/puppeteer-core/src/bidi/core/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/core/Connection.ts
@@ -107,6 +107,11 @@ export interface Commands {
     returnType: Bidi.EmptyResult;
   };
 
+  'permissions.setPermission': {
+    params: Bidi.Permissions.SetPermissionParameters;
+    returnType: Bidi.EmptyResult;
+  };
+
   'session.end': {
     params: Bidi.EmptyParams;
     returnType: Bidi.EmptyResult;

--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -214,6 +214,24 @@ export class UserContext extends EventEmitter<{
     });
   }
 
+  @throwIfDisposed<UserContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
+  async setPermissions(
+    origin: string,
+    descriptor: Bidi.Permissions.PermissionDescriptor,
+    state: Bidi.Permissions.PermissionState
+  ): Promise<void> {
+    await this.#session.send('permissions.setPermission', {
+      origin,
+      descriptor,
+      state,
+      // @ts-expect-error not standard implementation.
+      'goog:userContext': this.#id,
+    });
+  }
+
   [disposeSymbol](): void {
     this.#reason ??=
       'User context already closed, probably because the browser disconnected/closed.';

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -18,12 +18,6 @@
     "expectations": ["SKIP"]
   },
   {
-    "testIdPattern": "[browsercontext.spec] BrowserContext BrowserContext.overridePermissions *",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[device-request-prompt.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -231,12 +225,6 @@
     "testIdPattern": "[browsercontext.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
-    "testIdPattern": "[browsercontext.spec] BrowserContext BrowserContext.overridePermissions *",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"]
   },
   {
@@ -705,12 +693,6 @@
     "expectations": ["FAIL"]
   },
   {
-    "testIdPattern": "[page.spec] Page Page.setGeolocation should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"]
-  },
-  {
     "testIdPattern": "[page.spec] Page Page.setOfflineMode should emulate navigator.onLine",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -921,6 +903,12 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[browsercontext.spec] BrowserContext BrowserContext.overridePermissions should fail when bad permission is given",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["PASS"]
   },
   {
     "testIdPattern": "[browsercontext.spec] BrowserContext BrowserContext.overridePermissions should grant permission when listed",
@@ -1571,12 +1559,6 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["SKIP"]
-  },
-  {
-    "testIdPattern": "[idle_override.spec] Emulate idle state changing idle state emulation causes change of the IdleDetector state",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
   },
   {
     "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails Network redirects should report SecurityDetails",
@@ -2935,6 +2917,12 @@
     "testIdPattern": "[page.spec] Page Page.setCacheEnabled should stay disabled when toggling request interception on/off",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"]
+  },
+  {
+    "testIdPattern": "[page.spec] Page Page.setGeolocation should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"]
   },
   {


### PR DESCRIPTION
Note: the current API in Puppeteer does not match WebDriver BiDi or modern CDP methods and we would likely want to refactor it later:

- setting a permission, should not deny other permissions
- it should accept all possible web permissions instead of maintaining a list
- clearing a permission should be the same as setting a permission
