### PR TITLE
fix: use CJS for Puppeteer CLI

### DIFF
--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -9,7 +9,7 @@
     "automation"
   ],
   "type": "commonjs",
-  "bin": "./lib/esm/puppeteer/node/cli.js",
+  "bin": "./lib/cjs/puppeteer/node/cli.js",
   "main": "./lib/cjs/puppeteer/puppeteer.js",
   "types": "./lib/types.d.ts",
   "exports": {


### PR DESCRIPTION
Related to #12900 

While we set the `"type": "commonjs"` we should only use CJS in bin and  main.