### PR TITLE
test: verify closing last page does not close connection

### DIFF
--- a/test/src/browser.spec.ts
+++ b/test/src/browser.spec.ts
@@ -6,7 +6,7 @@
 
 import expect from 'expect';
 
-import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+import {getTestState, launch, setupTestBrowserHooks} from './mocha-utils.js';
 
 describe('Browser specs', function () {
   setupTestBrowserHooks();
@@ -63,6 +63,23 @@ describe('Browser specs', function () {
       });
       expect(remoteBrowser.process()).toBe(null);
       await remoteBrowser.disconnect();
+    });
+    it('should keep connected after the last page is closed', async () => {
+      const {browser, close} = await launch({}, {createContext: false});
+      try {
+        const pages = await browser.pages();
+        await Promise.all(
+          pages.map(page => {
+            return page.close();
+          })
+        );
+        // Verify the browser is still connected.
+        expect(browser.connected).toBe(true);
+        // Verify the browser can open a new page.
+        await browser.newPage();
+      } finally {
+        await close();
+      }
     });
   });
 

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -18,7 +18,7 @@ import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage
 import {Deferred} from 'puppeteer-core/internal/util/Deferred.js';
 import sinon from 'sinon';
 
-import {getTestState, launch, setupTestBrowserHooks} from './mocha-utils.js';
+import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {attachFrame, detachFrame, isFavicon, waitEvent} from './utils.js';
 
 describe('Page', function () {
@@ -109,28 +109,6 @@ describe('Page', function () {
           'Frame detached',
         ]);
         expect(message).not.toContain('Timeout');
-      }
-    });
-    it('closing last tab should not close the browser', async () => {
-      // This test asserts the behavior is consistent between protocols and browsers.
-      // WebDriver Classic requires the session to be closed after the last page is
-      // closed: https://w3c.github.io/webdriver/#dfn-close-window.
-      // WebDriver BiDi does not specify behavior for closing the last page:
-      // https://github.com/w3c/webdriver-bidi/issues/187
-      const {browser, close} = await launch({}, {createContext: false});
-      try {
-        const pages = await browser.pages();
-        await Promise.all(
-          pages.map(page => {
-            return page.close();
-          })
-        );
-        // Verify the browser is still connected.
-        expect(browser.isConnected()).toBe(true);
-        // Verify the browser can open a new page.
-        await browser.newPage();
-      } finally {
-        await close();
       }
     });
   });


### PR DESCRIPTION
Add test to verify behavior consistency between browsers and protocols. 

Required for [Specify behavior for `browsingContext.close` when closing the last browsing context · Issue #187 · w3c/webdriver-bidi](https://github.com/w3c/webdriver-bidi/issues/187)