### PR TITLE
feat: support custom baseUrl

### DIFF
--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -176,7 +176,6 @@ async function getServerAndUrl(
   baseUrl: string;
   server: BuilderRun | null;
 }> {
-  console.log(options);
   if (options.baseUrl) {
     return {
       baseUrl: options.baseUrl,

--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -169,6 +169,30 @@ async function startServer(
   return server;
 }
 
+async function getServerAndUrl(
+  options: PuppeteerBuilderOptions,
+  context: BuilderContext
+): Promise<{
+  baseUrl: string;
+  server: BuilderRun | null;
+}> {
+  console.log(options);
+  if (options.baseUrl) {
+    return {
+      baseUrl: options.baseUrl,
+      server: null,
+    };
+  }
+
+  const server = await startServer(options, context);
+  const result = await server.result;
+
+  return {
+    baseUrl: result['baseUrl'],
+    server,
+  };
+}
+
 async function executeE2ETest(
   options: PuppeteerBuilderOptions,
   context: BuilderContext
@@ -178,13 +202,13 @@ async function executeE2ETest(
     message('\n Building tests 🛠️ ... \n', context);
     await executeCommand(context, [`tsc`, '-p', 'e2e/tsconfig.json']);
 
-    server = await startServer(options, context);
-    const result = await server.result;
+    const result = await getServerAndUrl(options, context);
+    server = result.server;
 
     message('\n Running tests 🧪 ... \n', context);
     const testRunnerCommand = getCommandForRunner(options.testRunner);
     await executeCommand(context, testRunnerCommand, {
-      baseUrl: result['baseUrl'],
+      baseUrl: result.baseUrl,
     });
 
     message('\n 🚀 Test ran successfully! 🚀 ', context, 'success');

--- a/packages/ng-schematics/src/builders/puppeteer/schema.json
+++ b/packages/ng-schematics/src/builders/puppeteer/schema.json
@@ -20,6 +20,10 @@
     "port": {
       "type": ["number", "null"],
       "description": "Port to run the test server on."
+    },
+    "baseUrl": {
+      "type": ["string", "null"],
+      "description": "Base Url to run test ageist. If provided no test server will be spawned."
     }
   },
   "additionalProperties": true

--- a/packages/ng-schematics/src/builders/puppeteer/types.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/types.ts
@@ -12,4 +12,5 @@ export interface PuppeteerBuilderOptions extends JsonObject {
   testRunner: TestRunner;
   devServerTarget: string;
   port: number | null;
+  baseUrl: string | null;
 }


### PR DESCRIPTION
Ref: https://github.com/puppeteer/puppeteer/issues/12222

If `baseUrl` is provided it will not spawn a test server.
Supported as command line: 
```
ng e2e --base-url="http://localhost:4200/"
```

Supported in `configuration` options: 
```json
{
  ...
  "e2e": {
    "builder": "@puppeteer/ng-schematics:puppeteer",
    "options": {
      "devServerTarget": "<project>:serve",
      "testRunner": "node"
    },
    "configurations": {
      "production": {
        "devServerTarget": "<project>:serve:production"
      },
      "ci": {
        "baseUrl": "http://localhost:4200/"
      }
    }
  }
}
```
 