### PR TITLE
chore: Remove workaround for Firefox addIntercept contexts argument

### DIFF
--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -185,11 +185,6 @@ export class BidiBrowserContext extends BrowserContext {
     }
 
     try {
-      for (const page of await this.pages()) {
-        // Workaround for Firefox
-        // TODO: Remove once https://bugzilla.mozilla.org/show_bug.cgi?id=1882260 is fixed
-        await page.setRequestInterception(false);
-      }
       await this.userContext.remove();
     } catch (error) {
       debugError(error);

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -202,11 +202,6 @@ export class BidiPage extends Page {
 
   override async close(options?: {runBeforeUnload?: boolean}): Promise<void> {
     try {
-      if (this.#interception) {
-        // Workaround for Firefox
-        // TODO: Remove once https://bugzilla.mozilla.org/show_bug.cgi?id=1882260 is fixed
-        await this.setRequestInterception(false);
-      }
       await this.#frame.browsingContext.close(options?.runBeforeUnload);
     } catch {
       return;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1882260 has been fixed and should be in the latest Nightly.