### PR TITLE
chore: sync firefox no-remote arg removal Bug 1906260

### DIFF
--- a/packages/browsers/test/src/firefox/launch.spec.ts
+++ b/packages/browsers/test/src/firefox/launch.spec.ts
@@ -59,7 +59,7 @@ describe('Firefox', () => {
     it('should launch a Firefox browser', async () => {
       const userDataDir = path.join(tmpDir, 'profile');
       function getArgs(): string[] {
-        const firefoxArguments = ['--no-remote'];
+        const firefoxArguments = [];
         switch (os.platform()) {
           case 'darwin':
             firefoxArguments.push('--foreground');

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -217,7 +217,7 @@ export class FirefoxLauncher extends ProductLauncher {
       userDataDir = null,
     } = options;
 
-    const firefoxArguments = ['--no-remote'];
+    const firefoxArguments = [];
 
     switch (os.platform()) {
       case 'darwin':

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -406,7 +406,6 @@ describe('Launcher specs', function () {
           );
         } else if (isFirefox) {
           expect(puppeteer.defaultArgs()).toContain('--headless');
-          expect(puppeteer.defaultArgs()).toContain('--no-remote');
           if (os.platform() === 'darwin') {
             expect(puppeteer.defaultArgs()).toContain('--foreground');
           } else {

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -485,8 +485,8 @@ describe('Launcher specs', function () {
         const defaultArgs = puppeteer.defaultArgs();
         const {browser, close} = await launch(
           Object.assign({}, defaultBrowserOptions, {
-            // Only the first argument is fixed, others are optional.
-            ignoreDefaultArgs: [defaultArgs[0]!],
+            // All arguments are optional.
+            ignoreDefaultArgs: [],
           })
         );
         try {
@@ -494,8 +494,7 @@ describe('Launcher specs', function () {
           if (!spawnargs) {
             throw new Error('spawnargs not present');
           }
-          expect(spawnargs.indexOf(defaultArgs[0]!)).toBe(-1);
-          expect(spawnargs.indexOf(defaultArgs[1]!)).not.toBe(-1);
+          expect(spawnargs.indexOf(defaultArgs[0]!)).not.toBe(-1);
         } finally {
           await close();
         }


### PR DESCRIPTION
We are cleaning up references to no-remote in the Firefox codebase and making this argument a noop.
Our vendored puppeteer got updated via https://phabricator.services.mozilla.com/D217569 so we are proposing to synchronize the changes here.

For the context you can take a look at https://bugzilla.mozilla.org/show_bug.cgi?id=1906260#c0 but tldr, no-remote was mostly useless since Firefox 67. The only scenario where it could be sometimes useful was to allow to use the same profile simultaneously, but that was actually leading to errors anyway.