### PR TITLE
build: abort git clean if the git root is not puppeteer

### DIFF
--- a/tools/clean.mjs
+++ b/tools/clean.mjs
@@ -18,10 +18,9 @@ const confirmation = new Promise((res, rej) => {
 });
 
 if (process.env.npm_command !== 'run-script') {
-  console.log(
-    'Running command outside from non Puppeteer directory may result in data loss'
-  );
+  console.log('Running command directly may result in data loss.');
   console.log('Ref: https://github.com/puppeteer/puppeteer/issues/12917');
+  console.log('Please use the provided npm scripts!');
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,

--- a/tools/clean.mjs
+++ b/tools/clean.mjs
@@ -8,11 +8,49 @@
 
 import {exec} from 'child_process';
 import {readdirSync} from 'fs';
+import readline from 'node:readline';
 
-exec(
-  `git clean -Xf ${readdirSync(process.cwd())
-    .filter(file => {
-      return file !== 'node_modules';
-    })
-    .join(' ')}`
-);
+let resolver;
+let rejector;
+const confirmation = new Promise((res, rej) => {
+  resolver = res;
+  rejector = rej;
+});
+
+if (process.env.npm_command !== 'run-script') {
+  console.log(
+    'Running command outside from non Puppeteer directory may result in data loss'
+  );
+  console.log('Ref: https://github.com/puppeteer/puppeteer/issues/12917');
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  rl.question('Do you want to proceed? (y/N) ', answer => {
+    rl.close();
+    if (
+      answer.localeCompare('y', undefined, {
+        sensitivity: 'base',
+      }) === 'y' ||
+      answer === 'yes'
+    ) {
+      resolver();
+    } else {
+      rejector('Canceled');
+    }
+  });
+} else {
+  resolver();
+}
+
+try {
+  await confirmation;
+  exec(
+    `git clean -Xf ${readdirSync(process.cwd())
+      .filter(file => {
+        return file !== 'node_modules';
+      })
+      .join(' ')}`
+  );
+} catch {}


### PR DESCRIPTION
Addresses https://github.com/puppeteer/puppeteer/issues/12917

When running though NPM the command will have a proper `cwd` to the selected package so the we will remove only things in Puppeteer. We only do this for individual packages so if people have things on the top level that will be kept around.