### PR TITLE
fix: reload should not resolve early on fragment navigations

### DIFF
--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -63,6 +63,10 @@ export interface WaitForOptions {
    * @defaultValue `'load'`
    */
   waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
+  /**
+   * @internal
+   */
+  ignoreSameDocumentNavigation?: boolean;
 }
 
 /**

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -206,6 +206,7 @@ export class CdpFrame extends Frame {
     options: {
       timeout?: number;
       waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
+      ignoreSameDocumentNavigation?: boolean;
     } = {}
   ): Promise<HTTPResponse | null> {
     const {
@@ -220,7 +221,9 @@ export class CdpFrame extends Frame {
     );
     const error = await Deferred.race([
       watcher.terminationPromise(),
-      watcher.sameDocumentNavigationPromise(),
+      ...(options.ignoreSameDocumentNavigation
+        ? []
+        : [watcher.sameDocumentNavigationPromise()]),
       watcher.newDocumentNavigationPromise(),
     ]);
     try {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -916,7 +916,10 @@ export class CdpPage extends Page {
     options?: WaitForOptions
   ): Promise<HTTPResponse | null> {
     const [result] = await Promise.all([
-      this.waitForNavigation(options),
+      this.waitForNavigation({
+        ...options,
+        ignoreSameDocumentNavigation: true,
+      }),
       this.#primaryTargetClient.send('Page.reload'),
     ]);
 

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -112,6 +112,27 @@ describe('navigation', function () {
       const response = await page.goto(server.PREFIX + '/grid.html');
       expect(response!.status()).toBe(200);
     });
+    it('should work when reload causes history API in beforeunload', async () => {
+      const {page, server} = await getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      await page.evaluate(() => {
+        window.addEventListener(
+          'beforeunload',
+          () => {
+            return history.replaceState(null, 'initial', window.location.href);
+          },
+          false
+        );
+      });
+      await page.reload();
+      // Evaluate still works.
+      expect(
+        await page.evaluate(() => {
+          return 1;
+        })
+      ).toBe(1);
+    });
     it('should navigate to empty page with networkidle0', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
Reload would always trigger a new document navigation so it should wait for it instead of potential intermediate same-document navigations. 

Closes https://github.com/puppeteer/puppeteer/issues/10435