### PR TITLE
refactor: remove code for getting Firefox version from `latest`

### DIFF
--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -66,11 +66,6 @@ export abstract class BrowserLauncher {
   /**
    * @internal
    */
-  protected actualBrowserRevision?: string;
-
-  /**
-   * @internal
-   */
   constructor(puppeteer: PuppeteerNode, browser: SupportedBrowser) {
     this.puppeteer = puppeteer;
     this.#browser = browser;
@@ -222,15 +217,6 @@ export abstract class BrowserLauncher {
   abstract executablePath(channel?: ChromeReleaseChannel): string;
 
   abstract defaultArgs(object: BrowserLaunchArgumentOptions): string[];
-
-  /**
-   * Set only for Firefox, after the launcher resolves the `latest` revision to
-   * the actual revision.
-   * @internal
-   */
-  getActualBrowserRevision(): string | undefined {
-    return this.actualBrowserRevision;
-  }
 
   /**
    * @internal

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -9,13 +9,7 @@ import {rename, unlink, mkdtemp} from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
-import {
-  Browser as SupportedBrowsers,
-  createProfile,
-  Cache,
-  detectBrowserPlatform,
-  Browser,
-} from '@puppeteer/browsers';
+import {Browser as SupportedBrowsers, createProfile} from '@puppeteer/browsers';
 
 import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
@@ -193,19 +187,6 @@ export class FirefoxLauncher extends BrowserLauncher {
   }
 
   override executablePath(): string {
-    // replace 'latest' placeholder with actual downloaded revision
-    if (this.puppeteer.browserRevision === 'latest') {
-      const cache = new Cache(this.puppeteer.defaultDownloadPath!);
-      const installedFirefox = cache.getInstalledBrowsers().find(browser => {
-        return (
-          browser.platform === detectBrowserPlatform() &&
-          browser.browser === Browser.FIREFOX
-        );
-      });
-      if (installedFirefox) {
-        this.actualBrowserRevision = installedFirefox.buildId;
-      }
-    }
     return this.resolveExecutablePath();
   }
 

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -209,11 +209,7 @@ export class PuppeteerNode extends Puppeteer {
    * @internal
    */
   get browserRevision(): string {
-    return (
-      this.#_launcher?.getActualBrowserRevision() ??
-      this.configuration.browserRevision ??
-      this.defaultBrowserRevision!
-    );
+    return this.configuration.browserRevision ?? this.defaultBrowserRevision!;
   }
 
   /**


### PR DESCRIPTION
This can me merged after we move away from `latest` for Firefox.