### PR TITLE
chore(build): use a object to represent supported versions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -288,8 +288,8 @@ The following steps are manual version of the script above.
 1. Find a suitable Chrome `revision` and `version` via https://googlechromelabs.github.io/chrome-for-testing/ or https://chromiumdash.appspot.com/.
 2. Update `packages/puppeteer-core/src/revisions.ts` with the found `version`
    number.
-3. Update `versions.js` with the new Chrome-to-Puppeteer `version` mapping and
-   update `lastMaintainedChromeVersion` with the next one in from the list.
+3. Update `versions.json` with the new Chrome-to-Puppeteer `version` mapping and
+   update `lastMaintainedVersion` with the next one in from the list.
 4. Run `npm run check`. If it fails, update
    `packages/puppeteer-core/package.json`
    with the expected `devtools-protocol` version and run `npm install` to generate an updated `package-lock.json`.

--- a/tools/get_deprecated_version_range.mjs
+++ b/tools/get_deprecated_version_range.mjs
@@ -7,7 +7,7 @@
 import data from '../versions.json' assert {type: 'json'};
 
 const version = data.versions.find(([puppeteerVersion, browserVersions]) => {
-  return browserVersions.chrome === data.lastMaintainedChromeVersion;
+  return browserVersions.chrome === data.lastMaintainedVersion.chrome;
 });
 const puppeteerVersion = version[0];
 if (puppeteerVersion === 'NEXT') {

--- a/tools/update_chrome_revision.mjs
+++ b/tools/update_chrome_revision.mjs
@@ -146,7 +146,7 @@ async function updateVersionFileLastMaintained(oldVersion, newVersion) {
 
   if (newSemVer.compareMain(oldSemVer) !== 0) {
     const lastMaintainedSemVer = new SemVer(
-      versionData.lastMaintainedChromeVersion,
+      versionData.lastMaintainedVersion.chrome,
       true
     );
     const newLastMaintainedMajor = lastMaintainedSemVer.major + 1;
@@ -155,7 +155,7 @@ async function updateVersionFileLastMaintained(oldVersion, newVersion) {
       return new SemVer(version, true).major === newLastMaintainedMajor;
     });
 
-    versionData.lastMaintainedChromeVersion = nextMaintainedVersion;
+    versionData.lastMaintainedVersion.chrome = nextMaintainedVersion;
   }
 
   await saveVersionData(versionData);

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,8 @@
 {
-  "lastMaintainedChromeVersion": "123.0.6312.122",
+  "lastMaintainedVersion": {
+    "chrome": "123.0.6312.122",
+    "firefox": "latest"
+  },
   "versions": [
     [
       "v22.13.1",


### PR DESCRIPTION
This matches the object we provide for each version, and makes it easier to work with.