### PR TITLE
fix: make sure bindings are working after a page is restored from bfcache

### DIFF
--- a/packages/puppeteer-core/src/cdp/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/cdp/ExecutionContext.ts
@@ -124,11 +124,11 @@ export class ExecutionContext
         'Runtime.addBinding',
         this.#name
           ? {
-              name: binding.name,
+              name: '_' + binding.name,
               executionContextName: this.#name,
             }
           : {
-              name: binding.name,
+              name: '_' + binding.name,
               executionContextId: this.#id,
             }
       );

--- a/packages/puppeteer-core/src/cdp/ExecutionContext.ts
+++ b/packages/puppeteer-core/src/cdp/ExecutionContext.ts
@@ -34,6 +34,7 @@ import type {IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
 import {
   addPageBinding,
+  CDP_BINDING_PREFIX,
   createEvaluationError,
   valueFromRemoteObject,
 } from './utils.js';
@@ -124,16 +125,21 @@ export class ExecutionContext
         'Runtime.addBinding',
         this.#name
           ? {
-              name: '_' + binding.name,
+              name: CDP_BINDING_PREFIX + binding.name,
               executionContextName: this.#name,
             }
           : {
-              name: '_' + binding.name,
+              name: CDP_BINDING_PREFIX + binding.name,
               executionContextId: this.#id,
             }
       );
 
-      await this.evaluate(addPageBinding, 'internal', binding.name);
+      await this.evaluate(
+        addPageBinding,
+        'internal',
+        binding.name,
+        CDP_BINDING_PREFIX
+      );
 
       this.#bindings.set(binding.name, binding);
     } catch (error) {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -678,7 +678,9 @@ export class CdpPage extends Page {
     this.#bindings.set(name, binding);
 
     const expression = pageBindingInitString('exposedFun', name);
-    await this.#primaryTargetClient.send('Runtime.addBinding', {name});
+    await this.#primaryTargetClient.send('Runtime.addBinding', {
+      name: '_' + name,
+    });
     // TODO: investigate this as it appears to only apply to the main frame and
     // local subframes instead of the entire frame tree (including future
     // frame).

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -77,6 +77,7 @@ import type {TargetManager} from './TargetManager.js';
 import {TargetManagerEvent} from './TargetManager.js';
 import {Tracing} from './Tracing.js';
 import {
+  CDP_BINDING_PREFIX,
   createClientError,
   pageBindingInitString,
   valueFromRemoteObject,
@@ -679,7 +680,7 @@ export class CdpPage extends Page {
 
     const expression = pageBindingInitString('exposedFun', name);
     await this.#primaryTargetClient.send('Runtime.addBinding', {
-      name: '_' + name,
+      name: CDP_BINDING_PREFIX + name,
     });
     // TODO: investigate this as it appears to only apply to the main frame and
     // local subframes instead of the entire frame tree (including future

--- a/packages/puppeteer-core/src/cdp/utils.ts
+++ b/packages/puppeteer-core/src/cdp/utils.ts
@@ -169,7 +169,11 @@ export function valueFromRemoteObject(
 /**
  * @internal
  */
-export function addPageBinding(type: string, name: string): void {
+export function addPageBinding(
+  type: string,
+  name: string,
+  prefix: string
+): void {
   // Depending on the frame loading state either Runtime.evaluate or
   // Page.addScriptToEvaluateOnNewDocument might succeed. Let's check that we
   // don't re-wrap Puppeteer's binding.
@@ -192,7 +196,8 @@ export function addPageBinding(type: string, name: string): void {
       callPuppeteer.args.set(seq, args);
 
       // @ts-expect-error: In a different context.
-      globalThis['_' + name](
+      // Needs to be the same as CDP_BINDING_PREFIX.
+      globalThis[prefix + name](
         JSON.stringify({
           type,
           name,
@@ -223,6 +228,11 @@ export function addPageBinding(type: string, name: string): void {
 /**
  * @internal
  */
+export const CDP_BINDING_PREFIX = 'puppeteer_';
+
+/**
+ * @internal
+ */
 export function pageBindingInitString(type: string, name: string): string {
-  return evaluationString(addPageBinding, type, name);
+  return evaluationString(addPageBinding, type, name, CDP_BINDING_PREFIX);
 }

--- a/packages/puppeteer-core/src/cdp/utils.ts
+++ b/packages/puppeteer-core/src/cdp/utils.ts
@@ -170,14 +170,11 @@ export function valueFromRemoteObject(
  * @internal
  */
 export function addPageBinding(type: string, name: string): void {
-  // This is the CDP binding.
-  // @ts-expect-error: In a different context.
-  const callCdp = globalThis[name];
-
   // Depending on the frame loading state either Runtime.evaluate or
   // Page.addScriptToEvaluateOnNewDocument might succeed. Let's check that we
   // don't re-wrap Puppeteer's binding.
-  if (callCdp[Symbol.toStringTag] === 'PuppeteerBinding') {
+  // @ts-expect-error: In a different context.
+  if (globalThis[name]) {
     return;
   }
 
@@ -194,7 +191,8 @@ export function addPageBinding(type: string, name: string): void {
       callPuppeteer.lastSeq = seq;
       callPuppeteer.args.set(seq, args);
 
-      callCdp(
+      // @ts-expect-error: In a different context.
+      globalThis['_' + name](
         JSON.stringify({
           type,
           name,
@@ -220,8 +218,6 @@ export function addPageBinding(type: string, name: string): void {
       });
     },
   });
-  // @ts-expect-error: In a different context.
-  globalThis[name][Symbol.toStringTag] = 'PuppeteerBinding';
 }
 
 /**

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -863,6 +863,13 @@
     "comment": "times out flakily"
   },
   {
+    "testIdPattern": "[bfcache.spec] BFCache can call a function exposed on a page restored from bfcache",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "addBinding is not supported"
+  },
+  {
     "testIdPattern": "[bfcache.spec] BFCache can navigate to a BFCached page containing an OOPIF and a worker",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/cdp/bfcache.spec.ts
+++ b/test/src/cdp/bfcache.spec.ts
@@ -37,6 +37,48 @@ describe('BFCache', function () {
     }
   });
 
+  it('can call a function exposed on a page restored from bfcache', async () => {
+    const {httpsServer, page, close} = await launch({
+      ignoreHTTPSErrors: true,
+    });
+    let message = '';
+    try {
+      page.setDefaultTimeout(3000);
+      await page.exposeFunction('ping', (msg: string) => {
+        console.log('called', msg);
+        message = msg;
+      });
+      await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');
+
+      await page.evaluate(async () => {
+        await (window as any).ping('1');
+      });
+      expect(message).toBe('1');
+
+      await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
+
+      expect(page.url()).toContain('target.html');
+
+      await page.evaluate(async () => {
+        await (window as any).ping('2');
+      });
+      expect(message).toBe('2');
+
+      await Promise.all([page.waitForNavigation(), page.goBack()]);
+      await page.evaluate(async () => {
+        await (window as any).ping('3');
+      });
+      expect(message).toBe('3');
+      expect(
+        await page.evaluate(() => {
+          return document.body.innerText;
+        })
+      ).toBe('BFCachednext');
+    } finally {
+      await close();
+    }
+  });
+
   it('can navigate to a BFCached page containing an OOPIF and a worker', async () => {
     const {httpsServer, page, close} = await launch({
       ignoreHTTPSErrors: true,


### PR DESCRIPTION
When a page is restored from bfcache, the CDP bindings are restored and overwrite CDP wrappers. To avoid the issue, this PR changes Puppeteer to expose two global variables (one is the raw CDP binding and another one the wrapper intended for Puppeteer users). The wrapper processes non-string arguments and calls the raw CDP binding according to the internal protocol between the page and Puppeteer. For end users, this fix should not cause any changes except for an extra global function `puppeteer_$FunctionName` being added to the globalThis.

Fixes  https://github.com/puppeteer/puppeteer/issues/12662