### PR TITLE
refactor: only await args if there are LazyArgs

### DIFF
--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -157,13 +157,19 @@ export abstract class BidiRealm extends Realm {
         functionDeclaration,
         /* awaitPromise= */ true,
         {
-          arguments: args.length
+          // LazyArgs are used only internally and should not affect the order
+          // evaluate calls for the public APIs.
+          arguments: args.some(arg => {
+            return arg instanceof LazyArg;
+          })
             ? await Promise.all(
                 args.map(arg => {
-                  return this.serialize(arg);
+                  return this.serializeAsync(arg);
                 })
               )
-            : [],
+            : args.map(arg => {
+                return this.serialize(arg);
+              }),
           resultOwnership,
           userActivation: true,
           serializationOptions,
@@ -194,11 +200,14 @@ export abstract class BidiRealm extends Realm {
     return BidiJSHandle.from(result, this);
   }
 
-  async serialize(arg: unknown): Promise<Bidi.Script.LocalValue> {
+  async serializeAsync(arg: unknown): Promise<Bidi.Script.LocalValue> {
     if (arg instanceof LazyArg) {
       arg = await arg.get(this);
     }
+    return this.serialize(arg);
+  }
 
+  serialize(arg: unknown): Bidi.Script.LocalValue {
     if (arg instanceof BidiJSHandle || arg instanceof BidiElementHandle) {
       if (arg.realm !== this) {
         if (


### PR DESCRIPTION
So I checked and LazyArgs are only passed on in the internal evaluate calls where we would not have any dependencies on whether the evaluate call is dispatched immediately or at the end of the macro task. Therefore, it makes sense to conditionally await if any LazyArgs are actually provided. This allows the user-called evaluate call to always be dispatched immediately.

Closes #11507