### PR TITLE
fix(webdriver): emit single HTTPRequest for Auth requests

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -252,8 +252,9 @@ export class BrowsingContext extends EventEmitter<{
       if (event.context !== this.id) {
         return;
       }
-      if (event.redirectCount !== 0) {
+      if (this.#requests.has(event.request.request)) {
         // Means the request is a redirect. This is handled in Request.
+        // Or an Auth event was issued
         return;
       }
 


### PR DESCRIPTION
As redirect, auth required events also create BeforeRequestWillBeSent event, our current implementation does not handle that correctly so we send to HTTPRequest to the user and naturally all the second command to that request fail. 