### PR TITLE
feat: support passing `capabilities` to bidi

### DIFF
--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -39,6 +39,7 @@ export interface BidiBrowserOptions {
   process?: ChildProcess;
   closeCallback?: BrowserCloseCallback;
   connection: BidiConnection;
+  capabilities?: Bidi.Session.CapabilitiesRequest;
   cdpConnection?: CdpConnection;
   defaultViewport: Viewport | null;
   ignoreHTTPSErrors?: boolean;
@@ -71,11 +72,13 @@ export class BidiBrowser extends Browser {
 
   static async create(opts: BidiBrowserOptions): Promise<BidiBrowser> {
     const session = await Session.from(opts.connection, {
+      ...opts.capabilities,
       alwaysMatch: {
         acceptInsecureCerts: opts.ignoreHTTPSErrors,
         unhandledPromptBehavior: {
           default: Bidi.Session.UserPromptHandlerType.Ignore,
         },
+        ...opts.capabilities?.alwaysMatch,
         webSocketUrl: true,
       },
     });

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
+
 import type {
   IsPageTargetCallback,
   TargetFilterCallback,
@@ -16,6 +18,11 @@ import type {Viewport} from './Viewport.js';
  * @public
  */
 export type ProtocolType = 'cdp' | 'webDriverBiDi';
+
+/**
+ * @public
+ */
+export type Capabilities = Bidi.Session.CapabilitiesRequest;
 
 /**
  * Generic browser options that can be passed when launching any browser or when
@@ -59,6 +66,14 @@ export interface BrowserConnectOptions {
    * @defaultValue `180_000`
    */
   protocolTimeout?: number;
+
+  /**
+   * Capabilities passed to BiDi `session.new`.
+   *
+   * @remarks
+   * Only works for `protocol="webDriverBiDi"`
+   */
+  capabilities?: Capabilities;
 }
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add tests for your changes?**

Not yet, have to figure out how to do this.

**If relevant, did you update the documentation?**

Updated doc comments?

**Summary**

If using a hub intermediary (e.g. one day BrowserStack supports native BiDi) then passing `capabilities` to a session is kinda necessary to decide which instance to forward the websocket to.

There are two other points where `BidiBrowser.create` is called but they appear to be for launching the browser directly from the user's machine. Perhaps there is a use case here for passing capabilities… but it seemed less valuable and so has been omitted from this change currently.

**Does this PR introduce a breaking change?**

No.

**Other information**

N/A