### PR TITLE
build: abort clean.mjs if not in a git repository

### DIFF
--- a/tools/clean.mjs
+++ b/tools/clean.mjs
@@ -14,6 +14,14 @@ import {promisify} from 'util';
 
 const execAsync = promisify(exec);
 
+try {
+  await execAsync('git status');
+} catch (e) {
+  // If `git status` threw an error, we are not in a git repository, bail out.
+  console.log('Not inside a .git repository');
+  process.exit(0);
+}
+
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const puppeteerRoot = path.join(__dirname, '../');
 


### PR DESCRIPTION
Followup to #12919

When trying to vendor puppeteer tests or run puppeteer tests from a hg clone of mozilla central, there is a lot of error spam:

```
Error: Command failed: git rev-parse --show-toplevel
fatal: not a git repository (or any of the parent directories): .git

    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:1098:16)
    at Socket.<anonymous> (node:internal/child_process:450:11)
    at Socket.emit (node:events:517:28)
    at Pipe.<anonymous> (node:net:350:12) {
  code: 128,
  killed: false,
  signal: null,
  cmd: 'git rev-parse --show-toplevel',
  stdout: '',
  stderr: 'fatal: not a git repository (or any of the parent directories): .git\n'
}
```

The previous implementation using child_process exec directly was probably simply swallowing the errors.
This PR makes the issue less verbose by logging a simple message and exiting with exit(0).