### PR TITLE
fix: do not wait for extension page targets on connect

### DIFF
--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -122,10 +122,15 @@ export class ChromeTargetManager
         this,
         undefined
       );
+      // Targets that will not be auto-attached. Therefore, we should
+      // not add them to #targetsIdsForInit.
+      const skipTarget =
+        targetInfo.type === 'browser' ||
+        targetInfo.url.startsWith('chrome-extension://');
       if (
         (!this.#targetFilterCallback ||
           this.#targetFilterCallback(targetForFilter)) &&
-        targetInfo.type !== 'browser'
+        !skipTarget
       ) {
         this.#targetsIdsForInit.add(targetId);
       }


### PR DESCRIPTION
[Some extension targets](https://developer.chrome.com/docs/extensions/reference/api/offscreen) would not be auto-attached so we do not need to wait for them when connecting. Waiting for the targets from extensions would cause Puppeteer to hang.