### PR TITLE
ci: use standard definition

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -5,8 +5,8 @@ permissions: read-all
 
 on:
   schedule:
-    # Run everyday at: https://crontab.guru/#0_8_*_*_*.
-    - cron: '0 8 * * MON-FRI'
+    # Run everyday at: https://crontab.guru/#0_8_*_*_1-5.
+    - cron: '0 8 * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Not sure if GitHub Actions support that expression, this should be more recognized.