### PR TITLE
fix: wait for fonts before pdf printing

### DIFF
--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -321,6 +321,17 @@ export class BidiPage extends Page {
       preferCSSPageSize,
     } = parsePDFOptions(options, 'cm');
     const pageRanges = ranges ? ranges.split(', ') : [];
+
+    await firstValueFrom(
+      from(
+        this.mainFrame()
+          .isolatedRealm()
+          .evaluate(() => {
+            return document.fonts.ready;
+          })
+      ).pipe(raceWith(timeout(ms)))
+    );
+
     const data = await firstValueFrom(
       from(
         this.#frame.browsingContext.print({

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -1133,6 +1133,16 @@ export class CdpPage extends Page {
       await this.#emulationManager.setTransparentBackgroundColor();
     }
 
+    await firstValueFrom(
+      from(
+        this.mainFrame()
+          .isolatedRealm()
+          .evaluate(() => {
+            return document.fonts.ready;
+          })
+      ).pipe(raceWith(timeout(ms)))
+    );
+
     const printCommandPromise = this.#primaryTargetClient.send(
       'Page.printToPDF',
       {


### PR DESCRIPTION
This PR adds a command to always wait for the web fonts readiness before generating a PDF.

Closes https://github.com/puppeteer/puppeteer/issues/3183
