### PR TITLE
test: do not check for secure field in test for delete cookies

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1250,13 +1250,6 @@
   {
     "testIdPattern": "[cookies.spec] Cookie specs Page.deleteCookie should not delete cookie for different domain",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox default partition key is inconsistent: #12004"
-  },
-  {
-    "testIdPattern": "[cookies.spec] Cookie specs Page.deleteCookie should not delete cookie for different domain",
-    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Not supported with cdp"

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -618,7 +618,6 @@ describe('Cookie specs', () => {
           expires: -1,
           size: 51,
           httpOnly: false,
-          secure: true,
           session: true,
           sourceScheme: 'Secure',
         },


### PR DESCRIPTION
Similar to the changes in #12039, checking for `secure` field being `true` will not be compatible with Firefox.

Note: the test will not pass yet for Firefox. **Update:** It passes now.
