### PR TITLE
fix: only wait for page and frame targets when connecting

### DIFF
--- a/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/ChromeTargetManager.ts
@@ -122,16 +122,16 @@ export class ChromeTargetManager
         this,
         undefined
       );
-      // Targets from extensions and the browser that will not be
-      // auto-attached. Therefore, we should not add them to
-      // #targetsIdsForInit.
-      const skipTarget =
-        targetInfo.type === 'browser' ||
-        targetInfo.url.startsWith('chrome-extension://');
+      // Only wait for pages and frames (except those from extensions)
+      // to auto-attach.
+      const isPageOrFrame =
+        targetInfo.type === 'page' || targetInfo.type === 'iframe';
+      const isExtension = targetInfo.url.startsWith('chrome-extension://');
       if (
         (!this.#targetFilterCallback ||
           this.#targetFilterCallback(targetForFilter)) &&
-        !skipTarget
+        isPageOrFrame &&
+        !isExtension
       ) {
         this.#targetsIdsForInit.add(targetId);
       }


### PR DESCRIPTION
Only wait for page and frame targets when connecting. Waiting for targets upon connection allows consistently getting the same number of pages from `browser.pages()` after connecting to a running instance. Previously, we waited for all targets except for the ones we knew were not going to auto-attach but issues like https://github.com/puppeteer/puppeteer/issues/12715 indicate that there could some conditions (potentially, bugs in Chrome) with some worker targets being reported but never auto-attached. This PR changes the logic to only wait for page and iframe targets and ignore any other target.

Closes https://github.com/puppeteer/puppeteer/issues/12715