### PR TITLE
build: explicitly set typeRoots

### DIFF
--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -45,14 +45,18 @@ jobs:
               - 'tools/mocha-runner/**'
               - '.mocharc.cjs'
               - 'tools/doctest/**'
+              - 'tsconfig.base.json'
             website:
               - '.github/workflows/ci.yml'
               - 'docs/**'
               - 'website/**'
               - 'README.md'
+              - 'tsconfig.base.json'
             ng-schematics:
               - '.github/workflows/ci.yml'
               - 'packages/ng-schematics/**'
+              - 'tsconfig.base.json'
             browsers:
               - '.github/workflows/ci.yml'
               - 'packages/browsers/**'
+              - 'tsconfig.base.json'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
     "strictBindCallApply": true,
@@ -27,7 +28,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "ES2022",
-    "useUnknownInCatchVariables": true,
-    "skipLibCheck": true
+    "typeRoots": ["./node_modules/@types"],
+    "useUnknownInCatchVariables": true
   }
 }


### PR DESCRIPTION
This allows building Puppeteer while having other node_modules in the parent directories. See https://phabricator.services.mozilla.com/D213871#7341451

The default behavior is to walk the filesystem tree in search of node_modules https://www.typescriptlang.org/tsconfig/#typeRoots