### PR TITLE
feat: improve type inference for selectors by adopting "typed-query-selector"

### DIFF
--- a/docs/api/puppeteer.nodefor.md
+++ b/docs/api/puppeteer.nodefor.md
@@ -8,13 +8,5 @@ sidebar_label: NodeFor
 
 ```typescript
 export type NodeFor<ComplexSelector extends string> =
-  TypeSelectorOfComplexSelector<ComplexSelector> extends infer TypeSelector
-    ? TypeSelector extends
-        | keyof HTMLElementTagNameMap
-        | keyof SVGElementTagNameMap
-      ? ElementFor<TypeSelector>
-      : Element
-    : never;
+  ParseSelector<ComplexSelector>;
 ```
-
-**References:** [ElementFor](./puppeteer.elementfor.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14166,7 +14166,8 @@
         "chromium-bidi": "0.6.4",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1312386",
-        "puppeteer-core": "23.0.2"
+        "puppeteer-core": "23.0.2",
+        "typed-query-selector": "^2.11.4"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -14186,6 +14187,7 @@
         "chromium-bidi": "0.6.4",
         "debug": "^4.3.6",
         "devtools-protocol": "0.0.1312386",
+        "typed-query-selector": "^2.11.4",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -14237,6 +14239,12 @@
       "version": "2.6.2",
       "dev": true,
       "license": "0BSD"
+    },
+    "packages/puppeteer-core/node_modules/typed-query-selector": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.4.tgz",
+      "integrity": "sha512-O/56BMFJc62KLGaw1HTz66N2RRCPU+JnoJUL5q07LVmTXTlhoUdm9azor7keLwSncKTeVtWTJP3TZlMopynJBw==",
+      "license": "MIT"
     },
     "packages/puppeteer/node_modules/@types/node": {
       "version": "18.17.15",
@@ -14300,6 +14308,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/puppeteer/node_modules/typed-query-selector": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.4.tgz",
+      "integrity": "sha512-O/56BMFJc62KLGaw1HTz66N2RRCPU+JnoJUL5q07LVmTXTlhoUdm9azor7keLwSncKTeVtWTJP3TZlMopynJBw==",
+      "license": "MIT"
     },
     "packages/testserver": {
       "name": "@pptr/testserver",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14167,7 +14167,7 @@
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1312386",
         "puppeteer-core": "23.0.2",
-        "typed-query-selector": "^2.11.4"
+        "typed-query-selector": "^2.12.0"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -14187,7 +14187,7 @@
         "chromium-bidi": "0.6.4",
         "debug": "^4.3.6",
         "devtools-protocol": "0.0.1312386",
-        "typed-query-selector": "^2.11.4",
+        "typed-query-selector": "^2.12.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -14241,9 +14241,9 @@
       "license": "0BSD"
     },
     "packages/puppeteer-core/node_modules/typed-query-selector": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.4.tgz",
-      "integrity": "sha512-O/56BMFJc62KLGaw1HTz66N2RRCPU+JnoJUL5q07LVmTXTlhoUdm9azor7keLwSncKTeVtWTJP3TZlMopynJBw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT"
     },
     "packages/puppeteer/node_modules/@types/node": {
@@ -14310,9 +14310,9 @@
       }
     },
     "packages/puppeteer/node_modules/typed-query-selector": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.4.tgz",
-      "integrity": "sha512-O/56BMFJc62KLGaw1HTz66N2RRCPU+JnoJUL5q07LVmTXTlhoUdm9azor7keLwSncKTeVtWTJP3TZlMopynJBw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT"
     },
     "packages/testserver": {

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -124,7 +124,7 @@
     "chromium-bidi": "0.6.4",
     "debug": "^4.3.6",
     "devtools-protocol": "0.0.1312386",
-    "typed-query-selector": "^2.11.4",
+    "typed-query-selector": "^2.12.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -124,12 +124,13 @@
     "chromium-bidi": "0.6.4",
     "debug": "^4.3.6",
     "devtools-protocol": "0.0.1312386",
+    "typed-query-selector": "^2.11.4",
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@types/chrome": "0.0.269",
     "@types/debug": "4.1.12",
     "@types/node": "18.17.15",
-    "@types/chrome": "0.0.269",
     "@types/ws": "8.5.11",
     "mitt": "3.0.1",
     "parsel-js": "1.1.2",

--- a/packages/puppeteer-core/src/common/types.ts
+++ b/packages/puppeteer-core/src/common/types.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {ParseSelector} from 'typed-query-selector/parser.js';
+
 import type {ElementHandle} from '../api/ElementHandle.js';
 import type {JSHandle} from '../api/JSHandle.js';
 
@@ -123,103 +125,4 @@ export type EvaluateFuncWith<V, T extends unknown[]> = (
  * @public
  */
 export type NodeFor<ComplexSelector extends string> =
-  TypeSelectorOfComplexSelector<ComplexSelector> extends infer TypeSelector
-    ? TypeSelector extends
-        | keyof HTMLElementTagNameMap
-        | keyof SVGElementTagNameMap
-      ? ElementFor<TypeSelector>
-      : Element
-    : never;
-
-type TypeSelectorOfComplexSelector<ComplexSelector extends string> =
-  CompoundSelectorsOfComplexSelector<ComplexSelector> extends infer CompoundSelectors
-    ? CompoundSelectors extends NonEmptyReadonlyArray<string>
-      ? Last<CompoundSelectors> extends infer LastCompoundSelector
-        ? LastCompoundSelector extends string
-          ? TypeSelectorOfCompoundSelector<LastCompoundSelector>
-          : never
-        : never
-      : unknown
-    : never;
-
-type TypeSelectorOfCompoundSelector<CompoundSelector extends string> =
-  SplitWithDelemiters<
-    CompoundSelector,
-    BeginSubclassSelectorTokens
-  > extends infer CompoundSelectorTokens
-    ? CompoundSelectorTokens extends [infer TypeSelector, ...any[]]
-      ? TypeSelector extends ''
-        ? unknown
-        : TypeSelector
-      : never
-    : never;
-
-type Last<Arr extends NonEmptyReadonlyArray<unknown>> = Arr extends [
-  infer Head,
-  ...infer Tail,
-]
-  ? Tail extends NonEmptyReadonlyArray<unknown>
-    ? Last<Tail>
-    : Head
-  : never;
-
-type NonEmptyReadonlyArray<T> = [T, ...(readonly T[])];
-
-type CompoundSelectorsOfComplexSelector<ComplexSelector extends string> =
-  SplitWithDelemiters<
-    ComplexSelector,
-    CombinatorTokens
-  > extends infer IntermediateTokens
-    ? IntermediateTokens extends readonly string[]
-      ? Drop<IntermediateTokens, ''>
-      : never
-    : never;
-
-type SplitWithDelemiters<
-  Input extends string,
-  Delemiters extends readonly string[],
-> = Delemiters extends [infer FirstDelemiter, ...infer RestDelemiters]
-  ? FirstDelemiter extends string
-    ? RestDelemiters extends readonly string[]
-      ? FlatmapSplitWithDelemiters<Split<Input, FirstDelemiter>, RestDelemiters>
-      : never
-    : never
-  : [Input];
-
-type BeginSubclassSelectorTokens = ['.', '#', '[', ':'];
-
-type CombinatorTokens = [' ', '>', '+', '~', '|', '|'];
-
-type Drop<
-  Arr extends readonly unknown[],
-  Remove,
-  Acc extends unknown[] = [],
-> = Arr extends [infer Head, ...infer Tail]
-  ? Head extends Remove
-    ? Drop<Tail, Remove>
-    : Drop<Tail, Remove, [...Acc, Head]>
-  : Acc;
-
-type FlatmapSplitWithDelemiters<
-  Inputs extends readonly string[],
-  Delemiters extends readonly string[],
-  Acc extends string[] = [],
-> = Inputs extends [infer FirstInput, ...infer RestInputs]
-  ? FirstInput extends string
-    ? RestInputs extends readonly string[]
-      ? FlatmapSplitWithDelemiters<
-          RestInputs,
-          Delemiters,
-          [...Acc, ...SplitWithDelemiters<FirstInput, Delemiters>]
-        >
-      : Acc
-    : Acc
-  : Acc;
-
-type Split<
-  Input extends string,
-  Delimiter extends string,
-  Acc extends string[] = [],
-> = Input extends `${infer Prefix}${Delimiter}${infer Suffix}`
-  ? Split<Suffix, Delimiter, [...Acc, Prefix]>
-  : [...Acc, Input];
+  ParseSelector<ComplexSelector>;

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -123,11 +123,12 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "dependencies": {
+    "@puppeteer/browsers": "2.3.0",
     "chromium-bidi": "0.6.4",
     "cosmiconfig": "^9.0.0",
+    "devtools-protocol": "0.0.1312386",
     "puppeteer-core": "23.0.2",
-    "@puppeteer/browsers": "2.3.0",
-    "devtools-protocol": "0.0.1312386"
+    "typed-query-selector": "^2.11.4"
   },
   "devDependencies": {
     "@types/node": "18.17.15"

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -128,7 +128,7 @@
     "cosmiconfig": "^9.0.0",
     "devtools-protocol": "0.0.1312386",
     "puppeteer-core": "23.0.2",
-    "typed-query-selector": "^2.11.4"
+    "typed-query-selector": "^2.12.0"
   },
   "devDependencies": {
     "@types/node": "18.17.15"

--- a/test-d/NodeFor.test-d.ts
+++ b/test-d/NodeFor.test-d.ts
@@ -120,6 +120,10 @@ declare const nodeFor: <Selector extends string>(
     expectType<HTMLAnchorElement>(nodeFor('a::-p-text(Hello)'));
     expectNotType<Element>(nodeFor('a::-p-text(Hello)'));
   }
+  {
+    expectType<HTMLAnchorElement>(nodeFor('a:is([href], [href])'));
+    expectNotType<Element>(nodeFor('a:is([href], [href])'));
+  }
 }
 {
   {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Adopt "[typed-query-selector](https://github.com/g-plane/typed-query-selector)" to parse CSS selector.

**Did you add tests for your changes?**

Yes.

**If relevant, did you update the documentation?**

No.

**Summary**

The current implementation of CSS selector parser can't handle some cases. For example, it can't parse `a:is([href], [href])` which is just `a`. Fixing these cases will highly increase the complexity, so I introduce the "typed-query-selector". Lighthouse is using it:
https://github.com/GoogleChrome/lighthouse/blob/c79628af9bdaa537a2abd1b34da922e28b81bd98/package.json#L178

typed-query-selector is well tested: https://github.com/g-plane/typed-query-selector/blob/main/parser.test.ts

**Does this PR introduce a breaking change?**

No.
