### PR TITLE
refactor: include the cause into locator abort and timeout errors

### DIFF
--- a/packages/puppeteer-core/src/common/Errors.ts
+++ b/packages/puppeteer-core/src/common/Errors.ts
@@ -13,8 +13,8 @@ export class PuppeteerError extends Error {
   /**
    * @internal
    */
-  constructor(message?: string) {
-    super(message);
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = this.constructor.name;
   }
 

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -312,12 +312,12 @@ export function validateDialogType(
 /**
  * @internal
  */
-export function timeout(ms: number): Observable<never> {
+export function timeout(ms: number, cause?: Error): Observable<never> {
   return ms === 0
     ? NEVER
     : timer(ms).pipe(
         map(() => {
-          throw new TimeoutError(`Timed out after waiting ${ms}ms`);
+          throw new TimeoutError(`Timed out after waiting ${ms}ms`, {cause});
         })
       );
 }


### PR DESCRIPTION
And the cause should contain the stacktrace for where the locator call has started.

Closes https://github.com/puppeteer/puppeteer/issues/12194