### PR TITLE
test: rewrite and rename an interception test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3071,13 +3071,6 @@
     "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with encoded server - 2",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs investigation"
-  },
-  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with file URLs",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3167,13 +3160,6 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
     "comment": "TODO: Needs support for enabling cache in BiDi without CDP https://github.com/w3c/webdriver-bidi/issues/582"
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with encoded server - 2",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: Needs investigation"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with file URLs",

--- a/test/assets/style-404.html
+++ b/test/assets/style-404.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="/fonts-404?helvetica|arial"/>

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -603,7 +603,7 @@ describe('cooperative request interception', function () {
       const response = await page.goto(server.PREFIX + '/malformed?rnd=%911');
       expect(response!.status()).toBe(200);
     });
-    it('should work with encoded server - 2', async () => {
+    it('should work with missing stylesheets', async () => {
       const {page, server} = await getTestState();
 
       // The requestWillBeSent will report URL as-is, whereas interception will
@@ -616,10 +616,8 @@ describe('cooperative request interception', function () {
           requests.push(request);
         }
       });
-      const response = await page.goto(
-        `data:text/html,<link rel="stylesheet" href="${server.PREFIX}/fonts?helvetica|arial"/>`
-      );
-      expect(response!.status()).toBe(200);
+      const response = (await page.goto(server.PREFIX + '/style-404.html'))!;
+      expect(response.status()).toBe(200);
       expect(requests).toHaveLength(2);
       expect(requests[1]!.response()!.status()).toBe(404);
     });

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -525,7 +525,7 @@ describe('request interception', function () {
       ))!;
       expect(response.status()).toBe(200);
     });
-    it('should work with encoded server - 2', async () => {
+    it('should work with missing stylesheets', async () => {
       const {page, server} = await getTestState();
 
       // The requestWillBeSent will report URL as-is, whereas interception will
@@ -538,9 +538,7 @@ describe('request interception', function () {
           requests.push(request);
         }
       });
-      const response = (await page.goto(
-        `data:text/html,<link rel="stylesheet" href="${server.PREFIX}/fonts?helvetica|arial"/>`
-      ))!;
+      const response = (await page.goto(server.PREFIX + '/style-404.html'))!;
       expect(response.status()).toBe(200);
       expect(requests).toHaveLength(2);
       expect(requests[1]!.response()!.status()).toBe(404);


### PR DESCRIPTION
to prevent opaque origin response blocking and clarify what the test does.