### PR TITLE
fix: include iframes into the a11y snapshot

### DIFF
--- a/docs/api/puppeteer.snapshotoptions.md
+++ b/docs/api/puppeteer.snapshotoptions.md
@@ -35,6 +35,27 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="includeiframes">includeIframes</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+If true, gets accessibility trees for each of the iframes in the frame subtree.
+
+</td><td>
+
+`false`
+
+</td></tr>
+<tr><td>
+
 <span id="interestingonly">interestingOnly</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -115,7 +115,7 @@ export class BidiFrame extends Frame {
         this,
       ),
     };
-    this.accessibility = new Accessibility(this.realms.default);
+    this.accessibility = new Accessibility(this.realms.default, this._id);
   }
 
   #initialize(): void {

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -79,7 +79,7 @@ export class CdpFrame extends Frame {
       ),
     };
 
-    this.accessibility = new Accessibility(this.worlds[MAIN_WORLD]);
+    this.accessibility = new Accessibility(this.worlds[MAIN_WORLD], frameId);
 
     this.on(FrameEvent.FrameSwappedByActivation, () => {
       // Emulate loading process for swapped frames.


### PR DESCRIPTION
This PR adds querying for iframe a11y tree snapshots as part of the `page.accessibility.snapshot()` if `includeIframes` option is set to true.

Closes https://github.com/puppeteer/puppeteer/issues/7744