### PR TITLE
ci: fix devtools

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -54,10 +54,6 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: puppeteer-build
-      - name: Set up Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version-file: '.nvmrc'
       - name: Checkout depot_tools
         run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
       - name: Add depot_tools to path


### PR DESCRIPTION
We do not do a checkout so we do not need to set up node (I believe some Node version is pre-configured)