### PR TITLE
test: improve `target.asPage` tests

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2458,7 +2458,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
     };
     if (options.type === undefined && options.path !== undefined) {
       const filePath = options.path;
-      // Note we cannot use Node.js here due to browser compatability.
+      // Note we cannot use Node.js here due to browser compatibility.
       const extension = filePath
         .slice(filePath.lastIndexOf('.') + 1)
         .toLowerCase();

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -363,14 +363,14 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[devtools.spec] DevTools target.page() should return Page when calling asPage on DevTools target",
+    "testIdPattern": "[devtools.spec] DevTools target.page() should return a DevTools page if custom isPageTarget is provided",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[devtools.spec] DevTools target.page() should return a DevTools page if custom isPageTarget is provided",
+    "testIdPattern": "[devtools.spec] DevTools target.page() should return Page when calling asPage on DevTools target",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
@@ -3831,14 +3831,14 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[devtools.spec] DevTools target.page() should return Page when calling asPage on DevTools target",
+    "testIdPattern": "[devtools.spec] DevTools target.page() should return a DevTools page if custom isPageTarget is provided",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[devtools.spec] DevTools target.page() should return a DevTools page if custom isPageTarget is provided",
+    "testIdPattern": "[devtools.spec] DevTools target.page() should return Page when calling asPage on DevTools target",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["SKIP"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -363,7 +363,7 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[devtools.spec] DevTools target.page() should return a DevTools page if asPage is used",
+    "testIdPattern": "[devtools.spec] DevTools target.page() should return Page when calling asPage on DevTools target",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
@@ -3831,7 +3831,7 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[devtools.spec] DevTools target.page() should return a DevTools page if asPage is used",
+    "testIdPattern": "[devtools.spec] DevTools target.page() should return Page when calling asPage on DevTools target",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["SKIP"],

--- a/test/src/cdp/devtools.spec.ts
+++ b/test/src/cdp/devtools.spec.ts
@@ -69,7 +69,7 @@ describe('DevTools', function () {
     ).toBe(6);
     expect(await browser.pages()).toContain(page);
   });
-  it('target.page() should return a DevTools page if asPage is used', async function () {
+  it('target.page() should return Page when calling asPage on DevTools target', async function () {
     const {puppeteer} = await getTestState({skipLaunch: true});
     const originalBrowser = await launchBrowser(launchOptions);
 

--- a/test/src/cdp/devtools.spec.ts
+++ b/test/src/cdp/devtools.spec.ts
@@ -67,7 +67,7 @@ describe('DevTools', function () {
         return 2 * 3;
       })
     ).toBe(6);
-    expect(await browser.pages()).toContainEqual(page);
+    expect(await browser.pages()).toContain(page);
   });
   it('target.page() should return a DevTools page if asPage is used', async function () {
     const {puppeteer} = await getTestState({skipLaunch: true});
@@ -87,7 +87,8 @@ describe('DevTools', function () {
         return 2 * 3;
       })
     ).toBe(6);
-    expect(await browser.pages()).toContainEqual(page);
+    // The page won't be part of browser.pages() if a custom isPageTarget is not provided
+    expect(await browser.pages()).not.toContain(page);
   });
   it('should open devtools when "devtools: true" option is given', async () => {
     const browser = await launchBrowser(


### PR DESCRIPTION
Some tests in the `devtools.spec.ts` file used `toContainEqual` to look for a page in `browser.pages()`.
The problem with `toContainEqual` is that it compares field by field. And jest is only finding two fields, `_isDragging` and `_timeoutSettings`, matching pages that are not technically equal.

Based on that, I change the `target.page() should return a DevTools page if asPage is used` test because `browser.pages()` won't return the devtools page without a custom `isPageTarget` function.
