### PR TITLE
Update install.mjs

### DIFF
--- a/packages/puppeteer/install.mjs
+++ b/packages/puppeteer/install.mjs
@@ -28,7 +28,7 @@ async function importInstaller() {
 }
 
 try {
-  const {downloadBrowser} = await importInstaller();
+  const {downloadBrowser} = importInstaller();
   downloadBrowser();
 } catch (error) {
   console.warn('Browser download failed', error);


### PR DESCRIPTION
The moment we are trying to install the latest version it is giving an error of 
  const {downloadBrowser} = await importInstaller();
                            ^^^^^

SyntaxError: await is only valid in async function

So fixed that