### PR TITLE
docs: Reference Page.setDefaultTimeout for timeout option

### DIFF
--- a/docs/api/puppeteer.pdfoptions.md
+++ b/docs/api/puppeteer.pdfoptions.md
@@ -376,6 +376,8 @@ number
 
 Timeout in milliseconds. Pass `0` to disable timeout.
 
+The default value can be changed by using [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md)
+
 </td><td>
 
 `30_000`

--- a/packages/puppeteer-core/src/common/PDFOptions.ts
+++ b/packages/puppeteer-core/src/common/PDFOptions.ts
@@ -172,6 +172,9 @@ export interface PDFOptions {
   outline?: boolean;
   /**
    * Timeout in milliseconds. Pass `0` to disable timeout.
+   *
+   * The default value can be changed by using {@link Page.setDefaultTimeout}
+   *
    * @defaultValue `30_000`
    */
   timeout?: number;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation clarification

**Summary**

Per the implementation of `Page.pdf` (`Page.createPDFStream`), the `timeout` option will fallback to use the value assigned by `Page.setDefaultTimeout`. See https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/cdp/Page.ts#L1083

This updates the `PDFOptions` documentation to match