### PR TITLE
fix: don't rely on Buffer to be present

### DIFF
--- a/docs/api/puppeteer.responseforrequest.md
+++ b/docs/api/puppeteer.responseforrequest.md
@@ -43,7 +43,7 @@ Default
 
 </td><td>
 
-string \| Buffer
+string \| Uint8Array
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/HTTPRequest.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.test.ts
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import {describe, it} from 'node:test';
 
 import expect from 'expect';

--- a/packages/puppeteer-core/src/api/HTTPRequest.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.test.ts
@@ -29,16 +29,16 @@ describe('HTTPRequest', () => {
 
       expect(response.contentLength).toBe(body.byteLength);
     });
-    it('should get body length from empty string', async () => {
+    it('should get base64 from empty string', async () => {
       const response = HTTPRequest.getResponse('');
 
       expect(response.base64).toBe(Buffer.from('').toString('base64'));
     });
-    it('should get body length from latin string', async () => {
+    it('should get base64 from latin string', async () => {
       const body = 'Lorem ipsum dolor sit amet';
       const response = HTTPRequest.getResponse(body);
 
-      expect(response.contentLength).toBe(Buffer.from(body).toString('base64'));
+      expect(response.base64).toBe(Buffer.from(body).toString('base64'));
     });
     it('should get base64 from string with emoji', async () => {
       const body = 'What am I in base64 🤔?';

--- a/packages/puppeteer-core/src/api/HTTPRequest.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.test.ts
@@ -1,0 +1,34 @@
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {HTTPRequest} from './HTTPRequest.js';
+
+describe('HTTPRequest', () => {
+  describe('getResponse', () => {
+    it('should get body length from string', async () => {
+      const body = 'How Long is this string in bytes 📏?';
+      const response = HTTPRequest.getResponse(body);
+
+      expect(response.contentLength).toBe(Buffer.from(body).byteLength);
+    });
+    it('should get body length from Uint8Array', async () => {
+      const body = Buffer.from('How Long is this string in bytes 📏?');
+      const response = HTTPRequest.getResponse(body);
+
+      expect(response.contentLength).toBe(body.byteLength);
+    });
+    it('should get base64 from string', async () => {
+      const body = 'What am I in base64 🤔?';
+      const response = HTTPRequest.getResponse(body);
+
+      expect(response.base64).toBe(Buffer.from(body).toString('base64'));
+    });
+    it('should get base64 length from Uint8Array', async () => {
+      const body = Buffer.from('What am I in base64 🤔?');
+      const response = HTTPRequest.getResponse(body);
+
+      expect(response.base64).toBe(body.toString('base64'));
+    });
+  });
+});

--- a/packages/puppeteer-core/src/api/HTTPRequest.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.test.ts
@@ -6,7 +6,18 @@ import {HTTPRequest} from './HTTPRequest.js';
 
 describe('HTTPRequest', () => {
   describe('getResponse', () => {
-    it('should get body length from string', async () => {
+    it('should get body length from empty string', async () => {
+      const response = HTTPRequest.getResponse('');
+
+      expect(response.contentLength).toBe(Buffer.from('').byteLength);
+    });
+    it('should get body length from latin string', async () => {
+      const body = 'Lorem ipsum dolor sit amet';
+      const response = HTTPRequest.getResponse(body);
+
+      expect(response.contentLength).toBe(Buffer.from(body).byteLength);
+    });
+    it('should get body length from string with emoji', async () => {
       const body = 'How Long is this string in bytes 📏?';
       const response = HTTPRequest.getResponse(body);
 
@@ -18,7 +29,18 @@ describe('HTTPRequest', () => {
 
       expect(response.contentLength).toBe(body.byteLength);
     });
-    it('should get base64 from string', async () => {
+    it('should get body length from empty string', async () => {
+      const response = HTTPRequest.getResponse('');
+
+      expect(response.base64).toBe(Buffer.from('').toString('base64'));
+    });
+    it('should get body length from latin string', async () => {
+      const body = 'Lorem ipsum dolor sit amet';
+      const response = HTTPRequest.getResponse(body);
+
+      expect(response.contentLength).toBe(Buffer.from(body).toString('base64'));
+    });
+    it('should get base64 from string with emoji', async () => {
       const body = 'What am I in base64 🤔?';
       const response = HTTPRequest.getResponse(body);
 

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -559,8 +559,14 @@ export abstract class HTTPRequest {
     let contentLength: number;
     let base64: string;
     if (isString(body)) {
-      contentLength = new TextEncoder().encode(body).byteLength;
-      base64 = btoa(body);
+      const encodedBody = new TextEncoder().encode(body);
+      contentLength = encodedBody.byteLength;
+
+      const bytes = [];
+      for (const byte of encodedBody) {
+        bytes.push(String.fromCharCode(byte));
+      }
+      base64 = btoa(bytes.join(''));
     } else {
       contentLength = Buffer.byteLength(body);
       base64 = body.toString('base64');

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -6,7 +6,7 @@
 import type {Protocol} from 'devtools-protocol';
 
 import type {ProtocolError} from '../common/Errors.js';
-import {debugError} from '../common/util.js';
+import {debugError, isString} from '../common/util.js';
 import {assert} from '../util/assert.js';
 
 import type {CDPSession} from './CDPSession.js';
@@ -547,6 +547,28 @@ export abstract class HTTPRequest {
       };
       return;
     }
+  }
+
+  /**
+   * @internal
+   */
+  static getResponse(body: string | Buffer): {
+    contentLength: number;
+    base64: string;
+  } {
+    let contentLength: number;
+    let base64: string;
+    if (isString(body)) {
+      contentLength = new TextEncoder().encode(body).byteLength;
+      base64 = btoa(body);
+    } else {
+      contentLength = Buffer.byteLength(body);
+      base64 = body.toString('base64');
+    }
+    return {
+      contentLength,
+      base64,
+    };
   }
 }
 

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -46,7 +46,7 @@ export interface ResponseForRequest {
    */
   headers: Record<string, unknown>;
   contentType: string;
-  body: string | Buffer;
+  body: string | Uint8Array;
 }
 
 /**
@@ -552,28 +552,23 @@ export abstract class HTTPRequest {
   /**
    * @internal
    */
-  static getResponse(body: string | Buffer): {
+  static getResponse(body: string | Uint8Array): {
     contentLength: number;
     base64: string;
   } {
-    let contentLength: number;
-    let base64: string;
-    if (isString(body)) {
-      const encodedBody = new TextEncoder().encode(body);
-      contentLength = encodedBody.byteLength;
+    // Needed to get the correct byteLength
+    const byteBody: Uint8Array = isString(body)
+      ? new TextEncoder().encode(body)
+      : body;
 
-      const bytes = [];
-      for (const byte of encodedBody) {
-        bytes.push(String.fromCharCode(byte));
-      }
-      base64 = btoa(bytes.join(''));
-    } else {
-      contentLength = Buffer.byteLength(body);
-      base64 = body.toString('base64');
+    const bytes = [];
+    for (const byte of byteBody) {
+      bytes.push(String.fromCharCode(byte));
     }
+
     return {
-      contentLength,
-      base64,
+      contentLength: byteBody.byteLength,
+      base64: btoa(bytes.join('')),
     };
   }
 }

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -18,7 +18,6 @@ import {
 } from '../api/HTTPRequest.js';
 import {PageEvent} from '../api/Page.js';
 import {UnsupportedOperation} from '../common/Errors.js';
-import {isString} from '../common/util.js';
 
 import type {Request} from './core/Request.js';
 import type {BidiFrame} from './Frame.js';

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -232,10 +232,13 @@ export class BidiHTTPRequest extends HTTPRequest {
   ): Promise<void> {
     this.interception.handled = true;
 
+    let responseContentLength: number | undefined;
     let responseBodyBase64: string | undefined;
     if (response.body && isString(response.body)) {
+      responseContentLength = new TextEncoder().encode(response.body).length;
       responseBodyBase64 = btoa(response.body);
     } else if (response.body) {
+      responseContentLength = Buffer.byteLength(response.body);
       responseBodyBase64 = response.body.toString('base64');
     }
 
@@ -254,14 +257,12 @@ export class BidiHTTPRequest extends HTTPRequest {
       });
     }
 
-    if (responseBodyBase64 && !hasContentLength) {
+    if (responseContentLength && !hasContentLength) {
       headers.push({
         name: 'content-length',
         value: {
           type: 'string',
-          value: String(
-            new TextEncoder().encode(responseBodyBase64).byteLength
-          ),
+          value: String(responseContentLength),
         },
       });
     }

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -16,7 +16,7 @@ import {
   STATUS_TEXTS,
   handleError,
 } from '../api/HTTPRequest.js';
-import {debugError, isString} from '../common/util.js';
+import {debugError} from '../common/util.js';
 
 import type {CdpHTTPResponse} from './HTTPResponse.js';
 

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -196,10 +196,13 @@ export class CdpHTTPRequest extends HTTPRequest {
   async _respond(response: Partial<ResponseForRequest>): Promise<void> {
     this.interception.handled = true;
 
+    let responseContentLength: number | undefined;
     let responseBodyBase64: string | undefined;
     if (response.body && isString(response.body)) {
+      responseContentLength = new TextEncoder().encode(response.body).length;
       responseBodyBase64 = btoa(response.body);
     } else if (response.body) {
+      responseContentLength = Buffer.byteLength(response.body);
       responseBodyBase64 = response.body.toString('base64');
     }
 
@@ -218,10 +221,8 @@ export class CdpHTTPRequest extends HTTPRequest {
     if (response.contentType) {
       responseHeaders['content-type'] = response.contentType;
     }
-    if (responseBodyBase64 && !('content-length' in responseHeaders)) {
-      responseHeaders['content-length'] = String(
-        new TextEncoder().encode(responseBodyBase64).length
-      );
+    if (responseContentLength && !('content-length' in responseHeaders)) {
+      responseHeaders['content-length'] = String(responseContentLength);
     }
 
     const status = response.status || 200;

--- a/test/src/cdp/bfcache.spec.ts
+++ b/test/src/cdp/bfcache.spec.ts
@@ -45,7 +45,6 @@ describe('BFCache', function () {
     try {
       page.setDefaultTimeout(3000);
       await page.exposeFunction('ping', (msg: string) => {
-        console.log('called', msg);
         message = msg;
       });
       await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -963,34 +963,34 @@ describe('request interception', function () {
       );
     });
 
-    it('should report correct content-length header with string', async () => {
+    it.only('should report correct content-length header with string', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
       page.on('request', request => {
         void request.respond({
           status: 200,
-          body: 'Correct length?',
+          body: 'Correct length 📏?',
         });
       });
       const response = (await page.goto(server.EMPTY_PAGE))!;
       const headers = response.headers();
-      expect(headers['content-length']).toBe('15');
+      expect(headers['content-length']).toBe('20');
     });
 
-    it('should report correct content-length header with string', async () => {
+    it.only('should report correct content-length header with string', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
       page.on('request', request => {
         void request.respond({
           status: 200,
-          body: Buffer.from('Correct length?'),
+          body: Buffer.from('Correct length 📏?'),
         });
       });
       const response = (await page.goto(server.EMPTY_PAGE))!;
       const headers = response.headers();
-      expect(headers['content-length']).toBe('15');
+      expect(headers['content-length']).toBe('20');
     });
   });
 

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -962,6 +962,36 @@ describe('request interception', function () {
         /Invalid header|Expected "header"|invalid argument/
       );
     });
+
+    it('should report correct content-length header with string', async () => {
+      const {page, server} = await getTestState();
+
+      await page.setRequestInterception(true);
+      page.on('request', request => {
+        void request.respond({
+          status: 200,
+          body: 'Correct length?',
+        });
+      });
+      const response = (await page.goto(server.EMPTY_PAGE))!;
+      const headers = response.headers();
+      expect(headers['content-length']).toBe('15');
+    });
+
+    it('should report correct content-length header with string', async () => {
+      const {page, server} = await getTestState();
+
+      await page.setRequestInterception(true);
+      page.on('request', request => {
+        void request.respond({
+          status: 200,
+          body: Buffer.from('Correct length?'),
+        });
+      });
+      const response = (await page.goto(server.EMPTY_PAGE))!;
+      const headers = response.headers();
+      expect(headers['content-length']).toBe('15');
+    });
   });
 
   describe('Request.resourceType', () => {

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -963,7 +963,7 @@ describe('request interception', function () {
       );
     });
 
-    it.only('should report correct content-length header with string', async () => {
+    it('should report correct content-length header with string', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
@@ -978,7 +978,7 @@ describe('request interception', function () {
       expect(headers['content-length']).toBe('20');
     });
 
-    it.only('should report correct content-length header with string', async () => {
+    it('should report correct content-length header with string', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/issues/12700

It seems to be not straight forward to use only `Uint8Array` when loading a file and providing it's buffer,
so we still fallback to `Buffer.toString('base64')`, when we encounter non-string.