### PR TITLE
feat: support --install-deps flag in the browsers CLI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,17 @@
 FROM node:20@sha256:a4d1de4c7339eabcf78a90137dfd551b798829e3ef3e399e0036ac454afa1291
 
-# Configure default locale (important for chrome-headless-shell). 
+# Configure default locale (important for chrome-headless-shell).
 ENV LANG en_US.UTF-8
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chrome that Puppeteer
 # installs, work.
 RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg \
-    && sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] https://dl-ssl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 dbus dbus-x11 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r pptruser && useradd -rm -g pptruser -G audio,video pptruser
+    && apt-get install -y --no-install-recommends fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros \
+    fonts-kacst fonts-freefont-ttf dbus dbus-x11
+
+# Add pptruser.
+RUN groupadd -r pptruser && useradd -rm -g pptruser -G audio,video pptruser
 
 USER pptruser
 
@@ -26,7 +23,12 @@ ENV DBUS_SESSION_BUS_ADDRESS autolaunch:
 
 # Install @puppeteer/browsers, puppeteer and puppeteer-core into /home/pptruser/node_modules.
 RUN npm i ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz \
-    && rm ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz \
-    && (node -e "require('child_process').execSync(require('puppeteer').executablePath() + ' --credits', {stdio: 'inherit'})" > THIRD_PARTY_NOTICES)
+    && rm ./puppeteer-browsers-latest.tgz ./puppeteer-core-latest.tgz ./puppeteer-latest.tgz
 
-CMD ["google-chrome-stable"]
+# Install system dependencies as root.
+USER root
+RUN npx puppeteer browsers install chrome --install-deps
+
+USER pptruser
+# Generate THIRD_PARTY_NOTICES using chrome --credits.
+RUN node -e "require('child_process').execSync(require('puppeteer').executablePath() + ' --credits', {stdio: 'inherit'})" > THIRD_PARTY_NOTICES

--- a/docs/browsers-api/browsers.installoptions.md
+++ b/docs/browsers-api/browsers.installoptions.md
@@ -147,6 +147,29 @@ Provides information about the progress of the download.
 </td></tr>
 <tr><td>
 
+<span id="installdeps">installDeps</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether to attempt to install system-level dependencies required for the browser.
+
+Currently, only supported for Debian and Ubuntu and only for Chrome. Requires root privileges.
+
+</td><td>
+
+`false`
+
+</td></tr>
+<tr><td>
+
 <span id="platform">platform</span>
 
 </td><td>

--- a/docs/browsers-api/browsers.installoptions.md
+++ b/docs/browsers-api/browsers.installoptions.md
@@ -161,7 +161,7 @@ boolean
 
 Whether to attempt to install system-level dependencies required for the browser.
 
-Currently, only supported for Debian and Ubuntu and only for Chrome. Requires root privileges.
+Only supported for Chrome on Debian or Ubuntu. Requires system-level privileges to run `apt-get`.
 
 </td><td>
 

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -36,6 +36,7 @@ interface InstallArgs {
   path?: string;
   platform?: BrowserPlatform;
   baseUrl?: string;
+  installDeps?: boolean;
 }
 
 interface LaunchArgs {
@@ -180,6 +181,11 @@ export class CLI {
           if (this.#pinnedBrowsers) {
             yargs.example('$0 install', 'Install all pinned browsers');
           }
+          yargs.option('install-deps', {
+            type: 'boolean',
+            desc: 'Whether to attempt installing system dependencies (only supported on Linux, requires root privileges).',
+            default: false,
+          });
           yargs.example(
             '$0 install chrome',
             `Install the ${latestOrPinned} available build of the Chrome browser.`
@@ -440,6 +446,7 @@ export class CLI {
       baseUrl: args.baseUrl,
       buildIdAlias:
         originalBuildId !== args.browser.buildId ? originalBuildId : undefined,
+      installDeps: args.installDeps,
     });
     console.log(
       `${args.browser.name}@${args.browser.buildId} ${computeExecutablePath({

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -6,7 +6,7 @@
 
 import assert from 'assert';
 import {spawnSync} from 'child_process';
-import {existsSync} from 'fs';
+import {existsSync, readFileSync} from 'fs';
 import {mkdir, unlink} from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -98,6 +98,17 @@ export interface InstallOptions {
    * @defaultValue `false`
    */
   forceFallbackForTesting?: boolean;
+
+  /**
+   * Whether to attempt to install system-level dependencies required
+   * for the browser.
+   *
+   * Currently, only supported for Debian and Ubuntu and only for Chrome.
+   * Requires root privileges.
+   *
+   * @defaultValue `false`
+   */
+  installDeps?: boolean;
 }
 
 /**
@@ -194,6 +205,47 @@ export async function install(
   }
 }
 
+async function installDeps(installedBrowser: InstalledBrowser) {
+  if (
+    process.platform !== 'linux' ||
+    installedBrowser.platform !== BrowserPlatform.LINUX
+  ) {
+    return;
+  }
+  // Currently, only Debian-like deps are supported.
+  const depsPath = path.join(
+    path.dirname(installedBrowser.executablePath),
+    'deb.deps'
+  );
+  if (existsSync(depsPath)) {
+    debugInstall(`deb.deps file was not found at ${depsPath}`);
+    return;
+  }
+  const data = readFileSync(depsPath, 'utf-8').split('\n').join(',');
+  if (process.getuid?.() !== 0) {
+    throw new Error('Installing system dependencies requires root privileges');
+  }
+  let result = spawnSync('apt-get', ['-v']);
+  if (result.status !== 0) {
+    throw new Error(
+      'Failed to install system dependencies: apt-get does not seem to be available'
+    );
+  }
+  debugInstall(`Trying to install dependencies: ${data}`);
+  result = spawnSync('apt-get', [
+    'satisfy',
+    '-y',
+    data,
+    '--no-install-recommends',
+  ]);
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to install system dependencies: status=${result.status},error=${result.error},stdout=${result.stdout.toString('utf8')},stderr=${result.stderr.toString('utf8')}`
+    );
+  }
+  debugInstall(`Installed system dependencies ${data}`);
+}
+
 async function installUrl(
   url: URL,
   options: InstallOptions
@@ -244,6 +296,9 @@ async function installUrl(
         );
       }
       await runSetup(installedBrowser);
+      if (options.installDeps) {
+        await installDeps(installedBrowser);
+      }
       return installedBrowser;
     }
     debugInstall(`Downloading binary from ${url}`);
@@ -275,6 +330,9 @@ async function installUrl(
     }
 
     await runSetup(installedBrowser);
+    if (options.installDeps) {
+      await installDeps(installedBrowser);
+    }
     return installedBrowser;
   } finally {
     if (existsSync(archivePath)) {

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -103,8 +103,8 @@ export interface InstallOptions {
    * Whether to attempt to install system-level dependencies required
    * for the browser.
    *
-   * Currently, only supported for Debian and Ubuntu and only for Chrome.
-   * Requires root privileges.
+   * Only supported for Chrome on Debian or Ubuntu.
+   * Requires system-level privileges to run `apt-get`.
    *
    * @defaultValue `false`
    */
@@ -217,7 +217,7 @@ async function installDeps(installedBrowser: InstalledBrowser) {
     path.dirname(installedBrowser.executablePath),
     'deb.deps'
   );
-  if (existsSync(depsPath)) {
+  if (!existsSync(depsPath)) {
     debugInstall(`deb.deps file was not found at ${depsPath}`);
     return;
   }


### PR DESCRIPTION
The new flag will attempt installing system dependencies required for Chrome using `apt-get`. Currently, only Debian and Ubuntu are supported.

The Docker image is updated to install dependencies using the new flag. chrome-stable installation is, therefore, removed since it is not needed for installing system dependencies.