### PR TITLE
fix: don't start dbus service during build in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \
       --no-install-recommends \
-    && service dbus start \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r pptruser && useradd -rm -g pptruser -G audio,video pptruser
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Removing from image build phase a command that only makes sense at runtime.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

No tests, no doc updates

Other changes will be required to maintain the intent of the dbus service command, but that will be informed by the direction of the project.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This will prevent a developer thinking that dbus *should* be running, when the actual command runs the service for a short time only during build not during runtime.

**Does this PR introduce a breaking change?**

Probably not

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**


Please feel free to reject this, and incorporate an alternative PR. I'm just highlighting the issue.