### PR TITLE
refactor!: use Uint8Array instead of Buffer for browser compatibility

### DIFF
--- a/docs/api/puppeteer.elementhandle.screenshot.md
+++ b/docs/api/puppeteer.elementhandle.screenshot.md
@@ -51,13 +51,13 @@ Readonly&lt;[ScreenshotOptions](./puppeteer.screenshotoptions.md)&gt; &amp; &#12
 
 Promise&lt;string&gt;
 
-<h2 id="screenshot-1">screenshot(): Promise&lt;Buffer&gt;</h2>
+<h2 id="screenshot-1">screenshot(): Promise&lt;Uint8Array&gt;</h2>
 
 ### Signature
 
 ```typescript
 class ElementHandle {
-  screenshot(options?: Readonly<ScreenshotOptions>): Promise<Buffer>;
+  screenshot(options?: Readonly<ScreenshotOptions>): Promise<Uint8Array>;
 }
 ```
 
@@ -92,4 +92,4 @@ _(Optional)_
 </tbody></table>
 **Returns:**
 
-Promise&lt;Buffer&gt;
+Promise&lt;Uint8Array&gt;

--- a/docs/api/puppeteer.httpresponse.content.md
+++ b/docs/api/puppeteer.httpresponse.content.md
@@ -1,8 +1,8 @@
 ---
-sidebar_label: HTTPResponse.buffer
+sidebar_label: HTTPResponse.content
 ---
 
-# HTTPResponse.buffer() method
+# HTTPResponse.content() method
 
 Promise which resolves to a buffer with response body.
 
@@ -10,13 +10,13 @@ Promise which resolves to a buffer with response body.
 
 ```typescript
 class HTTPResponse {
-  buffer(): Promise<Buffer>;
+  abstract content(): Promise<Uint8Array>;
 }
 ```
 
 **Returns:**
 
-Promise&lt;Buffer&gt;
+Promise&lt;Uint8Array&gt;
 
 ## Remarks
 

--- a/docs/api/puppeteer.httpresponse.md
+++ b/docs/api/puppeteer.httpresponse.md
@@ -48,6 +48,21 @@ The buffer might be re-encoded by the browser based on HTTP-headers or other heu
 </td></tr>
 <tr><td>
 
+<span id="content">[content()](./puppeteer.httpresponse.content.md)</span>
+
+</td><td>
+
+</td><td>
+
+Promise which resolves to a buffer with response body.
+
+**Remarks:**
+
+The buffer might be re-encoded by the browser based on HTTP-headers or other heuristics. If the browser failed to detect the correct encoding, the buffer might be encoded incorrectly. See https://github.com/puppeteer/puppeteer/issues/6478.
+
+</td></tr>
+<tr><td>
+
 <span id="frame">[frame()](./puppeteer.httpresponse.frame.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.page.pdf.md
+++ b/docs/api/puppeteer.page.pdf.md
@@ -10,7 +10,7 @@ Generates a PDF of the page with the `print` CSS media type.
 
 ```typescript
 class Page {
-  abstract pdf(options?: PDFOptions): Promise<Buffer>;
+  abstract pdf(options?: PDFOptions): Promise<Uint8Array>;
 }
 ```
 
@@ -45,7 +45,7 @@ _(Optional)_ options for generating the PDF.
 </tbody></table>
 **Returns:**
 
-Promise&lt;Buffer&gt;
+Promise&lt;Uint8Array&gt;
 
 ## Remarks
 

--- a/docs/api/puppeteer.page.screenshot.md
+++ b/docs/api/puppeteer.page.screenshot.md
@@ -59,13 +59,13 @@ While a screenshot is being taken in a [BrowserContext](./puppeteer.browserconte
 
 Calling [Page.bringToFront()](./puppeteer.page.bringtofront.md) will not wait for existing screenshot operations.
 
-<h2 id="screenshot-1">screenshot(): Promise&lt;Buffer&gt;</h2>
+<h2 id="screenshot-1">screenshot(): Promise&lt;Uint8Array&gt;</h2>
 
 ### Signature
 
 ```typescript
 class Page {
-  screenshot(options?: Readonly<ScreenshotOptions>): Promise<Buffer>;
+  screenshot(options?: Readonly<ScreenshotOptions>): Promise<Uint8Array>;
 }
 ```
 
@@ -100,4 +100,4 @@ _(Optional)_
 </tbody></table>
 **Returns:**
 
-Promise&lt;Buffer&gt;
+Promise&lt;Uint8Array&gt;

--- a/docs/api/puppeteer.tracing.stop.md
+++ b/docs/api/puppeteer.tracing.stop.md
@@ -10,12 +10,12 @@ Stops a trace started with the `start` method.
 
 ```typescript
 class Tracing {
-  stop(): Promise<Buffer | undefined>;
+  stop(): Promise<Uint8Array | undefined>;
 }
 ```
 
 **Returns:**
 
-Promise&lt;Buffer \| undefined&gt;
+Promise&lt;Uint8Array \| undefined&gt;
 
 Promise which resolves to buffer with trace data.

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -1354,13 +1354,13 @@ export abstract class ElementHandle<
   async screenshot(
     options: Readonly<ScreenshotOptions> & {encoding: 'base64'}
   ): Promise<string>;
-  async screenshot(options?: Readonly<ScreenshotOptions>): Promise<Buffer>;
+  async screenshot(options?: Readonly<ScreenshotOptions>): Promise<Uint8Array>;
   @throwIfDisposed()
   @ElementHandle.bindIsolatedHandle
   async screenshot(
     this: ElementHandle<Element>,
     options: Readonly<ElementScreenshotOptions> = {}
-  ): Promise<string | Buffer> {
+  ): Promise<string | Uint8Array> {
     const {scrollIntoView = true, clip} = options;
 
     const page = this.frame.page();

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -8,6 +8,7 @@ import type {Protocol} from 'devtools-protocol';
 import type {ProtocolError} from '../common/Errors.js';
 import {debugError, isString} from '../common/util.js';
 import {assert} from '../util/assert.js';
+import {typedArrayToBase64} from '../util/encoding.js';
 
 import type {CDPSession} from './CDPSession.js';
 import type {Frame} from './Frame.js';
@@ -561,14 +562,9 @@ export abstract class HTTPRequest {
       ? new TextEncoder().encode(body)
       : body;
 
-    const bytes = [];
-    for (const byte of byteBody) {
-      bytes.push(String.fromCharCode(byte));
-    }
-
     return {
       contentLength: byteBody.byteLength,
-      base64: btoa(bytes.join('')),
+      base64: typedArrayToBase64(byteBody),
     };
   }
 }

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -89,14 +89,14 @@ export abstract class HTTPResponse {
    * failed to detect the correct encoding, the buffer might
    * be encoded incorrectly. See https://github.com/puppeteer/puppeteer/issues/6478.
    */
-  abstract buffer(): Promise<Buffer>;
+  abstract buffer(): Promise<Uint8Array>;
 
   /**
    * Promise which resolves to a text (utf8) representation of response body.
    */
   async text(): Promise<string> {
     const content = await this.buffer();
-    return content.toString('utf8');
+    return new TextDecoder().decode(content);
   }
 
   /**

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -89,13 +89,20 @@ export abstract class HTTPResponse {
    * failed to detect the correct encoding, the buffer might
    * be encoded incorrectly. See https://github.com/puppeteer/puppeteer/issues/6478.
    */
-  abstract buffer(): Promise<Uint8Array>;
+  abstract content(): Promise<Uint8Array>;
 
+  /**
+   * {@inheritDoc HTTPResponse.content}
+   */
+  async buffer(): Promise<Buffer> {
+    const content = await this.content();
+    return Buffer.from(content);
+  }
   /**
    * Promise which resolves to a text (utf8) representation of response body.
    */
   async text(): Promise<string> {
-    const content = await this.buffer();
+    const content = await this.content();
     return new TextDecoder().decode(content);
   }
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -79,6 +79,7 @@ import {
   DisposableStack,
   disposeSymbol,
 } from '../util/disposable.js';
+import {stringToTypedArray} from '../util/typedArray.js';
 
 import type {Browser} from './Browser.js';
 import type {BrowserContext} from './BrowserContext.js';
@@ -2588,15 +2589,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       return data;
     }
 
-    function base64ToTypedArray(base64: string) {
-      const binaryString = atob(base64);
-      const bytes = new Uint8Array(binaryString.length);
-      for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-      }
-      return bytes;
-    }
-    const typedArray = base64ToTypedArray(data);
+    const typedArray = stringToTypedArray(data);
     await this._maybeWriteTypedArrayToFile(options.path, typedArray);
     return typedArray;
   }

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2278,15 +2278,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
   /**
    * @internal
    */
-  async _maybeWriteBufferToFile(
+  async _maybeWriteTypedArrayToFile(
     path: string | undefined,
-    buffer: Uint8Array
+    typedArray: Uint8Array
   ): Promise<void> {
     if (!path) {
       return;
     }
 
-    await environment.value.fs.promises.writeFile(path, buffer);
+    await environment.value.fs.promises.writeFile(path, typedArray);
   }
 
   /**
@@ -2588,7 +2588,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       return data;
     }
 
-    function base64ToArrayBuffer(base64: string) {
+    function base64ToTypedArray(base64: string) {
       const binaryString = atob(base64);
       const bytes = new Uint8Array(binaryString.length);
       for (let i = 0; i < binaryString.length; i++) {
@@ -2596,9 +2596,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
       }
       return bytes;
     }
-    const buffer = base64ToArrayBuffer(data);
-    await this._maybeWriteBufferToFile(options.path, buffer);
-    return buffer;
+    const typedArray = base64ToTypedArray(data);
+    await this._maybeWriteTypedArrayToFile(options.path, typedArray);
+    return typedArray;
   }
 
   /**

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -79,7 +79,7 @@ import {
   DisposableStack,
   disposeSymbol,
 } from '../util/disposable.js';
-import {stringToTypedArray} from '../util/typedArray.js';
+import {stringToTypedArray} from '../util/encoding.js';
 
 import type {Browser} from './Browser.js';
 import type {BrowserContext} from './BrowserContext.js';

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2280,7 +2280,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    */
   async _maybeWriteBufferToFile(
     path: string | undefined,
-    buffer: Buffer
+    buffer: Uint8Array
   ): Promise<void> {
     if (!path) {
       return;
@@ -2482,13 +2482,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
   async screenshot(
     options: Readonly<ScreenshotOptions> & {encoding: 'base64'}
   ): Promise<string>;
-  async screenshot(options?: Readonly<ScreenshotOptions>): Promise<Buffer>;
+  async screenshot(options?: Readonly<ScreenshotOptions>): Promise<Uint8Array>;
   @guarded(function () {
     return this.browser();
   })
   async screenshot(
     userOptions: Readonly<ScreenshotOptions> = {}
-  ): Promise<Buffer | string> {
+  ): Promise<Uint8Array | string> {
     using _guard = await this.browserContext().startScreenshot();
 
     await this.bringToFront();
@@ -2587,7 +2587,16 @@ export abstract class Page extends EventEmitter<PageEvents> {
     if (options.encoding === 'base64') {
       return data;
     }
-    const buffer = Buffer.from(data, 'base64');
+
+    function base64ToArrayBuffer(base64: string) {
+      const binaryString = atob(base64);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      return bytes;
+    }
+    const buffer = base64ToArrayBuffer(data);
     await this._maybeWriteBufferToFile(options.path, buffer);
     return buffer;
   }
@@ -2620,7 +2629,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
   /**
    * {@inheritDoc Page.createPDFStream}
    */
-  abstract pdf(options?: PDFOptions): Promise<Buffer>;
+  abstract pdf(options?: PDFOptions): Promise<Uint8Array>;
 
   /**
    * The page's title

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2589,7 +2589,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       return data;
     }
 
-    const typedArray = stringToTypedArray(data);
+    const typedArray = stringToTypedArray(data, true);
     await this._maybeWriteTypedArrayToFile(options.path, typedArray);
     return typedArray;
   }

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -18,6 +18,7 @@ import {
 } from '../api/HTTPRequest.js';
 import {PageEvent} from '../api/Page.js';
 import {UnsupportedOperation} from '../common/Errors.js';
+import {stringToBase64} from '../util/encoding.js';
 
 import type {Request} from './core/Request.js';
 import type {BidiFrame} from './Frame.js';
@@ -221,7 +222,7 @@ export class BidiHTTPRequest extends HTTPRequest {
         body: overrides.postData
           ? {
               type: 'base64',
-              value: btoa(overrides.postData),
+              value: stringToBase64(overrides.postData),
             }
           : undefined,
         headers: headers.length > 0 ? headers : undefined,

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -145,7 +145,7 @@ export class BidiHTTPResponse extends HTTPResponse {
     return this.#securityDetails ?? null;
   }
 
-  override buffer(): never {
+  override content(): never {
     throw new UnsupportedOperation();
   }
 }

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -50,8 +50,8 @@ import {
 import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {bubble} from '../util/decorators.js';
+import {stringToTypedArray} from '../util/encoding.js';
 import {isErrorLike} from '../util/ErrorLike.js';
-import {stringToTypedArray} from '../util/typedArray.js';
 
 import type {BidiBrowser} from './Browser.js';
 import type {BidiBrowserContext} from './BrowserContext.js';

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -374,7 +374,7 @@ export class BidiPage extends Page {
     return this.#viewport;
   }
 
-  override async pdf(options: PDFOptions = {}): Promise<Buffer> {
+  override async pdf(options: PDFOptions = {}): Promise<Uint8Array> {
     const {timeout: ms = this._timeoutSettings.timeout(), path = undefined} =
       options;
     const {
@@ -416,7 +416,16 @@ export class BidiPage extends Page {
       ).pipe(raceWith(timeout(ms)))
     );
 
-    const buffer = Buffer.from(data, 'base64');
+    function base64ToArrayBuffer(base64: string) {
+      const binaryString = atob(base64);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      return bytes;
+    }
+
+    const buffer = base64ToArrayBuffer(data);
 
     await this._maybeWriteBufferToFile(path, buffer);
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -416,7 +416,7 @@ export class BidiPage extends Page {
       ).pipe(raceWith(timeout(ms)))
     );
 
-    function base64ToArrayBuffer(base64: string) {
+    function base64ToTypedArray(base64: string) {
       const binaryString = atob(base64);
       const bytes = new Uint8Array(binaryString.length);
       for (let i = 0; i < binaryString.length; i++) {
@@ -425,21 +425,21 @@ export class BidiPage extends Page {
       return bytes;
     }
 
-    const buffer = base64ToArrayBuffer(data);
+    const typedArray = base64ToTypedArray(data);
 
-    await this._maybeWriteBufferToFile(path, buffer);
+    await this._maybeWriteTypedArrayToFile(path, typedArray);
 
-    return buffer;
+    return typedArray;
   }
 
   override async createPDFStream(
     options?: PDFOptions | undefined
   ): Promise<ReadableStream<Uint8Array>> {
-    const buffer = await this.pdf(options);
+    const typedArray = await this.pdf(options);
 
     return new ReadableStream({
       start(controller) {
-        controller.enqueue(buffer);
+        controller.enqueue(typedArray);
         controller.close();
       },
     });

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -51,6 +51,7 @@ import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {bubble} from '../util/decorators.js';
 import {isErrorLike} from '../util/ErrorLike.js';
+import {stringToTypedArray} from '../util/typedArray.js';
 
 import type {BidiBrowser} from './Browser.js';
 import type {BidiBrowserContext} from './BrowserContext.js';
@@ -416,16 +417,7 @@ export class BidiPage extends Page {
       ).pipe(raceWith(timeout(ms)))
     );
 
-    function base64ToTypedArray(base64: string) {
-      const binaryString = atob(base64);
-      const bytes = new Uint8Array(binaryString.length);
-      for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-      }
-      return bytes;
-    }
-
-    const typedArray = base64ToTypedArray(data);
+    const typedArray = stringToTypedArray(data, true);
 
     await this._maybeWriteTypedArrayToFile(path, typedArray);
 

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -17,6 +17,7 @@ import {
   handleError,
 } from '../api/HTTPRequest.js';
 import {debugError} from '../common/util.js';
+import {stringToBase64} from '../util/encoding.js';
 
 import type {CdpHTTPResponse} from './HTTPResponse.js';
 
@@ -172,7 +173,9 @@ export class CdpHTTPRequest extends HTTPRequest {
     const {url, method, postData, headers} = overrides;
     this.interception.handled = true;
 
-    const postDataBinaryBase64 = postData ? btoa(postData) : undefined;
+    const postDataBinaryBase64 = postData
+      ? stringToBase64(postData)
+      : undefined;
 
     if (this._interceptionId === undefined) {
       throw new Error(

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -137,7 +137,11 @@ export class CdpHTTPResponse extends HTTPResponse {
             const body = response.base64Encoded
               ? atob(response.body)
               : response.body;
-            return new TextEncoder().encode(body);
+            const bytes = new Uint8Array(body.length);
+            for (let i = 0; i < body.length; i++) {
+              bytes[i] = body.charCodeAt(i);
+            }
+            return bytes;
           } catch (error) {
             if (
               error instanceof ProtocolError &&

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -135,7 +135,7 @@ export class CdpHTTPResponse extends HTTPResponse {
             );
 
             const body = response.base64Encoded
-              ? btoa(response.body)
+              ? atob(response.body)
               : response.body;
             return new TextEncoder().encode(body);
           } catch (error) {

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -122,7 +122,7 @@ export class CdpHTTPResponse extends HTTPResponse {
     return this.#timing;
   }
 
-  override buffer(): Promise<Uint8Array> {
+  override content(): Promise<Uint8Array> {
     if (!this.#contentPromise) {
       this.#contentPromise = this.#bodyLoadedDeferred
         .valueOrThrow()

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -11,7 +11,7 @@ import {HTTPResponse, type RemoteAddress} from '../api/HTTPResponse.js';
 import {ProtocolError} from '../common/Errors.js';
 import {SecurityDetails} from '../common/SecurityDetails.js';
 import {Deferred} from '../util/Deferred.js';
-import {stringToTypedArray} from '../util/typedArray.js';
+import {stringToTypedArray} from '../util/encoding.js';
 
 import type {CdpHTTPRequest} from './HTTPRequest.js';
 

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -11,6 +11,7 @@ import {HTTPResponse, type RemoteAddress} from '../api/HTTPResponse.js';
 import {ProtocolError} from '../common/Errors.js';
 import {SecurityDetails} from '../common/SecurityDetails.js';
 import {Deferred} from '../util/Deferred.js';
+import {stringToTypedArray} from '../util/typedArray.js';
 
 import type {CdpHTTPRequest} from './HTTPRequest.js';
 
@@ -134,14 +135,7 @@ export class CdpHTTPResponse extends HTTPResponse {
               }
             );
 
-            const body = response.base64Encoded
-              ? atob(response.body)
-              : response.body;
-            const bytes = new Uint8Array(body.length);
-            for (let i = 0; i < body.length; i++) {
-              bytes[i] = body.charCodeAt(i);
-            }
-            return bytes;
+            return stringToTypedArray(response.body, response.base64Encoded);
           } catch (error) {
             if (
               error instanceof ProtocolError &&

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -1097,7 +1097,7 @@ export class CdpPage extends Page {
     );
   }
 
-  override async pdf(options: PDFOptions = {}): Promise<Buffer> {
+  override async pdf(options: PDFOptions = {}): Promise<Uint8Array> {
     const {path = undefined} = options;
     const readable = await this.createPDFStream(options);
     const buffer = await getReadableAsBuffer(readable, path);

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -44,7 +44,7 @@ import type {BindingPayload, HandleFor} from '../common/types.js';
 import {
   debugError,
   evaluationString,
-  getReadableAsBuffer,
+  getReadableAsTypedArray,
   getReadableFromProtocolStream,
   parsePDFOptions,
   timeout,
@@ -1100,9 +1100,9 @@ export class CdpPage extends Page {
   override async pdf(options: PDFOptions = {}): Promise<Uint8Array> {
     const {path = undefined} = options;
     const readable = await this.createPDFStream(options);
-    const buffer = await getReadableAsBuffer(readable, path);
-    assert(buffer, 'Could not create buffer');
-    return buffer;
+    const typedArray = await getReadableAsTypedArray(readable, path);
+    assert(typedArray, 'Could not create typed array');
+    return typedArray;
   }
 
   override async close(

--- a/packages/puppeteer-core/src/cdp/Tracing.ts
+++ b/packages/puppeteer-core/src/cdp/Tracing.ts
@@ -114,8 +114,8 @@ export class Tracing {
    * Stops a trace started with the `start` method.
    * @returns Promise which resolves to buffer with trace data.
    */
-  async stop(): Promise<Buffer | undefined> {
-    const contentDeferred = Deferred.create<Buffer | undefined>();
+  async stop(): Promise<Uint8Array | undefined> {
+    const contentDeferred = Deferred.create<Uint8Array | undefined>();
     this.#client.once('Tracing.tracingComplete', async event => {
       try {
         assert(event.stream, 'Missing "stream"');

--- a/packages/puppeteer-core/src/cdp/Tracing.ts
+++ b/packages/puppeteer-core/src/cdp/Tracing.ts
@@ -5,7 +5,7 @@
  */
 import type {CDPSession} from '../api/CDPSession.js';
 import {
-  getReadableAsBuffer,
+  getReadableAsTypedArray,
   getReadableFromProtocolStream,
 } from '../common/util.js';
 import {assert} from '../util/assert.js';
@@ -123,8 +123,8 @@ export class Tracing {
           this.#client,
           event.stream
         );
-        const buffer = await getReadableAsBuffer(readable, this.#path);
-        contentDeferred.resolve(buffer ?? undefined);
+        const typedArray = await getReadableAsTypedArray(readable, this.#path);
+        contentDeferred.resolve(typedArray ?? undefined);
       } catch (error) {
         if (isErrorLike(error)) {
           contentDeferred.reject(error);

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -19,6 +19,7 @@ import type {CDPSession} from '../api/CDPSession.js';
 import {environment} from '../environment.js';
 import {packageVersion} from '../generated/version.js';
 import {assert} from '../util/assert.js';
+import {mergeUint8Arrays} from '../util/typedArray.js';
 
 import {debug} from './Debug.js';
 import {TimeoutError} from './Errors.js';

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -19,7 +19,7 @@ import type {CDPSession} from '../api/CDPSession.js';
 import {environment} from '../environment.js';
 import {packageVersion} from '../generated/version.js';
 import {assert} from '../util/assert.js';
-import {mergeUint8Arrays} from '../util/typedArray.js';
+import {mergeUint8Arrays} from '../util/encoding.js';
 
 import {debug} from './Debug.js';
 import {TimeoutError} from './Errors.js';

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -208,7 +208,11 @@ function mergeUint8Arrays(mergable: Uint8Array[]): Uint8Array {
 
   return mergedArray;
 }
-export async function getReadableAsBuffer(
+
+/**
+ * @internal
+ */
+export async function getReadableAsTypedArray(
   readable: ReadableStream<Uint8Array>,
   path?: string
 ): Promise<Uint8Array | null> {

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -193,26 +193,6 @@ export function evaluationString(
 /**
  * @internal
  */
-function mergeUint8Arrays(mergable: Uint8Array[]): Uint8Array {
-  let length = 0;
-  mergable.forEach(item => {
-    length += item.length;
-  });
-
-  // Create a new array with total length and merge all source arrays.
-  const mergedArray = new Uint8Array(length);
-  let offset = 0;
-  mergable.forEach(item => {
-    mergedArray.set(item, offset);
-    offset += item.length;
-  });
-
-  return mergedArray;
-}
-
-/**
- * @internal
- */
 export async function getReadableAsTypedArray(
   readable: ReadableStream<Uint8Array>,
   path?: string

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -195,8 +195,8 @@ export function evaluationString(
 export async function getReadableAsBuffer(
   readable: ReadableStream<Uint8Array>,
   path?: string
-): Promise<Buffer | null> {
-  const buffers: Uint8Array[] = [];
+): Promise<Uint8Array | null> {
+  const buffers: number[] = [];
   const reader = readable.getReader();
   if (path) {
     const fileHandle = await environment.value.fs.promises.open(path, 'w+');
@@ -206,7 +206,7 @@ export async function getReadableAsBuffer(
         if (done) {
           break;
         }
-        buffers.push(value);
+        buffers.push(...value);
         await fileHandle.writeFile(value);
       }
     } finally {
@@ -218,11 +218,15 @@ export async function getReadableAsBuffer(
       if (done) {
         break;
       }
-      buffers.push(value);
+      buffers.push(...value);
     }
   }
   try {
-    return Buffer.concat(buffers);
+    const concat = new Uint8Array(buffers);
+    if (concat.length === 0) {
+      return null;
+    }
+    return concat;
   } catch (error) {
     debugError(error);
     return null;

--- a/packages/puppeteer-core/src/util/encoding.test.ts
+++ b/packages/puppeteer-core/src/util/encoding.test.ts
@@ -58,5 +58,13 @@ describe('Typed Array helpers', function () {
         new Uint8Array([1, 12, 123])
       );
     });
+
+    it('should work with empty arrays', () => {
+      const one = new Uint8Array([1]);
+      const two = new Uint8Array([]);
+      const three = new Uint8Array([]);
+
+      expect(mergeUint8Arrays([one, two, three])).toEqual(new Uint8Array([1]));
+    });
   });
 });

--- a/packages/puppeteer-core/src/util/encoding.test.ts
+++ b/packages/puppeteer-core/src/util/encoding.test.ts
@@ -8,7 +8,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {mergeUint8Arrays, stringToTypedArray} from './typedArray.js';
+import {mergeUint8Arrays, stringToTypedArray} from './encoding.js';
 
 describe('Typed Array helpers', function () {
   describe('stringToTypedArray', function () {
@@ -35,6 +35,16 @@ describe('Typed Array helpers', function () {
       const result = stringToTypedArray(body, true);
 
       expect(Buffer.from(body, 'base64').compare(Buffer.from(result))).toBe(0);
+    });
+
+    it('should get body length from base64 containing emoji', async () => {
+      // 'How Long is this string in bytes 📏?';
+      const base64 = 'SG93IExvbmcgaXMgdGhpcyBzdHJpbmcgaW4gYnl0ZXMg8J+Tjz8=';
+      const result = stringToTypedArray(base64, true);
+
+      expect(Buffer.from(base64, 'base64').compare(Buffer.from(result))).toBe(
+        0
+      );
     });
   });
 

--- a/packages/puppeteer-core/src/util/encoding.ts
+++ b/packages/puppeteer-core/src/util/encoding.ts
@@ -4,21 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @internal
+ */
 export function stringToTypedArray(
   string: string,
   base64Encoded = false
 ): Uint8Array {
   if (base64Encoded) {
     const binaryString = atob(string);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes;
+    // @ts-expect-error There are non-proper overloads
+    return Uint8Array.from(binaryString, m => {
+      return m.codePointAt(0);
+    });
   }
   return new TextEncoder().encode(string);
 }
 
+/**
+ * @internal
+ */
+export function stringToBase64(str: string): string {
+  return typedArrayToBase64(new TextEncoder().encode(str));
+}
+
+/**
+ * @internal
+ */
+export function typedArrayToBase64(typedArray: Uint8Array): string {
+  const binaryString = Array.from(typedArray, byte => {
+    return String.fromCodePoint(byte);
+  }).join('');
+  return btoa(binaryString);
+}
+
+/**
+ * @internal
+ */
 export function mergeUint8Arrays(items: Uint8Array[]): Uint8Array {
   let length = 0;
   for (const item of items) {

--- a/packages/puppeteer-core/src/util/typedArray.test.ts
+++ b/packages/puppeteer-core/src/util/typedArray.test.ts
@@ -8,9 +8,9 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {stringToTypedArray} from './typedArray.js';
+import {mergeUint8Arrays, stringToTypedArray} from './typedArray.js';
 
-describe('Function', function () {
+describe('Typed Array helpers', function () {
   describe('stringToTypedArray', function () {
     it('should get body length from empty string', async () => {
       const result = stringToTypedArray('');
@@ -35,6 +35,18 @@ describe('Function', function () {
       const result = stringToTypedArray(body, true);
 
       expect(Buffer.from(body, 'base64').compare(Buffer.from(result))).toBe(0);
+    });
+  });
+
+  describe('mergeUint8Arrays', () => {
+    it('should work', () => {
+      const one = new Uint8Array([1]);
+      const two = new Uint8Array([12]);
+      const three = new Uint8Array([123]);
+
+      expect(mergeUint8Arrays([one, two, three])).toEqual(
+        new Uint8Array([1, 12, 123])
+      );
     });
   });
 });

--- a/packages/puppeteer-core/src/util/typedArray.test.ts
+++ b/packages/puppeteer-core/src/util/typedArray.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {stringToTypedArray} from './typedArray.js';
+
+describe('Function', function () {
+  describe('stringToTypedArray', function () {
+    it('should get body length from empty string', async () => {
+      const result = stringToTypedArray('');
+
+      expect(Buffer.from('').compare(Buffer.from(result))).toBe(0);
+    });
+    it('should get body length from latin string', async () => {
+      const body = 'Lorem ipsum dolor sit amet';
+      const result = stringToTypedArray(body);
+
+      expect(Buffer.from(body).compare(Buffer.from(result))).toBe(0);
+    });
+    it('should get body length from string with emoji', async () => {
+      const body = 'How Long is this string in bytes 📏?';
+      const result = stringToTypedArray(body);
+
+      expect(Buffer.from(body).compare(Buffer.from(result))).toBe(0);
+    });
+
+    it('should get body length from base64', async () => {
+      const body = btoa('Lorem ipsum dolor sit amet');
+      const result = stringToTypedArray(body, true);
+
+      expect(Buffer.from(body, 'base64').compare(Buffer.from(result))).toBe(0);
+    });
+  });
+});

--- a/packages/puppeteer-core/src/util/typedArray.ts
+++ b/packages/puppeteer-core/src/util/typedArray.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function stringToTypedArray(
+  string: string,
+  base64Encoded = false
+): Uint8Array {
+  const parsedString = base64Encoded ? atob(string) : string;
+  return Uint8Array.from(
+    [...parsedString].map(char => {
+      return char.charCodeAt(0);
+    })
+  );
+}
+
+export function mergeUint8Arrays(mergables: Uint8Array[]): Uint8Array {
+  let length = 0;
+  mergables.forEach(item => {
+    length += item.length;
+  });
+
+  // Create a new array with total length and merge all source arrays.
+  const mergedArray = new Uint8Array(length);
+  let offset = 0;
+  mergables.forEach(item => {
+    mergedArray.set(item, offset);
+    offset += item.length;
+  });
+
+  return mergedArray;
+}

--- a/packages/puppeteer-core/src/util/typedArray.ts
+++ b/packages/puppeteer-core/src/util/typedArray.ts
@@ -9,26 +9,22 @@ export function stringToTypedArray(
   base64Encoded = false
 ): Uint8Array {
   const parsedString = base64Encoded ? atob(string) : string;
-  return Uint8Array.from(
-    [...parsedString].map(char => {
-      return char.charCodeAt(0);
-    })
-  );
+  return new TextEncoder().encode(parsedString);
 }
 
-export function mergeUint8Arrays(mergables: Uint8Array[]): Uint8Array {
+export function mergeUint8Arrays(items: Uint8Array[]): Uint8Array {
   let length = 0;
-  mergables.forEach(item => {
+  for (const item of items) {
     length += item.length;
-  });
+  }
 
   // Create a new array with total length and merge all source arrays.
-  const mergedArray = new Uint8Array(length);
+  const result = new Uint8Array(length);
   let offset = 0;
-  mergables.forEach(item => {
-    mergedArray.set(item, offset);
+  for (const item of items) {
+    result.set(item, offset);
     offset += item.length;
-  });
+  }
 
-  return mergedArray;
+  return result;
 }

--- a/packages/puppeteer-core/src/util/typedArray.ts
+++ b/packages/puppeteer-core/src/util/typedArray.ts
@@ -8,8 +8,15 @@ export function stringToTypedArray(
   string: string,
   base64Encoded = false
 ): Uint8Array {
-  const parsedString = base64Encoded ? atob(string) : string;
-  return new TextEncoder().encode(parsedString);
+  if (base64Encoded) {
+    const binaryString = atob(string);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
+  }
+  return new TextEncoder().encode(string);
 }
 
 export function mergeUint8Arrays(items: Uint8Array[]): Uint8Array {

--- a/test/src/golden-utils.ts
+++ b/test/src/golden-utils.ts
@@ -76,7 +76,10 @@ const compareText = (
   actual: string | Buffer,
   expectedBuffer: string | Buffer
 ): DiffFile | undefined => {
-  assert(typeof actual === 'string');
+  assert(
+    typeof actual === 'string',
+    `Expected type string got ${typeof actual}`
+  );
   const expected = expectedBuffer.toString('utf-8');
   if (expected === actual) {
     return;

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -403,7 +403,8 @@ describe('network', function () {
         path.join(__dirname, '../assets', 'pptr.png')
       );
       const responseBuffer = await response.buffer();
-      expect(responseBuffer.equals(imageBuffer)).toBe(true);
+
+      expect(Buffer.from(responseBuffer).equals(imageBuffer)).toBe(true);
     });
     it('should work with compression', async () => {
       const {page, server} = await getTestState();
@@ -414,7 +415,7 @@ describe('network', function () {
         path.join(__dirname, '../assets', 'pptr.png')
       );
       const responseBuffer = await response.buffer();
-      expect(responseBuffer.equals(imageBuffer)).toBe(true);
+      expect(Buffer.from(responseBuffer).equals(imageBuffer)).toBe(true);
     });
     it('should throw if the response does not have a body', async () => {
       const {page, server} = await getTestState();

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -14,7 +14,7 @@ import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {isFavicon, waitEvent} from './utils.js';
 
-describe.only('request interception', function () {
+describe('request interception', function () {
   setupTestBrowserHooks();
 
   describe('Page.setRequestInterception', function () {

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -14,7 +14,7 @@ import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
 import {isFavicon, waitEvent} from './utils.js';
 
-describe('request interception', function () {
+describe.only('request interception', function () {
   setupTestBrowserHooks();
 
   describe('Page.setRequestInterception', function () {
@@ -733,29 +733,29 @@ describe('request interception', function () {
 
       await page.setRequestInterception(true);
       page.on('request', request => {
-        void request.continue({postData: 'doggo'});
+        void request.continue({postData: '🐶'});
       });
       const [serverRequest] = await Promise.all([
         server.waitForRequest('/sleep.zzz'),
         page.evaluate(() => {
-          return fetch('/sleep.zzz', {method: 'POST', body: 'birdy'});
+          return fetch('/sleep.zzz', {method: 'POST', body: '🐦'});
         }),
       ]);
-      expect(await serverRequest.postBody).toBe('doggo');
+      expect(await serverRequest.postBody).toBe('🐶');
     });
     it('should amend both post data and method on navigation', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
       page.on('request', request => {
-        void request.continue({method: 'POST', postData: 'doggo'});
+        void request.continue({method: 'POST', postData: '🐶'});
       });
       const [serverRequest] = await Promise.all([
         server.waitForRequest('/empty.html'),
         page.goto(server.EMPTY_PAGE),
       ]);
       expect(serverRequest.method).toBe('POST');
-      expect(await serverRequest.postBody).toBe('doggo');
+      expect(await serverRequest.postBody).toBe('🐶');
     });
     it('should fail if the header value is invalid', async () => {
       const {page, server} = await getTestState();
@@ -858,7 +858,7 @@ describe('request interception', function () {
             arr: ['1', '2'],
             'set-cookie': ['first=1', 'second=2'],
           },
-          body: 'Hello world',
+          body: 'Hello 🌐',
         });
       });
       const response = (await page.goto(server.EMPTY_PAGE))!;
@@ -890,7 +890,7 @@ describe('request interception', function () {
       expect(firstCookie?.value).toBe('1');
       expect(secondCookie?.value).toBe('2');
     });
-    it.only('should allow mocking binary responses', async () => {
+    it('should allow mocking binary responses', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
@@ -954,7 +954,7 @@ describe('request interception', function () {
           });
         await request.respond({
           status: 200,
-          body: 'Hello World',
+          body: 'Hello 🌐',
         });
       });
       await page.goto(server.PREFIX + '/empty.html');

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -890,7 +890,7 @@ describe('request interception', function () {
       expect(firstCookie?.value).toBe('1');
       expect(secondCookie?.value).toBe('2');
     });
-    it('should allow mocking binary responses', async () => {
+    it.only('should allow mocking binary responses', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -179,7 +179,7 @@ describe('Screenshots', function () {
         const screenshot = await page.screenshot({
           fullPage: true,
         });
-        expect(screenshot).toBeInstanceOf(Buffer);
+        expect(screenshot).toBeInstanceOf(Uint8Array);
       } finally {
         await close();
       }
@@ -398,7 +398,7 @@ describe('Screenshots', function () {
         type: 'webp',
       });
 
-      expect(screenshot).toBeInstanceOf(Buffer);
+      expect(screenshot).toBeInstanceOf(Uint8Array);
     });
 
     it('should run in parallel in multiple pages', async () => {

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -116,8 +116,8 @@ describe('Tracing', function () {
     await page.tracing.start({screenshots: true});
     await page.goto(server.PREFIX + '/grid.html');
 
-    const oldGetReadableAsBuffer = utils.getReadableAsBuffer;
-    sinon.stub(utils, 'getReadableAsBuffer').callsFake(() => {
+    const oldGetReadableAsBuffer = utils.getReadableAsTypedArray;
+    sinon.stub(utils, 'getReadableAsTypedArray').callsFake(() => {
       return oldGetReadableAsBuffer({
         getReader() {
           return {

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -91,13 +91,14 @@ describe('Tracing', function () {
     expect(error).toBeTruthy();
     await page.tracing.stop();
   });
-  it('should return a buffer', async () => {
+  it('should return a typedArray', async () => {
     const {page, server} = testState;
 
     await page.tracing.start({screenshots: true, path: outputFile});
     await page.goto(server.PREFIX + '/grid.html');
     const trace = (await page.tracing.stop())!;
     const buf = fs.readFileSync(outputFile);
+    expect(trace).toBeInstanceOf(Uint8Array);
     expect(Buffer.from(trace).toString()).toEqual(buf.toString());
   });
   it('should work without options', async () => {
@@ -137,7 +138,7 @@ describe('Tracing', function () {
     expect(trace).toEqual(undefined);
   });
 
-  it('should support a buffer without a path', async () => {
+  it('should support a typedArray without a path', async () => {
     const {page, server} = testState;
 
     await page.tracing.start({screenshots: true});

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -143,7 +143,7 @@ describe('Tracing', function () {
     await page.tracing.start({screenshots: true});
     await page.goto(server.PREFIX + '/grid.html');
     const trace = (await page.tracing.stop())!;
-    expect(trace.toString()).toContain('screenshot');
+    expect(Buffer.from(trace).toString()).toContain('screenshot');
   });
 
   it('should properly fail if readProtocolStream errors out', async () => {

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -124,7 +124,7 @@ describe('Tracing', function () {
             read() {
               if (!this.done) {
                 this.done = true;
-                return {done: false, value: 42};
+                return {done: false, value: null};
               }
               return {done: true};
             },

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -98,7 +98,7 @@ describe('Tracing', function () {
     await page.goto(server.PREFIX + '/grid.html');
     const trace = (await page.tracing.stop())!;
     const buf = fs.readFileSync(outputFile);
-    expect(trace.toString()).toEqual(buf.toString());
+    expect(Buffer.from(trace).toString()).toEqual(buf.toString());
   });
   it('should work without options', async () => {
     const {page, server} = testState;

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -33,7 +33,9 @@ export const extendExpectWithToBeGolden = (
       const result = compare(
         goldenDir,
         outputDir,
-        Buffer.from(testScreenshot),
+        typeof testScreenshot === 'string'
+          ? testScreenshot
+          : Buffer.from(testScreenshot),
         goldenFilePath
       );
 

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -26,11 +26,14 @@ export const extendExpectWithToBeGolden = (
   outputDir: string
 ): void => {
   expect.extend({
-    toBeGolden: (testScreenshot: string | Buffer, goldenFilePath: string) => {
+    toBeGolden: (
+      testScreenshot: string | Uint8Array,
+      goldenFilePath: string
+    ) => {
       const result = compare(
         goldenDir,
         outputDir,
-        testScreenshot,
+        Buffer.from(testScreenshot),
         goldenFilePath
       );
 


### PR DESCRIPTION
We want users to be able to use Puppeteer in different environments, most notably in the browser.
Therefore, we want to move away from Node-specific API and rely on the ECMAScript APIs more and this
change replaces Node's Buffer in various Puppeteer APIs with [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array).

If you want to convert Uint8Array to Buffer, call [`Buffer.from`](https://nodejs.org/api/buffer.html#static-method-bufferfromarraybuffer-byteoffset-length). For example, instead of

```
const buffer = await page.screenshot();
```

convert to Buffer explicitly:

```
const buffer = Buffer.from(await page.screenshot());
```

Many Node APIs accept Uint8Arrays so it should not be needed unless you want to use Buffer-specific APIs.