### PR TITLE
fix: execution contexts might be created before previous is destroyed

### DIFF
--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -454,10 +454,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
       }
       if (contextPayload.auxData && contextPayload.auxData['isDefault']) {
         world = frame.worlds[MAIN_WORLD];
-      } else if (
-        contextPayload.name === UTILITY_WORLD_NAME &&
-        !frame.worlds[PUPPETEER_WORLD].hasContext()
-      ) {
+      } else if (contextPayload.name === UTILITY_WORLD_NAME) {
         // In case of multiple sessions to the same target, there's a race between
         // connections so we might end up creating multiple isolated worlds.
         // We can use either.

--- a/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
+++ b/packages/puppeteer-core/src/cdp/IsolatedWorld.ts
@@ -16,6 +16,7 @@ import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {
   fromEmitterEvent,
+  timeout,
   withSourcePuppeteerURLIfNone,
 } from '../common/util.js';
 import {disposeSymbol} from '../util/disposable.js';
@@ -143,7 +144,8 @@ export class IsolatedWorld extends Realm {
               // The message has to match the CDP message expected by the WaitTask class.
               throw new Error('Execution context was destroyed');
             })
-          )
+          ),
+          timeout(this.timeoutSettings.timeout())
         )
       )
     );


### PR DESCRIPTION
It looks like the check existed since https://github.com/puppeteer/puppeteer/pull/4276 but it might not hold true anymore:

1) if a context is created before the previous context is destroyed, it will be omitted by puppeteer.
2) this seems to happen now if the frames are swapped.

Not sure if using the latest context would regress anything in case of multiple sessions? Would we need a unique utility world name per session? The comment says it is okay to use any world there.

Adding a test is challenging since it seems to happen under some circumstances on a live website in a flaky manner.

Closes https://github.com/puppeteer/puppeteer/issues/12665