### PR TITLE
refactor: remove deferred from addScriptTag

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -649,7 +649,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
     "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "See https://github.com/puppeteer/puppeteer/issues/4840"
   },
   {
     "testIdPattern": "[page.spec] Page Page.addStyleTag should throw when added with content to the CSP page",
@@ -3010,7 +3010,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome"],
     "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "See https://github.com/puppeteer/puppeteer/issues/4840"
   },
   {
     "testIdPattern": "[page.spec] Page Page.addScriptTag should throw when added with content to the CSP page",


### PR DESCRIPTION
It saves a large script eval. Drive-by: restructured event listeners.