### PR TITLE
chore(deps): Bump chromium-bidi to 0.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12155,7 +12155,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.1.0",
-        "chromium-bidi": "0.5.11",
+        "chromium-bidi": "0.5.12",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1249869",
@@ -12179,9 +12179,9 @@
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.11.tgz",
-      "integrity": "sha512-HXp1nvjgSKdBig+yUFZlRqgoDtsakOKThFuPPJi2FTa3nSB8JAKaH3qNjjZLjf8QJ8ckzQA/Bq+GFoDBgQKAWw==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.12.tgz",
+      "integrity": "sha512-sZMgEBWKbupD0Q7lyFu8AWkrE+rs5ycE12jFkGwIgD/VS8lDPtelPlXM7LYaq4zrkZ/O2L3f4afHUHL0ICdKog==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0"

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -120,7 +120,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.1.0",
-    "chromium-bidi": "0.5.11",
+    "chromium-bidi": "0.5.12",
     "cross-fetch": "4.0.0",
     "debug": "4.3.4",
     "devtools-protocol": "0.0.1249869",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2508,7 +2508,7 @@
     "testIdPattern": "[network.spec] network Response.fromCache should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"]
+    "expectations": ["FAIL", "PASS"]
   },
   {
     "testIdPattern": "[network.spec] network Response.fromServiceWorker Response.fromServiceWorker",


### PR DESCRIPTION
## [0.5.12](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.11...chromium-bidi-v0.5.12) (2024-02-29)


### Features

* implement `storage.deleteCookies` ([#1915](https://github.com/GoogleChromeLabs/chromium-bidi/issues/1915)) ([18d3d4f](https://github.com/GoogleChromeLabs/chromium-bidi/commit/18d3d4f197320dcb152d9d0b729bcf2a77720cec))


### Bug Fixes

* implement less flaky network module ([#1871](https://github.com/GoogleChromeLabs/chromium-bidi/issues/1871)) ([4ec8bad](https://github.com/GoogleChromeLabs/chromium-bidi/commit/4ec8bad7d1f42b916bbab207ab68371e79063ff1))
* parse `browser.RemoveUserContextParameters` ([#1905](https://github.com/GoogleChromeLabs/chromium-bidi/issues/1905)) ([a50821b](https://github.com/GoogleChromeLabs/chromium-bidi/commit/a50821b2661777be4509bf9bc9c6a0890e5e5a7a))