### PR TITLE
fix(webdriver): allow accessing raw CDP connection when using WebDriver BiDi

### DIFF
--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -19,6 +19,7 @@ import {
 import {BrowserContextEvent} from '../api/BrowserContext.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
+import type {Connection as CdpConnection} from '../cdp/Connection.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
@@ -38,6 +39,7 @@ export interface BidiBrowserOptions {
   process?: ChildProcess;
   closeCallback?: BrowserCloseCallback;
   connection: BidiConnection;
+  cdpConnection?: CdpConnection;
   defaultViewport: Viewport | null;
   ignoreHTTPSErrors?: boolean;
 }
@@ -98,6 +100,7 @@ export class BidiBrowser extends Browser {
   #defaultViewport: Viewport | null;
   #browserContexts = new WeakMap<UserContext, BidiBrowserContext>();
   #target = new BidiBrowserTarget(this);
+  #cdpConnection?: CdpConnection;
 
   private constructor(browserCore: BrowserCore, opts: BidiBrowserOptions) {
     super();
@@ -105,6 +108,7 @@ export class BidiBrowser extends Browser {
     this.#closeCallback = opts.closeCallback;
     this.#browserCore = browserCore;
     this.#defaultViewport = opts.defaultViewport;
+    this.#cdpConnection = opts.cdpConnection;
   }
 
   #initialize() {
@@ -131,7 +135,11 @@ export class BidiBrowser extends Browser {
   }
 
   get cdpSupported(): boolean {
-    return !this.#browserName.toLocaleLowerCase().includes('firefox');
+    return this.#cdpConnection !== undefined;
+  }
+
+  get cdpConnection(): CdpConnection | undefined {
+    return this.#cdpConnection;
   }
 
   override async userAgent(): Promise<string> {

--- a/packages/puppeteer-core/src/bidi/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserConnector.ts
@@ -33,14 +33,12 @@ export async function _connectToBiDiBrowser(
   const {ignoreHTTPSErrors = false, defaultViewport = DEFAULT_VIEWPORT} =
     options;
 
-  const {bidiConnection, closeCallback} = await getBiDiConnection(
-    connectionTransport,
-    url,
-    options
-  );
+  const {bidiConnection, cdpConnection, closeCallback} =
+    await getBiDiConnection(connectionTransport, url, options);
   const BiDi = await import(/* webpackIgnore: true */ './bidi.js');
   const bidiBrowser = await BiDi.BidiBrowser.create({
     connection: bidiConnection,
+    cdpConnection,
     closeCallback,
     process: undefined,
     defaultViewport: defaultViewport,
@@ -61,6 +59,7 @@ async function getBiDiConnection(
   url: string,
   options: BrowserConnectOptions
 ): Promise<{
+  cdpConnection?: Connection;
   bidiConnection: BidiConnection;
   closeCallback: BrowserCloseCallback;
 }> {
@@ -113,6 +112,7 @@ async function getBiDiConnection(
     acceptInsecureCerts: ignoreHTTPSErrors,
   });
   return {
+    cdpConnection,
     bidiConnection: bidiOverCdpConnection,
     closeCallback: async () => {
       // In case of BiDi over CDP, we need to close browser via CDP.

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -81,14 +81,6 @@ export class BidiConnection
     return this.#url;
   }
 
-  get delay(): number {
-    return this.#delay;
-  }
-
-  get timeout(): number {
-    return this.#timeout;
-  }
-
   pipeTo<Events extends BidiEvents>(emitter: EventEmitter<Events>): void {
     this.#emitters.push(emitter);
   }

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -52,7 +52,7 @@ export class BidiConnection
   #url: string;
   #transport: ConnectionTransport;
   #delay: number;
-  #timeout? = 0;
+  #timeout = 0;
   #closed = false;
   #callbacks = new CallbackRegistry();
   #emitters: Array<EventEmitter<any>> = [];
@@ -79,6 +79,14 @@ export class BidiConnection
 
   get url(): string {
     return this.#url;
+  }
+
+  get delay(): number {
+    return this.#delay;
+  }
+
+  get timeout(): number {
+    return this.#timeout;
   }
 
   pipeTo<Events extends BidiEvents>(emitter: EventEmitter<Events>): void {

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -465,13 +465,7 @@ export class BidiFrame extends Frame {
     }
 
     const cdpConnection = this.page().browser().cdpConnection!;
-
-    const result = await cdpConnection.send('Target.attachToTarget', {
-      targetId: this._id,
-      flatten: true,
-    });
-
-    return cdpConnection.session(result.sessionId)!;
+    return await cdpConnection._createSession({targetId: this._id});
   }
 
   @throwIfDetached

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -460,12 +460,18 @@ export class BidiFrame extends Frame {
   }
 
   async createCDPSession(): Promise<CDPSession> {
-    const {sessionId} = await this.client.send('Target.attachToTarget', {
+    if (!this.page().browser().cdpSupported) {
+      throw new UnsupportedOperation();
+    }
+
+    const cdpConnection = this.page().browser().cdpConnection!;
+
+    const result = await cdpConnection.send('Target.attachToTarget', {
       targetId: this._id,
       flatten: true,
     });
-    await this.browsingContext.subscribe([Bidi.ChromiumBidi.BiDiModule.Cdp]);
-    return new BidiCdpSession(this, sessionId);
+
+    return cdpConnection.session(result.sessionId)!;
   }
 
   @throwIfDetached

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -229,7 +229,7 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
    * @internal
    */
   async _createSession(
-    targetInfo: Protocol.Target.TargetInfo,
+    targetInfo: {targetId: string},
     isAutoAttachEmulated = true
   ): Promise<CDPSession> {
     if (!isAutoAttachEmulated) {

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -55,7 +55,7 @@ export async function _connectToBrowser(
  * Establishes a websocket connection by given options and returns both transport and
  * endpoint url the transport is connected to.
  */
-async function getConnectionTransport(
+export async function getConnectionTransport(
   options: BrowserConnectOptions & ConnectOptions
 ): Promise<{connectionTransport: ConnectionTransport; endpointUrl: string}> {
   const {browserWSEndpoint, browserURL, transport, headers = {}} = options;

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -55,7 +55,7 @@ export async function _connectToBrowser(
  * Establishes a websocket connection by given options and returns both transport and
  * endpoint url the transport is connected to.
  */
-export async function getConnectionTransport(
+async function getConnectionTransport(
   options: BrowserConnectOptions & ConnectOptions
 ): Promise<{connectionTransport: ConnectionTransport; endpointUrl: string}> {
   const {browserWSEndpoint, browserURL, transport, headers = {}} = options;

--- a/packages/puppeteer-core/src/node/ProductLauncher.ts
+++ b/packages/puppeteer-core/src/node/ProductLauncher.ts
@@ -347,6 +347,7 @@ export abstract class ProductLauncher {
     });
     return await BiDi.BidiBrowser.create({
       connection: bidiConnection,
+      cdpConnection: connection,
       closeCallback,
       process: browserProcess.nodeProcess,
       defaultViewport: opts.defaultViewport,

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -940,13 +940,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[CDPSession.spec] Target.createCDPSession should expose the underlying connection",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
     "testIdPattern": "[CDPSession.spec] Target.createCDPSession should respect custom timeout",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -940,6 +940,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[CDPSession.spec] Target.createCDPSession should not send extra events",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Fails with Firefox CDP"
+  },
+  {
+    "testIdPattern": "[CDPSession.spec] Target.createCDPSession should not send extra events",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "https://github.com/GoogleChromeLabs/chromium-bidi/issues/2420"
+  },
+  {
     "testIdPattern": "[CDPSession.spec] Target.createCDPSession should respect custom timeout",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -60,6 +60,26 @@ describe('Target.createCDPSession', function () {
     expect(events).toHaveLength(1);
   });
 
+  it('should not send extra events', async () => {
+    const {page, server} = await getTestState();
+
+    const client = await page.createCDPSession();
+    await client.send('Network.enable');
+    const events = new Set();
+    client.on('*', name => {
+      if (typeof name !== 'string') {
+        return;
+      }
+      events.add((name as string).split('.').shift());
+    });
+    await Promise.all([
+      waitEvent(client, 'Network.requestWillBeSent'),
+      page.goto(server.EMPTY_PAGE),
+    ]);
+    expect(events.size).toBe(1);
+    expect(events).toContain('Network');
+  });
+
   it('should enable and disable domains independently', async () => {
     const {page} = await getTestState();
 

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -59,6 +59,7 @@ describe('Target.createCDPSession', function () {
     ]);
     expect(events).toHaveLength(1);
   });
+
   it('should enable and disable domains independently', async () => {
     const {page} = await getTestState();
 


### PR DESCRIPTION
Changes createCDPSession to use CDP connection directly instead of bidi+.

Refs https://github.com/puppeteer/puppeteer/issues/12768