### PR TITLE
test: add cache tests using scripts instead of stylesheets

### DIFF
--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -537,6 +537,10 @@ export class BidiPage extends Page {
   }
 
   override async setCacheEnabled(enabled?: boolean): Promise<void> {
+    if (!this.#browserContext.browser().cdpSupported) {
+      await this.#frame.browsingContext.setCacheBypass(enabled);
+      return;
+    }
     // TODO: handle CDP-specific cases such as mprach.
     await this._client().send('Network.setCacheDisabled', {
       cacheDisabled: !enabled,

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -538,7 +538,7 @@ export class BidiPage extends Page {
 
   override async setCacheEnabled(enabled?: boolean): Promise<void> {
     if (!this.#browserContext.browser().cdpSupported) {
-      await this.#frame.browsingContext.setCacheBypass(!enabled ?? true);
+      await this.#frame.browsingContext.setCacheBypass(!enabled);
       return;
     }
     // TODO: handle CDP-specific cases such as mprach.

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -538,7 +538,7 @@ export class BidiPage extends Page {
 
   override async setCacheEnabled(enabled?: boolean): Promise<void> {
     if (!this.#browserContext.browser().cdpSupported) {
-      await this.#frame.browsingContext.setCacheBypass(enabled);
+      await this.#frame.browsingContext.setCacheBypass(enabled ?? false);
       return;
     }
     // TODO: handle CDP-specific cases such as mprach.

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -538,7 +538,7 @@ export class BidiPage extends Page {
 
   override async setCacheEnabled(enabled?: boolean): Promise<void> {
     if (!this.#browserContext.browser().cdpSupported) {
-      await this.#frame.browsingContext.setCacheBypass(enabled ?? false);
+      await this.#frame.browsingContext.setCacheBypass(!enabled ?? true);
       return;
     }
     // TODO: handle CDP-specific cases such as mprach.

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -423,7 +423,7 @@ export class BrowsingContext extends EventEmitter<{
   })
   async setCacheBypass(enabled: boolean): Promise<void> {
     // @ts-expect-error not in BiDi types yet.
-    await this.#session.send('browsingContext.setCacheBypass', {
+    await this.#session.send('network.setCacheBypass', {
       contexts: [this.id],
       bypass: enabled,
     });

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -421,6 +421,18 @@ export class BrowsingContext extends EventEmitter<{
     // SAFETY: Disposal implies this exists.
     return context.#reason!;
   })
+  async setCacheBypass(enabled?: boolean): Promise<void> {
+    // @ts-expect-error not in BiDi types yet.
+    await this.#session.send('browsingContext.setCacheBypass', {
+      contexts: [this.id],
+      bypass: enabled,
+    });
+  }
+
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
   async print(options: PrintOptions = {}): Promise<string> {
     const {
       result: {data},

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -421,7 +421,7 @@ export class BrowsingContext extends EventEmitter<{
     // SAFETY: Disposal implies this exists.
     return context.#reason!;
   })
-  async setCacheBypass(enabled?: boolean): Promise<void> {
+  async setCacheBypass(enabled: boolean): Promise<void> {
     // @ts-expect-error not in BiDi types yet.
     await this.#session.send('browsingContext.setCacheBypass', {
       contexts: [this.id],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3050,13 +3050,6 @@
     "comment": "TODO: BiDi does not support custom errors - https://github.com/w3c/webdriver-bidi/issues/508"
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cooperatively respond by priority",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for arguments in network.provideResponse in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1853882"
-  },
-  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cache stylesheet if cache enabled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3050,13 +3050,6 @@
     "comment": "TODO: BiDi does not support custom errors - https://github.com/w3c/webdriver-bidi/issues/508"
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cache if cache enabled",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
-  },
-  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cooperatively respond by priority",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3064,18 +3057,18 @@
     "comment": "TODO: Needs support for arguments in network.provideResponse in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1853882"
   },
   {
+    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cache stylesheet if cache enabled",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Needs Firefox support for network events for cached stylesheets https://bugzilla.mozilla.org/show_bug.cgi?id=1879438"
+  },
+  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should load fonts if cache enabled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
-  },
-  {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should not cache if cache disabled",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
+    "comment": "TODO: Needs investigation"
   },
   {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with encoded server - 2",
@@ -3148,18 +3141,11 @@
     "comment": "TODO: BiDi does not support custom errors - https://github.com/w3c/webdriver-bidi/issues/508"
   },
   {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should cache if cache enabled",
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should cache stylesheet if cache enabled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should load fonts if cache enabled",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
+    "expectations": ["FAIL"],
+    "comment": "Needs Firefox support for network events for cached stylesheets https://bugzilla.mozilla.org/show_bug.cgi?id=1879438"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should navigate to URL with hash and fire requests without hash",
@@ -3167,13 +3153,6 @@
     "parameters": ["cdp", "chrome"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should not cache if cache disabled",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with encoded server - 2",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -482,6 +482,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[network.spec] network Page.authenticate should not disable caching for *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
     "testIdPattern": "[network.spec] network Request.initiator should return the initiator",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -526,6 +540,20 @@
     "parameters": ["webDriverBiDi"],
     "expectations": ["SKIP"],
     "comment": "Not implemented for BiDi yet."
+  },
+  {
+    "testIdPattern": "[network.spec] network Response.fromCache should work for *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[network.spec] network Response.fromCache should work for *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
     "testIdPattern": "[network.spec] network Response.fromServiceWorker Response.fromServiceWorker",
@@ -2338,18 +2366,11 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache",
+    "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache for stylesheet",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
-    "comment": "Firefox does not send events for the cached event (bypasses network?)"
+    "comment": "Needs Firefox support for network events for cached stylesheets https://bugzilla.mozilla.org/show_bug.cgi?id=1879438"
   },
   {
     "testIdPattern": "[network.spec] network Network Events Page.Events.Response",
@@ -2408,18 +2429,18 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[network.spec] network Page.authenticate should not disable caching",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[network.spec] network Page.authenticate should not disable caching",
+    "testIdPattern": "[network.spec] network Page.authenticate should not disable caching for script",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox returns `fromCache: false`"
+    "expectations": ["SKIP"],
+    "comment": "TODO: Needs investigation, isCached is false for the script request handle via network interception"
+  },
+  {
+    "testIdPattern": "[network.spec] network Page.authenticate should not disable caching for stylesheet",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "Needs Firefox support for network events for cached stylesheets https://bugzilla.mozilla.org/show_bug.cgi?id=1879438"
   },
   {
     "testIdPattern": "[network.spec] network Page.authenticate should work",
@@ -2527,25 +2548,11 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[network.spec] network Response.fromCache should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[network.spec] network Response.fromCache should work",
+    "testIdPattern": "[network.spec] network Response.fromCache should work for stylesheet",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
-    "comment": "Needs investigation, it looks like a bug in Puppeteer"
-  },
-  {
-    "testIdPattern": "[network.spec] network Response.fromCache should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL", "PASS"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "Needs Firefox support for network events for cached stylesheets https://bugzilla.mozilla.org/show_bug.cgi?id=1879438"
   },
   {
     "testIdPattern": "[network.spec] network Response.fromServiceWorker Response.fromServiceWorker",

--- a/test/assets/cached/one-script.html
+++ b/test/assets/cached/one-script.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div>hello, world!</div>
+<script type="text/javascript" src="./one-script.js"></script>

--- a/test/assets/cached/one-script.js
+++ b/test/assets/cached/one-script.js
@@ -1,0 +1,3 @@
+"use strict";
+
+console.log(1);

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -603,46 +603,52 @@ describe('request interception', function () {
       expect(urls.has('one-style.html')).toBe(true);
       expect(urls.has('one-style.css')).toBe(true);
     });
-    it('should not cache if cache disabled', async () => {
-      const {page, server} = await getTestState();
 
-      // Load and re-load to make sure it's cached.
-      await page.goto(server.PREFIX + '/cached/one-style.html');
+    for (const {resourceType, url} of [
+      {url: '/cached/one-style.html', resourceType: 'stylesheet'},
+      {url: '/cached/one-script.html', resourceType: 'script'},
+    ]) {
+      it(`should not cache ${resourceType} if cache disabled`, async () => {
+        const {page, server} = await getTestState();
 
-      await page.setRequestInterception(true);
-      await page.setCacheEnabled(false);
-      page.on('request', request => {
-        return request.continue();
+        // Load and re-load to make sure it's cached.
+        await page.goto(server.PREFIX + url);
+
+        await page.setRequestInterception(true);
+        await page.setCacheEnabled(false);
+        page.on('request', request => {
+          return request.continue();
+        });
+
+        const cached: HTTPRequest[] = [];
+        page.on('requestservedfromcache', r => {
+          return cached.push(r);
+        });
+
+        await page.reload();
+        expect(cached).toHaveLength(0);
       });
+      it(`should cache ${resourceType} if cache enabled`, async () => {
+        const {page, server} = await getTestState();
 
-      const cached: HTTPRequest[] = [];
-      page.on('requestservedfromcache', r => {
-        return cached.push(r);
+        // Load and re-load to make sure it's cached.
+        await page.goto(server.PREFIX + url);
+
+        await page.setRequestInterception(true);
+        await page.setCacheEnabled(true);
+        page.on('request', request => {
+          return request.continue();
+        });
+
+        const cached: HTTPRequest[] = [];
+        page.on('requestservedfromcache', r => {
+          return cached.push(r);
+        });
+
+        await page.reload();
+        expect(cached).toHaveLength(1);
       });
-
-      await page.reload();
-      expect(cached).toHaveLength(0);
-    });
-    it('should cache if cache enabled', async () => {
-      const {page, server} = await getTestState();
-
-      // Load and re-load to make sure it's cached.
-      await page.goto(server.PREFIX + '/cached/one-style.html');
-
-      await page.setRequestInterception(true);
-      await page.setCacheEnabled(true);
-      page.on('request', request => {
-        return request.continue();
-      });
-
-      const cached: HTTPRequest[] = [];
-      page.on('requestservedfromcache', r => {
-        return cached.push(r);
-      });
-
-      await page.reload();
-      expect(cached).toHaveLength(1);
-    });
+    }
     it('should load fonts if cache enabled', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Duplicates two tests around cached requests which currently use cached stylesheets. The alternate versions use scripts instead. At the moment Firefox does not emit network event for CSS Loader cache hits, so cached stylesheet network events are missing (same for images). However other cached requests should be visible, eg documents and scripts, so it would be interesting to have some tests to reflect that.

This PR is not removing any test, so it will not increase the number of passes for Firefox. The proposal is to downgrade all the stylesheet-only tests to P3, since their counterpart using scripts seem to pass.

Apart from the expected failures linked to missing network events for stylesheets, we also have frequent failures for `[network.spec] network Page.authenticate should not disable caching ...`

In theory this should work with scripts, and seems to work locally when running in isolation. However on CI or during full runs it often fails.