### PR TITLE
refactor: remove superfluous 'async' from Promise executor

### DIFF
--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -89,7 +89,7 @@ async function executeCommand(
     command[0] = updateExecutablePath(command[0]!, String(project['root']));
   }
 
-  await new Promise(async (resolve, reject) => {
+  await new Promise((resolve, reject) => {
     context.logger.debug(`Trying to execute command - ${command.join(' ')}.`);
     const {executable, args, debugError, error} = getExecutable(command);
     let path = context.workspaceRoot;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

a (potential) bugfix

**Did you add tests for your changes?**

no, I deemed it straightforward enough

**If relevant, did you update the documentation?**

n/a

**Summary**

This 'async' is not needed here, because there is no 'await' in its body.

Having an async function as the executor for 'new Promise' is suboptimal, as it swallows synchronous errors that might be thrown in the body. 

See https://stackoverflow.com/a/43050114/3394495

**Does this PR introduce a breaking change?**

no

**Other information**
n/a