### PR TITLE
docs: fix URL for `network-interception` page

### DIFF
--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -973,7 +973,7 @@ Activating request interception enables [HTTPRequest.abort()](./puppeteer.httpre
 
 Once request interception is enabled, every request will stall unless it's continued, responded or aborted; or completed using the browser cache.
 
-See the [Request interception guide](https://pptr.dev/next/guides/request-interception) for more details.
+See the [Request interception guide](https://pptr.dev/next/guides/network-interception) for more details.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.setrequestinterception.md
+++ b/docs/api/puppeteer.page.setrequestinterception.md
@@ -8,7 +8,7 @@ Activating request interception enables [HTTPRequest.abort()](./puppeteer.httpre
 
 Once request interception is enabled, every request will stall unless it's continued, responded or aborted; or completed using the browser cache.
 
-See the [Request interception guide](https://pptr.dev/next/guides/request-interception) for more details.
+See the [Request interception guide](https://pptr.dev/next/guides/network-interception) for more details.
 
 #### Signature:
 

--- a/docs/webdriver-bidi.md
+++ b/docs/webdriver-bidi.md
@@ -111,7 +111,7 @@ This is an exciting step towards a more unified and efficient cross-browser auto
   - BrowserContext.clearPermissionOverrides()
   - BrowserContext.overridePermissions()
 
-- [Request interception](https://pptr.dev/guides/request-interception)
+- [Request interception](https://pptr.dev/guides/network-interception)
   - HTTPRequest.abort() (no custom error support)
   - HTTPRequest.abortErrorReason()
   - HTTPRequest.continue()

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -842,7 +842,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * continued, responded or aborted; or completed using the browser cache.
    *
    * See the
-   * {@link https://pptr.dev/next/guides/request-interception|Request interception guide}
+   * {@link https://pptr.dev/next/guides/network-interception|Request interception guide}
    * for more details.
    *
    * @example

--- a/website/versioned_docs/version-22.6.5/api/puppeteer.page.md
+++ b/website/versioned_docs/version-22.6.5/api/puppeteer.page.md
@@ -973,7 +973,7 @@ Activating request interception enables [HTTPRequest.abort()](./puppeteer.httpre
 
 Once request interception is enabled, every request will stall unless it's continued, responded or aborted; or completed using the browser cache.
 
-See the [Request interception guide](https://pptr.dev/next/guides/request-interception) for more details.
+See the [Request interception guide](https://pptr.dev/next/guides/network-interception) for more details.
 
 </td></tr>
 <tr><td>

--- a/website/versioned_docs/version-22.6.5/api/puppeteer.page.setrequestinterception.md
+++ b/website/versioned_docs/version-22.6.5/api/puppeteer.page.setrequestinterception.md
@@ -8,7 +8,7 @@ Activating request interception enables [HTTPRequest.abort()](./puppeteer.httpre
 
 Once request interception is enabled, every request will stall unless it's continued, responded or aborted; or completed using the browser cache.
 
-See the [Request interception guide](https://pptr.dev/next/guides/request-interception) for more details.
+See the [Request interception guide](https://pptr.dev/next/guides/network-interception) for more details.
 
 #### Signature:
 

--- a/website/versioned_docs/version-22.6.5/webdriver-bidi.md
+++ b/website/versioned_docs/version-22.6.5/webdriver-bidi.md
@@ -102,7 +102,7 @@ This is an exciting step towards a more unified and efficient cross-browser auto
 
 ## Puppeteer features not yet supported over WebDriver BiDi
 
-- [Request interception](https://pptr.dev/guides/request-interception)
+- [Request interception](https://pptr.dev/guides/network-interception)
 
   - HTTPRequest.abort()
   - HTTPRequest.abortErrorReason()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Documentation update

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No (Not Applicable I guess)

**If relevant, did you update the documentation?**

Yes

**Summary**

The "Request Interception" page does not exist (https://pptr.dev/next/guides/request-interception) and it was linked to in several places of the code/docs (example: https://pptr.dev/api/puppeteer.page.setrequestinterception). I changed them all to point to the correct/new URL for "Network Interception" guide. (https://pptr.dev/guides/network-interception/)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Docs point to a missing page for request interception.
[screen-capture - 2024-04-20T065747.255.webm](https://github.com/puppeteer/puppeteer/assets/5755214/4ae6a64e-d34d-480e-9421-a54c694eba4f)


In addition to docs page links broken, also searching in google, lands on "Page not found". (I don't think this MR will resolve that issue)
[screen-capture - 2024-04-20T065600.071.webm](https://github.com/puppeteer/puppeteer/assets/5755214/03df41f2-cfb0-4e87-8b0e-12abaf0bbe82)

**Does this PR introduce a breaking change?**

No?

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
