### PR TITLE
fix: add missing partitionKey for page.deleteCookie()

### DIFF
--- a/docs/api/puppeteer.cookie.md
+++ b/docs/api/puppeteer.cookie.md
@@ -117,7 +117,7 @@ string
 
 </td><td>
 
-Cookie partition key. The site of the top-level URL the browser was visiting at the start of the request to the endpoint that set the cookie. Supported only in Chrome.
+Cookie partition key. In Chrome, it is the top-level site the partitioned cookie is available in. In Firefox, it matches the source origin (https://w3c.github.io/webdriver-bidi/\#type-storage-PartitionKey).
 
 </td><td>
 

--- a/docs/api/puppeteer.cookieparam.md
+++ b/docs/api/puppeteer.cookieparam.md
@@ -123,7 +123,7 @@ string
 
 </td><td>
 
-Cookie partition key. The site of the top-level URL the browser was visiting at the start of the request to the endpoint that set the cookie. If not set, the cookie will be set as not partitioned.
+Cookie partition key. In Chrome, it matches the top-level site the partitioned cookie is available in. In Firefox, it matches the source origin (https://w3c.github.io/webdriver-bidi/\#type-storage-PartitionKey).
 
 </td><td>
 

--- a/docs/api/puppeteer.deletecookiesrequest.md
+++ b/docs/api/puppeteer.deletecookiesrequest.md
@@ -83,7 +83,7 @@ string
 
 </td><td>
 
-If specified, deletes only cookies with the the given name and partitionKey where domain matches provided URL.
+If specified, deletes cookies in the given partition key. In Chrome, partitionKey matches the top-level site the partitioned cookie is available in. In Firefox, it matches the source origin (https://w3c.github.io/webdriver-bidi/\#type-storage-PartitionKey).
 
 </td><td>
 

--- a/docs/api/puppeteer.deletecookiesrequest.md
+++ b/docs/api/puppeteer.deletecookiesrequest.md
@@ -71,6 +71,25 @@ Name of the cookies to remove.
 </td></tr>
 <tr><td>
 
+<span id="partitionkey">partitionKey</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+If specified, deletes only cookies with the the given name and partitionKey where domain matches provided URL.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="path">path</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -915,6 +915,22 @@ function testUrlMatchCookie(cookie: Cookie, url: URL): boolean {
 }
 
 function bidiToPuppeteerCookie(bidiCookie: Bidi.Network.Cookie): Cookie {
+  const partitionKey = bidiCookie[CDP_SPECIFIC_PREFIX + 'partitionKey'];
+
+  function getParitionKey(): {partitionKey?: string} {
+    if (typeof partitionKey === 'string') {
+      return {partitionKey};
+    }
+    if (typeof partitionKey === 'object' && partitionKey !== null) {
+      return {
+        // TODO: a breaking change in Puppeteer is required to change
+        // partitionKey type and report the composite partition key.
+        partitionKey: partitionKey.topLevelSite,
+      };
+    }
+    return {};
+  }
+
   return {
     name: bidiCookie.name,
     // Presents binary value as base64 string.
@@ -932,10 +948,10 @@ function bidiToPuppeteerCookie(bidiCookie: Bidi.Network.Cookie): Cookie {
       bidiCookie,
       'sameParty',
       'sourceScheme',
-      'partitionKey',
       'partitionKeyOpaque',
       'priority'
     ),
+    ...getParitionKey(),
   };
 }
 

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -604,7 +604,14 @@ export class CdpPage extends Page {
   ): Promise<void> {
     const pageURL = this.url();
     for (const cookie of cookies) {
-      const item = Object.assign({}, cookie);
+      const item = {
+        ...cookie,
+        // TODO: a breaking change neeeded to change the partition key
+        // type in Puppeteer.
+        partitionKey: cookie.partitionKey
+          ? {topLevelSite: cookie.partitionKey, hasCrossSiteAncestor: false}
+          : undefined,
+      };
       if (!cookie.url && pageURL.startsWith('http')) {
         item.url = pageURL;
       }

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -616,6 +616,17 @@ export class CdpPage extends Page {
         item.url = pageURL;
       }
       await this.#primaryTargetClient.send('Network.deleteCookies', item);
+      if (pageURL.startsWith('http') && !item.partitionKey) {
+        const url = new URL(pageURL);
+        // Delete also cookies from the page's partition.
+        await this.#primaryTargetClient.send('Network.deleteCookies', {
+          ...item,
+          partitionKey: {
+            topLevelSite: url.origin.replace(`:${url.port}`, ''),
+            hasCrossSiteAncestor: false,
+          },
+        });
+      }
     }
   }
 

--- a/packages/puppeteer-core/src/common/Cookie.ts
+++ b/packages/puppeteer-core/src/common/Cookie.ts
@@ -89,8 +89,10 @@ export interface Cookie {
    */
   sourceScheme?: CookieSourceScheme;
   /**
-   * Cookie partition key. The site of the top-level URL the browser was visiting at the
-   * start of the request to the endpoint that set the cookie. Supported only in Chrome.
+   * Cookie partition key. In Chrome, it is the top-level site the
+   * partitioned cookie is available in. In Firefox, it matches the
+   * source origin
+   * (https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
    */
   partitionKey?: string;
   /**
@@ -155,9 +157,10 @@ export interface CookieParam {
    */
   sourceScheme?: CookieSourceScheme;
   /**
-   * Cookie partition key. The site of the top-level URL the browser was visiting at the
-   * start of the request to the endpoint that set the cookie. If not set, the cookie will
-   * be set as not partitioned.
+   * Cookie partition key. In Chrome, it matches the top-level site the
+   * partitioned cookie is available in. In Firefox, it matches the
+   * source origin
+   * (https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
    */
   partitionKey?: string;
 }
@@ -184,9 +187,10 @@ export interface DeleteCookiesRequest {
    */
   path?: string;
   /**
-   * If specified, deletes only cookies with the the given name
-   * and partitionKey where domain
-   * matches provided URL.
+   * If specified, deletes cookies in the given partition key. In
+   * Chrome, partitionKey matches the top-level site the partitioned
+   * cookie is available in. In Firefox, it matches the source origin
+   * (https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
    */
   partitionKey?: string;
 }

--- a/packages/puppeteer-core/src/common/Cookie.ts
+++ b/packages/puppeteer-core/src/common/Cookie.ts
@@ -183,4 +183,10 @@ export interface DeleteCookiesRequest {
    * If specified, deletes only cookies with the exact path.
    */
   path?: string;
+  /**
+   * If specified, deletes only cookies with the the given name
+   * and partitionKey where domain
+   * matches provided URL.
+   */
+  partitionKey?: string;
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1129,11 +1129,25 @@
     "comment": "Not supported with cdp"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.deleteCookie should delete cookie with partition key if partition key is specified",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported"
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.deleteCookie should not delete cookie for different domain",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Not supported with cdp"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.deleteCookie should only delete cookie from the default partition if partitionkey is not specified",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported"
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should default to setting secure cookie for HTTPS websites",
@@ -1155,6 +1169,13 @@
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set a cookie with a partitionKey",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported"
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set a cookie with a path",

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -800,21 +800,24 @@ describe('Cookie specs', () => {
       expect(await page.cookies()).toHaveLength(0);
     });
     it('should delete cookie with partition key if partition key is specified', async () => {
-      const {page, server} = await getTestState();
+      const {page, server, isChrome} = await getTestState();
       const url = new URL(server.EMPTY_PAGE);
       await page.goto(url.toString());
+      const origin = isChrome
+        ? url.origin.replace(`:${url.port}`, '')
+        : url.origin;
       await page.setCookie({
         url: url.toString(),
         name: 'partitionCookie',
         value: 'partition',
         secure: true,
-        partitionKey: url.origin,
+        partitionKey: origin,
       });
       expect(await page.cookies()).toHaveLength(1);
       await page.deleteCookie({
         url: url.toString(),
         name: 'partitionCookie',
-        partitionKey: url.origin,
+        partitionKey: origin,
       });
       expect(await page.cookies()).toHaveLength(0);
     });

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -781,84 +781,42 @@ describe('Cookie specs', () => {
       // Expect the cookie for the COOKIE_DESTINATION from URL_1 is deleted.
       expect(await page.cookies(COOKIE_DESTINATION_URL)).toHaveLength(0);
     });
-    it('should only delete cookie without partition key if partitionkey is not specified', async () => {
-      const {page} = await getTestState();
-      const url = 'https://example.com';
-      await page.goto(url);
+    it('should only delete cookie from the default partition if partitionkey is not specified', async () => {
+      const {page, server} = await getTestState();
+      const url = new URL(server.EMPTY_PAGE);
+      await page.goto(url.toString());
       await page.setCookie({
-        url,
+        url: url.toString(),
         name: 'partitionCookie',
         value: 'partition',
-        partitionKey: url,
-      });
-
-      await page.setCookie({
-        url,
-        name: 'partitionCookie',
-        value: 'partition',
-      });
-      expect(await page.cookies()).toHaveLength(2);
-      await page.deleteCookie({
-        url,
-        name: 'partitionCookie',
+        secure: true,
+        partitionKey: url.origin,
       });
       expect(await page.cookies()).toHaveLength(1);
-      await expectCookieEquals(await page.cookies(), [
-        {
-          name: 'partitionCookie',
-          value: 'partition',
-          domain: 'example.com',
-          path: '/',
-          expires: -1,
-          size: 24,
-          httpOnly: false,
-          secure: true,
-          session: true,
-          sameParty: false,
-          sourceScheme: 'Secure',
-          partitionKey: url,
-        },
-      ]);
+      await page.deleteCookie({
+        url: url.toString(),
+        name: 'partitionCookie',
+      });
+      expect(await page.cookies()).toHaveLength(0);
     });
-    it('should only delete cookie with partition key if partition key is specified', async () => {
-      const {page} = await getTestState();
-      const url = 'https://example.com';
-      await page.goto(url);
+    it('should delete cookie with partition key if partition key is specified', async () => {
+      const {page, server} = await getTestState();
+      const url = new URL(server.EMPTY_PAGE);
+      await page.goto(url.toString());
       await page.setCookie({
-        url,
+        url: url.toString(),
         name: 'partitionCookie',
         value: 'partition',
-        partitionKey: url,
-      });
-
-      await page.setCookie({
-        url,
-        name: 'partitionCookie',
-        value: 'partition',
-      });
-      expect(await page.cookies()).toHaveLength(2);
-      await page.deleteCookie({
-        url,
-        name: 'partitionCookie',
-        partitionKey: url,
+        secure: true,
+        partitionKey: url.origin,
       });
       expect(await page.cookies()).toHaveLength(1);
-      await expectCookieEquals(await page.cookies(), [
-        {
-          name: 'partitionCookie',
-          value: 'partition',
-          domain: 'example.com',
-          path: '/',
-          expires: -1,
-          size: 24,
-          httpOnly: false,
-          secure: true,
-          session: true,
-          sameParty: false,
-          sourceScheme: 'Secure',
-          partitionKey: undefined,
-        },
-      ]);
+      await page.deleteCookie({
+        url: url.toString(),
+        name: 'partitionCookie',
+        partitionKey: url.origin,
+      });
+      expect(await page.cookies()).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
According to the devtools protocol interface DeleteCookiesRequest, partitionKey missed in interface DeleteCookiesRequest in Cookie.ts file. This PR is to add it to the file.