### PR TITLE
feat: add last locator method

### DIFF
--- a/docs/api/puppeteer.locator.last.md
+++ b/docs/api/puppeteer.locator.last.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: Locator.last
+---
+
+# Locator.last() method
+
+Trying to locate all the elements for locator array in parallel and return the last locator that locate element.
+
+#### Signature:
+
+```typescript
+class Locator {
+  static last<Locators extends readonly unknown[] | []>(
+    locators: Locators
+  ): Locator<AwaitedLocator<Locators[number]>>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+locators
+
+</td><td>
+
+Locators
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Locator](./puppeteer.locator.md)&lt;[AwaitedLocator](./puppeteer.awaitedlocator.md)&lt;Locators\[number\]&gt;&gt;

--- a/docs/api/puppeteer.locator.last.md
+++ b/docs/api/puppeteer.locator.last.md
@@ -4,7 +4,7 @@ sidebar_label: Locator.last
 
 # Locator.last() method
 
-Trying to locate all the elements for locator array in parallel and return the last locator that locate element.
+Waits for multiple locators to locate elements in DOM and calls the action on the last locator waiting for action-specific preconditions. If any of the elements identified by locators is not found, the last locator times out.
 
 #### Signature:
 
@@ -46,3 +46,13 @@ Locators
 **Returns:**
 
 [Locator](./puppeteer.locator.md)&lt;[AwaitedLocator](./puppeteer.awaitedlocator.md)&lt;Locators\[number\]&gt;&gt;
+
+## Example
+
+```ts
+await Locator.last([
+  page.locator('#locator1'),
+  page.locator('#locator2'),
+]).wait();
+await page.locator('#locator3').click();
+```

--- a/docs/api/puppeteer.locator.md
+++ b/docs/api/puppeteer.locator.md
@@ -151,7 +151,7 @@ Hovers over the located element.
 
 </td><td>
 
-Trying to locate all the elements for locator array in parallel and return the last locator that locate element.
+Waits for multiple locators to locate elements in DOM and calls the action on the last locator waiting for action-specific preconditions. If any of the elements identified by locators is not found, the last locator times out.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.locator.md
+++ b/docs/api/puppeteer.locator.md
@@ -143,6 +143,19 @@ Hovers over the located element.
 </td></tr>
 <tr><td>
 
+<span id="last">[last(locators)](./puppeteer.locator.last.md)</span>
+
+</td><td>
+
+`static`
+
+</td><td>
+
+Trying to locate all the elements for locator array in parallel and return the last locator that locate element.
+
+</td></tr>
+<tr><td>
+
 <span id="map">[map(mapper)](./puppeteer.locator.map.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/locators/locators.ts
+++ b/packages/puppeteer-core/src/api/locators/locators.ts
@@ -115,8 +115,9 @@ export abstract class Locator<T> extends EventEmitter<LocatorEvents> {
   }
 
   /**
-   * Trying to locate all the elements for locator array in parallel
-   * and return the last locator that locate element.
+   * Waits for multiple locators to locate elements in DOM and 
+   * calls the action on the last locator waiting for action-specific preconditions.
+   * If any of the elements identified by locators is not found, the last locator times out.
    *
    * @public
    */

--- a/packages/puppeteer-core/src/api/locators/locators.ts
+++ b/packages/puppeteer-core/src/api/locators/locators.ts
@@ -115,9 +115,19 @@ export abstract class Locator<T> extends EventEmitter<LocatorEvents> {
   }
 
   /**
-   * Waits for multiple locators to locate elements in DOM and 
+   * Waits for multiple locators to locate elements in DOM and
    * calls the action on the last locator waiting for action-specific preconditions.
-   * If any of the elements identified by locators is not found, the last locator times out.
+   * If any of the elements identified by locators is not found, the last locator
+   * times out.
+   * @example
+   *
+   * ```ts
+   * await Locator.last([
+   *   page.locator('#locator1'),
+   *   page.locator('#locator2'),
+   * ]).wait();
+   * await page.locator('#locator3').click();
+   * ```
    *
    * @public
    */

--- a/packages/puppeteer-core/third_party/rxjs/rxjs.ts
+++ b/packages/puppeteer-core/third_party/rxjs/rxjs.ts
@@ -41,6 +41,7 @@ export {
   throwIfEmpty,
   timer,
   zip,
+  takeLast,
 } from 'rxjs';
 
 export type * from 'rxjs';

--- a/test/src/locator.spec.ts
+++ b/test/src/locator.spec.ts
@@ -581,6 +581,38 @@ describe('Locator', function () {
     });
   });
 
+  describe('Locator.last', () => {
+    it('should time out when any one of the locaters do not match', async () => {
+      const clock = sinon.useFakeTimers({
+        shouldClearNativeTimers: true,
+        shouldAdvanceTime: true,
+      });
+      try {
+        const {page} = await getTestState();
+
+        await page.setViewport({width: 500, height: 500});
+        await page.setContent(`
+        <button id="test1">test1</button>
+        <input id="test2">test2</input>
+      `);
+        const result = Locator.last([
+          page.locator('#test1'),
+          page.locator('#test2'),
+          page.locator('#test3'),
+        ])
+          .setTimeout(5000)
+          .waitHandle();
+        clock.tick(5100);
+        await expect(result).rejects.toEqual(
+          new TimeoutError('Timed out after waiting 5000ms')
+        );
+        clock.tick(5100);
+      } finally {
+        clock.restore();
+      }
+    });
+  });
+
   describe('Locator.prototype.map', () => {
     it('should work', async () => {
       const {page} = await getTestState();

--- a/test/src/locator.spec.ts
+++ b/test/src/locator.spec.ts
@@ -655,7 +655,7 @@ describe('Locator', function () {
 
       await page.setViewport({width: 500, height: 500});
       await page.setContent(`
-        <button id="test1">test1</button>
+        <div id="test1" style="width: 0px; height: 0px">test1</div>
          <script>
           setTimeout(() => {
             const element = document.createElement("button");

--- a/test/src/locator.spec.ts
+++ b/test/src/locator.spec.ts
@@ -582,7 +582,7 @@ describe('Locator', function () {
   });
 
   describe('Locator.last', () => {
-    it('should time out when any one of the locaters do not match', async () => {
+    it('should time out when any one of the locators do not match', async () => {
       const clock = sinon.useFakeTimers({
         shouldClearNativeTimers: true,
         shouldAdvanceTime: true,

--- a/test/src/locator.spec.ts
+++ b/test/src/locator.spec.ts
@@ -617,9 +617,15 @@ describe('Locator', function () {
 
       await page.setViewport({width: 500, height: 500});
       await page.setContent(`
-        <button id="test1" onclick="window.count++;">test1</button>
+        <button id="test1">test1</button>
         <div id="test2"></div>
+        <div id="test4"></div>
          <script>
+          const button1 = document.getElementById("test1");
+          button1.onclick = () => {
+            const div2 = document.getElementById("test4");
+            div2.innerText = "test4";
+          };
           setTimeout(() => {
             const element = document.createElement("button");
             element.id = "test3";
@@ -631,23 +637,18 @@ describe('Locator', function () {
           }, 50);
         </script>
       `);
-      await page.evaluate(() => {
-        // @ts-expect-error different context.
-        window.count = 0;
-      });
       await Locator.last([
         page.locator('#test1'),
         page.locator('#test3'),
       ]).click();
-      const count = await page.evaluate(() => {
-        // @ts-expect-error different context.
-        return globalThis.count;
-      });
       const innerText = await page.evaluate(() => {
         return document.getElementById('test2')?.innerText;
       });
-      expect(count).toBe(0);
+      const innerText2 = await page.evaluate(() => {
+        return document.getElementById('test4')?.innerText;
+      });
       expect(innerText).toBe('test2');
+      expect(innerText2).toBe('');
     });
 
     it('click the last one successfully with only the last one is clikable', async () => {


### PR DESCRIPTION
Sometimes in the test we need to wait for several locators to locate elements in order to continue the test. It is more convenient to provide such a method.