### PR TITLE
performance: faster implementation of typedArrayToBase64

### DIFF
--- a/packages/puppeteer-core/src/util/encoding.ts
+++ b/packages/puppeteer-core/src/util/encoding.ts
@@ -32,9 +32,17 @@ export function stringToBase64(str: string): string {
  * @internal
  */
 export function typedArrayToBase64(typedArray: Uint8Array): string {
-  const binaryString = Array.from(typedArray, byte => {
-    return String.fromCodePoint(byte);
-  }).join('');
+  // chunkSize should be less V8 limit on number of arguments!
+  // https://github.com/v8/v8/blob/d3de848bea727518aee94dd2fd42ba0b62037a27/src/objects/code.h#L444
+  const chunkSize = 65534;
+  const chunks = [];
+
+  for (let i = 0; i < typedArray.length; i += chunkSize) {
+    const chunk = typedArray.subarray(i, i + chunkSize);
+    chunks.push(String.fromCodePoint.apply(null, chunk as unknown as number[]));
+  }
+
+  const binaryString = chunks.join('');
   return btoa(binaryString);
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Speedup for processing response bodies.

**Summary**
Switch from 22.12.1 to 22.13.0 made my test fail with timeout, most of tests stopped to fit within default 5 second interval. Reverting to 22.12.1 made them fast again. I found that the reason for that is typedArrayToBase64(), which processes body one byte at a time. By using String.fromCodePoint.apply in chunks, it is possible to significantly speedup the puppeteer with request interception.

**Does this PR introduce a breaking change?**

No

**Other information**
