### PR TITLE
refactor!: replace dynamic imports with static dependency injection

### DIFF
--- a/docs/guides/running-puppeteer-in-extensions.md
+++ b/docs/guides/running-puppeteer-in-extensions.md
@@ -58,6 +58,9 @@ export default {
     format: 'esm',
     dir: 'out',
   },
+  // If you do not need to use WebDriver BiDi protocol,
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       // Indicate that we target a browser environment.

--- a/docs/guides/running-puppeteer-in-the-browser.md
+++ b/docs/guides/running-puppeteer-in-the-browser.md
@@ -48,6 +48,9 @@ export default {
     format: 'esm',
     dir: 'out',
   },
+  // If you do not need to use WebDriver BiDi protocol,
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       // Indicate that we target a browser environment.

--- a/examples/puppeteer-in-browser/rollup.config.mjs
+++ b/examples/puppeteer-in-browser/rollup.config.mjs
@@ -11,6 +11,9 @@ export default {
     format: 'esm',
     dir: 'out',
   },
+  // If you do not need to use WebDriver BiDi protocol,
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       browser: true,

--- a/examples/puppeteer-in-extension/rollup.config.mjs
+++ b/examples/puppeteer-in-extension/rollup.config.mjs
@@ -11,6 +11,9 @@ export default {
     format: 'esm',
     dir: 'out',
   },
+  // If you do not need to use WebDriver BiDi protocol,
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       browser: true,

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -27,10 +27,8 @@ import type {
   HandleFor,
   NodeFor,
 } from '../common/types.js';
-import {
-  importFSPromises,
-  withSourcePuppeteerURLIfNone,
-} from '../common/util.js';
+import {withSourcePuppeteerURLIfNone} from '../common/util.js';
+import {environment} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
@@ -911,8 +909,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
     }
 
     if (path) {
-      const fs = await importFSPromises();
-      content = await fs.readFile(path, 'utf8');
+      content = await environment.value.fs.readFile(path, 'utf8');
       content += `//# sourceURL=${path.replace(/\n/g, '')}`;
     }
 
@@ -992,9 +989,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
     }
 
     if (path) {
-      const fs = await importFSPromises();
-
-      content = await fs.readFile(path, 'utf8');
+      content = await environment.value.fs.readFile(path, 'utf8');
       content += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';
       options.content = content;
     }

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -909,7 +909,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
     }
 
     if (path) {
-      content = await environment.value.fs.readFile(path, 'utf8');
+      content = await environment.value.fs.promises.readFile(path, 'utf8');
       content += `//# sourceURL=${path.replace(/\n/g, '')}`;
     }
 
@@ -989,7 +989,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
     }
 
     if (path) {
-      content = await environment.value.fs.readFile(path, 'utf8');
+      content = await environment.value.fs.promises.readFile(path, 'utf8');
       content += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';
       options.content = content;
     }

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -63,7 +63,6 @@ import {
   debugError,
   fromEmitterEvent,
   filterAsync,
-  importFSPromises,
   isString,
   NETWORK_IDLE_TIME,
   timeout,
@@ -71,6 +70,7 @@ import {
   fromAbortSignal,
 } from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
+import {environment} from '../environment.js';
 import type {ScreenRecorder} from '../node/ScreenRecorder.js';
 import {guarded} from '../util/decorators.js';
 import {
@@ -2286,9 +2286,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       return;
     }
 
-    const fs = await importFSPromises();
-
-    await fs.writeFile(path, buffer);
+    await environment.value.fs.writeFile(path, buffer);
   }
 
   /**

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2286,7 +2286,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       return;
     }
 
-    await environment.value.fs.writeFile(path, buffer);
+    await environment.value.fs.promises.writeFile(path, buffer);
   }
 
   /**
@@ -2332,12 +2332,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
   async screencast(
     options: Readonly<ScreencastOptions> = {}
   ): Promise<ScreenRecorder> {
-    const [{ScreenRecorder}, [width, height, devicePixelRatio]] =
-      await Promise.all([
-        import('../node/ScreenRecorder.js'),
-        this.#getNativePixelDimensions(),
-      ]);
-
+    const ScreenRecorder = environment.value.ScreenRecorder;
+    const [width, height, devicePixelRatio] =
+      await this.#getNativePixelDimensions();
     let crop: BoundingBox | undefined;
     if (options.crop) {
       const {
@@ -2396,7 +2393,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       throw error;
     }
     if (options.path) {
-      const {createWriteStream} = await import('fs');
+      const {createWriteStream} = environment.value.fs;
       const stream = createWriteStream(options.path, 'binary');
       recorder.pipe(stream);
     }

--- a/packages/puppeteer-core/src/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/bidi/ElementHandle.ts
@@ -8,6 +8,7 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {ElementHandle, type AutofillData} from '../api/ElementHandle.js';
 import type {AwaitableIterable} from '../common/types.js';
+import {environment} from '../environment.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
 
@@ -96,19 +97,7 @@ export class BidiElementHandle<
     ...files: string[]
   ): Promise<void> {
     // Locate all files and confirm that they exist.
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    let path: typeof import('path');
-    try {
-      path = await import('path');
-    } catch (error) {
-      if (error instanceof TypeError) {
-        throw new Error(
-          `JSHandle#uploadFile can only be used in Node-like environments.`
-        );
-      }
-      throw error;
-    }
-
+    const path = environment.value.path;
     files = files.map(file => {
       if (path.win32.isAbsolute(file) || path.posix.isAbsolute(file)) {
         return file;

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -4,14 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type Path from 'path';
-
 import type {Protocol} from 'devtools-protocol';
 
 import type {CDPSession} from '../api/CDPSession.js';
 import {ElementHandle, type AutofillData} from '../api/ElementHandle.js';
 import type {AwaitableIterable} from '../common/types.js';
 import {debugError} from '../common/util.js';
+import {environment} from '../environment.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
@@ -109,17 +108,7 @@ export class CdpElementHandle<
     );
 
     // Locate all files and confirm that they exist.
-    let path: typeof Path;
-    try {
-      path = await import('path');
-    } catch (error) {
-      if (error instanceof TypeError) {
-        throw new Error(
-          `JSHandle#uploadFile can only be used in Node-like environments.`
-        );
-      }
-      throw error;
-    }
+    const path = environment.value.path;
     const files = filePaths.map(filePath => {
       if (path.win32.isAbsolute(filePath) || path.posix.isAbsolute(filePath)) {
         return filePath;

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type FS from 'fs/promises';
-
 import type {OperatorFunction} from '../../third_party/rxjs/rxjs.js';
 import {
   filter,
@@ -19,6 +17,7 @@ import {
 } from '../../third_party/rxjs/rxjs.js';
 import type {CDPSession} from '../api/CDPSession.js';
 import {packageVersion} from '../generated/version.js';
+import {environment} from '../environment.js';
 import {assert} from '../util/assert.js';
 
 import {debug} from './Debug.js';
@@ -193,29 +192,6 @@ export function evaluationString(
 /**
  * @internal
  */
-let fs: typeof FS | null = null;
-/**
- * @internal
- */
-export async function importFSPromises(): Promise<typeof FS> {
-  if (!fs) {
-    try {
-      fs = await import('fs/promises');
-    } catch (error) {
-      if (error instanceof TypeError) {
-        throw new Error(
-          'Cannot write to a path outside of a Node-like environment.'
-        );
-      }
-      throw error;
-    }
-  }
-  return fs;
-}
-
-/**
- * @internal
- */
 export async function getReadableAsBuffer(
   readable: ReadableStream<Uint8Array>,
   path?: string
@@ -223,7 +199,7 @@ export async function getReadableAsBuffer(
   const buffers: Uint8Array[] = [];
   const reader = readable.getReader();
   if (path) {
-    const fs = await importFSPromises();
+    const fs = environment.value.fs;
     const fileHandle = await fs.open(path, 'w+');
     try {
       while (true) {

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -16,8 +16,8 @@ import {
   timer,
 } from '../../third_party/rxjs/rxjs.js';
 import type {CDPSession} from '../api/CDPSession.js';
-import {packageVersion} from '../generated/version.js';
 import {environment} from '../environment.js';
+import {packageVersion} from '../generated/version.js';
 import {assert} from '../util/assert.js';
 
 import {debug} from './Debug.js';

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -199,8 +199,7 @@ export async function getReadableAsBuffer(
   const buffers: Uint8Array[] = [];
   const reader = readable.getReader();
   if (path) {
-    const fs = environment.value.fs;
-    const fileHandle = await fs.open(path, 'w+');
+    const fileHandle = await environment.value.fs.promises.open(path, 'w+');
     try {
       while (true) {
         const {done, value} = await reader.read();

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type FS from 'fs/promises';
+import type FS from 'fs';
+import type Path from 'path';
+
+import type {ScreenRecorder} from './node/ScreenRecorder.js';
 
 /**
  * @internal
@@ -13,6 +16,8 @@ export const isNode = !!(typeof process !== 'undefined' && process.version);
 
 export interface EnvironmentDependencies {
   fs: typeof FS;
+  path: typeof Path;
+  ScreenRecorder: typeof ScreenRecorder;
 }
 
 /**
@@ -24,7 +29,13 @@ export const environment: {
 } = {
   value: {
     get fs(): typeof FS {
-      throw new Error('fs/promises is not available in this environment');
+      throw new Error('fs is not available in this environment');
+    },
+    get path(): typeof Path {
+      throw new Error('path is not available in this environment');
+    },
+    get ScreenRecorder(): typeof ScreenRecorder {
+      throw new Error('ScreenRecorder is not available in this environment');
     },
   },
 };

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -4,7 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type FS from 'fs/promises';
+
 /**
  * @internal
  */
 export const isNode = !!(typeof process !== 'undefined' && process.version);
+
+export interface EnvironmentDependencies {
+  fs: typeof FS;
+}
+
+/**
+ * Holder for environment dependencies. These dependencies cannot
+ * be used during the module instantiation.
+ */
+export const environment: {
+  value: EnvironmentDependencies;
+} = {
+  value: {
+    get fs(): typeof FS {
+      throw new Error('fs/promises is not available in this environment');
+    },
+  },
+};

--- a/packages/puppeteer-core/src/puppeteer-core-browser.ts
+++ b/packages/puppeteer-core/src/puppeteer-core-browser.ts
@@ -8,6 +8,8 @@ export * from './index-browser.js';
 
 import {Puppeteer} from './common/Puppeteer.js';
 
+// Set up browser-specific environment dependencies here.
+
 /**
  * @public
  */

--- a/packages/puppeteer-core/src/puppeteer-core-browser.ts
+++ b/packages/puppeteer-core/src/puppeteer-core-browser.ts
@@ -8,8 +8,6 @@ export * from './index-browser.js';
 
 import {Puppeteer} from './common/Puppeteer.js';
 
-// Set up browser-specific environment dependencies here.
-
 /**
  * @public
  */

--- a/packages/puppeteer-core/src/puppeteer-core.ts
+++ b/packages/puppeteer-core/src/puppeteer-core.ts
@@ -6,14 +6,18 @@
 
 export * from './index.js';
 
-import FS from 'fs/promises';
+import fs from 'fs';
+import path from 'path';
 
 import {environment} from './environment.js';
 import {PuppeteerNode} from './node/PuppeteerNode.js';
+import {ScreenRecorder} from './node/ScreenRecorder.js';
 
 // Set up Node-specific environment dependencies.
 environment.value = {
-  fs: FS,
+  fs,
+  path,
+  ScreenRecorder,
 };
 /**
  * @public

--- a/packages/puppeteer-core/src/puppeteer-core.ts
+++ b/packages/puppeteer-core/src/puppeteer-core.ts
@@ -6,8 +6,15 @@
 
 export * from './index.js';
 
+import FS from 'fs/promises';
+
+import {environment} from './environment.js';
 import {PuppeteerNode} from './node/PuppeteerNode.js';
 
+// Set up Node-specific environment dependencies.
+environment.value = {
+  fs: FS,
+};
 /**
  * @public
  */


### PR DESCRIPTION
Dynamic imports get included by bundlers and extra configuration is needed to disable or work around them. The best solution is that the browser specific entrypoint does not include any Node imports (either dynamic or static).

This PR implements a container to resolve environment-specific dependencies that does not require dynamic imports. As the first step, importFSPromises is migrated.

Issue https://github.com/puppeteer/puppeteer/issues/12703