### PR TITLE
fix: add browser entrypoint to package.json of puppeteer-core

### DIFF
--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -11,6 +11,7 @@
   "type": "commonjs",
   "main": "./lib/cjs/puppeteer/puppeteer-core.js",
   "types": "./lib/types.d.ts",
+  "browser": "./lib/esm/puppeteer/puppeteer-core-browser.js",
   "exports": {
     ".": {
       "types": "./lib/types.d.ts",


### PR DESCRIPTION
it should allow bundlers configured to produce browser-compatible builds to automatically pick up the browser entrypoint.

See https://github.com/defunctzombie/package-browser-field-spec