### PR TITLE
chore: expose quality variable

### DIFF
--- a/docs/api/puppeteer.screencastoptions.md
+++ b/docs/api/puppeteer.screencastoptions.md
@@ -106,7 +106,7 @@ number
 
 </td><td>
 
-Specifies the video quality to record at
+Specifies the video quality to record at.
 
 The quality value can be from 0-63. Lower values mean better quality.
 

--- a/docs/api/puppeteer.screencastoptions.md
+++ b/docs/api/puppeteer.screencastoptions.md
@@ -94,6 +94,29 @@ File path to save the screencast to.
 </td></tr>
 <tr><td>
 
+<span id="quality">quality</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Specifies the video quality to record at
+
+The quality value can be from 0-63. Lower values mean better quality.
+
+</td><td>
+
+`30`
+
+</td></tr>
+<tr><td>
+
 <span id="scale">scale</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -350,6 +350,14 @@ export interface ScreencastOptions {
    * Required if `ffmpeg` is not in your PATH.
    */
   ffmpegPath?: string;
+  /**
+   * Specifies the video quality to record at
+   *
+   * The quality value can be from 0-63. Lower values mean better quality.
+   *
+   * @defaultValue `30`
+   */
+  quality?: number;
 }
 
 /**

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -351,7 +351,7 @@ export interface ScreencastOptions {
    */
   ffmpegPath?: string;
   /**
-   * Specifies the video quality to record at
+   * Specifies the video quality to record at.
    *
    * The quality value can be from 0-63. Lower values mean better quality.
    *

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2393,6 +2393,12 @@ export abstract class Page extends EventEmitter<PageEvents> {
     if (options.scale !== undefined && options.scale <= 0) {
       throw new Error(`\`scale\` must be greater than 0.`);
     }
+    if (
+      options.quality !== undefined &&
+      (options.quality < 0 || options.quality > 63)
+    ) {
+      throw new Error(`\`quality\` must be between 0 and 63, inclusive.`);
+    }
 
     const recorder = new ScreenRecorder(this, width, height, {
       ...options,

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -43,6 +43,7 @@ export interface ScreenRecorderOptions {
   format?: 'gif' | 'webm';
   scale?: number;
   path?: string;
+  quality?: number;
 }
 
 /**
@@ -63,7 +64,7 @@ export class ScreenRecorder extends PassThrough {
     page: Page,
     width: number,
     height: number,
-    {speed, scale, crop, format, path}: ScreenRecorderOptions = {}
+    {speed, scale, crop, format, path, quality}: ScreenRecorderOptions = {}
   ) {
     super({allowHalfOpen: false});
 
@@ -104,7 +105,7 @@ export class ScreenRecorder extends PassThrough {
         // Specifies the frame rate we are giving ffmpeg.
         ['-framerate', `${DEFAULT_FPS}`],
         // Specifies the encoding and format we are using.
-        this.#getFormatArgs(format ?? 'webm'),
+        this.#getFormatArgs(format ?? 'webm', quality ?? CRF_VALUE),
         // Disable bitrate.
         ['-b:v', '0'],
         // Filters to ensure the images are piped correctly.
@@ -174,7 +175,7 @@ export class ScreenRecorder extends PassThrough {
     );
   }
 
-  #getFormatArgs(format: 'webm' | 'gif') {
+  #getFormatArgs(format: 'webm' | 'gif', quality: number) {
     switch (format) {
       case 'webm':
         return [
@@ -183,7 +184,7 @@ export class ScreenRecorder extends PassThrough {
           // Sets the format
           ['-f', 'webm'],
           // Sets the quality. Lower the better.
-          ['-crf', `${CRF_VALUE}`],
+          ['-crf', `${quality}`],
           // Sets the quality and how efficient the compression will be.
           ['-deadline', 'realtime', '-cpu-used', '8'],
         ].flat();


### PR DESCRIPTION
Sometimes users do not want very high quality video that may take much disk space or they may want clearer video. This PR is to expose quality variable so that users can adjust it themselves to meet the needs of testing.