### PR TITLE
chore: implement improved `waitForNavigation`

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -117,6 +117,13 @@ export class BrowsingContext extends EventEmitter<{
     /** The realm for the new dedicated worker */
     realm: DedicatedWorkerRealm;
   };
+  /** Emitted whenever the browsing context fragment navigates */
+  fragment: {
+    /** The new url */
+    url: string;
+    /** The timestamp of the navigation */
+    timestamp: Date;
+  };
 }> {
   static from(
     userContext: UserContext,
@@ -238,27 +245,36 @@ export class BrowsingContext extends EventEmitter<{
           this.#requests.delete(id);
         }
       }
+
       // If the navigation hasn't finished, then this is nested navigation. The
       // current navigation will handle this.
       if (this.#navigation !== undefined && !this.#navigation.disposed) {
         return;
       }
 
-      // Note the navigation ID is null for this event.
-      this.#navigation = Navigation.from(this);
+      this.#navigation = Navigation.from(this, info.url);
 
       const navigationEmitter = this.#disposables.use(
         new EventEmitter(this.#navigation)
       );
-      for (const eventName of ['fragment', 'failed', 'aborted'] as const) {
-        navigationEmitter.once(eventName, ({url}) => {
+      for (const eventName of ['failed', 'aborted'] as const) {
+        navigationEmitter.once(eventName, () => {
           navigationEmitter[disposeSymbol]();
-
-          this.#url = url;
         });
       }
 
       this.emit('navigation', {navigation: this.#navigation});
+    });
+    sessionEmitter.on('browsingContext.fragmentNavigated', info => {
+      if (info.context !== this.id) {
+        return;
+      }
+      this.#url = info.url;
+
+      this.emit('fragment', {
+        url: info.url,
+        timestamp: new Date(info.timestamp),
+      });
     });
     sessionEmitter.on('network.beforeRequestSent', event => {
       if (event.context !== this.id) {

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -59,19 +59,6 @@ export class Session
     browserEmitter.once('closed', ({reason}) => {
       this.dispose(reason);
     });
-
-    // TODO: Currently, some implementations do not emit navigationStarted event
-    // for fragment navigations (as per spec) and some do. This could emits a
-    // synthetic navigationStarted to work around this inconsistency.
-    const seen = new WeakSet();
-    this.on('browsingContext.fragmentNavigated', info => {
-      if (seen.has(info)) {
-        return;
-      }
-      seen.add(info);
-      this.emit('browsingContext.navigationStarted', info);
-      this.emit('browsingContext.fragmentNavigated', info);
-    });
   }
 
   get capabilities(): Bidi.Session.NewResult['capabilities'] {

--- a/packages/puppeteer-core/third_party/rxjs/rxjs.ts
+++ b/packages/puppeteer-core/third_party/rxjs/rxjs.ts
@@ -14,7 +14,6 @@ export {
   first,
   firstValueFrom,
   forkJoin,
-  delayWhen,
   from,
   fromEvent,
   identity,


### PR DESCRIPTION
This PR implements a waitForNavigation that doesn't validate the expected flow and instead only cares about results.

It will wait for a response if it can.
It will wait for the first navigation (fragment or not).
It will wait for the completion condition (if available).
It will wait for other conditions when navigation is not fragment navigation.
This also modifies the bidi/core API to match the BiDi spec as defined.

Rebased https://github.com/puppeteer/puppeteer/pull/11929