### PR TITLE
docs:updated docs so that the selector param description is consistent

### DIFF
--- a/docs/api/puppeteer.page.click.md
+++ b/docs/api/puppeteer.page.click.md
@@ -39,7 +39,7 @@ string
 
 </td><td>
 
-A `selector` to search for element to click. If there are multiple elements satisfying the `selector`, the first will be clicked
+A [selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) of an element to type into. If there are multiple elements satisfying the selector, the first will be used.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.click.md
+++ b/docs/api/puppeteer.page.click.md
@@ -39,7 +39,7 @@ string
 
 </td><td>
 
-A [selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) of an element to type into. If there are multiple elements satisfying the selector, the first will be used.
+A [selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) of an element to click. If there are multiple elements satisfying the selector, the first will be clicked.
 
 </td></tr>
 <tr><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2674,7 +2674,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * Shortcut for {@link Frame.click | page.mainFrame().click(selector[, options]) }.
    * @param selector - A
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors | selector}
-   * of an element to type into. If there are multiple elements satisfying the
+   * of an element to click. If there are multiple elements satisfying the
    * selector, the first will be clicked.
    * @param options - `Object`
    * @returns Promise which resolves when the element matching `selector` is

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2672,8 +2672,10 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * ```
    *
    * Shortcut for {@link Frame.click | page.mainFrame().click(selector[, options]) }.
-   * @param selector - A `selector` to search for element to click. If there are
-   * multiple elements satisfying the `selector`, the first will be clicked
+   * @param selector - A
+   * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors | selector}
+   * of an element to type into. If there are multiple elements satisfying the
+   * selector, the first will be clicked.
    * @param options - `Object`
    * @returns Promise which resolves when the element matching `selector` is
    * successfully clicked. The Promise will be rejected if there is no element


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Docs update so that the description for selector is consistent with other descriptions for it

**Did you add tests for your changes?**
No

**Summary**
I noticed that the selector didn't link to the docs on mdn so i added it to the Page.click docs. 

I wanted to add this because when i was looking through the docs for clicking and the selector seamed ambiguous to me.

**Does this PR introduce a breaking change?**
no

