### PR TITLE
refactor: move binding called handling

### DIFF
--- a/packages/puppeteer-core/src/cdp/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/cdp/ExecutionContext.ts
@@ -72,10 +72,10 @@ export class ExecutionContext
   }>
   implements Disposable
 {
-  _client: CDPSession;
-  _world: IsolatedWorld;
-  _contextId: number;
-  _contextName?: string;
+  #client: CDPSession;
+  #world: IsolatedWorld;
+  #id: number;
+  #name?: string;
 
   readonly #disposables = new DisposableStack();
 
@@ -85,16 +85,16 @@ export class ExecutionContext
     world: IsolatedWorld
   ) {
     super();
-    this._client = client;
-    this._world = world;
-    this._contextId = contextPayload.id;
+    this.#client = client;
+    this.#world = world;
+    this.#id = contextPayload.id;
     if (contextPayload.name) {
-      this._contextName = contextPayload.name;
+      this.#name = contextPayload.name;
     }
-    const clientEmitter = this.#disposables.use(new EventEmitter(this._client));
+    const clientEmitter = this.#disposables.use(new EventEmitter(this.#client));
     clientEmitter.on('Runtime.bindingCalled', this.#onBindingCalled.bind(this));
     clientEmitter.on('Runtime.executionContextDestroyed', async event => {
-      if (event.executionContextId === this._contextId) {
+      if (event.executionContextId === this.#id) {
         this[disposeSymbol]();
       }
     });
@@ -120,16 +120,16 @@ export class ExecutionContext
 
     using _ = await this.#mutex.acquire();
     try {
-      await this._client.send(
+      await this.#client.send(
         'Runtime.addBinding',
-        this._contextName
+        this.#name
           ? {
               name: binding.name,
-              executionContextName: this._contextName,
+              executionContextName: this.#name,
             }
           : {
               name: binding.name,
-              executionContextId: this._contextId,
+              executionContextId: this.#id,
             }
       );
 
@@ -177,7 +177,7 @@ export class ExecutionContext
     }
 
     try {
-      if (event.executionContextId !== this._contextId) {
+      if (event.executionContextId !== this.#id) {
         return;
       }
 
@@ -188,8 +188,12 @@ export class ExecutionContext
     }
   }
 
+  get id(): number {
+    return this.#id;
+  }
+
   #onConsoleAPI(event: Protocol.Runtime.ConsoleAPICalledEvent): void {
-    if (event.executionContextId !== this._contextId) {
+    if (event.executionContextId !== this.#id) {
       return;
     }
     this.emit('consoleapicalled', event);
@@ -369,13 +373,13 @@ export class ExecutionContext
     );
 
     if (isString(pageFunction)) {
-      const contextId = this._contextId;
+      const contextId = this.#id;
       const expression = pageFunction;
       const expressionWithSourceUrl = SOURCE_URL_REGEX.test(expression)
         ? expression
         : `${expression}\n${sourceUrlComment}\n`;
 
-      const {exceptionDetails, result: remoteObject} = await this._client
+      const {exceptionDetails, result: remoteObject} = await this.#client
         .send('Runtime.evaluate', {
           expression: expressionWithSourceUrl,
           contextId,
@@ -391,7 +395,7 @@ export class ExecutionContext
 
       return returnByValue
         ? valueFromRemoteObject(remoteObject)
-        : this._world.createCdpHandle(remoteObject);
+        : this.#world.createCdpHandle(remoteObject);
     }
 
     const functionDeclaration = stringifyFunction(pageFunction);
@@ -402,9 +406,9 @@ export class ExecutionContext
       : `${functionDeclaration}\n${sourceUrlComment}\n`;
     let callFunctionOnPromise;
     try {
-      callFunctionOnPromise = this._client.send('Runtime.callFunctionOn', {
+      callFunctionOnPromise = this.#client.send('Runtime.callFunctionOn', {
         functionDeclaration: functionDeclarationWithSourceUrl,
-        executionContextId: this._contextId,
+        executionContextId: this.#id,
         arguments: args.length
           ? await Promise.all(args.map(convertArgument.bind(this)))
           : [],
@@ -428,7 +432,7 @@ export class ExecutionContext
     }
     return returnByValue
       ? valueFromRemoteObject(remoteObject)
-      : this._world.createCdpHandle(remoteObject);
+      : this.#world.createCdpHandle(remoteObject);
 
     async function convertArgument(
       this: ExecutionContext,
@@ -458,7 +462,7 @@ export class ExecutionContext
           ? arg
           : null;
       if (objectHandle) {
-        if (objectHandle.realm !== this._world) {
+        if (objectHandle.realm !== this.#world) {
           throw new Error(
             'JSHandles can be evaluated only in the context they were created!'
           );

--- a/packages/puppeteer-core/src/cdp/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/cdp/ExecutionContext.ts
@@ -67,6 +67,8 @@ export class ExecutionContext
     /** Emitted when this execution context is disposed. */
     disposed: undefined;
     consoleapicalled: Protocol.Runtime.ConsoleAPICalledEvent;
+    /** Emitted when a binding that is not installed by the ExecutionContext is called. */
+    bindingcalled: Protocol.Runtime.BindingCalledEvent;
   }>
   implements Disposable
 {
@@ -166,9 +168,11 @@ export class ExecutionContext
     }
     const {type, name, seq, args, isTrivial} = payload;
     if (type !== 'internal') {
+      this.emit('bindingcalled', event);
       return;
     }
     if (!this.#bindings.has(name)) {
+      this.emit('bindingcalled', event);
       return;
     }
 

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -80,12 +80,23 @@ export class CdpFrame extends Frame {
       'consoleapicalled',
       this.#onMainWorldConsoleApiCalled.bind(this)
     );
+    this.worlds[MAIN_WORLD].emitter.on(
+      'bindingcalled',
+      this.#onMainWorldBindingCalled.bind(this)
+    );
   }
 
   #onMainWorldConsoleApiCalled(
     event: Protocol.Runtime.ConsoleAPICalledEvent
   ): void {
     this._frameManager.emit(FrameManagerEvent.ConsoleApiCalled, [
+      this.worlds[MAIN_WORLD],
+      event,
+    ]);
+  }
+
+  #onMainWorldBindingCalled(event: Protocol.Runtime.BindingCalledEvent) {
+    this._frameManager.emit(FrameManagerEvent.BindingCalled, [
       this.worlds[MAIN_WORLD],
       event,
     ]);

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -41,7 +41,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
   #page: CdpPage;
   #networkManager: NetworkManager;
   #timeoutSettings: TimeoutSettings;
-  #contextIdToContext = new Map<string, ExecutionContext>();
   #isolatedWorlds = new Set<string>();
   #client: CDPSession;
 
@@ -221,22 +220,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
 
       throw error;
     }
-  }
-
-  executionContextById(
-    contextId: number,
-    session: CDPSession = this.#client
-  ): ExecutionContext {
-    const context = this.getExecutionContextById(contextId, session);
-    assert(context, 'INTERNAL ERROR: missing context with id = ' + contextId);
-    return context;
-  }
-
-  getExecutionContextById(
-    contextId: number,
-    session: CDPSession = this.#client
-  ): ExecutionContext | undefined {
-    return this.#contextIdToContext.get(`${session.id()}:${contextId}`);
   }
 
   page(): CdpPage {
@@ -491,16 +474,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
       world
     );
     world.setContext(context);
-    const key = `${session.id()}:${contextPayload.id}`;
-    this.#contextIdToContext.set(key, context);
-    context.once('disposed', () => {
-      const key = `${session.id()}:${contextPayload.id}`;
-      const context = this.#contextIdToContext.get(key);
-      if (!context) {
-        return;
-      }
-      this.#contextIdToContext.delete(key);
-    });
   }
 
   #removeFramesRecursively(frame: CdpFrame): void {

--- a/packages/puppeteer-core/src/cdp/FrameManagerEvents.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManagerEvents.ts
@@ -28,6 +28,7 @@ export namespace FrameManagerEvent {
     'FrameManager.FrameNavigatedWithinDocument'
   );
   export const ConsoleApiCalled = Symbol('FrameManager.ConsoleApiCalled');
+  export const BindingCalled = Symbol('FrameManager.BindingCalled');
 }
 
 /**
@@ -44,5 +45,9 @@ export interface FrameManagerEvents extends Record<EventType, unknown> {
   [FrameManagerEvent.ConsoleApiCalled]: [
     IsolatedWorld,
     Protocol.Runtime.ConsoleAPICalledEvent,
+  ];
+  [FrameManagerEvent.BindingCalled]: [
+    IsolatedWorld,
+    Protocol.Runtime.BindingCalledEvent,
   ];
 }

--- a/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
@@ -204,7 +204,7 @@ export class IsolatedWorld extends Realm {
     }
     const {object} = await this.client.send('DOM.resolveNode', {
       backendNodeId: backendNodeId,
-      executionContextId: context._contextId,
+      executionContextId: context.id,
     });
     return this.createCdpHandle(object) as JSHandle<Node>;
   }

--- a/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
@@ -54,6 +54,8 @@ type IsolatedWorldEmitter = EventEmitter<{
   disposed: undefined;
   // Emitted when a new console message is logged.
   consoleapicalled: Protocol.Runtime.ConsoleAPICalledEvent;
+  /** Emitted when a binding that is not installed by the ExecutionContext is called. */
+  bindingcalled: Protocol.Runtime.BindingCalledEvent;
 }>;
 
 /**
@@ -89,6 +91,7 @@ export class IsolatedWorld extends Realm {
     this.#context?.[disposeSymbol]();
     context.once('disposed', this.#onContextDisposed.bind(this));
     context.on('consoleapicalled', this.#onContextConsoleApiCalled.bind(this));
+    context.on('bindingcalled', this.#onContextBindingCalled.bind(this));
     this.#context = context;
     this.#emitter.emit('context', context);
     void this.taskManager.rerunAll();
@@ -107,8 +110,16 @@ export class IsolatedWorld extends Realm {
     this.#emitter.emit('consoleapicalled', event);
   }
 
+  #onContextBindingCalled(event: Protocol.Runtime.BindingCalledEvent): void {
+    this.#emitter.emit('bindingcalled', event);
+  }
+
   hasContext(): boolean {
     return !!this.#context;
+  }
+
+  get context(): ExecutionContext | undefined {
+    return this.#context;
   }
 
   #executionContext(): ExecutionContext | undefined {


### PR DESCRIPTION
Similar change to bubble events up from the execution context. This allows us to remove context tracking in the frame manager and also hide all attributes of the execution context.