### PR TITLE
fix: remove NetworkServiceInProcess2 set by default

### DIFF
--- a/packages/browsers/test/src/chrome/launch.spec.ts
+++ b/packages/browsers/test/src/chrome/launch.spec.ts
@@ -77,7 +77,6 @@ describe('Chrome', () => {
         '--disable-renderer-backgrounding',
         '--disable-sync',
         '--enable-automation',
-        '--enable-features=NetworkServiceInProcess2',
         '--export-tagged-pdf',
         '--force-color-profile=srgb',
         '--headless=new',

--- a/packages/browsers/test/src/chromium/launch.spec.ts
+++ b/packages/browsers/test/src/chromium/launch.spec.ts
@@ -77,7 +77,6 @@ describe('Chromium', () => {
         '--disable-renderer-backgrounding',
         '--disable-sync',
         '--enable-automation',
-        '--enable-features=NetworkServiceInProcess2',
         '--export-tagged-pdf',
         '--force-color-profile=srgb',
         '--headless=new',

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -192,7 +192,7 @@ export class ChromeLauncher extends ProductLauncher {
 
     // Merge default enabled features with user-provided ones, if any.
     const enabledFeatures = [
-      'NetworkServiceInProcess2',
+      // Add features to enable by default here.
       ...userEnabledFeatures,
     ].filter(feature => {
       return feature !== '';


### PR DESCRIPTION
Puppeteer has relied on this flag for a [long time](https://github.com/puppeteer/puppeteer/pull/3738) but it looks like it is not required anymore and it might lead to crashes in the latest versions of Chrome for desktop. This CL removes the flag.

Issue #12257