### PR TITLE
refactor: configure https error handling globally

### DIFF
--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -59,7 +59,6 @@ export class CdpBrowser extends BrowserBase {
       product,
       connection,
       contextIds,
-      ignoreHTTPSErrors,
       defaultViewport,
       process,
       closeCallback,
@@ -67,10 +66,14 @@ export class CdpBrowser extends BrowserBase {
       isPageTargetCallback,
       waitForInitiallyDiscoveredTargets
     );
+    if (ignoreHTTPSErrors) {
+      await connection.send('Security.setIgnoreCertificateErrors', {
+        ignore: true,
+      });
+    }
     await browser._attach();
     return browser;
   }
-  #ignoreHTTPSErrors: boolean;
   #defaultViewport?: Viewport | null;
   #process?: ChildProcess;
   #connection: Connection;
@@ -85,7 +88,6 @@ export class CdpBrowser extends BrowserBase {
     product: 'chrome' | 'firefox' | undefined,
     connection: Connection,
     contextIds: string[],
-    ignoreHTTPSErrors: boolean,
     defaultViewport?: Viewport | null,
     process?: ChildProcess,
     closeCallback?: BrowserCloseCallback,
@@ -95,7 +97,6 @@ export class CdpBrowser extends BrowserBase {
   ) {
     super();
     product = product || 'chrome';
-    this.#ignoreHTTPSErrors = ignoreHTTPSErrors;
     this.#defaultViewport = defaultViewport;
     this.#process = process;
     this.#connection = connection;
@@ -268,7 +269,6 @@ export class CdpBrowser extends BrowserBase {
         context,
         this.#targetManager,
         createSession,
-        this.#ignoreHTTPSErrors,
         this.#defaultViewport ?? null
       );
     }
@@ -279,7 +279,6 @@ export class CdpBrowser extends BrowserBase {
         context,
         this.#targetManager,
         createSession,
-        this.#ignoreHTTPSErrors,
         this.#defaultViewport ?? null
       );
     }

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -76,13 +76,12 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
   constructor(
     client: CDPSession,
     page: CdpPage,
-    ignoreHTTPSErrors: boolean,
     timeoutSettings: TimeoutSettings
   ) {
     super();
     this.#client = client;
     this.#page = page;
-    this.#networkManager = new NetworkManager(ignoreHTTPSErrors, this);
+    this.#networkManager = new NetworkManager(this);
     this.#timeoutSettings = timeoutSettings;
     this.setupEventListeners(this.#client);
     client.once(CDPSessionEvent.Disconnected, () => {

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -37,7 +37,7 @@ class MockCDPSession extends EventEmitter<CDPSessionEvents> {
 describe('NetworkManager', () => {
   it('should process extra info on multiple redirects', async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },
@@ -477,7 +477,7 @@ describe('NetworkManager', () => {
   });
   it(`should handle "double pause" (crbug.com/1196004) Fetch.requestPaused events for the same Network.requestWillBeSent event`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },
@@ -561,7 +561,7 @@ describe('NetworkManager', () => {
   });
   it(`should handle Network.responseReceivedExtraInfo event after Network.responseReceived event (github.com/puppeteer/puppeteer/issues/8234)`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },
@@ -678,7 +678,7 @@ describe('NetworkManager', () => {
 
   it(`should resolve the response once the late responseReceivedExtraInfo event arrives`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },
@@ -829,7 +829,7 @@ describe('NetworkManager', () => {
 
   it(`should send responses for iframe that don't receive loadingFinished event`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },
@@ -992,7 +992,7 @@ describe('NetworkManager', () => {
 
   it(`should send responses for iframe that don't receive loadingFinished event`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },
@@ -1137,7 +1137,7 @@ describe('NetworkManager', () => {
 
   it(`should handle cached redirects`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager(true, {
+    const manager = new NetworkManager({
       frame(): CdpFrame | null {
         return null;
       },

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -61,7 +61,6 @@ export interface FrameProvider {
  * @internal
  */
 export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
-  #ignoreHTTPSErrors: boolean;
   #frameManager: FrameProvider;
   #networkEventManager = new NetworkEventManager();
   #extraHTTPHeaders?: Record<string, string>;
@@ -88,9 +87,8 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
 
   #clients = new Map<CDPSession, DisposableStack>();
 
-  constructor(ignoreHTTPSErrors: boolean, frameManager: FrameProvider) {
+  constructor(frameManager: FrameProvider) {
     super();
-    this.#ignoreHTTPSErrors = ignoreHTTPSErrors;
     this.#frameManager = frameManager;
   }
 
@@ -109,11 +107,6 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     }
 
     await Promise.all([
-      this.#ignoreHTTPSErrors
-        ? client.send('Security.setIgnoreCertificateErrors', {
-            ignore: true,
-          })
-        : null,
       client.send('Network.enable'),
       this.#applyExtraHTTPHeaders(client),
       this.#applyNetworkConditions(client),

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -100,10 +100,9 @@ export class CdpPage extends Page {
   static async _create(
     client: CDPSession,
     target: CdpTarget,
-    ignoreHTTPSErrors: boolean,
     defaultViewport: Viewport | null
   ): Promise<CdpPage> {
-    const page = new CdpPage(client, target, ignoreHTTPSErrors);
+    const page = new CdpPage(client, target);
     await page.#initialize();
     if (defaultViewport) {
       try {
@@ -228,11 +227,7 @@ export class CdpPage extends Page {
     ['Page.fileChooserOpened', this.#onFileChooser.bind(this)],
   ] as const;
 
-  constructor(
-    client: CDPSession,
-    target: CdpTarget,
-    ignoreHTTPSErrors: boolean
-  ) {
+  constructor(client: CDPSession, target: CdpTarget) {
     super();
     this.#primaryTargetClient = client;
     this.#tabTargetClient = client.parentSession()!;
@@ -245,12 +240,7 @@ export class CdpPage extends Page {
     this.#mouse = new CdpMouse(client, this.#keyboard);
     this.#touchscreen = new CdpTouchscreen(client, this.#keyboard);
     this.#accessibility = new Accessibility(client);
-    this.#frameManager = new FrameManager(
-      client,
-      this,
-      ignoreHTTPSErrors,
-      this._timeoutSettings
-    );
+    this.#frameManager = new FrameManager(client, this, this._timeoutSettings);
     this.#emulationManager = new EmulationManager(client);
     this.#tracing = new Tracing(client);
     this.#coverage = new Coverage(client);

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -74,10 +74,10 @@ export class CdpTarget extends Target {
     const session = this._session();
     if (!session) {
       return await this.createCDPSession().then(client => {
-        return CdpPage._create(client, this, false, null);
+        return CdpPage._create(client, this, null);
       });
     }
-    return await CdpPage._create(session, this, false, null);
+    return await CdpPage._create(session, this, null);
   }
 
   _subtype(): string | undefined {
@@ -196,7 +196,6 @@ export class CdpTarget extends Target {
 export class PageTarget extends CdpTarget {
   #defaultViewport?: Viewport;
   protected pagePromise?: Promise<Page>;
-  #ignoreHTTPSErrors: boolean;
 
   constructor(
     targetInfo: Protocol.Target.TargetInfo,
@@ -204,11 +203,9 @@ export class PageTarget extends CdpTarget {
     browserContext: BrowserContext,
     targetManager: TargetManager,
     sessionFactory: (isAutoAttachEmulated: boolean) => Promise<CDPSession>,
-    ignoreHTTPSErrors: boolean,
     defaultViewport: Viewport | null
   ) {
     super(targetInfo, session, browserContext, targetManager, sessionFactory);
-    this.#ignoreHTTPSErrors = ignoreHTTPSErrors;
     this.#defaultViewport = defaultViewport ?? undefined;
   }
 
@@ -246,12 +243,7 @@ export class PageTarget extends CdpTarget {
           ? Promise.resolve(session)
           : this._sessionFactory()(/* isAutoAttachEmulated=*/ false)
       ).then(client => {
-        return CdpPage._create(
-          client,
-          this,
-          this.#ignoreHTTPSErrors,
-          this.#defaultViewport ?? null
-        );
+        return CdpPage._create(client, this, this.#defaultViewport ?? null);
       });
     }
     return (await this.pagePromise) ?? null;


### PR DESCRIPTION
configuring it globally should make it work for all types of targets