### PR TITLE
docs: add missing libgbm1 dependency to GitLab CI section

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -483,7 +483,7 @@ launch headless Chrome in your docker env:
 before_script:
   - apt-get update
   - apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2
-    libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4
+    libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4
     libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0
     libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1
     libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds missing `libgbm1` dependency to GitLab CI section of troubleshooting guide

**Did you add tests for your changes?**

Verified in a GitLab CI/CD pipeline that adding resolves the error mentioned below.

**If relevant, did you update the documentation?**

Yes.

**Summary**

In GitLab CI/CD, I was following the instructions for [Running Puppeteer on GitlabCI](https://pptr.dev/troubleshooting#running-puppeteer-on-gitlabci), but running into this error:
```
/root/.cache/puppeteer/chrome/linux-1108766/chrome-linux/chrome: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
```

Apparently this package was omitted in 0180a882e264ea9b1858cda131871b1a7aaa47f6, despite prior 5c839f5e48dffd57cbf740f4a980b154682a2d87 which added it elsewhere.

See also #290

**Does this PR introduce a breaking change?**

No.

**Other information**
