### PR TITLE
test: update canary expectations

### DIFF
--- a/test/CanaryTestExpectations.json
+++ b/test/CanaryTestExpectations.json
@@ -2,14 +2,14 @@
   {
     "testIdPattern": "[pdf.spec] Page.pdf can print to PDF with outline",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headful"],
+    "parameters": ["chrome", "headful", "cdp"],
     "expectations": ["PASS"],
     "comment": "fixed in canary"
   },
   {
     "testIdPattern": "[pdf.spec] Page.pdf can print to PDF with outline",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless"],
+    "parameters": ["chrome", "headless", "cdp"],
     "expectations": ["PASS"],
     "comment": "fixed in canary"
   }


### PR DESCRIPTION
outline only works with CDP.