### PR TITLE
docs: use .png extenstion instead of .pdf in screenshot guide

### DIFF
--- a/docs/guides/screenshots.md
+++ b/docs/guides/screenshots.md
@@ -9,7 +9,7 @@ await page.goto('https://news.ycombinator.com', {
   waitUntil: 'networkidle2',
 });
 await page.screenshot({
-  path: 'hn.pdf',
+  path: 'hn.png',
 });
 
 await browser.close();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
There is a .pdf extension for screenshot docs (example). This PR request changes that extension to .png (As screenshots are always image)

**Did you add tests for your changes?**
As the changes in docs, it's not needed to testing