### PR TITLE
refactor: remove EventSubscription

### DIFF
--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -9,7 +9,7 @@ import type {Protocol} from 'devtools-protocol';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
 import type {Frame} from '../api/Frame.js';
 import type {Credentials} from '../api/Page.js';
-import {EventEmitter, EventSubscription} from '../common/EventEmitter.js';
+import {EventEmitter} from '../common/EventEmitter.js';
 import {
   NetworkManagerEvent,
   type NetworkManagerEvents,
@@ -100,14 +100,12 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     }
     const subscriptions = new DisposableStack();
     this.#clients.set(client, subscriptions);
+    const clientEmitter = subscriptions.use(new EventEmitter(client));
+
     for (const [event, handler] of this.#handlers) {
-      subscriptions.use(
-        // TODO: Remove any here.
-        new EventSubscription(client, event, (arg: any) => {
-          return handler.bind(this)(client, arg);
-        })
-      );
+      clientEmitter.on(event, handler as any);
     }
+
     await Promise.all([
       this.#ignoreHTTPSErrors
         ? client.send('Security.setIgnoreCertificateErrors', {

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -75,15 +75,21 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #userAgentMetadata?: Protocol.Emulation.UserAgentMetadata;
 
   readonly #handlers = [
-    ['Fetch.requestPaused', this.#onRequestPaused],
-    ['Fetch.authRequired', this.#onAuthRequired],
-    ['Network.requestWillBeSent', this.#onRequestWillBeSent],
-    ['Network.requestServedFromCache', this.#onRequestServedFromCache],
-    ['Network.responseReceived', this.#onResponseReceived],
-    ['Network.loadingFinished', this.#onLoadingFinished],
-    ['Network.loadingFailed', this.#onLoadingFailed],
-    ['Network.responseReceivedExtraInfo', this.#onResponseReceivedExtraInfo],
-    [CDPSessionEvent.Disconnected, this.#removeClient],
+    ['Fetch.requestPaused', this.#onRequestPaused.bind(this)],
+    ['Fetch.authRequired', this.#onAuthRequired.bind(this)],
+    ['Network.requestWillBeSent', this.#onRequestWillBeSent.bind(this)],
+    [
+      'Network.requestServedFromCache',
+      this.#onRequestServedFromCache.bind(this),
+    ],
+    ['Network.responseReceived', this.#onResponseReceived.bind(this)],
+    ['Network.loadingFinished', this.#onLoadingFinished.bind(this)],
+    ['Network.loadingFailed', this.#onLoadingFailed.bind(this)],
+    [
+      'Network.responseReceivedExtraInfo',
+      this.#onResponseReceivedExtraInfo.bind(this),
+    ],
+    [CDPSessionEvent.Disconnected, this.#removeClient.bind(this)],
   ] as const;
 
   #clients = new Map<CDPSession, DisposableStack>();

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -75,21 +75,15 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #userAgentMetadata?: Protocol.Emulation.UserAgentMetadata;
 
   readonly #handlers = [
-    ['Fetch.requestPaused', this.#onRequestPaused.bind(this)],
-    ['Fetch.authRequired', this.#onAuthRequired.bind(this)],
-    ['Network.requestWillBeSent', this.#onRequestWillBeSent.bind(this)],
-    [
-      'Network.requestServedFromCache',
-      this.#onRequestServedFromCache.bind(this),
-    ],
-    ['Network.responseReceived', this.#onResponseReceived.bind(this)],
-    ['Network.loadingFinished', this.#onLoadingFinished.bind(this)],
-    ['Network.loadingFailed', this.#onLoadingFailed.bind(this)],
-    [
-      'Network.responseReceivedExtraInfo',
-      this.#onResponseReceivedExtraInfo.bind(this),
-    ],
-    [CDPSessionEvent.Disconnected, this.#removeClient.bind(this)],
+    ['Fetch.requestPaused', this.#onRequestPaused],
+    ['Fetch.authRequired', this.#onAuthRequired],
+    ['Network.requestWillBeSent', this.#onRequestWillBeSent],
+    ['Network.requestServedFromCache', this.#onRequestServedFromCache],
+    ['Network.responseReceived', this.#onResponseReceived],
+    ['Network.loadingFinished', this.#onLoadingFinished],
+    ['Network.loadingFailed', this.#onLoadingFailed],
+    ['Network.responseReceivedExtraInfo', this.#onResponseReceivedExtraInfo],
+    [CDPSessionEvent.Disconnected, this.#removeClient],
   ] as const;
 
   #clients = new Map<CDPSession, DisposableStack>();
@@ -109,7 +103,9 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     const clientEmitter = subscriptions.use(new EventEmitter(client));
 
     for (const [event, handler] of this.#handlers) {
-      clientEmitter.on(event, handler as any);
+      clientEmitter.on(event, (arg: any) => {
+        return handler.bind(this)(client, arg);
+      });
     }
 
     await Promise.all([


### PR DESCRIPTION
With this we have a single way of adding EventEmitter to disposable stacks.
The `EventSubscription`  is still used on the `PipeTransport`, and our higher order EventEmitter does not support common EventEmitter. Will refactor in another PR and drop `EventSubscription`.