### PR TITLE
fix: use NodeNext in ng-schematics default tsconfig

### DIFF
--- a/packages/ng-schematics/src/schematics/ng-add/files/common/e2e/tsconfig.json.template
+++ b/packages/ng-schematics/src/schematics/ng-add/files/common/e2e/tsconfig.json.template
@@ -1,7 +1,8 @@
 {
   "extends": "<%= tsConfigPath %>",
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "rootDir": "tests/",
     "outDir": "build/",
     "types": ["<%= testRunner %>"]

--- a/packages/ng-schematics/test/src/ng-add.test.ts
+++ b/packages/ng-schematics/test/src/ng-add.test.ts
@@ -109,7 +109,8 @@ void describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tsConfig).toMatchObject({
         extends: '../tsconfig.json',
         compilerOptions: {
-          module: 'CommonJS',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
         },
       });
     });
@@ -222,7 +223,8 @@ void describe('@puppeteer/ng-schematics: ng-add', () => {
       expect(tsConfig).toMatchObject({
         extends: '../../../tsconfig.json',
         compilerOptions: {
-          module: 'CommonJS',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
         },
       });
     });


### PR DESCRIPTION
This solves the issue of a fresh project failing with `error TS5095: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later.`

Closes https://github.com/puppeteer/puppeteer/issues/12530