### PR TITLE
chore: don't try to update angular deps automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     ignore:
       - dependency-name: devtools-protocol
       - dependency-name: '@types/node'
+      - dependency-name: '@angular-devkit/*'
     groups:
       dependencies:
         dependency-type: production


### PR DESCRIPTION
Closes #12214

The Angular deps should all be updated together else the `tsc` fails to build due to not all code path referencing the same types.
Dependabot fails to update them together for some reason. We don't release a new version unless there are major version for Angular.