### PR TITLE
fix: add an option to not wait for fonts when pdf printing

### DIFF
--- a/docs/api/puppeteer.pdfoptions.md
+++ b/docs/api/puppeteer.pdfoptions.md
@@ -385,6 +385,27 @@ The default value can be changed by using [Page.setDefaultTimeout()](./puppeteer
 </td></tr>
 <tr><td>
 
+<span id="waitforfonts">waitForFonts</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+If true, waits for `document.fonts.ready` to resolve. This might require activating the page using [Page.bringToFront()](./puppeteer.page.bringtofront.md) if the page is in the background.
+
+</td><td>
+
+`true`
+
+</td></tr>
+<tr><td>
+
 <span id="width">width</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -1096,21 +1096,24 @@ export class CdpPage extends Page {
       omitBackground,
       tagged: generateTaggedPDF,
       outline: generateDocumentOutline,
+      waitForFonts,
     } = parsePDFOptions(options);
 
     if (omitBackground) {
       await this.#emulationManager.setTransparentBackgroundColor();
     }
 
-    await firstValueFrom(
-      from(
-        this.mainFrame()
-          .isolatedRealm()
-          .evaluate(() => {
-            return document.fonts.ready;
-          })
-      ).pipe(raceWith(timeout(ms)))
-    );
+    if (waitForFonts) {
+      await firstValueFrom(
+        from(
+          this.mainFrame()
+            .isolatedRealm()
+            .evaluate(() => {
+              return document.fonts.ready;
+            })
+        ).pipe(raceWith(timeout(ms)))
+      );
+    }
 
     const printCommandPromise = this.#primaryTargetClient.send(
       'Page.printToPDF',

--- a/packages/puppeteer-core/src/common/PDFOptions.ts
+++ b/packages/puppeteer-core/src/common/PDFOptions.ts
@@ -178,6 +178,14 @@ export interface PDFOptions {
    * @defaultValue `30_000`
    */
   timeout?: number;
+  /**
+   * If true, waits for `document.fonts.ready` to resolve. This might require
+   * activating the page using {@link Page.bringToFront} if the page is in the
+   * background.
+   *
+   * @defaultValue `true`
+   */
+  waitForFonts?: boolean;
 }
 
 /**

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -363,6 +363,7 @@ export function parsePDFOptions(
     omitBackground: false,
     outline: false,
     tagged: true,
+    waitForFonts: true,
   };
 
   let width = 8.5;


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/pull/12175 added waiting for fonts by default to address a common issue that PDFs are missing the fonts. It turned out that if the page is in the background, the `document.fonts.ready` callback is not always invoked since it depends on request animation frames which might be throttled in the background. For users who might not need to wait for fonts to load, this PR adds an option to revert to the old behavior. Eventually, if there is a way to wait for fonts that is not throttled in background tabs, we could remove this option.

Closes https://github.com/puppeteer/puppeteer/issues/12598