### PR TITLE
fix(cli): puppeteer CLI should read the project configuration

### DIFF
--- a/docs/api/puppeteer.configuration.md
+++ b/docs/api/puppeteer.configuration.md
@@ -57,8 +57,6 @@ Can be overridden by `PUPPETEER_BROWSER_REVISION`.
 
 See [puppeteer.launch](./puppeteer.puppeteernode.launch.md) on how executable path is inferred.
 
-Use a specific browser version (e.g., 119.0.6045.105). If you use an alias such `stable` or `canary` it will only work during the installation of Puppeteer and it will fail when launching the browser.
-
 </td><td>
 
 The pinned browser version supported by the current Puppeteer version.

--- a/packages/puppeteer-core/src/common/Configuration.ts
+++ b/packages/puppeteer-core/src/common/Configuration.ts
@@ -32,10 +32,6 @@ export interface Configuration {
    * See {@link PuppeteerNode.launch | puppeteer.launch} on how executable path
    * is inferred.
    *
-   * Use a specific browser version (e.g., 119.0.6045.105). If you use an alias
-   * such `stable` or `canary` it will only work during the installation of
-   * Puppeteer and it will fail when launching the browser.
-   *
    * @example 119.0.6045.105
    * @defaultValue The pinned browser version supported by the current Puppeteer
    * version.

--- a/packages/puppeteer/src/node/cli.ts
+++ b/packages/puppeteer/src/node/cli.ts
@@ -22,8 +22,17 @@ void new CLI({
   },
   allowCachePathOverride: false,
   pinnedBrowsers: {
-    [Browser.CHROME]: PUPPETEER_REVISIONS.chrome,
-    [Browser.FIREFOX]: PUPPETEER_REVISIONS.firefox,
-    [Browser.CHROMEHEADLESSSHELL]: PUPPETEER_REVISIONS['chrome-headless-shell'],
+    [Browser.CHROME]:
+      puppeteer.configuration.browserRevision ||
+      PUPPETEER_REVISIONS['chrome'] ||
+      'latest',
+    [Browser.FIREFOX]:
+      puppeteer.configuration.browserRevision ||
+      PUPPETEER_REVISIONS['firefox'] ||
+      'latest',
+    [Browser.CHROMEHEADLESSSHELL]:
+      puppeteer.configuration.browserRevision ||
+      PUPPETEER_REVISIONS['chrome-headless-shell'] ||
+      'latest',
   },
 }).run(process.argv);

--- a/test/installation/assets/puppeteer/configuration/.puppeteerrc-browserVersion.cjs
+++ b/test/installation/assets/puppeteer/configuration/.puppeteerrc-browserVersion.cjs
@@ -1,0 +1,9 @@
+const {join} = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+  cacheDirectory: join(__dirname, '.cache', 'puppeteer'),
+  browserRevision: '121',
+};

--- a/test/installation/src/puppeteer-configuration.spec.ts
+++ b/test/installation/src/puppeteer-configuration.spec.ts
@@ -5,6 +5,8 @@
  */
 
 import assert from 'assert';
+import {spawnSync} from 'child_process';
+import {existsSync, readFileSync} from 'fs';
 import {readdir, writeFile} from 'fs/promises';
 import {join} from 'path';
 
@@ -68,6 +70,61 @@ describe('`puppeteer` with configuration', () => {
 
       const script = await readAsset('puppeteer', 'basic.js');
       await this.runScript(script, 'mjs');
+    });
+  });
+
+  describe('CLI', () => {
+    configureSandbox({
+      dependencies: ['@puppeteer/browsers', 'puppeteer-core', 'puppeteer'],
+      env: cwd => {
+        return {
+          PUPPETEER_CACHE_DIR: join(cwd, '.cache', 'puppeteer'),
+          PUPPETEER_SKIP_DOWNLOAD: 'true',
+        };
+      },
+      before: async cwd => {
+        await writeFile(
+          join(cwd, '.puppeteerrc.cjs'),
+          // config specifies 121 as the browserVersion.
+          await readAsset(
+            'puppeteer',
+            'configuration',
+            '.puppeteerrc-browserVersion.cjs'
+          )
+        );
+      },
+    });
+
+    it('installs the browser version from the configuration', async function () {
+      assert.ok(!existsSync(join(this.sandbox, '.cache', 'puppeteer')));
+      const result = spawnSync(
+        'npx',
+        ['puppeteer', 'browsers', 'install', 'chrome'],
+        {
+          // npx is not found without the shell flag on Windows.
+          shell: process.platform === 'win32',
+          cwd: this.sandbox,
+          env: {
+            ...process.env,
+            PUPPETEER_CACHE_DIR: join(this.sandbox, '.cache', 'puppeteer'),
+          },
+        }
+      );
+      assert.strictEqual(
+        result.status,
+        0,
+        `${result.stdout}\n${result.stderr}`
+      );
+      const metadataFilePath = join(
+        this.sandbox,
+        '.cache',
+        'puppeteer',
+        'chrome',
+        '.metadata'
+      );
+      assert.ok(existsSync(metadataFilePath));
+      const metadata = JSON.parse(readFileSync(metadataFilePath, 'utf8'));
+      assert.ok(metadata['aliases']['121']);
     });
   });
 });


### PR DESCRIPTION
With this PR, running `npm puppeteer browsers install chrome` or `npm puppeteer browsers install firefox` will use the browserRevision from the Puppeteer configuration file or environment variables, falling back to the pinned browser version. Note that `browserRevision` is not browser-specific and will be used to for any browser you try to install.

Closes https://github.com/puppeteer/puppeteer/issues/12701