### PR TITLE
test: remove non-cross browser assertion in the cookie test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1185,13 +1185,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookies from a frame",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set multiple cookies",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -463,7 +463,6 @@ describe('Cookie specs', () => {
       expect(await page.evaluate('document.cookie')).toBe(
         'localhost-cookie=best'
       );
-      expect(await page.frames()[1]!.evaluate('document.cookie')).toBe('');
 
       await expectCookieEquals(await page.cookies(), [
         {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
From what I've understood in this test we create a cookie with the domain of the iframe, but we set it for top context, in case of Firefox we partition it on top context origin, so I think it's correct that in this case `document.cookie` returns the cookie. Where for Chrome, since the cookie for iframe is not partitioned it's not available with `document.cookie` since it's cross-origin context. So maybe we could remove this check, @OrKoN, @sadym-chromium, what do you think?
