### PR TITLE
refactor: simplify the Lifecycle Watcher

### DIFF
--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -268,7 +268,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
       return;
     }
     frame._onLifecycleEvent(event.loaderId, event.name);
-    this.emit(FrameManagerEvent.LifecycleEvent, frame);
     frame.emit(FrameEvent.LifecycleEvent, undefined);
   }
 
@@ -286,7 +285,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
       return;
     }
     frame._onLoadingStopped();
-    this.emit(FrameManagerEvent.LifecycleEvent, frame);
     frame.emit(FrameEvent.LifecycleEvent, undefined);
   }
 

--- a/packages/puppeteer-core/src/cdp/FrameManagerEvents.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManagerEvents.ts
@@ -39,7 +39,6 @@ export interface FrameManagerEvents extends Record<EventType, unknown> {
   [FrameManagerEvent.FrameNavigated]: CdpFrame;
   [FrameManagerEvent.FrameDetached]: CdpFrame;
   [FrameManagerEvent.FrameSwapped]: CdpFrame;
-  [FrameManagerEvent.LifecycleEvent]: CdpFrame;
   [FrameManagerEvent.FrameNavigatedWithinDocument]: CdpFrame;
   // Emitted when a new console message is logged.
   [FrameManagerEvent.ConsoleApiCalled]: [

--- a/packages/puppeteer-core/src/cdp/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/cdp/LifecycleWatcher.ts
@@ -223,8 +223,10 @@ export class LifecycleWatcher {
   }
 
   #checkLifecycleComplete(): void {
-    if (!checkLifecycle(this.#frame, this.#expectedLifecycle)) {
-      return;
+    for (const event of this.#expectedLifecycle) {
+      if (!this.#frame._lifecycleEvents.has(event)) {
+        return;
+      }
     }
 
     this.#lifecycleDeferred.resolve();
@@ -233,19 +235,6 @@ export class LifecycleWatcher {
     }
     if (this.#swapped || this.#frame._loaderId !== this.#initialLoaderId) {
       this.#newDocumentNavigationDeferred.resolve(undefined);
-    }
-
-    function checkLifecycle(
-      frame: CdpFrame,
-      expectedLifecycle: ProtocolLifeCycleEvent[]
-    ): boolean {
-      for (const event of expectedLifecycle) {
-        if (!frame._lifecycleEvents.has(event)) {
-          return false;
-        }
-      }
-
-      return true;
     }
   }
 

--- a/packages/puppeteer-core/src/cdp/LifecycleWatcher.ts
+++ b/packages/puppeteer-core/src/cdp/LifecycleWatcher.ts
@@ -223,7 +223,6 @@ export class LifecycleWatcher {
   }
 
   #checkLifecycleComplete(): void {
-    console.log('Check Lifecycle for', this.#frame._id);
     if (!checkLifecycle(this.#frame, this.#expectedLifecycle)) {
       return;
     }


### PR DESCRIPTION
We can expect the correct order of event for `DOMContentLoaded` and `load` events,
that the main frame's will come last [upstream CL](https://chromium-review.googlesource.com/c/chromium/src/+/4684286).