### PR TITLE
fix(webdriver): request redirect chain

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -403,10 +403,7 @@ export class BidiFrame extends Frame {
             return null;
           }
           const httpRequest = requests.get(request)!;
-          const lastRedirect = httpRequest.redirectChain().at(-1);
-          return (
-            lastRedirect !== undefined ? lastRedirect : httpRequest
-          ).response();
+          return httpRequest.response();
         }),
         raceWith(
           timeout(ms),

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -402,7 +402,8 @@ export class BidiFrame extends Frame {
           if (!request) {
             return null;
           }
-          const httpRequest = requests.get(request)!;
+          const lastRequest = request.lastRedirect ?? request;
+          const httpRequest = requests.get(lastRequest)!;
           return httpRequest.response();
         }),
         raceWith(

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -66,8 +66,8 @@ export class BidiHTTPRequest extends HTTPRequest {
 
   #initialize() {
     this.#request.on('redirect', request => {
-      BidiHTTPRequest.from(request, this.#frame, this);
-      void this.#redirect.finalizeInterceptions();
+      const httpRequest = BidiHTTPRequest.from(request, this.#frame, this);
+      void httpRequest.finalizeInterceptions();
     });
     this.#request.once('success', data => {
       this.#response = BidiHTTPResponse.from(data, this);

--- a/packages/puppeteer-core/src/bidi/core/Request.ts
+++ b/packages/puppeteer-core/src/bidi/core/Request.ts
@@ -135,6 +135,16 @@ export class Request extends EventEmitter<{
   get redirect(): Request | undefined {
     return this.#redirect;
   }
+  get lastRedirect(): Request | undefined {
+    let redirect = this.#redirect;
+    while (redirect) {
+      if (redirect && !redirect.#redirect) {
+        return redirect;
+      }
+      redirect = redirect.#redirect;
+    }
+    return redirect;
+  }
   get response(): Bidi.Network.ResponseData | undefined {
     return this.#response;
   }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -834,13 +834,6 @@
     "comment": "TODO: Needs full support for continueResponse in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1853887"
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Request.respond should redirect",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Puppeteer request.redirectChain issue"
-  },
-  {
     "testIdPattern": "[requestinterception.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -3744,13 +3737,6 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["PASS"]
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Request.respond should redirect",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Puppeteer request.redirectChain issue"
   },
   {
     "testIdPattern": "[screenshot.spec] Screenshots Cdp should use scale for clip",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3551,13 +3551,6 @@
     "expectations": ["PASS"]
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Request.respond should redirect",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Firefox does not support headers in provideResponse"
-  },
-  {
     "testIdPattern": "[requestinterception-experimental.spec] request interception \"after each\" hook in \"request interception\"",
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome"],


### PR DESCRIPTION
HTTPRequest should be backwards facing, while `(BiDi)Request` is only forward facing.
Time ====>
`(BiDi)Request` -(ref)-> `(BiDi)Request`  -(ref)-> `(BiDi)Request`
`HTTPRequest`  <-(ref)- `HTTPRequest` <-(ref)- `HTTPRequest`

This still means that if you were to get the first HTTPRequest you can't get the last request from the chain