### PR TITLE
fix(cdp): throw on closed connection

### DIFF
--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -18,6 +18,7 @@ import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {debug} from '../common/Debug.js';
 import {TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
+import {assert} from '../util/assert.js';
 import {createProtocolErrorMessage} from '../util/ErrorLike.js';
 
 import {CdpCDPSession} from './CDPSession.js';
@@ -117,6 +118,8 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
     sessionId?: string,
     options?: CommandOptions
   ): Promise<ProtocolMapping.Commands[T]['returnType']> {
+    assert(!this.#closed, 'Protocol error: Connection closed.');
+
     return callbacks.create(method, options?.timeout ?? this.#timeout, id => {
       const stringifiedMessage = JSON.stringify({
         method,


### PR DESCRIPTION
Prevent users from having to wait for the `ProtocolTimeout` which is very long as we know it will never resolve