### PR TITLE
fix: don't keep connection alive after redirect

### DIFF
--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -54,6 +54,8 @@ export function httpRequest(
       res.headers.location
     ) {
       httpRequest(new URL(res.headers.location), method, response);
+      // consume response data to free up memory
+      // And prevents the connection from being kept alive
       res.resume();
     } else {
       response(res);

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -46,12 +46,7 @@ export function httpRequest(
     agent: new ProxyAgent(),
   };
 
-  const request =
-    options.protocol === 'https:'
-      ? https.request(options, requestCallback)
-      : http.request(options, requestCallback);
-
-  function requestCallback(res: http.IncomingMessage) {
+  const requestCallback = (res: http.IncomingMessage): void => {
     if (
       res.statusCode &&
       res.statusCode >= 300 &&
@@ -59,12 +54,15 @@ export function httpRequest(
       res.headers.location
     ) {
       httpRequest(new URL(res.headers.location), method, response);
-      // Destroy the request to allow the connection to close
-      request.destroy();
+      res.resume();
     } else {
       response(res);
     }
-  }
+  };
+  const request =
+    options.protocol === 'https:'
+      ? https.request(options, requestCallback)
+      : http.request(options, requestCallback);
   request.end();
   return request;
 }


### PR DESCRIPTION
When we redirect the request we need to resume the initial response else it may lead to keeping the connection open forever.