### PR TITLE
test: ignore favicon requests in the network test for redirects

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2457,13 +2457,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[network.spec] network Network Events should support redirects",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Response completed for the redirect get emitter after the beforeSent (or flushed with the last responseCompleted)"
-  },
-  {
     "testIdPattern": "[network.spec] network Page.authenticate should allow disable authentication",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -599,16 +599,18 @@ describe('network', function () {
 
       const events: string[] = [];
       page.on('request', request => {
-        return events.push(`${request.method()} ${request.url()}`);
+        !isFavicon(request) &&
+          events.push(`${request.method()} ${request.url()}`);
       });
       page.on('response', response => {
-        return events.push(`${response.status()} ${response.url()}`);
+        !isFavicon(response) &&
+          events.push(`${response.status()} ${response.url()}`);
       });
       page.on('requestfinished', request => {
-        return events.push(`DONE ${request.url()}`);
+        !isFavicon(request) && events.push(`DONE ${request.url()}`);
       });
       page.on('requestfailed', request => {
-        return events.push(`FAIL ${request.url()}`);
+        !isFavicon(request) && events.push(`FAIL ${request.url()}`);
       });
       server.setRedirect('/foo.html', '/empty.html');
       const FOO_URL = server.PREFIX + '/foo.html';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
For Firefox, the favicon requests sometimes happen before the navigation command returns to avoid intermittent failures, let just ignore the favicon requests.