### PR TITLE
test(testserver): fix issue with query params

### DIFF
--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -227,7 +227,7 @@ export class TestServer {
     });
     assert(request.url);
     const url = new URL(request.url, `https://${request.headers.host}`);
-    const path = url.pathname + url.search;
+    const path = url.pathname;
     const auth = this.#auths.get(path);
     if (auth) {
       const credentials = Buffer.from(

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -590,11 +590,11 @@ describe('cooperative request interception', function () {
       );
       expect(response!.status()).toBe(404);
     });
-    it('should work with badly encoded server', async () => {
+    it.only('should work with badly encoded server', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
-      server.setRoute('/malformed?rnd=%911', (_req, res) => {
+      server.setRoute('/malformed', (_req, res) => {
         return res.end();
       });
       page.on('request', request => {

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -590,7 +590,7 @@ describe('cooperative request interception', function () {
       );
       expect(response!.status()).toBe(404);
     });
-    it.only('should work with badly encoded server', async () => {
+    it('should work with badly encoded server', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -514,7 +514,7 @@ describe('request interception', function () {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
-      server.setRoute('/malformed?rnd=%911', (_req, res) => {
+      server.setRoute('/malformed', (_req, res) => {
         return res.end();
       });
       page.on('request', request => {


### PR DESCRIPTION
If you tried to navigate to a page with query params, the files were never going to be resolved as it took the query params as part of the path so `index.html?param=true` was trying to read that as full file rather then `index.html`.