### PR TITLE
chore: don't detach CdpSession

### DIFF
--- a/packages/puppeteer-core/src/bidi/CDPSession.ts
+++ b/packages/puppeteer-core/src/bidi/CDPSession.ts
@@ -21,7 +21,7 @@ export class BidiCdpSession extends CDPSession {
   static sessions = new Map<string, BidiCdpSession>();
 
   #detached = false;
-  readonly #connection: BidiConnection | undefined = undefined;
+  readonly #connection?: BidiConnection;
   readonly #sessionId = Deferred.create<string>();
   readonly frame: BidiFrame;
 
@@ -41,11 +41,11 @@ export class BidiCdpSession extends CDPSession {
     } else {
       (async () => {
         try {
-          const session = await connection.send('cdp.getSession', {
+          const {result} = await connection.send('cdp.getSession', {
             context: frame._id,
           });
-          this.#sessionId.resolve(session.result.session!);
-          BidiCdpSession.sessions.set(session.result.session!, this);
+          this.#sessionId.resolve(result.session!);
+          BidiCdpSession.sessions.set(result.session!, this);
         } catch (error) {
           this.#sessionId.reject(error as Error);
         }
@@ -89,13 +89,29 @@ export class BidiCdpSession extends CDPSession {
   }
 
   override async detach(): Promise<void> {
-    if (this.#connection === undefined || this.#detached) {
+    if (
+      this.#connection === undefined ||
+      this.#connection.closed ||
+      this.#detached
+    ) {
       return;
     }
+    try {
+      await this.frame.client.send('Target.detachFromTarget', {
+        sessionId: this.id(),
+      });
+    } finally {
+      this.onClose();
+    }
+  }
 
+  /**
+   * @internal
+   */
+  onClose = (): void => {
     BidiCdpSession.sessions.delete(this.id());
     this.#detached = true;
-  }
+  };
 
   override id(): string {
     const value = this.#sessionId.value();

--- a/packages/puppeteer-core/src/bidi/CDPSession.ts
+++ b/packages/puppeteer-core/src/bidi/CDPSession.ts
@@ -92,14 +92,9 @@ export class BidiCdpSession extends CDPSession {
     if (this.#connection === undefined || this.#detached) {
       return;
     }
-    try {
-      await this.frame.client.send('Target.detachFromTarget', {
-        sessionId: this.id(),
-      });
-    } finally {
-      BidiCdpSession.sessions.delete(this.id());
-      this.#detached = true;
-    }
+
+    BidiCdpSession.sessions.delete(this.id());
+    this.#detached = true;
   }
 
   override id(): string {

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -106,7 +106,7 @@ export class BidiFrame extends Frame {
     this.browsingContext.on('closed', () => {
       for (const session of BidiCdpSession.sessions.values()) {
         if (session.frame === this) {
-          void session.detach().catch(debugError);
+          session.onClose();
         }
       }
       this.page().trustedEmitter.emit(PageEvent.FrameDetached, this);


### PR DESCRIPTION
Allow the Mapper to handle it's own clean-up, else w get errors in the logs + we send too many commands.
Users should clean the CdpSession on their own if created via `createCDPSession`