### PR TITLE
fix: correct quality condition judgement

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2513,7 +2513,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       }
     }
     if (options.quality !== undefined) {
-      if (options.quality < 0 && options.quality > 100) {
+      if (options.quality < 0 || options.quality > 100) {
         throw new Error(
           `Expected 'quality' (${options.quality}) to be between 0 and 100, inclusive.`
         );


### PR DESCRIPTION
This is a fix. The operator for screen shot quality judgement should be || instead of &&.