### PR TITLE
chore: allow links in to be clickable

### DIFF
--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -435,14 +435,14 @@ export abstract class ProductLauncher {
             `Could not find Chrome (ver. ${this.puppeteer.browserRevision}). This can occur if either\n` +
               ' 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or\n' +
               ` 2. your cache path is incorrectly configured (which is: ${this.puppeteer.configuration.cacheDirectory}).\n` +
-              'For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.'
+              'For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration'
           );
         case 'firefox':
           throw new Error(
             `Could not find Firefox (rev. ${this.puppeteer.browserRevision}). This can occur if either\n` +
               ' 1. you did not perform an installation for Firefox before running the script (e.g. `npx puppeteer browsers install firefox`) or\n' +
               ` 2. your cache path is incorrectly configured (which is: ${this.puppeteer.configuration.cacheDirectory}).\n` +
-              'For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.'
+              'For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration'
           );
       }
     }


### PR DESCRIPTION
When the error messages are printed to a terminal the period at the end prevents the URL to be turned to an anchor for easier navigation. 