### PR TITLE
chore: set "network.cookie.cookieBehavior" preference to "0" only for CDP

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -235,10 +235,6 @@ function defaultProfilePreferences(
     // Disable the GFX sanity window
     'media.sanity-test.disabled': true,
 
-    // Prevent various error message on the console
-    // jest-puppeteer asserts that no error message is emitted by the console
-    'network.cookie.cookieBehavior': 0,
-
     // Disable experimental feature that is only available in Nightly
     'network.cookie.sameSite.laxByDefault': false,
 

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -50,6 +50,9 @@ export class FirefoxLauncher extends ProductLauncher {
         : {
             // Do not close the window when the last tab gets closed
             'browser.tabs.closeWindowWithLastTab': false,
+            // Prevent various error message on the console
+            // jest-puppeteer asserts that no error message is emitted by the console
+            'network.cookie.cookieBehavior': 0,
             // Temporarily force disable BFCache in parent (https://bit.ly/bug-1732263)
             'fission.bfcacheInParent': false,
             // Only enable the CDP protocol


### PR DESCRIPTION
We would like to not set this for BiDi, so this PR moves the preference to CDP only preferences.