### PR TITLE
fix!: remove whitespace normalization from a11y selectors

### DIFF
--- a/packages/puppeteer-core/src/cdp/AriaQueryHandler.ts
+++ b/packages/puppeteer-core/src/cdp/AriaQueryHandler.ts
@@ -21,10 +21,6 @@ const isKnownAttribute = (
   return ['name', 'role'].includes(attribute);
 };
 
-const normalizeValue = (value: string): string => {
-  return value.replace(/ +/g, ' ').trim();
-};
-
 /**
  * The selectors consist of an accessible name to query for and optionally
  * further aria attributes on the form `[<attribute>=<value>]`.
@@ -43,17 +39,16 @@ const parseARIASelector = (selector: string): ARIASelector => {
   const defaultName = selector.replace(
     ATTRIBUTE_REGEXP,
     (_, attribute, __, value) => {
-      attribute = attribute.trim();
       assert(
         isKnownAttribute(attribute),
         `Unknown aria attribute "${attribute}" in selector`
       );
-      queryOptions[attribute] = normalizeValue(value);
+      queryOptions[attribute] = value;
       return '';
     }
   );
   if (defaultName && !queryOptions.name) {
-    queryOptions.name = normalizeValue(defaultName);
+    queryOptions.name = defaultName;
   }
   return queryOptions;
 };

--- a/test/src/ariaqueryhandler.spec.ts
+++ b/test/src/ariaqueryhandler.spec.ts
@@ -17,6 +17,73 @@ describe('AriaQueryHandler', () => {
   setupTestBrowserHooks();
 
   describe('parseAriaSelector', () => {
+    it('should handle non-breaking spaces', async () => {
+      const {page} = await getTestState();
+      await page.setContent(
+        '<button id="btn" role="button"><span>&nbsp;</span><span>&nbsp;</span>Submit button and some spaces</button>'
+      );
+      const expectFound = async (button: ElementHandle | null) => {
+        assert(button);
+        const id = await button.evaluate(button => {
+          return button.id;
+        });
+        expect(id).toBe('btn');
+      };
+      {
+        using button = await page.$(
+          'aria/\u00A0\u00A0Submit button and some spaces'
+        );
+        await expectFound(button);
+      }
+      {
+        using button = await page.$('aria/Submit button and some spaces');
+        expect(button).toBe(null);
+      }
+    });
+    it('should handle non-breaking spaces', async () => {
+      const {page} = await getTestState();
+      await page.setContent(
+        '<button id="btn" role="button">  Submit button and some spaces</button>'
+      );
+      const expectFound = async (button: ElementHandle | null) => {
+        assert(button);
+        const id = await button.evaluate(button => {
+          return button.id;
+        });
+        expect(id).toBe('btn');
+      };
+      {
+        using button = await page.$('aria/ubmit button and some spaces');
+        expect(button).toBe(null);
+      }
+      {
+        using button = await page.$('aria/Submit button and some spaces');
+        await expectFound(button);
+      }
+    });
+    it('should handle zero width spaces', async () => {
+      const {page} = await getTestState();
+      await page.setContent(
+        '<button id="btn" role="button"><span>&ZeroWidthSpace;</span><span>&ZeroWidthSpace;</span>Submit button and some spaces</button>'
+      );
+      const expectFound = async (button: ElementHandle | null) => {
+        assert(button);
+        const id = await button.evaluate(button => {
+          return button.id;
+        });
+        expect(id).toBe('btn');
+      };
+      {
+        using button = await page.$(
+          'aria/\u200B\u200BSubmit button and some spaces'
+        );
+        await expectFound(button);
+      }
+      {
+        using button = await page.$('aria/Submit button and some spaces');
+        expect(button).toBe(null);
+      }
+    });
     it('should find button', async () => {
       const {page} = await getTestState();
       await page.setContent(
@@ -41,21 +108,23 @@ describe('AriaQueryHandler', () => {
         );
         await expectFound(button);
       }
-      using button = await page.$(
-        'aria/  Submit button and some spaces[role="button"]'
-      );
-      await expectFound(button);
+      {
+        using button = await page.$(
+          'aria/  Submit button and some spaces[role="button"]'
+        );
+        expect(button).toBe(null);
+      }
       {
         using button = await page.$(
           'aria/Submit button and some spaces  [role="button"]'
         );
-        await expectFound(button);
+        expect(button).toBe(null);
       }
       {
         using button = await page.$(
           'aria/Submit  button   and  some  spaces   [  role  =  "button" ] '
         );
-        await expectFound(button);
+        expect(button).toBe(null);
       }
       {
         using button = await page.$(
@@ -73,17 +142,17 @@ describe('AriaQueryHandler', () => {
         using button = await page.$(
           'aria/[name="  Submit  button and some  spaces"][role="button"]'
         );
-        await expectFound(button);
+        expect(button).toBe(null);
       }
       {
         using button = await page.$(
           "aria/[name='  Submit  button and some  spaces'][role='button']"
         );
-        await expectFound(button);
+        expect(button).toBe(null);
       }
       {
         using button = await page.$(
-          'aria/ignored[name="Submit  button and some  spaces"][role="button"]'
+          'aria/ignored[name="Submit button and some spaces"][role="button"]'
         );
         await expectFound(button);
         await expect(page.$('aria/smth[smth="true"]')).rejects.toThrow(


### PR DESCRIPTION
Previously, Puppeteer incorrectly normalized whitespaces in ARIA selectors in a way that did not not allow distinguishing between the following two HTML structures:

- `<p>  text<p>`
- `<p><span>&nbsp;</span><span>&nbsp;</span>text<p>`

In the first case, the spaces are not part of the element's textual content, and the element should be found via `aria/text`.

In the second case, the spaces are part of the p element and the query `aria/\u00A0\u00A0text` should find it while `aria/text` should not. The whitespace normalization in Puppeteer would previously prevent searching for the element with whitespaces in the textual content.

Related: the step 2.F of https://www.w3.org/TR/accname-1.2/#computation-steps defines how child elements contribute to the parent element's computed name.

If you need the old behavior, apply `selector.replace(/ +/g, ' ').trim()` to your ARIA selector.