### PR TITLE
refactor: move console event handling

### DIFF
--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -20,6 +20,7 @@ import type {
   DeviceRequestPromptManager,
 } from './DeviceRequestPrompt.js';
 import type {FrameManager} from './FrameManager.js';
+import {FrameManagerEvent} from './FrameManagerEvents.js';
 import type {IsolatedWorldChart} from './IsolatedWorld.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD, PUPPETEER_WORLD} from './IsolatedWorlds.js';
@@ -74,6 +75,20 @@ export class CdpFrame extends Frame {
       this._onLoadingStarted();
       this._onLoadingStopped();
     });
+
+    this.worlds[MAIN_WORLD].emitter.on(
+      'consoleapicalled',
+      this.#onMainWorldConsoleApiCalled.bind(this)
+    );
+  }
+
+  #onMainWorldConsoleApiCalled(
+    event: Protocol.Runtime.ConsoleAPICalledEvent
+  ): void {
+    this._frameManager.emit(FrameManagerEvent.ConsoleApiCalled, [
+      this.worlds[MAIN_WORLD],
+      event,
+    ]);
   }
 
   /**

--- a/packages/puppeteer-core/src/cdp/FrameManagerEvents.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManagerEvents.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type Protocol from 'devtools-protocol';
+
 import type {EventType} from '../common/EventEmitter.js';
 
 import type {CdpFrame} from './Frame.js';
+import type {IsolatedWorld} from './IsolatedWorld.js';
 
 /**
  * We use symbols to prevent external parties listening to these events.
@@ -24,6 +27,7 @@ export namespace FrameManagerEvent {
   export const FrameNavigatedWithinDocument = Symbol(
     'FrameManager.FrameNavigatedWithinDocument'
   );
+  export const ConsoleApiCalled = Symbol('FrameManager.ConsoleApiCalled');
 }
 
 /**
@@ -36,4 +40,9 @@ export interface FrameManagerEvents extends Record<EventType, unknown> {
   [FrameManagerEvent.FrameSwapped]: CdpFrame;
   [FrameManagerEvent.LifecycleEvent]: CdpFrame;
   [FrameManagerEvent.FrameNavigatedWithinDocument]: CdpFrame;
+  // Emitted when a new console message is logged.
+  [FrameManagerEvent.ConsoleApiCalled]: [
+    IsolatedWorld,
+    Protocol.Runtime.ConsoleAPICalledEvent,
+  ];
 }

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -73,7 +73,9 @@ describe('Launcher specs', function () {
             });
           await remote.disconnect();
           const error = await watchdog;
-          expect(error.message).toContain('Session closed.');
+          expect(error.message).toContain(
+            'Waiting for selector `div` failed: waitForFunction failed: frame got detached.'
+          );
         } finally {
           await close();
         }

--- a/test/src/worker.spec.ts
+++ b/test/src/worker.spec.ts
@@ -53,8 +53,8 @@ describe('Workers', function () {
       return error;
     });
     expect(error.message).atLeastOneToContain([
-      'Most likely the worker has been closed.',
       'Realm already destroyed.',
+      'Execution context is not available in detached frame',
     ]);
   });
   it('should report console logs', async () => {


### PR DESCRIPTION
The console events would propagate as following: ExecutionContext -> IsolatedWorld -> Frame -> FrameManager -> Page or ExecutionContext -> IsolatedWorld -> WebWorker instead of trying to locate the execution context for an event determined at the page level.

Also, it adds explicit disposal of the instances when the client is gone.