### PR TITLE
fix(deps): bump ws to 8.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9659,26 +9659,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -12089,7 +12069,7 @@
         "chromium-bidi": "0.5.23",
         "debug": "4.3.5",
         "devtools-protocol": "0.0.1299070",
-        "ws": "8.17.0"
+        "ws": "8.17.1"
       },
       "devDependencies": {
         "@types/chrome": "0.0.268",
@@ -12139,6 +12119,26 @@
       "version": "2.6.2",
       "dev": true,
       "license": "0BSD"
+    },
+    "packages/puppeteer-core/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "packages/puppeteer/node_modules/@types/node": {
       "version": "18.17.15",
@@ -12196,10 +12196,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "mime": "3.0.0",
-        "ws": "8.17.0"
+        "ws": "8.17.1"
       },
       "devDependencies": {
         "@types/mime": "3.0.4"
+      }
+    },
+    "packages/testserver/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "test": {

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -123,7 +123,7 @@
     "chromium-bidi": "0.5.23",
     "debug": "4.3.5",
     "devtools-protocol": "0.0.1299070",
-    "ws": "8.17.0"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.12",

--- a/packages/testserver/package.json
+++ b/packages/testserver/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "mime": "3.0.0",
-    "ws": "8.17.0"
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@types/mime": "3.0.4"


### PR DESCRIPTION
See https://github.com/websockets/ws/releases/tag/8.17.1

(we do not use the ws server though but useful to bump to avoid automated warnings)