### PR TITLE
feat: pin Firefox to stable_129.0

### DIFF
--- a/packages/puppeteer-core/src/revisions.ts
+++ b/packages/puppeteer-core/src/revisions.ts
@@ -10,5 +10,5 @@
 export const PUPPETEER_REVISIONS = Object.freeze({
   chrome: '127.0.6533.88',
   'chrome-headless-shell': '127.0.6533.88',
-  firefox: 'latest',
+  firefox: 'stable_129.0',
 });


### PR DESCRIPTION
With this change, Puppeteer will start downloading the stable Firefox version by default (instead of Nightly).