### PR TITLE
feat!: default to WebDriver BiDi for Firefox

### DIFF
--- a/docs/api/puppeteer.browserconnectoptions.md
+++ b/docs/api/puppeteer.browserconnectoptions.md
@@ -93,7 +93,13 @@ Whether to ignore HTTPS errors during navigation.
 
 </td><td>
 
-'cdp' when launching Chrome and 'webDriverBiDi' when launching Firefox. When connecting to a running browser, defaults to 'cdp'.
+Determined at run time:
+
+- Launching Chrome - 'cdp'.
+
+- Launching Firefox - 'webDriverBiDi'.
+
+- Connecting to a browser - 'cdp'.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browserconnectoptions.md
+++ b/docs/api/puppeteer.browserconnectoptions.md
@@ -93,7 +93,7 @@ Whether to ignore HTTPS errors during navigation.
 
 </td><td>
 
-'cdp'
+'cdp' when launching Chrome and 'webDriverBiDi' when launching Firefox. When connecting to a running browser, defaults to 'cdp'.
 
 </td></tr>
 <tr><td>

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -49,9 +49,14 @@ export interface BrowserConnectOptions {
   _isPageTarget?: IsPageTargetCallback;
 
   /**
-   * @defaultValue 'cdp' when launching Chrome and 'webDriverBiDi' when
-   * launching Firefox. When connecting to a running browser, defaults
-   * to 'cdp'.
+   * @defaultValue Determined at run time:
+   *
+   * - Launching Chrome - 'cdp'.
+   *
+   * - Launching Firefox - 'webDriverBiDi'.
+   *
+   * - Connecting to a browser - 'cdp'.
+   *
    * @public
    */
   protocol?: ProtocolType;

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -49,7 +49,9 @@ export interface BrowserConnectOptions {
   _isPageTarget?: IsPageTargetCallback;
 
   /**
-   * @defaultValue 'cdp'
+   * @defaultValue 'cdp' when launching Chrome and 'webDriverBiDi' when
+   * launching Firefox. When connecting to a running browser, defaults
+   * to 'cdp'.
    * @public
    */
   protocol?: ProtocolType;

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -93,8 +93,14 @@ export abstract class ProductLauncher {
       timeout = 30000,
       waitForInitialPage = true,
       protocolTimeout,
-      protocol,
     } = options;
+
+    let {protocol} = options;
+
+    // Default to 'webDriverBiDi' for Firefox.
+    if (this.#product === 'firefox' && protocol === undefined) {
+      protocol = 'webDriverBiDi';
+    }
 
     const launchArgs = await this.computeLaunchArguments(options);
 


### PR DESCRIPTION
This PR changes the default protocol used when launching Firefox to WebDriver BiDi. 