### PR TITLE
test: fix the window.stop test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2382,16 +2382,9 @@
   {
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work when subframe issues window.stop()",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work when subframe issues window.stop()",
-    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "TODO: evaluating in the frame that was just attached causes an error in chromium-bidi"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.waitForNavigation should work with DOM history.back()/history.forward()",

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -719,9 +719,6 @@ describe('navigation', function () {
           waitEvent(page, 'frameattached').then(_frame => {
             return (frame = _frame);
           }),
-          waitEvent(page, 'framenavigated', f => {
-            return f === frame;
-          }),
         ]),
         Deferred.create({
           message: `should work when subframe issues window.stop()`,


### PR DESCRIPTION
For Chrome, we still get an error like `Protocol error (script.callFunction): unknown error No default realm for browsing context C0E35C68450C656C78F60812BBC14199 Error: No default realm for browsing context C0E35C68450C656C78F60812BBC14199`