### PR TITLE
fix(webdriver): emit CDP events

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -467,11 +467,11 @@ export class BidiFrame extends Frame {
   }
 
   async createCDPSession(): Promise<CDPSession> {
-    await this.browsingContext.subscribe([Bidi.ChromiumBidi.BiDiModule.Cdp]);
     const {sessionId} = await this.client.send('Target.attachToTarget', {
       targetId: this._id,
       flatten: true,
     });
+    await this.browsingContext.subscribe([Bidi.ChromiumBidi.BiDiModule.Cdp]);
     return new BidiCdpSession(this, sessionId);
   }
 

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -467,6 +467,7 @@ export class BidiFrame extends Frame {
   }
 
   async createCDPSession(): Promise<CDPSession> {
+    await this.browsingContext.subscribe([Bidi.ChromiumBidi.BiDiModule.Cdp]);
     const {sessionId} = await this.client.send('Target.attachToTarget', {
       targetId: this._id,
       flatten: true,

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -539,6 +539,14 @@ export class BrowsingContext extends EventEmitter<{
     });
   }
 
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
+  async subscribe(events: string[]): Promise<void> {
+    await this.#session.subscribe(events, [this.id]);
+  }
+
   [disposeSymbol](): void {
     this.#reason ??=
       'Browsing context already closed, probably because the user context closed.';

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -163,9 +163,10 @@ export class Session
     // SAFETY: By definition of `disposed`, `#reason` is defined.
     return session.#reason!;
   })
-  async subscribe(events: string[]): Promise<void> {
+  async subscribe(events: string[], contexts?: string[]): Promise<void> {
     await this.send('session.subscribe', {
       events,
+      contexts,
     });
   }
 


### PR DESCRIPTION
We need to subscribe to the `cdp` module so `BiDi+` events are emitted.
Requires https://github.com/GoogleChromeLabs/chromium-bidi/pull/1979 to be merged.