### PR TITLE
Revert "chore(deps-dev): Bump @swc/core from 1.5.25 to 1.6.0 in /website in the all group"

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -26,7 +26,7 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.4.0",
         "@docusaurus/types": "3.4.0",
-        "@swc/core": "1.6.0",
+        "@swc/core": "1.5.25",
         "swc-loader": "0.2.6"
       }
     },
@@ -5036,14 +5036,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-Wynbo79uIVBgmq3TPcTMdtXUkqk69IPSVuzo7/Jl1OhR4msC7cUaoRB1216ZanWttrAZ4/g6u17w9XZG4fzp1A==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.25.tgz",
+      "integrity": "sha512-qdGEIdLVoTjEQ7w72UyyQ0wLFY4XbHfZiidmPHKJQsvSXzdpHXxPdlTCea/mY4AhMqo/M+pvkJSXJAxZnFl7qw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.8"
+        "@swc/types": "^0.1.7"
       },
       "engines": {
         "node": ">=10"
@@ -5053,16 +5053,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.6.0",
-        "@swc/core-darwin-x64": "1.6.0",
-        "@swc/core-linux-arm-gnueabihf": "1.6.0",
-        "@swc/core-linux-arm64-gnu": "1.6.0",
-        "@swc/core-linux-arm64-musl": "1.6.0",
-        "@swc/core-linux-x64-gnu": "1.6.0",
-        "@swc/core-linux-x64-musl": "1.6.0",
-        "@swc/core-win32-arm64-msvc": "1.6.0",
-        "@swc/core-win32-ia32-msvc": "1.6.0",
-        "@swc/core-win32-x64-msvc": "1.6.0"
+        "@swc/core-darwin-arm64": "1.5.25",
+        "@swc/core-darwin-x64": "1.5.25",
+        "@swc/core-linux-arm-gnueabihf": "1.5.25",
+        "@swc/core-linux-arm64-gnu": "1.5.25",
+        "@swc/core-linux-arm64-musl": "1.5.25",
+        "@swc/core-linux-x64-gnu": "1.5.25",
+        "@swc/core-linux-x64-musl": "1.5.25",
+        "@swc/core-win32-arm64-msvc": "1.5.25",
+        "@swc/core-win32-ia32-msvc": "1.5.25",
+        "@swc/core-win32-x64-msvc": "1.5.25"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -5074,9 +5074,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-darwin-arm64": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.0.tgz",
-      "integrity": "sha512-W1Mwk0WRrJ5lAVkYRPxpxOmwu8p9ASXeOmiORhXvE7DYREyI30005xlqSOITU1pfSNKj7G9u3+9DjsOzPPPbBw==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.25.tgz",
+      "integrity": "sha512-YbD0SBgVJS2DM0vwJTU5m7+wOyCjHPBDMf3nCBJQzFZzOLzK11eRW7SzU2jhJHr9HI9sKcNFfN4lIC2Sj+4inA==",
       "cpu": [
         "arm64"
       ],
@@ -5090,9 +5090,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-darwin-x64": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.0.tgz",
-      "integrity": "sha512-EzxLnpPC1zgLb2Y0iVUG6b+/GUv43k6uJUIs52UzxOnBElYP/WeItI3RJ+LUMFzCpZMk/IxB10wofEoeQ1H/Xg==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.25.tgz",
+      "integrity": "sha512-OhP4TROT6gQuozn+ah0Y4UidSdgDmxwtQq3lgCUIAxJYErJAQ82/Y0kve2UaNmkSGjOHU+/b4siHPrYTkXOk0Q==",
       "cpu": [
         "x64"
       ],
@@ -5106,9 +5106,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.0.tgz",
-      "integrity": "sha512-uP/STDjWZ5N6lc8mxJFsex4NXDaqhfzd8UOrI3LfdV97+4faE4/BC6bVqDNHFFzZi0PHuVBxD6md7IfPjugk6A==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.25.tgz",
+      "integrity": "sha512-tNmUfrAHxN2gvYPyYNnHx2CYlPO7DGAUuK/bZrqawu++djcg+atAV3eI3XYJgmHId7/sYAlDQ9wjkrOLofFjVg==",
       "cpu": [
         "arm"
       ],
@@ -5122,9 +5122,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.0.tgz",
-      "integrity": "sha512-UgNz6anowcnYzJtZohzpii31FOgouBHJqluiq+p2geX/agbC+KfOKwVXdljn95+Qc4ygBuw/hjKjgF2msOLeVg==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.25.tgz",
+      "integrity": "sha512-stzpke+bRaNFM/HrZPRjX0aQZ86S/2DChVCwb8NAV1n5lu9mz1CS750y7WbbtX/KZjk92FsCeRy2qwkvjI0gWw==",
       "cpu": [
         "arm64"
       ],
@@ -5138,9 +5138,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.0.tgz",
-      "integrity": "sha512-xPV6qrnj4nFwXQbIv70C1Kn5z5Th53sirIY76aEonr78qeC6+ywaBZR4uLFNHsljVjyuvVQfTTcl2qraGhu6oQ==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.25.tgz",
+      "integrity": "sha512-UckUfDYedish/bj2V1jgQDGgouLhyRpG7jgF3mp8jHir11V2K6JiTyjFoz99eOiclS3+hNdr4QLJ+ifrQMJNZw==",
       "cpu": [
         "arm64"
       ],
@@ -5154,9 +5154,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.0.tgz",
-      "integrity": "sha512-xTeWn4OT5uQ+DxT2cy94ngK8tF1U/5fMC49/V6FhCS2Wh+Xa/O+OWcOyKvYtk3b0eGYS4iNIRKgzog7fLSFtvQ==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.25.tgz",
+      "integrity": "sha512-LwbJEgNT3lXbvz4WFzVNXNvs8DvxpoXjMZk9K9Hig8tmZQJKHC2qZTGomcyK5EFzfj2HBuBXZnAEW8ZT9PcEaA==",
       "cpu": [
         "x64"
       ],
@@ -5170,9 +5170,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.0.tgz",
-      "integrity": "sha512-3P01mYD5XbyaVLT0MGZmZE+ZdgmGSvuvIhSejRDBlEXqkFnH79nWds+KsE+91hzVU8XsgzX57Yzv4eO5dlIuPw==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.25.tgz",
+      "integrity": "sha512-rsepMTgml0EkswWkBpg3Wrjj5eqjwTzZN5omAn1klzXSZnClTrfeHvBuoIJYVr1yx+jmBkqySgME2p7+magUAw==",
       "cpu": [
         "x64"
       ],
@@ -5186,9 +5186,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.0.tgz",
-      "integrity": "sha512-xFuook1efU0ctzMAEeol4eI7J6+k/c/pMJpp/NP/4JJDnhlHwAi2iyiZcID8YZS+ePHgXMLndGdIMHVv/wIPkQ==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.25.tgz",
+      "integrity": "sha512-DJDsLBsRBV3uQBShRK2x6fqzABp9RLNVxDUpTTvUjc7qywJ8vS/yn+POK/zCyVEqLagf1z/8D5CEQ+RAIJq1NA==",
       "cpu": [
         "arm64"
       ],
@@ -5202,9 +5202,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.0.tgz",
-      "integrity": "sha512-VCJa5vTywxzASqvf9OEUM5SZBcNrWbuIkSGM5T9guuBzyrh/tSqVHjzOWL9qpP69uPVj5G/I5bJObLiUKErhvQ==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.25.tgz",
+      "integrity": "sha512-BARL1ulHol53MEKC1ZVWM3A3FP757UUgG5Q8v97za+4a1SaIgbwvAQyHDxMYWi9+ij+OapK8YnWjJcFa17g8dw==",
       "cpu": [
         "ia32"
       ],
@@ -5218,9 +5218,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.0.tgz",
-      "integrity": "sha512-L7i8WBSIJTQiMONJGHnznDydZmlJIqHjZ3VhBHeTTms8cEAuwkAVgzPwgr5cD9GhmcwdeBI9iYdOuKr1pUx19Q==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.25.tgz",
+      "integrity": "sha512-o+MHUWrQI9iR6EusEV8eNU2Ezi3KtlhUR4gfptQN5MbVzlgjTvQbhiKpE1GYOxp+0BLBbKRwITKOcdhxfEJ2Uw==",
       "cpu": [
         "x64"
       ],
@@ -5234,9 +5234,9 @@
       }
     },
     "node_modules/@swc/core/node_modules/@swc/types": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.8.tgz",
-      "integrity": "sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.7.tgz",
+      "integrity": "sha512-scHWahbHF0eyj3JsxG9CFJgFdFNaVQCNAimBlT6PzS3n/HptxqREjsm4OH6AN3lYcffZYSPxXW8ua2BEHp0lJQ==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.4.0",
     "@docusaurus/types": "3.4.0",
-    "@swc/core": "1.6.0",
+    "@swc/core": "1.5.25",
     "swc-loader": "0.2.6"
   },
   "browserslist": {


### PR DESCRIPTION
Reverts puppeteer/puppeteer#12592

It seems to make local build (npm start) hang and cause high cpu usage. cc @Lightning00Blade 