### PR TITLE
test: update late responseCompleted tests to pass/fail for Firefox

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2324,6 +2324,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache for script",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the cached script might be emitted too late (Bug 1907589)"
+  },
+  {
     "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache for stylesheet",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -2525,6 +2532,13 @@
     "parameters": ["cdp", "firefox"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[network.spec] network Response.fromCache should work for script",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the cached script might be emitted too late (Bug 1907589)"
   },
   {
     "testIdPattern": "[network.spec] network Response.fromCache should work for stylesheet",
@@ -3022,6 +3036,13 @@
     "comment": "TODO: Needs support for data URIs in Firefox in content process https://bugzilla.mozilla.org/show_bug.cgi?id=1903060"
   },
   {
+    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cache script if cache enabled",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the cached script might be emitted too late (Bug 1907589)"
+  },
+  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should cache stylesheet if cache enabled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3041,6 +3062,13 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["SKIP"],
     "comment": "Test requires CDP"
+  },
+  {
+    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with missing stylesheets",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the missing stylesheet might be emitted too late (Bug 1907589)"
   },
   {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Request.continue should redirect in a way non-observable to page",
@@ -3106,6 +3134,13 @@
     "comment": "TODO: BiDi does not support custom errors - https://github.com/w3c/webdriver-bidi/issues/508"
   },
   {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should cache script if cache enabled",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the cached script might be emitted too late (Bug 1907589)"
+  },
+  {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should cache stylesheet if cache enabled",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3139,6 +3174,13 @@
     "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "CDP specific issue, maybe we can support it from BiDi+"
+  },
+  {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with missing stylesheets",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the missing stylesheet might be emitted too late (Bug 1907589)"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Request.continue should redirect in a way non-observable to page",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3057,18 +3057,18 @@
     "comment": "TODO: Needs support for file URIs in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1826210"
   },
   {
-    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with requests without networkId",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Test requires CDP"
-  },
-  {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with missing stylesheets",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL", "PASS"],
     "comment": "On Firefox, the responseCompleted event for the missing stylesheet might be emitted too late (Bug 1907589)"
+  },
+  {
+    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Page.setRequestInterception should work with requests without networkId",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "Test requires CDP"
   },
   {
     "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Request.continue should redirect in a way non-observable to page",
@@ -3162,6 +3162,13 @@
     "comment": "TODO: Needs support for file URIs in Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1826210"
   },
   {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with missing stylesheets",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "On Firefox, the responseCompleted event for the missing stylesheet might be emitted too late (Bug 1907589)"
+  },
+  {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with requests without networkId",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3174,13 +3181,6 @@
     "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "CDP specific issue, maybe we can support it from BiDi+"
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with missing stylesheets",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL", "PASS"],
-    "comment": "On Firefox, the responseCompleted event for the missing stylesheet might be emitted too late (Bug 1907589)"
   },
   {
     "testIdPattern": "[requestinterception.spec] request interception Request.continue should redirect in a way non-observable to page",


### PR DESCRIPTION
Updates 6 expectations to PASS/FAIL for firefox / bidi due to the responseCompleted event arriving too late. The investigation bug on mozilla's side is at https://bugzilla.mozilla.org/show_bug.cgi?id=1907589, though we hope that fixing https://bugzilla.mozilla.org/show_bug.cgi?id=1882803 will also address this.

Alternatively, we could update the tests in order to wait for the response to be populated, which would avoid marking them as pass / fail. But in general per spec the tests are correct and responseCompleted should have been received for those requests by the time load is emitted.
 