### PR TITLE
fix: typo 'maintin'

### DIFF
--- a/docs/guides/page-interactions.md
+++ b/docs/guides/page-interactions.md
@@ -391,7 +391,7 @@ declare global {
 
 :::caution
 
-While we maintin prefixed selectors, the recommended way is to use the selector syntax documented above.
+While we maintain prefixed selectors, the recommended way is to use the selector syntax documented above.
 
 :::
 

--- a/website/versioned_docs/version-22.10.0/guides/page-interactions.md
+++ b/website/versioned_docs/version-22.10.0/guides/page-interactions.md
@@ -391,7 +391,7 @@ declare global {
 
 :::caution
 
-While we maintin prefixed selectors, the recommended way is to use the selector syntax documented above.
+While we maintain prefixed selectors, the recommended way is to use the selector syntax documented above.
 
 :::
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Typo fix in the docs: 'maintin' should be 'maintain'. https://pptr.dev/guides/page-interactions/#query-selectors-legacy

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

Yes

**Summary**

N/A

**Does this PR introduce a breaking change?**

No

**Other information**

N/A