### PR TITLE
feat!: rename ignoreHttpsErrors to acceptInsecureCerts

### DIFF
--- a/docs/api/puppeteer.browserconnectoptions.md
+++ b/docs/api/puppeteer.browserconnectoptions.md
@@ -37,6 +37,27 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="acceptinsecurecerts">acceptInsecureCerts</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether to ignore HTTPS errors during navigation.
+
+</td><td>
+
+`false`
+
+</td></tr>
+<tr><td>
+
 <span id="defaultviewport">defaultViewport</span>
 
 </td><td>
@@ -54,27 +75,6 @@ Sets the viewport for each page.
 </td><td>
 
 '&#123;width: 800, height: 600&#125;'
-
-</td></tr>
-<tr><td>
-
-<span id="ignorehttpserrors">ignoreHTTPSErrors</span>
-
-</td><td>
-
-`optional`
-
-</td><td>
-
-boolean
-
-</td><td>
-
-Whether to ignore HTTPS errors during navigation.
-
-</td><td>
-
-`false`
 
 </td></tr>
 <tr><td>

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -41,7 +41,7 @@ export interface BidiBrowserOptions {
   connection: BidiConnection;
   cdpConnection?: CdpConnection;
   defaultViewport: Viewport | null;
-  ignoreHTTPSErrors?: boolean;
+  acceptInsecureCerts?: boolean;
 }
 
 /**
@@ -72,7 +72,7 @@ export class BidiBrowser extends Browser {
   static async create(opts: BidiBrowserOptions): Promise<BidiBrowser> {
     const session = await Session.from(opts.connection, {
       alwaysMatch: {
-        acceptInsecureCerts: opts.ignoreHTTPSErrors,
+        acceptInsecureCerts: opts.acceptInsecureCerts,
         unhandledPromptBehavior: {
           default: Bidi.Session.UserPromptHandlerType.Ignore,
         },

--- a/packages/puppeteer-core/src/bidi/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserConnector.ts
@@ -30,7 +30,7 @@ export async function _connectToBiDiBrowser(
   url: string,
   options: BrowserConnectOptions & ConnectOptions
 ): Promise<BidiBrowser> {
-  const {ignoreHTTPSErrors = false, defaultViewport = DEFAULT_VIEWPORT} =
+  const {acceptInsecureCerts = false, defaultViewport = DEFAULT_VIEWPORT} =
     options;
 
   const {bidiConnection, cdpConnection, closeCallback} =
@@ -42,7 +42,7 @@ export async function _connectToBiDiBrowser(
     closeCallback,
     process: undefined,
     defaultViewport: defaultViewport,
-    ignoreHTTPSErrors: ignoreHTTPSErrors,
+    acceptInsecureCerts: acceptInsecureCerts,
   });
   return bidiBrowser;
 }
@@ -64,7 +64,7 @@ async function getBiDiConnection(
   closeCallback: BrowserCloseCallback;
 }> {
   const BiDi = await import(/* webpackIgnore: true */ './bidi.js');
-  const {ignoreHTTPSErrors = false, slowMo = 0, protocolTimeout} = options;
+  const {acceptInsecureCerts = false, slowMo = 0, protocolTimeout} = options;
 
   // Try pure BiDi first.
   const pureBidiConnection = new BiDi.BidiConnection(
@@ -109,7 +109,7 @@ async function getBiDiConnection(
   }
 
   const bidiOverCdpConnection = await BiDi.connectBidiOverCdp(cdpConnection, {
-    acceptInsecureCerts: ignoreHTTPSErrors,
+    acceptInsecureCerts: acceptInsecureCerts,
   });
   return {
     cdpConnection,

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -47,7 +47,7 @@ export class CdpBrowser extends BrowserBase {
     product: 'firefox' | 'chrome' | undefined,
     connection: Connection,
     contextIds: string[],
-    ignoreHTTPSErrors: boolean,
+    acceptInsecureCerts: boolean,
     defaultViewport?: Viewport | null,
     process?: ChildProcess,
     closeCallback?: BrowserCloseCallback,
@@ -66,7 +66,7 @@ export class CdpBrowser extends BrowserBase {
       isPageTargetCallback,
       waitForInitiallyDiscoveredTargets
     );
-    if (ignoreHTTPSErrors) {
+    if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {
         ignore: true,
       });

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -26,7 +26,7 @@ export async function _connectToCdpBrowser(
   options: BrowserConnectOptions & ConnectOptions
 ): Promise<CdpBrowser> {
   const {
-    ignoreHTTPSErrors = false,
+    acceptInsecureCerts = false,
     defaultViewport = DEFAULT_VIEWPORT,
     targetFilter,
     _isPageTarget: isPageTarget,
@@ -53,7 +53,7 @@ export async function _connectToCdpBrowser(
     product || 'chrome',
     connection,
     browserContextIds,
-    ignoreHTTPSErrors,
+    acceptInsecureCerts,
     defaultViewport,
     undefined,
     () => {

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -27,7 +27,7 @@ export interface BrowserConnectOptions {
    * Whether to ignore HTTPS errors during navigation.
    * @defaultValue `false`
    */
-  ignoreHTTPSErrors?: boolean;
+  acceptInsecureCerts?: boolean;
   /**
    * Sets the viewport for each page.
    *

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -87,7 +87,7 @@ export abstract class BrowserLauncher {
       handleSIGINT = true,
       handleSIGTERM = true,
       handleSIGHUP = true,
-      ignoreHTTPSErrors = false,
+      acceptInsecureCerts = false,
       defaultViewport = DEFAULT_VIEWPORT,
       slowMo = 0,
       timeout = 30000,
@@ -164,7 +164,7 @@ export abstract class BrowserLauncher {
             protocolTimeout,
             slowMo,
             defaultViewport,
-            ignoreHTTPSErrors,
+            acceptInsecureCerts,
           }
         );
       } else {
@@ -188,7 +188,7 @@ export abstract class BrowserLauncher {
             browserCloseCallback,
             {
               defaultViewport,
-              ignoreHTTPSErrors,
+              acceptInsecureCerts,
             }
           );
         } else {
@@ -196,7 +196,7 @@ export abstract class BrowserLauncher {
             this.browser,
             cdpConnection,
             [],
-            ignoreHTTPSErrors,
+            acceptInsecureCerts,
             defaultViewport,
             browserProcess.nodeProcess,
             browserCloseCallback,
@@ -344,12 +344,12 @@ export abstract class BrowserLauncher {
     closeCallback: BrowserCloseCallback,
     opts: {
       defaultViewport: Viewport | null;
-      ignoreHTTPSErrors?: boolean;
+      acceptInsecureCerts?: boolean;
     }
   ): Promise<Browser> {
     const BiDi = await import(/* webpackIgnore: true */ '../bidi/bidi.js');
     const bidiConnection = await BiDi.connectBidiOverCdp(connection, {
-      acceptInsecureCerts: opts.ignoreHTTPSErrors ?? false,
+      acceptInsecureCerts: opts.acceptInsecureCerts ?? false,
     });
     return await BiDi.BidiBrowser.create({
       connection: bidiConnection,
@@ -357,7 +357,7 @@ export abstract class BrowserLauncher {
       closeCallback,
       process: browserProcess.nodeProcess,
       defaultViewport: opts.defaultViewport,
-      ignoreHTTPSErrors: opts.ignoreHTTPSErrors,
+      acceptInsecureCerts: opts.acceptInsecureCerts,
     });
   }
 
@@ -372,7 +372,7 @@ export abstract class BrowserLauncher {
       protocolTimeout: number | undefined;
       slowMo: number;
       defaultViewport: Viewport | null;
-      ignoreHTTPSErrors?: boolean;
+      acceptInsecureCerts?: boolean;
     }
   ): Promise<Browser> {
     const browserWSEndpoint =
@@ -393,7 +393,7 @@ export abstract class BrowserLauncher {
       closeCallback,
       process: browserProcess.nodeProcess,
       defaultViewport: opts.defaultViewport,
-      ignoreHTTPSErrors: opts.ignoreHTTPSErrors,
+      acceptInsecureCerts: opts.acceptInsecureCerts,
     });
   }
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -800,6 +800,48 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails Network redirects should report SecurityDetails",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails Network redirects should report SecurityDetails",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails should be |null| for non-secure requests",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts should work with request interception",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
     "testIdPattern": "[accessibility.spec] Accessibility get snapshots while the tree is re-calculated",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
@@ -1498,48 +1540,6 @@
     "expectations": ["PASS"]
   },
   {
-    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails Network redirects should report SecurityDetails",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL", "PASS"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails Network redirects should report SecurityDetails",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails should be |null| for non-secure requests",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors Response.securityDetails should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[ignorehttpserrors.spec] ignoreHTTPSErrors should work with request interception",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
     "testIdPattern": "[input.spec] input tests FileChooser.accept should accept single file",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
@@ -1988,14 +1988,14 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support ignoreHTTPSErrors option",
+    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support acceptInsecureCerts option",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "Firefox does not support multiple sessions in BiDi."
   },
   {
-    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support ignoreHTTPSErrors option",
+    "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should support acceptInsecureCerts option",
     "platforms": ["darwin"],
     "parameters": ["chrome", "headless"],
     "expectations": ["SKIP"],

--- a/test/src/acceptInsecureCerts.spec.ts
+++ b/test/src/acceptInsecureCerts.spec.ts
@@ -11,16 +11,16 @@ import type {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
 import {launch} from './mocha-utils.js';
 
-describe('ignoreHTTPSErrors', function () {
+describe('acceptInsecureCerts', function () {
   /* Note that this test creates its own browser rather than use
    * the one provided by the test set-up as we need one
-   * with ignoreHTTPSErrors set to true
+   * with acceptInsecureCerts set to true
    */
   let state: Awaited<ReturnType<typeof launch>>;
 
   before(async () => {
     state = await launch(
-      {ignoreHTTPSErrors: true},
+      {acceptInsecureCerts: true},
       {
         after: 'all',
       }

--- a/test/src/cdp/bfcache.spec.ts
+++ b/test/src/cdp/bfcache.spec.ts
@@ -13,7 +13,7 @@ import {waitEvent} from '../utils.js';
 describe('BFCache', function () {
   it('can navigate to a BFCached page', async () => {
     const {httpsServer, page, close} = await launch({
-      ignoreHTTPSErrors: true,
+      acceptInsecureCerts: true,
     });
 
     try {
@@ -39,7 +39,7 @@ describe('BFCache', function () {
 
   it('can call a function exposed on a page restored from bfcache', async () => {
     const {httpsServer, page, close} = await launch({
-      ignoreHTTPSErrors: true,
+      acceptInsecureCerts: true,
     });
     let message = '';
     try {
@@ -80,7 +80,7 @@ describe('BFCache', function () {
 
   it('can navigate to a BFCached page containing an OOPIF and a worker', async () => {
     const {httpsServer, page, close} = await launch({
-      ignoreHTTPSErrors: true,
+      acceptInsecureCerts: true,
     });
     try {
       page.setDefaultTimeout(3000);

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -538,7 +538,7 @@ describe('Cookie specs', () => {
     });
     it('should set secure same-site cookies from a frame', async () => {
       const {httpsServer, browser, close} = await launch({
-        ignoreHTTPSErrors: true,
+        acceptInsecureCerts: true,
       });
 
       try {

--- a/test/src/device-request-prompt.spec.ts
+++ b/test/src/device-request-prompt.spec.ts
@@ -15,7 +15,7 @@ describe('device request prompt', function () {
     state = await launch(
       {
         args: ['--enable-features=WebBluetoothNewPermissionsBackend'],
-        ignoreHTTPSErrors: true,
+        acceptInsecureCerts: true,
       },
       {
         after: 'all',

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -682,7 +682,7 @@ describe('Launcher specs', function () {
           await close();
         }
       });
-      it('should support ignoreHTTPSErrors option', async () => {
+      it('should support acceptInsecureCerts option', async () => {
         const {puppeteer, httpsServer, browser, close} = await launch(
           {},
           {
@@ -694,7 +694,7 @@ describe('Launcher specs', function () {
           const browserWSEndpoint = browser.wsEndpoint();
           using remoteBrowser = await puppeteer.connect({
             browserWSEndpoint,
-            ignoreHTTPSErrors: true,
+            acceptInsecureCerts: true,
             protocol: browser.protocol,
           });
           const page = await remoteBrowser.newPage();

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -876,7 +876,7 @@ describe('network', function () {
 
     it('Cross-origin set-cookie', async () => {
       const {page, httpsServer, close} = await launch({
-        ignoreHTTPSErrors: true,
+        acceptInsecureCerts: true,
       });
       try {
         await page.goto(httpsServer.PREFIX + '/empty.html');


### PR DESCRIPTION
Renaming to align better with the WebDriver specification and to clearly indicate that only insecure certificate errors will be suppressed and not all kinds of https errors as the flag name might suggest.

Closes https://github.com/puppeteer/puppeteer/issues/12341