### PR TITLE
chore: enable tests for Page.Events.Popup for Firefox.

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -621,13 +621,6 @@
   {
     "testIdPattern": "[page.spec] Page Page.Events.Popup *",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox does not support originalOpener yet."
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.Events.Popup *",
-    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["SKIP"],
     "comment": "Deprecated"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The support for `originalOpener` has landed in Firefox, so we can enable the tests which utilize it.