### PR TITLE
feat: allow downloading Firefox channels other than nightly

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -222,7 +222,31 @@ export class CLI {
           );
           yargs.example(
             '$0 install firefox',
-            'Install the latest available build of the Firefox browser.'
+            'Install the latest nightly available build of the Firefox browser.'
+          );
+          yargs.example(
+            '$0 install firefox@stable',
+            'Install the latest stable build of the Firefox browser.'
+          );
+          yargs.example(
+            '$0 install firefox@beta',
+            'Install the latest beta build of the Firefox browser.'
+          );
+          yargs.example(
+            '$0 install firefox@devedition',
+            'Install the latest devedition build of the Firefox browser.'
+          );
+          yargs.example(
+            '$0 install firefox@esr',
+            'Install the latest ESR build of the Firefox browser.'
+          );
+          yargs.example(
+            '$0 install firefox@nightly',
+            'Install the latest nightly build of the Firefox browser.'
+          );
+          yargs.example(
+            '$0 install firefox@stable_111.0.1',
+            'Install a specific version of the Firefox browser.'
           );
           yargs.example(
             '$0 install firefox --platform mac',
@@ -395,7 +419,7 @@ export function makeProgressCallback(
   return (downloadedBytes: number, totalBytes: number) => {
     if (!progressBar) {
       progressBar = new ProgressBar(
-        `Downloading ${browser} r${buildId} - ${toMegabytes(
+        `Downloading ${browser} ${buildId} - ${toMegabytes(
           totalBytes
         )} [:bar] :percent :etas `,
         {

--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -69,8 +69,10 @@ export async function resolveBuildId(
         case BrowserTag.BETA:
           return await firefox.resolveBuildId(firefox.FirefoxChannel.BETA);
         case BrowserTag.CANARY:
+        case BrowserTag.NIGHTLY:
           return await firefox.resolveBuildId(firefox.FirefoxChannel.NIGHTLY);
         case BrowserTag.DEV:
+        case BrowserTag.DEVEDITION:
           return await firefox.resolveBuildId(
             firefox.FirefoxChannel.DEVEDITION
           );
@@ -86,8 +88,10 @@ export async function resolveBuildId(
         case BrowserTag.BETA:
           return await chrome.resolveBuildId(ChromeReleaseChannel.BETA);
         case BrowserTag.CANARY:
+        case BrowserTag.NIGHTLY:
           return await chrome.resolveBuildId(ChromeReleaseChannel.CANARY);
         case BrowserTag.DEV:
+        case BrowserTag.DEVEDITION:
           return await chrome.resolveBuildId(ChromeReleaseChannel.DEV);
         case BrowserTag.STABLE:
           return await chrome.resolveBuildId(ChromeReleaseChannel.STABLE);

--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -65,14 +65,19 @@ export async function resolveBuildId(
     case Browser.FIREFOX:
       switch (tag as BrowserTag) {
         case BrowserTag.LATEST:
-          return await firefox.resolveBuildId('FIREFOX_NIGHTLY');
+          return await firefox.resolveBuildId(firefox.FirefoxChannel.NIGHTLY);
         case BrowserTag.BETA:
+          return await firefox.resolveBuildId(firefox.FirefoxChannel.BETA);
         case BrowserTag.CANARY:
+          return await firefox.resolveBuildId(firefox.FirefoxChannel.NIGHTLY);
         case BrowserTag.DEV:
-        case BrowserTag.STABLE:
-          throw new Error(
-            `${tag} is not supported for ${browser}. Use 'latest' instead.`
+          return await firefox.resolveBuildId(
+            firefox.FirefoxChannel.DEVEDITION
           );
+        case BrowserTag.STABLE:
+          return await firefox.resolveBuildId(firefox.FirefoxChannel.STABLE);
+        case BrowserTag.ESR:
+          return await firefox.resolveBuildId(firefox.FirefoxChannel.ESR);
       }
     case Browser.CHROME: {
       switch (tag as BrowserTag) {
@@ -86,6 +91,8 @@ export async function resolveBuildId(
           return await chrome.resolveBuildId(ChromeReleaseChannel.DEV);
         case BrowserTag.STABLE:
           return await chrome.resolveBuildId(ChromeReleaseChannel.STABLE);
+        case BrowserTag.ESR:
+          throw new Error('ESR is not available for Chrome');
         default:
           const result = await chrome.resolveBuildId(tag);
           if (result) {
@@ -105,6 +112,8 @@ export async function resolveBuildId(
           return await chromedriver.resolveBuildId(ChromeReleaseChannel.DEV);
         case BrowserTag.STABLE:
           return await chromedriver.resolveBuildId(ChromeReleaseChannel.STABLE);
+        case BrowserTag.ESR:
+          throw new Error('ESR is not available for ChromeDriver');
         default:
           const result = await chromedriver.resolveBuildId(tag);
           if (result) {
@@ -132,6 +141,8 @@ export async function resolveBuildId(
           return await chromeHeadlessShell.resolveBuildId(
             ChromeReleaseChannel.STABLE
           );
+        case BrowserTag.ESR:
+          throw new Error('ESR is not available for chrome-headless-shell');
         default:
           const result = await chromeHeadlessShell.resolveBuildId(tag);
           if (result) {
@@ -148,6 +159,7 @@ export async function resolveBuildId(
         case BrowserTag.CANARY:
         case BrowserTag.DEV:
         case BrowserTag.STABLE:
+        case BrowserTag.ESR:
           throw new Error(
             `${tag} is not supported for ${browser}. Use 'latest' instead.`
           );

--- a/packages/browsers/src/browser-data/types.ts
+++ b/packages/browsers/src/browser-data/types.ts
@@ -39,6 +39,7 @@ export enum BrowserTag {
   BETA = 'beta',
   DEV = 'dev',
   STABLE = 'stable',
+  ESR = 'esr',
   LATEST = 'latest',
 }
 

--- a/packages/browsers/src/browser-data/types.ts
+++ b/packages/browsers/src/browser-data/types.ts
@@ -36,8 +36,10 @@ export enum BrowserPlatform {
  */
 export enum BrowserTag {
   CANARY = 'canary',
+  NIGHTLY = 'nightly',
   BETA = 'beta',
   DEV = 'dev',
+  DEVEDITION = 'devedition',
   STABLE = 'stable',
   ESR = 'esr',
   LATEST = 'latest',

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {exec as execChildProcess} from 'child_process';
+import {exec as execChildProcess, spawnSync} from 'child_process';
 import {createReadStream} from 'fs';
 import {mkdir, readdir} from 'fs/promises';
 import * as path from 'path';
@@ -30,6 +30,18 @@ export async function unpackArchive(
   } else if (archivePath.endsWith('.dmg')) {
     await mkdir(folderPath);
     await installDMG(archivePath, folderPath);
+  } else if (archivePath.endsWith('.exe')) {
+    // Firefox on Windows.
+    const result = spawnSync(archivePath, [`/ExtractDir=${folderPath}`], {
+      env: {
+        __compat_layer: 'RunAsInvoker',
+      },
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to extract ${archivePath} to ${folderPath}: ${result.output}`
+      );
+    }
   } else {
     throw new Error(`Unsupported archive format: ${archivePath}`);
   }

--- a/packages/browsers/test/src/chrome/install.spec.ts
+++ b/packages/browsers/test/src/chrome/install.spec.ts
@@ -138,6 +138,7 @@ describe('Chrome install', () => {
   });
 
   it('falls back to the chrome-for-testing dashboard URLs if URL is not available', async function () {
+    this.timeout(60000);
     const expectedOutputPath = path.join(
       tmpDir,
       'chrome',

--- a/packages/browsers/test/src/firefox/firefox-data.spec.ts
+++ b/packages/browsers/test/src/firefox/firefox-data.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../lib/cjs/browser-data/firefox.js';
 
 describe('Firefox', () => {
-  it('should resolve download URLs', () => {
+  it('should resolve download URLs for Nightly', () => {
     assert.strictEqual(
       resolveDownloadUrl(BrowserPlatform.LINUX, '111.0a1'),
       'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.linux-x86_64.tar.bz2'
@@ -38,6 +38,75 @@ describe('Firefox', () => {
     assert.strictEqual(
       resolveDownloadUrl(BrowserPlatform.WIN64, '111.0a1'),
       'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-111.0a1.en-US.win64.zip'
+    );
+  });
+
+  it('should resolve download URLs for beta', () => {
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.LINUX, 'beta_115.0b8'),
+      'https://archive.mozilla.org/pub/firefox/releases/115.0b8/linux-x86_64/en-US/firefox-115.0b8.tar.bz2'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.MAC, 'beta_115.0b8'),
+      'https://archive.mozilla.org/pub/firefox/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.MAC_ARM, 'beta_115.0b8'),
+      'https://archive.mozilla.org/pub/firefox/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.WIN32, 'beta_115.0b8'),
+      'https://archive.mozilla.org/pub/firefox/releases/115.0b8/win32/en-US/Firefox Setup 115.0b8.exe'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.WIN64, 'beta_115.0b8'),
+      'https://archive.mozilla.org/pub/firefox/releases/115.0b8/win64/en-US/Firefox Setup 115.0b8.exe'
+    );
+  });
+
+  it('should resolve download URLs for stable', () => {
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.LINUX, 'stable_111.0.1'),
+      'https://archive.mozilla.org/pub/firefox/releases/111.0.1/linux-x86_64/en-US/firefox-111.0.1.tar.bz2'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.MAC, 'stable_111.0.1'),
+      'https://archive.mozilla.org/pub/firefox/releases/111.0.1/mac/en-US/Firefox 111.0.1.dmg'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.MAC_ARM, 'stable_111.0.1'),
+      'https://archive.mozilla.org/pub/firefox/releases/111.0.1/mac/en-US/Firefox 111.0.1.dmg'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.WIN32, 'stable_111.0.1'),
+      'https://archive.mozilla.org/pub/firefox/releases/111.0.1/win32/en-US/Firefox Setup 111.0.1.exe'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.WIN64, 'stable_111.0.1'),
+      'https://archive.mozilla.org/pub/firefox/releases/111.0.1/win64/en-US/Firefox Setup 111.0.1.exe'
+    );
+  });
+
+  it('should resolve download URLs for devedition', () => {
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.LINUX, 'devedition_115.0b8'),
+      'https://archive.mozilla.org/pub/devedition/releases/115.0b8/linux-x86_64/en-US/firefox-115.0b8.tar.bz2'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.MAC, 'devedition_115.0b8'),
+      'https://archive.mozilla.org/pub/devedition/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.MAC_ARM, 'devedition_115.0b8'),
+      'https://archive.mozilla.org/pub/devedition/releases/115.0b8/mac/en-US/Firefox 115.0b8.dmg'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.WIN32, 'devedition_115.0b8'),
+      'https://archive.mozilla.org/pub/devedition/releases/115.0b8/win32/en-US/Firefox Setup 115.0b8.exe'
+    );
+    assert.strictEqual(
+      resolveDownloadUrl(BrowserPlatform.WIN64, 'devedition_115.0b8'),
+      'https://archive.mozilla.org/pub/devedition/releases/115.0b8/win64/en-US/Firefox Setup 115.0b8.exe'
     );
   });
 

--- a/test/installation/src/puppeteer-firefox.spec.ts
+++ b/test/installation/src/puppeteer-firefox.spec.ts
@@ -5,6 +5,8 @@
  */
 
 import assert from 'assert';
+import {spawnSync} from 'child_process';
+import {existsSync} from 'fs';
 import {readdir} from 'fs/promises';
 import {platform} from 'os';
 import {join} from 'path';
@@ -49,3 +51,36 @@ import {readAsset} from './util.js';
     });
   }
 );
+
+describe('Firefox download', () => {
+  configureSandbox({
+    dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
+    env: cwd => {
+      return {
+        PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
+        PUPPETEER_SKIP_DOWNLOAD: 'true',
+      };
+    },
+  });
+
+  it('can download Firefox stable', async function () {
+    assert.ok(!existsSync(join(this.sandbox, '.cache', 'puppeteer')));
+    const result = spawnSync(
+      'npx',
+      ['puppeteer', 'browsers', 'install', 'firefox@stable'],
+      {
+        // npx is not found without the shell flag on Windows.
+        shell: process.platform === 'win32',
+        cwd: this.sandbox,
+        env: {
+          ...process.env,
+          PUPPETEER_CACHE_DIR: join(this.sandbox, '.cache', 'puppeteer'),
+        },
+      }
+    );
+    assert.strictEqual(result.status, 0);
+    const files = await readdir(join(this.sandbox, '.cache', 'puppeteer'));
+    assert.equal(files.length, 1);
+    assert.equal(files[0], 'firefox');
+  });
+});


### PR DESCRIPTION
This PR adds support for the following commands:

```
npx @puppeteer/browsers install firefox@stable --path /tmp/test
npx @puppeteer/browsers install firefox@devedition --path /tmp/test
npx @puppeteer/browsers install firefox@beta --path /tmp/test
npx @puppeteer/browsers install firefox@esr --path /tmp/test
npx @puppeteer/browsers install firefox@nightly --path /tmp/test
```

To distinguish between different channels with the same version, the channel name is prepended to the `buildId` used by Puppeteer. Unprefixed versions are all considered to be nightly versions.

Closes #10420