### PR TITLE
chore: for Firefox enable only the required protocol (CDP or BiDi)

### DIFF
--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -43,12 +43,17 @@ export class FirefoxLauncher extends ProductLauncher {
     return {
       ...extraPrefsFirefox,
       ...(protocol === 'webDriverBiDi'
-        ? {}
+        ? {
+            // Only enable the WebDriver BiDi protocol
+            'remote.active-protocols': 1,
+          }
         : {
             // Do not close the window when the last tab gets closed
             'browser.tabs.closeWindowWithLastTab': false,
             // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
             'fission.bfcacheInParent': false,
+            // Only enable the CDP protocol
+            'remote.active-protocols': 2,
           }),
       // Force all web content to use a single content process. TODO: remove
       // this once Firefox supports mouse event dispatch from the main frame

--- a/test/src/fixtures.spec.ts
+++ b/test/src/fixtures.spec.ts
@@ -42,7 +42,8 @@ describe('Fixtures', function () {
     expect(dumpioData).toContain('message from dumpio');
   });
   it('should dump browser process stderr', async () => {
-    const {defaultBrowserOptions, puppeteerPath} = await getTestState();
+    const {defaultBrowserOptions, isFirefox, puppeteerPath} =
+      await getTestState();
 
     let dumpioData = '';
     const options = Object.assign({}, defaultBrowserOptions, {dumpio: true});
@@ -57,7 +58,11 @@ describe('Fixtures', function () {
     await new Promise(resolve => {
       return res.on('close', resolve);
     });
-    expect(dumpioData).toContain('DevTools listening on ws://');
+    if (isFirefox && defaultBrowserOptions.protocol === 'webDriverBiDi') {
+      expect(dumpioData).toContain('WebDriver BiDi listening on ws://');
+    } else {
+      expect(dumpioData).toContain('DevTools listening on ws://');
+    }
   });
   it('should close the browser when the node process closes', async () => {
     const {defaultBrowserOptions, puppeteerPath, puppeteer} =


### PR DESCRIPTION
At some point we want to deprecate CDP and not enable it by default anymore. That means that CDP clients have to explicitly set the preference `[remote.active-protocols](https://searchfox.org/mozilla-central/rev/d87ac4f189d6c1ad068bc3d1cdf50d2f871028c2/modules/libpref/init/all.js#3826-3830)` to `2`. For WebDriver BiDi it will be `1`.

This will also reduce conflicts between CDP and BiDi because at the moment both protocols are active and especially for CDP we need special settings for preferences which then also can negatively affect BiDi. The related bug for us is https://bugzilla.mozilla.org/show_bug.cgi?id=1882085.

CC @OrKoN 