### PR TITLE
fix: providing null to page.authenticate should disable authentication

### DIFF
--- a/docs/api/puppeteer.page.authenticate.md
+++ b/docs/api/puppeteer.page.authenticate.md
@@ -10,7 +10,7 @@ Provide credentials for `HTTP authentication`.
 
 ```typescript
 class Page {
-  abstract authenticate(credentials: Credentials): Promise<void>;
+  abstract authenticate(credentials: Credentials | null): Promise<void>;
 }
 ```
 
@@ -35,7 +35,7 @@ credentials
 
 </td><td>
 
-[Credentials](./puppeteer.credentials.md)
+[Credentials](./puppeteer.credentials.md) \| null
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -523,6 +523,14 @@ export interface PageEvents extends Record<EventType, unknown> {
 /**
  * @public
  */
+export interface Credentials {
+  username: string;
+  password: string;
+}
+
+/**
+ * @public
+ */
 export interface NewDocumentScriptEvaluation {
   identifier: string;
 }
@@ -1420,7 +1428,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @remarks
    * To disable authentication, pass `null`.
    */
-  abstract authenticate(credentials: Credentials): Promise<void>;
+  abstract authenticate(credentials: Credentials | null): Promise<void>;
 
   /**
    * The extra HTTP headers will be sent with every request the page initiates.

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -523,14 +523,6 @@ export interface PageEvents extends Record<EventType, unknown> {
 /**
  * @public
  */
-export interface Credentials {
-  username: string;
-  password: string;
-}
-
-/**
- * @public
- */
 export interface NewDocumentScriptEvaluation {
   identifier: string;
 }

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -64,7 +64,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #frameManager: FrameProvider;
   #networkEventManager = new NetworkEventManager();
   #extraHTTPHeaders?: Record<string, string>;
-  #credentials?: Credentials;
+  #credentials: Credentials | null = null;
   #attemptedAuthentications = new Set<string>();
   #userRequestInterceptionEnabled = false;
   #protocolRequestInterceptionEnabled = false;
@@ -121,7 +121,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     this.#clients.delete(client);
   }
 
-  async authenticate(credentials?: Credentials): Promise<void> {
+  async authenticate(credentials: Credentials | null): Promise<void> {
     this.#credentials = credentials;
     const enabled = this.#userRequestInterceptionEnabled || !!this.#credentials;
     if (enabled === this.#protocolRequestInterceptionEnabled) {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -743,7 +743,7 @@ export class CdpPage extends Page {
     this.#bindings.delete(name);
   }
 
-  override async authenticate(credentials: Credentials): Promise<void> {
+  override async authenticate(credentials: Credentials | null): Promise<void> {
     return await this.#frameManager.networkManager.authenticate(credentials);
   }
 

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -751,10 +751,7 @@ describe('network', function () {
       });
       let response = (await page.goto(server.EMPTY_PAGE))!;
       expect(response.status()).toBe(200);
-      await page.authenticate({
-        username: '',
-        password: '',
-      });
+      await page.authenticate(null);
       // Navigate to a different origin to bust Chrome's credential caching.
       try {
         response = (await page.goto(


### PR DESCRIPTION
Aligns with our documentation that tell's we  can use `null` to disable,
Providing `user/pass` with `undefined` did not disable the `Fetch` domain as it should.

