### PR TITLE
chore: update devcontainer.json to Node 18

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:1": {
       "version": "latest",
       "moby": true


### PR DESCRIPTION
This container set me up with Node 16

Based on https://github.com/devcontainers/features/tree/main/src/node, this should use 18.