### PR TITLE
add interface ClientProvider for EmulationManager

### DIFF
--- a/packages/puppeteer-core/src/cdp/EmulationManager.ts
+++ b/packages/puppeteer-core/src/cdp/EmulationManager.ts
@@ -114,7 +114,7 @@ export class EmulatedState<T extends {active: boolean}> {
 /**
  * @internal
  */
-export class EmulationManager {
+export class EmulationManager implements ClientProvider {
   #client: CDPSession;
 
   #emulatingMobile = false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

We can see from the Emulated State that It used ClientProvider interface as its parameter and we actually passed EmulationManager instance. So we better add interface ClientProvider to EmulationManager.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
