### PR TITLE
fix: set the default locale in Docker to en_US.UTF-8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20@sha256:cb7cd40ba6483f37f791e1aace576df449fc5f75332c19ff59e2c6064797160e
 
+# Configure default locale (important for chrome-headless-shell). 
+ENV LANG en_US.UTF-8
+
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chrome that Puppeteer
 # installs, work.


### PR DESCRIPTION
chrome-headless-shell [only includes the en-US locale ](https://source.chromium.org/chromium/chromium/src/+/main:headless/BUILD.gn;l=87;drc=354831d61640548053da768874e15a538d3d51cd) and the default locale in Docker is set to POSIX.

Bug: #12196