### PR TITLE
fix(webdriver): dispose resources to abort active listeners

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -71,7 +71,10 @@ export class UserContext extends EventEmitter<{
       new EventEmitter(this.browser)
     );
     browserEmitter.once('closed', ({reason}) => {
-      this.dispose(`User context already closed: ${reason}`);
+      this.dispose(`User context was closed: ${reason}`);
+    });
+    browserEmitter.once('disconnected', ({reason}) => {
+      this.dispose(`User context was closed: ${reason}`);
     });
 
     const sessionEmitter = this.#disposables.use(

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1936,7 +1936,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
-    "comment": "https://github.com/puppeteer/puppeteer/issues/11849"
+    "comment": "Requires support for multiple sessions"
   },
   {
     "testIdPattern": "[launcher.spec] Launcher specs Puppeteer Puppeteer.connect should be able to close remote browser",

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -49,6 +49,7 @@ describe('Launcher specs', function () {
               'Navigating frame was detached',
               'Protocol error (Page.navigate): Target closed.',
               'Protocol error (browsingContext.navigate): Target closed',
+              'Frame detached',
             ].some(message => {
               return error.message.startsWith(message);
             })


### PR DESCRIPTION
Ending a WebDriver BiDi session disposes the browser but didn't dispose user contexts and frames. That caused waiters to still remain active and only time out after the timeout period.

Closes https://github.com/puppeteer/puppeteer/issues/11849