### PR TITLE
feat(webdriver): support ARIA selectors

### DIFF
--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -10,6 +10,7 @@ import type {Frame} from '../api/Frame.js';
 import {getQueryHandlerAndSelector} from '../common/GetQueryHandler.js';
 import {LazyArg} from '../common/LazyArg.js';
 import type {
+  AwaitableIterable,
   ElementFor,
   EvaluateFuncWith,
   HandleFor,
@@ -872,6 +873,14 @@ export abstract class ElementHandle<
     this: ElementHandle<HTMLInputElement>,
     ...paths: string[]
   ): Promise<void>;
+
+  /**
+   * @internal
+   */
+  abstract queryAXTree(
+    name?: string,
+    role?: string
+  ): AwaitableIterable<ElementHandle<Node>>;
 
   /**
    * This method scrolls element into view if needed, and then uses

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -561,6 +561,18 @@ export class BidiFrame extends Frame {
       files
     );
   }
+
+  @throwIfDetached
+  async locateNodes(
+    element: BidiElementHandle,
+    locator: Bidi.BrowsingContext.Locator
+  ): Promise<Bidi.Script.NodeRemoteValue[]> {
+    return await this.browsingContext.locateNodes(
+      locator,
+      // SAFETY: ElementHandles are always remote references.
+      [element.remoteValue() as Bidi.Script.SharedReference]
+    );
+  }
 }
 
 function isConsoleLogEntry(

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -601,4 +601,21 @@ export class BrowsingContext extends EventEmitter<{
       })
     );
   }
+
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
+  async locateNodes(
+    locator: Bidi.BrowsingContext.Locator,
+    startNodes: [Bidi.Script.SharedReference, ...Bidi.Script.SharedReference[]]
+  ): Promise<Bidi.Script.NodeRemoteValue[]> {
+    // TODO: add other locateNodes options if needed.
+    const result = await this.#session.send('browsingContext.locateNodes', {
+      context: this.id,
+      locator,
+      startNodes: startNodes.length ? startNodes : undefined,
+    });
+    return result.result.nodes;
+  }
 }

--- a/packages/puppeteer-core/src/bidi/core/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/core/Connection.ts
@@ -69,6 +69,10 @@ export interface Commands {
     params: Bidi.BrowsingContext.GetTreeParameters;
     returnType: Bidi.BrowsingContext.GetTreeResult;
   };
+  'browsingContext.locateNodes': {
+    params: Bidi.BrowsingContext.LocateNodesParameters;
+    returnType: Bidi.BrowsingContext.LocateNodesResult;
+  };
   'browsingContext.navigate': {
     params: Bidi.BrowsingContext.NavigateParameters;
     returnType: Bidi.BrowsingContext.NavigateResult;

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -184,7 +184,7 @@ export class CdpElementHandle<
       role,
     });
 
-    const results = nodes.filter((node: Protocol.Accessibility.AXNode) => {
+    const results = nodes.filter(node => {
       if (node.ignored) {
         return false;
       }

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -10,14 +10,18 @@ import type {Protocol} from 'devtools-protocol';
 
 import type {CDPSession} from '../api/CDPSession.js';
 import {ElementHandle, type AutofillData} from '../api/ElementHandle.js';
+import type {AwaitableIterable} from '../common/types.js';
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
+import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
 import type {CdpFrame} from './Frame.js';
 import type {FrameManager} from './FrameManager.js';
 import type {IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
+
+const NON_ELEMENT_NODE_ROLES = new Set(['StaticText', 'InlineTextBox']);
 
 /**
  * The CdpElementHandle extends ElementHandle now to keep compatibility
@@ -167,6 +171,36 @@ export class CdpElementHandle<
       fieldId,
       frameId,
       card: data.creditCard,
+    });
+  }
+
+  override async *queryAXTree(
+    name?: string | undefined,
+    role?: string | undefined
+  ): AwaitableIterable<ElementHandle<Node>> {
+    const {nodes} = await this.client.send('Accessibility.queryAXTree', {
+      objectId: this.id,
+      accessibleName: name,
+      role,
+    });
+
+    const results = nodes.filter((node: Protocol.Accessibility.AXNode) => {
+      if (node.ignored) {
+        return false;
+      }
+      if (!node.role) {
+        return false;
+      }
+      if (NON_ELEMENT_NODE_ROLES.has(node.role.value)) {
+        return false;
+      }
+      return true;
+    });
+
+    return yield* AsyncIterableUtil.map(results, node => {
+      return this.realm.adoptBackendNode(node.backendDOMNodeId) as Promise<
+        ElementHandle<Node>
+      >;
     });
   }
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -4,7 +4,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "Firefox crashes when a document is provided as a start node"
   },
   {
     "testIdPattern": "[autofill.spec] *",
@@ -194,6 +194,13 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler queryOne (Chromium web test) should find by role \"heading\"",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "WebDriver BiDi locateNodes does not support shadow roots so far"
   },
   {
     "testIdPattern": "[autofill.spec] *",
@@ -911,13 +918,6 @@
   },
   {
     "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler queryOne (Chromium web test) should find by role \"button\"",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Querying by a11y attributes is not standard behavior"
-  },
-  {
-    "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler queryOne (Chromium web test) should find by role \"heading\"",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],


### PR DESCRIPTION
This PR switches the implementation for ARIA selectors to use browsingContext.locateNodes.

Note that this method does not pierce shadow roots.