### PR TITLE
fix: configure sandbox permissions for Chrome on Windows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -57,9 +57,6 @@ jobs:
         run: npm ci
         env:
           PUPPETEER_BROWSER_REVISION: canary
-      - name: Configure permissions
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: icacls $HOME/.cache/puppeteer/chrome /grant "ALL APPLICATION PACKAGES:(OI)(CI)(RX)"
       - name: Apply Canary expectations
         run: node tools/merge-canary-test-expectations.mjs
       - name: Run all tests (for non-Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,6 @@ jobs:
           key: Chrome-${{ runner.os }}-${{ hashFiles('packages/puppeteer-core/src/revisions.ts') }}-${{ hashFiles('packages/puppeteer/src/node/install.ts') }}
       - name: Install Chrome
         run: npm run postinstall
-      - name: Configure permissions
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: icacls $HOME/.cache/puppeteer/chrome /grant "ALL APPLICATION PACKAGES:(OI)(CI)(RX)"
       - name: Run all tests (for non-Linux)
         if: ${{ matrix.os != 'ubuntu-latest' }}
         run: npm run test -- --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json

--- a/packages/browsers/test/src/versions.ts
+++ b/packages/browsers/test/src/versions.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const testChromeBuildId = '121.0.6167.85';
+export const testChromeBuildId = '127.0.6533.72';
 export const testChromiumBuildId = '1083080';
 export const testFirefoxBuildId = '130.0a1';
-export const testChromeDriverBuildId = '121.0.6167.85';
-export const testChromeHeadlessShellBuildId = '121.0.6167.85';
+export const testChromeDriverBuildId = '127.0.6533.72';
+export const testChromeHeadlessShellBuildId = '127.0.6533.72';


### PR DESCRIPTION
Configure permissions by invoking setup.exe.

Closes https://github.com/puppeteer/puppeteer/issues/12471