### PR TITLE
docs: add Google Analytics with consent banner to pptr.dev

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -49,6 +49,10 @@ const config = {
   },
   scripts: [
     {
+      src: 'https://www.googletagmanager.com/gtag/js?id=G-J15CTWBVHX',
+      async: true,
+    },
+    {
       src: '/fix-location.js',
       async: false,
       defer: false,
@@ -354,6 +358,15 @@ const config = {
               {
                 label: 'YouTube',
                 href: 'https://goo.gle/devtools-youtube',
+              },
+            ],
+          },
+          {
+            title: 'Other',
+            items: [
+              {
+                label: 'Privacy policy',
+                href: 'https://policies.google.com/technologies/cookies',
               },
             ],
           },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -368,6 +368,10 @@ const config = {
                 label: 'Privacy policy',
                 href: 'https://policies.google.com/technologies/cookies',
               },
+              {
+                label: 'Cookie policy',
+                href: 'https://www.cookiechoices.org/',
+              },
             ],
           },
         ],

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "2.1.1",
         "prism-react-renderer": "2.3.1",
         "react": "18.3.1",
+        "react-cookie-consent": "9.0.0",
         "react-dom": "18.3.1",
         "semver": "7.6.3"
       },
@@ -9380,6 +9381,11 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12761,6 +12767,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cookie-consent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-9.0.0.tgz",
+      "integrity": "sha512-Blyj+m+Zz7SFHYqT18p16EANgnSg2sIyU6Yp3vk83AnOnSW7qnehPkUe4+8+qxztJrNmCH5GP+VHsWzAKVOoZA==",
+      "dependencies": {
+        "js-cookie": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/react-dev-utils": {

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "clsx": "2.1.1",
     "prism-react-renderer": "2.3.1",
     "react": "18.3.1",
+    "react-cookie-consent": "9.0.0",
     "react-dom": "18.3.1",
     "semver": "7.6.3"
   },

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, {useEffect} from 'react';
+import CookieConsent, {getCookieConsentValue} from 'react-cookie-consent';
+
+function enableGoogleAnalytics() {
+  const hasConsent = getCookieConsentValue();
+  if (!hasConsent) {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+  gtag('config', 'G-J15CTWBVHX');
+}
+
+export default function Root({children}) {
+  useEffect(enableGoogleAnalytics, []);
+
+  return (
+    <>
+      {children}
+      <CookieConsent
+        location="bottom"
+        buttonText="Okay, got it!"
+        disableButtonStyles={true}
+        buttonWrapperClasses="padding--sm"
+        buttonClasses="button button--primary button--outline"
+        contentStyle={{
+          fontSize: 'inherit',
+        }}
+        style={{
+          color: 'var(--ifm-color-primary-contrast-foreground)',
+          background: 'var(--ifm-color-primary-contrast-background)',
+        }}
+        onAccept={enableGoogleAnalytics}
+      >
+        pptr.dev, Puppeteer's documentation site, uses cookies from Google to
+        deliver and enhance the quality of its services and to analyze traffic.{' '}
+        <a href="https://policies.google.com/technologies/cookies">
+          Learn more.
+        </a>
+      </CookieConsent>
+    </>
+  );
+}

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -18,7 +18,7 @@ function enableGoogleAnalytics() {
     dataLayer.push(arguments);
   }
   gtag('js', new Date());
-  gtag('config', 'G-J15CTWBVHX');
+  gtag('config', 'G-J15CTWBVHX', {anonymize_ip: true});
 }
 
 export default function Root({children}) {


### PR DESCRIPTION
This PR adds Google Analytics to pptr.dev, using [react-cookie-consent](https://www.npmjs.com/package/react-cookie-consent) as a consent solution. To add the consent banner and analytics logics to all pages the root component of the Docusaurus app is swizzled as explained at https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root.

The goal of adding GA is to better understand usage of our documentation and spot potential gaps or under-communicated features.

This PR is pending privacy review, so do not merge until further notice.