### PR TITLE
fix(webdriver): frame url should not be updated on navigationStarted

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -219,7 +219,8 @@ export class BrowsingContext extends EventEmitter<{
       if (info.context !== this.id) {
         return;
       }
-      this.#url = info.url;
+      // Note: we should not update this.#url at this point since the context
+      // has not finished navigating to the info.url yet.
 
       for (const [id, request] of this.#requests) {
         if (request.disposed) {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -745,13 +745,6 @@
     "comment": "`HTTPRequest.resourceType()` has no eqivalent in BiDi spec"
   },
   {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should intercept",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "`request.postData()` has no eqivalent in BiDi spec"
-  },
-  {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should navigate to URL with hash and fire requests without hash",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -3197,13 +3190,6 @@
     "comment": "TODO: Needs support for arguments in network.provideResponse in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1853882"
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should intercept",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs Puppeteer support for BidiHTTPRequest.postData"
-  },
-  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should load fonts if cache enabled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3306,13 +3292,6 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
     "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should intercept",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs Puppeteer support for BidiHTTPRequest.postData"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should load fonts if cache enabled",
@@ -3752,13 +3731,6 @@
     "parameters": ["chrome", "headless", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "`HTTPRequest.resourceType()` has no eqivalent in BiDi spec"
-  },
-  {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should intercept",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "headless", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "`request.postData()` has no eqivalent in BiDi spec"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should be abortable",

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -104,10 +104,9 @@ describe('cooperative request interception', function () {
           expect(request.url()).toContain('empty.html');
           expect(request.headers()['user-agent']).toBeTruthy();
           expect(request.method()).toBe('GET');
-          expect(request.postData()).toBe(undefined);
           expect(request.isNavigationRequest()).toBe(true);
-          expect(request.frame()!.url()).toBe('about:blank');
           expect(request.frame() === page.mainFrame()).toBe(true);
+          expect(request.frame()!.url()).toBe('about:blank');
         } catch (error) {
           requestError = error;
         } finally {
@@ -121,7 +120,6 @@ describe('cooperative request interception', function () {
       }
 
       expect(response.ok()).toBe(true);
-      expect(response.remoteAddress().port).toBe(server.PORT);
     });
     // @see https://github.com/puppeteer/puppeteer/pull/3105
     it('should work when POST is redirected with 302', async () => {

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -33,10 +33,9 @@ describe('request interception', function () {
           expect(request.url()).toContain('empty.html');
           expect(request.headers()['user-agent']).toBeTruthy();
           expect(request.method()).toBe('GET');
-          expect(request.postData()).toBe(undefined);
           expect(request.isNavigationRequest()).toBe(true);
-          expect(request.frame()!.url()).toBe('about:blank');
           expect(request.frame() === page.mainFrame()).toBe(true);
+          expect(request.frame()!.url()).toBe('about:blank');
         } catch (error) {
           requestError = error;
         } finally {
@@ -50,7 +49,6 @@ describe('request interception', function () {
       }
 
       expect(response.ok()).toBe(true);
-      expect(response.remoteAddress().port).toBe(server.PORT);
     });
     // @see https://github.com/puppeteer/puppeteer/pull/3105
     it('should work when POST is redirected with 302', async () => {


### PR DESCRIPTION
- removed postData checks since there are dedicated tests for it
- removed remoteAddress checks since there are dedicated tests
- removed the URL updates for the navigation started events since the url is not finalized at that time