### PR TITLE
docs: remove obsolete page.target() from CDPSession doc

### DIFF
--- a/docs/api/puppeteer.cdpsession.md
+++ b/docs/api/puppeteer.cdpsession.md
@@ -25,7 +25,7 @@ The constructor for this class is marked as internal. Third-party code should no
 ## Example
 
 ```ts
-const client = await page.target().createCDPSession();
+const client = await page.createCDPSession();
 await client.send('Animation.enable');
 client.on('Animation.animationCreated', () =>
   console.log('Animation created!')

--- a/packages/puppeteer-core/src/api/CDPSession.ts
+++ b/packages/puppeteer-core/src/api/CDPSession.ts
@@ -74,7 +74,7 @@ export interface CommandOptions {
  * @example
  *
  * ```ts
- * const client = await page.target().createCDPSession();
+ * const client = await page.createCDPSession();
  * await client.send('Animation.enable');
  * client.on('Animation.animationCreated', () =>
  *   console.log('Animation created!')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

documentation fix

**Summary**

The code example on the [CDPSession doc](https://pptr.dev/api/puppeteer.cdpsession) uses `page.target().createCDPSession()`:

```js
const client = await page.target().createCDPSession();
await client.send('Animation.enable');
client.on('Animation.animationCreated', () =>
  console.log('Animation created!')
);
const response = await client.send('Animation.getPlaybackRate');
console.log('playback rate is ' + response.playbackRate);
await client.send('Animation.setPlaybackRate', {
  playbackRate: response.playbackRate / 2,
});
```

However according to the [Page.target()](https://pptr.dev/api/puppeteer.page.target) doc, the API is obsolete. It recommends using [Page.createCDPSession()](https://pptr.dev/api/puppeteer.page.createcdpsession) directly.

This PR updates the example in the CDPSession doc to use `page.createCDPSession()` directly.