### PR TITLE
fix: deprecate CDP for Firefox

### DIFF
--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -112,6 +112,18 @@ export abstract class ProductLauncher {
       });
     };
 
+    if (
+      this.#product === 'firefox' &&
+      protocol !== 'webDriverBiDi' &&
+      this.puppeteer.configuration.logLevel === 'warn'
+    ) {
+      console.warn(
+        `Chrome DevTools Protocol (CDP) support for Firefox is deprecated in Puppeteer ` +
+          `and it will be eventually removed. ` +
+          `Use WebDriver BiDi instead (see https://pptr.dev/webdriver-bidi#get-started).`
+      );
+    }
+
     const browserProcess = launch({
       executablePath: launchArgs.executablePath,
       args: launchArgs.args,


### PR DESCRIPTION
This PR adds a deprecation warning if Chrome DevTools Protocol (CDP) is used for Firefox. Instead CDP, use [WebDriver BiDi](https://pptr.dev/webdriver-bidi#get-started):

```
import puppeteer from 'puppeteer';

const browser = await puppeteer.launch({
  product: 'firefox',
  protocol: 'webDriverBiDi',
});
const page = await browser.newPage();
...
await browser.close();
```