### PR TITLE
fix: deprecate configuration via package.json

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -36,9 +36,6 @@ Puppeteer will look up the file tree for any of the following formats:
 - `puppeteer.config.js`, and
 - `puppeteer.config.cjs`
 
-Puppeteer will also read a `puppeteer` key from your application's
-`package.json`.
-
 See the [`Configuration`](../api/puppeteer.configuration) interface for possible
 options.
 
@@ -46,6 +43,13 @@ options.
 
 After adding a configuration file, you may need to remove and reinstall
 `puppeteer` for it to take effect if the changes affect installation.
+
+:::
+
+:::caution
+
+Previous versions of Puppeteer allowed configuration via the `config` key in
+`package.json`. This behavior is now deprecated and will be removed in the future.
 
 :::
 

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -127,6 +127,17 @@ export const getConfiguration = (): Configuration => {
       downloadHost;
   }
 
+  if (
+    Object.keys(process.env).some(key => {
+      return key.startsWith('npm_package_config_puppeteer_');
+    }) &&
+    configuration.logLevel === 'warn'
+  ) {
+    console.warn(
+      `Configuring Puppeteer via npm/package.json is deprecated. Use https://pptr.dev/guides/configuration instead.`
+    );
+  }
+
   configuration.cacheDirectory =
     process.env['PUPPETEER_CACHE_DIR'] ??
     process.env['npm_config_puppeteer_cache_dir'] ??


### PR DESCRIPTION
npm configs are not consistently working after https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md

Issue https://github.com/puppeteer/puppeteer/issues/10757