### PR TITLE
fix: do not use fallback download URLs if custom baseUrl is provided

### DIFF
--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -92,6 +92,11 @@ export interface InstallOptions {
    * @defaultValue `true`
    */
   unpack?: boolean;
+  /**
+   * @internal
+   * @defaultValue `false`
+   */
+  forceFallbackForTesting?: boolean;
 }
 
 /**
@@ -125,6 +130,10 @@ export async function install(
   try {
     return await installUrl(url, options);
   } catch (err) {
+    // If custom baseUrl is provided, do not fall back to CfT dashboard.
+    if (options.baseUrl && !options.forceFallbackForTesting) {
+      throw err;
+    }
     debugInstall(`Error downloading from ${url}.`);
     switch (options.browser) {
       case Browser.CHROME:

--- a/packages/browsers/test/src/chrome/install.spec.ts
+++ b/packages/browsers/test/src/chrome/install.spec.ts
@@ -151,6 +151,7 @@ describe('Chrome install', () => {
       platform: BrowserPlatform.LINUX,
       buildId: testChromeBuildId,
       baseUrl: 'https://127.0.0.1',
+      forceFallbackForTesting: true,
     });
     assert.strictEqual(fs.existsSync(expectedOutputPath), true);
   });


### PR DESCRIPTION
Closes https://github.com/puppeteer/puppeteer/issues/12204