### PR TITLE
chore(deps): Bump chromium-bidi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12181,7 +12181,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.2.0",
-        "chromium-bidi": "0.5.13",
+        "chromium-bidi": "0.5.14",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1262051",
         "ws": "8.16.0"
@@ -12204,9 +12204,9 @@
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.13.tgz",
-      "integrity": "sha512-OHbYCetDxdW/xmlrafgOiLsIrw4Sp1BEeolbZ1UGJO5v/nekQOJBj/Kzyw6sqKcAVabUTo0GS3cTYgr6zIf00g==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.14.tgz",
+      "integrity": "sha512-zm4mX61/U4KXs+S/0WIBHpOWqtpW6FPv1i7n4UZqDDc5LOQ9/Y1MAnB95nO7i/lFFuijLjpe1XMdNcqDqwlH5w==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -120,7 +120,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.2.0",
-    "chromium-bidi": "0.5.13",
+    "chromium-bidi": "0.5.14",
     "debug": "4.3.4",
     "devtools-protocol": "0.0.1262051",
     "ws": "8.16.0"


### PR DESCRIPTION
Bumps the dependencies group with 1 updates: [chromium-bidi](https://github.com/GoogleChromeLabs/chromium-bidi).

Updates `chromium-bidi` from 0.5.13 to 0.5.14
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/GoogleChromeLabs/chromium-bidi/releases">chromium-bidi's releases</a>.</em></p>
<blockquote>
<h2>chromium-bidi: v0.5.14</h2>
<h2><a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.13...chromium-bidi-v0.5.14">0.5.14</a> (2024-03-21)</h2>
<h3>Features</h3>
<ul>
<li>support <code>innerText</code> locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1988">#1988</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/8c415827ce62705184e920899cf4846a9fee71e0">8c41582</a>)</li>
<li>support <code>maxDepth</code> and <code>serializationOptions</code> in <code>browsingContext.locateNodes</code> (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2048">#2048</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/eca1e061f16abbaeafdcc57455e200dc68a0e224">eca1e06</a>)</li>
<li>support <code>maxNodeCount</code> in locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2040">#2040</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/ba68a852c9540f73605b28f7a1d9f2c3f63bca92">ba68a85</a>)</li>
<li>support <code>startNodes</code> in locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2042">#2042</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/62d58a9cf5dc59e768380c667f7dda7840b7175d">62d58a9</a>)</li>
<li>support userContext is setPermission (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2033">#2033</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/31865769195174da1fbcc15cc9632c5fcf8c7f25">3186576</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li>CDP quirkiness with intercept (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2021">#2021</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/8890fb0fa51ca4cc3bb15afc8eef9024dc6e77e2">8890fb0</a>)</li>
<li>check bidiValue before using (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2039">#2039</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/61544207d39a883c2558681b96df36637a32bed2">6154420</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/GoogleChromeLabs/chromium-bidi/blob/main/CHANGELOG.md">chromium-bidi's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.13...chromium-bidi-v0.5.14">0.5.14</a> (2024-03-21)</h2>
<h3>Features</h3>
<ul>
<li>support <code>innerText</code> locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1988">#1988</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/8c415827ce62705184e920899cf4846a9fee71e0">8c41582</a>)</li>
<li>support <code>maxDepth</code> and <code>serializationOptions</code> in <code>browsingContext.locateNodes</code> (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2048">#2048</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/eca1e061f16abbaeafdcc57455e200dc68a0e224">eca1e06</a>)</li>
<li>support <code>maxNodeCount</code> in locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2040">#2040</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/ba68a852c9540f73605b28f7a1d9f2c3f63bca92">ba68a85</a>)</li>
<li>support <code>startNodes</code> in locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2042">#2042</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/62d58a9cf5dc59e768380c667f7dda7840b7175d">62d58a9</a>)</li>
<li>support userContext is setPermission (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2033">#2033</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/31865769195174da1fbcc15cc9632c5fcf8c7f25">3186576</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li>CDP quirkiness with intercept (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2021">#2021</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/8890fb0fa51ca4cc3bb15afc8eef9024dc6e77e2">8890fb0</a>)</li>
<li>check bidiValue before using (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2039">#2039</a>) (<a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/61544207d39a883c2558681b96df36637a32bed2">6154420</a>)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/902dc642f29ba5abd5bea428932aa81504e1a204"><code>902dc64</code></a> chore(main): release chromium-bidi 0.5.14 (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2025">#2025</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/eca1e061f16abbaeafdcc57455e200dc68a0e224"><code>eca1e06</code></a> feat: support <code>maxDepth</code> and <code>serializationOptions</code> in `browsingContext.locat...</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/f886dab630fabb35d8cfef60336d9bdfe96d9f3b"><code>f886dab</code></a> chore: add wpt hash to runner (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2051">#2051</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/0e7b4710fba0892e78e8050bca89041c9919da5c"><code>0e7b471</code></a> chore: add chrome version to website (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2047">#2047</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/c3e29d1f1b660f0292b29362ce48c3386e6e2c62"><code>c3e29d1</code></a> build(deps): Bump wpt from <code>d17b37c</code> to <code>cc48615</code> (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2043">#2043</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/df62cb592ab4f7eb02ad906ab0e44695d1029d3e"><code>df62cb5</code></a> chore: less local output (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2046">#2046</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/62d58a9cf5dc59e768380c667f7dda7840b7175d"><code>62d58a9</code></a> feat: support <code>startNodes</code> in locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2042">#2042</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/ba68a852c9540f73605b28f7a1d9f2c3f63bca92"><code>ba68a85</code></a> feat: support <code>maxNodeCount</code> in locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2040">#2040</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/8c415827ce62705184e920899cf4846a9fee71e0"><code>8c41582</code></a> feat: support <code>innerText</code> locators (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/1988">#1988</a>)</li>
<li><a href="https://github.com/GoogleChromeLabs/chromium-bidi/commit/61544207d39a883c2558681b96df36637a32bed2"><code>6154420</code></a> fix: check bidiValue before using (<a href="https://redirect.github.com/GoogleChromeLabs/chromium-bidi/issues/2039">#2039</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v0.5.13...chromium-bidi-v0.5.14">compare view</a></li>
</ul>
</details>
<br />
