### PR TITLE
chore: Update test expectation for tests utilizing the unhandledPromptBehavior capability

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -293,13 +293,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[dialog.spec] Page.Events.Dialog *",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Firefox reports handler dismiss while we sent unhandledPromptBehavior ignore"
-  },
-  {
     "testIdPattern": "[drag-and-drop.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -2013,7 +2006,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "Firefox does not support multiple sessions in BiDi."
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support ignoreHTTPSErrors option",
@@ -2763,13 +2756,6 @@
     "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "https://github.com/GoogleChromeLabs/chromium-bidi/pull/2412"
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.close should run beforeunload if asked for",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox reports handler dismiss while we sent unhandledPromptBehavior ignore"
   },
   {
     "testIdPattern": "[page.spec] Page Page.close should terminate network waiters",


### PR DESCRIPTION
Once the change from https://hg.mozilla.org/mozilla-central/rev/002cacfd4d24 reaches the Nightly build this PR can be merged. Note that at the time of this push the CI checks will still fail. I'll re-trigger those once they should pass.