### PR TITLE
refactor: move selector parsing to Node

### DIFF
--- a/packages/puppeteer-core/Herebyfile.mjs
+++ b/packages/puppeteer-core/Herebyfile.mjs
@@ -48,9 +48,10 @@ export const generateInjectedTask = task({
       entryPoints: ['src/injected/injected.ts'],
       bundle: true,
       format: 'cjs',
-      target: ['chrome117', 'firefox118'],
+      target: ['chrome125', 'firefox125'],
       minify: true,
       write: false,
+      legalComments: 'none',
     });
     const template = await readFile('src/templates/injected.ts.tmpl', 'utf8');
     await mkdir('src/generated', {recursive: true});
@@ -133,6 +134,16 @@ export const buildTask = task({
           case 'mitt':
             license = await readFile(
               path.join(path.dirname(require.resolve('mitt')), '..', 'LICENSE'),
+              'utf-8'
+            );
+            break;
+          case 'parsel-js':
+            license = await readFile(
+              path.join(
+                path.dirname(require.resolve('parsel-js')),
+                '..',
+                'LICENSE'
+              ),
               'utf-8'
             );
             break;

--- a/packages/puppeteer-core/src/common/CSSQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/CSSQueryHandler.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type PuppeteerUtil from '../injected/injected.js';
+
+import {QueryHandler} from './QueryHandler.js';
+
+/**
+ * @internal
+ */
+export class CSSQueryHandler extends QueryHandler {
+  static override querySelector = (
+    element: Node,
+    selector: string,
+    {cssQuerySelector}: PuppeteerUtil
+  ): Node | null => {
+    return cssQuerySelector(element, selector);
+  };
+  static override querySelectorAll = (
+    element: Node,
+    selector: string,
+    {cssQuerySelectorAll}: PuppeteerUtil
+  ): Iterable<Node> => {
+    return cssQuerySelectorAll(element, selector);
+  };
+}

--- a/packages/puppeteer-core/src/common/GetQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/GetQueryHandler.ts
@@ -6,9 +6,11 @@
 
 import {ARIAQueryHandler} from '../cdp/AriaQueryHandler.js';
 
+import {CSSQueryHandler} from './CSSQueryHandler.js';
 import {customQueryHandlers} from './CustomQueryHandler.js';
 import {PierceQueryHandler} from './PierceQueryHandler.js';
 import {PQueryHandler} from './PQueryHandler.js';
+import {parsePSelectors} from './PSelectorParser.js';
 import type {QueryHandler} from './QueryHandler.js';
 import {TextQueryHandler} from './TextQueryHandler.js';
 import {XPathQueryHandler} from './XPathQueryHandler.js';
@@ -45,5 +47,15 @@ export function getQueryHandlerAndSelector(selector: string): {
       }
     }
   }
-  return {updatedSelector: selector, QueryHandler: PQueryHandler};
+  const [pSelector, isPureCSS] = parsePSelectors(selector);
+  if (isPureCSS) {
+    return {
+      updatedSelector: selector,
+      QueryHandler: CSSQueryHandler,
+    };
+  }
+  return {
+    updatedSelector: JSON.stringify(pSelector),
+    QueryHandler: PQueryHandler,
+  };
 }

--- a/packages/puppeteer-core/src/common/PSelectorParser.ts
+++ b/packages/puppeteer-core/src/common/PSelectorParser.ts
@@ -4,20 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {type Token, tokenize, TOKENS, stringify} from 'parsel-js';
-
-export type CSSSelector = string;
-export interface PPseudoSelector {
-  name: string;
-  value: string;
-}
-export const enum PCombinator {
-  Descendent = '>>>',
-  Child = '>>>>',
-}
-export type CompoundPSelector = Array<CSSSelector | PPseudoSelector>;
-export type ComplexPSelector = Array<CompoundPSelector | PCombinator>;
-export type ComplexPSelectorList = ComplexPSelector[];
+import {
+  type Token,
+  tokenize,
+  TOKENS,
+  stringify,
+} from '../../third_party/parsel-js/parsel-js.js';
+import type {
+  ComplexPSelector,
+  ComplexPSelectorList,
+  CompoundPSelector,
+} from '../injected/PQuerySelector.js';
+import {PCombinator} from '../injected/PQuerySelector.js';
 
 TOKENS['combinator'] = /\s*(>>>>?|[\s>+~])\s*/g;
 
@@ -34,6 +32,9 @@ const unquote = (text: string): string => {
   });
 };
 
+/**
+ * @internal
+ */
 export function parsePSelectors(
   selector: string
 ): [selector: ComplexPSelectorList, isPureCSS: boolean] {

--- a/packages/puppeteer-core/src/common/common.ts
+++ b/packages/puppeteer-core/src/common/common.ts
@@ -25,6 +25,7 @@ export * from './PDFOptions.js';
 export * from './PierceQueryHandler.js';
 export * from './PQueryHandler.js';
 export * from './Product.js';
+export * from './PSelectorParser.js';
 export * from './Puppeteer.js';
 export * from './QueryHandler.js';
 export * from './ScriptInjector.js';

--- a/packages/puppeteer-core/src/injected/CSSSelector.ts
+++ b/packages/puppeteer-core/src/injected/CSSSelector.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const cssQuerySelector = (
+  root: Node,
+  selector: string
+): Element | null => {
+  // @ts-expect-error assume element root
+  return root.querySelector(selector);
+};
+export const cssQuerySelectorAll = function (
+  root: Node,
+  selector: string
+): Iterable<Element> {
+  // @ts-expect-error assume element root
+  return root.querySelectorAll(selector);
+};

--- a/packages/puppeteer-core/src/injected/injected.ts
+++ b/packages/puppeteer-core/src/injected/injected.ts
@@ -8,6 +8,7 @@ import {Deferred} from '../util/Deferred.js';
 import {createFunction} from '../util/Function.js';
 
 import * as ARIAQuerySelector from './ARIAQuerySelector.js';
+import * as CSSSelector from './CSSSelector.js';
 import * as CustomQuerySelectors from './CustomQuerySelector.js';
 import * as PierceQuerySelector from './PierceQuerySelector.js';
 import {IntervalPoller, MutationPoller, RAFPoller} from './Poller.js';
@@ -31,6 +32,7 @@ const PuppeteerUtil = Object.freeze({
   ...TextQuerySelector,
   ...util,
   ...XPathQuerySelector,
+  ...CSSSelector,
   Deferred,
   createFunction,
   createTextContent,

--- a/packages/puppeteer-core/third_party/parsel-js/package.json
+++ b/packages/puppeteer-core/third_party/parsel-js/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/puppeteer-core/third_party/parsel-js/parsel-js.ts
+++ b/packages/puppeteer-core/third_party/parsel-js/parsel-js.ts
@@ -1,0 +1,4 @@
+// esline-disable rulesdir/check-license
+export {tokenize, TOKENS, stringify} from 'parsel-js';
+
+export type * from 'parsel-js';


### PR DESCRIPTION
- properly handled third party modules
- allows adjusting Puppeteer logic based on selector parsing later
- minimized injected code 