### PR TITLE
chore: fix Firefox missing profile error

### DIFF
--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -121,7 +121,7 @@ export class FirefoxLauncher extends ProductLauncher {
     if (profileArgIndex !== -1) {
       userDataDir = firefoxArguments[profileArgIndex + 1];
       if (!userDataDir) {
-        throw new Error(`Firefox profile not found at '${userDataDir}'`);
+        throw new Error(`Missing value for profile command line argument`);
       }
 
       // When using a custom Firefox profile it needs to be populated


### PR DESCRIPTION
`userDataDir` is undefined inside the `if` block.