### PR TITLE
fix(webdriver): prefer globalThis over window to make it work in Firefox

### DIFF
--- a/packages/puppeteer-core/src/injected/ARIAQuerySelector.ts
+++ b/packages/puppeteer-core/src/injected/ARIAQuerySelector.ts
@@ -21,11 +21,16 @@ export const ariaQuerySelector = (
   root: Node,
   selector: string
 ): Promise<Node | null> => {
-  return window.__ariaQuerySelector(root, selector);
+  // In Firefox sandboxes globalThis !== window and we expose bindings on globalThis.
+  return (globalThis as unknown as Window).__ariaQuerySelector(root, selector);
 };
 export const ariaQuerySelectorAll = async function* (
   root: Node,
   selector: string
 ): AsyncIterable<Node> {
-  yield* await window.__ariaQuerySelectorAll(root, selector);
+  // In Firefox sandboxes globalThis !== window and we expose bindings on globalThis.
+  yield* await (globalThis as unknown as Window).__ariaQuerySelectorAll(
+    root,
+    selector
+  );
 };

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -210,13 +210,6 @@
     "comment": "WebDriver BiDi locateNodes does not support shadow roots so far"
   },
   {
-    "testIdPattern": "[ariaqueryhandler.spec] AriaQueryHandler waitForSelector *",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs investigation"
-  },
-  {
     "testIdPattern": "[autofill.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "chrome-headless-shell"],


### PR DESCRIPTION
in Firefox, sandbox realms have an object that is not equal to window in globalThis.