### PR TITLE
test: add set cookie with all values test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1156,6 +1156,13 @@
     "comment": "Chromium-specific test. The test relies on the cookie in secure context to be secure. This is not the case for Firefox."
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Chromium-specific test. The sourceScheme property is chromium-specific."
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -237,6 +237,13 @@
     "comment": "The test relies on the default page partition key do not contain the source origin. This is not the case for Firefox."
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Chromium-specific test. The sourceScheme property is chromium-specific."
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set secure same-site cookies from a frame",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome"],
@@ -1154,13 +1161,6 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
     "comment": "Chromium-specific test. The test relies on the cookie in secure context to be secure. This is not the case for Firefox."
-  },
-  {
-    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["FAIL"],
-    "comment": "Chromium-specific test. The sourceScheme property is chromium-specific."
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should work",

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -311,6 +311,43 @@ describe('Cookie specs', () => {
         ]
       );
     });
+    it('should set cookie with all available properties', async () => {
+      const {page, server} = await getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      await page.setCookie({
+        name: 'password',
+        value: '123456',
+        domain: 'localhost',
+        path: '/',
+        sameParty: false,
+        expires: -1,
+        httpOnly: false,
+        secure: false,
+        sourceScheme: 'Unset',
+      });
+      const cookies = await page.cookies();
+      await expectCookieEquals(
+        cookies.sort((a, b) => {
+          return a.name.localeCompare(b.name);
+        }),
+        [
+          {
+            name: 'password',
+            value: '123456',
+            domain: 'localhost',
+            path: '/',
+            sameParty: false,
+            expires: -1,
+            size: 14,
+            httpOnly: false,
+            secure: false,
+            session: true,
+            sourceScheme: 'Unset',
+          },
+        ]
+      );
+    });
     it('should set a cookie with a path', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
No code changes. I'm just adding a test to validate that we can send a valid cookie with all the available properties to the browser.