### PR TITLE
fix: ensure selector parser falls back to CSS

### DIFF
--- a/packages/puppeteer-core/src/common/GetQueryHandler.ts
+++ b/packages/puppeteer-core/src/common/GetQueryHandler.ts
@@ -52,17 +52,25 @@ export function getQueryHandlerAndSelector(selector: string): {
       }
     }
   }
-  const [pSelector, isPureCSS, hasPseudoClasses] = parsePSelectors(selector);
-  if (isPureCSS) {
+  try {
+    const [pSelector, isPureCSS, hasPseudoClasses] = parsePSelectors(selector);
+    if (isPureCSS) {
+      return {
+        updatedSelector: selector,
+        selectorHasPseudoClasses: hasPseudoClasses,
+        QueryHandler: CSSQueryHandler,
+      };
+    }
+    return {
+      updatedSelector: JSON.stringify(pSelector),
+      selectorHasPseudoClasses: hasPseudoClasses,
+      QueryHandler: PQueryHandler,
+    };
+  } catch {
     return {
       updatedSelector: selector,
-      selectorHasPseudoClasses: hasPseudoClasses,
+      selectorHasPseudoClasses: false,
       QueryHandler: CSSQueryHandler,
     };
   }
-  return {
-    updatedSelector: JSON.stringify(pSelector),
-    selectorHasPseudoClasses: hasPseudoClasses,
-    QueryHandler: PQueryHandler,
-  };
 }

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -358,12 +358,22 @@ describe('Query handler tests', function () {
         })
       ).toBeTruthy();
 
+      using root = await page.$('div');
+      using button = await root!.$('& > button');
+      assert(button, 'Could not find element');
+      expect(
+        await button.evaluate(element => {
+          return element.id === 'b';
+        })
+      ).toBeTruthy();
+
       // Should parse more complex CSS selectors. Listing a few problematic
       // cases from bug reports.
       for (const selector of [
         '.user_row[data-user-id="\\38 "]:not(.deactivated_user)',
         `input[value='Search']:not([class='hidden'])`,
         `[data-test-id^="test-"]:not([data-test-id^="test-foo"])`,
+        `& > table`,
       ]) {
         await page.$$(selector);
       }


### PR DESCRIPTION
in case if selectors cannot be parsed, we should always fallback to CSS.

Closes #12584