### PR TITLE
docs: start to unify example resources

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,67 @@
+# Examples & Use cases
+
+## Official examples
+
+[The Puppeteer repository](https://github.com/puppeteer/puppeteer/tree/main/examples) includes a small number of examples maintained by the Puppeteer team.
+
+Follow the instructions in the README to run the examples, covering use cases like creating PDFs from websites, creating screenshots or intercepting requests.
+
+## Example suite
+
+Find a set of unstructured examples in Puppeteer's dedicated [example repository](https://github.com/puppeteer/examples).
+
+This suite is a collection of examples that has been growing over time and covers various use cases like forwarding events
+from your Puppeteer process to the browser, interacting with elements and running CDP commands.
+
+## Other projects, articles and demos
+
+See the following list for use cases and examples from categories like Rendering, Web scraping and Testing.
+
+### Rendering and web scraping
+
+- **[Puppetron](https://github.com/cheeaun/puppetron)**: Demo site that shows
+  how to use Puppeteer and Headless Chrome to render pages. Inspired by
+  [GoogleChrome/rendertron](https://github.com/GoogleChrome/rendertron).
+- **[Thal](https://medium.com/@e_mad_ehsan/getting-started-with-puppeteer-and-chrome-headless-for-web-scrapping-6bf5979dee3e)**:
+  Get started with Puppeteer and Chrome Headless for Web Scraping.
+- **[pupperender](https://github.com/LasaleFamine/pupperender)**: Express
+  middleware that checks the User-Agent header of incoming requests, and if
+  it matches one of a configurable set of bots, render the page using Puppeteer.
+  Useful for PWA rendering.
+- **[headless-chrome-crawler](https://github.com/yujiosaka/headless-chrome-crawler)**:
+  Crawler that provides APIs to manipulate Headless Chrome and lets you crawl
+  dynamic websites.
+- **[Puppeteer examples from Checkly](https://www.checklyhq.com/learn/headless/basics-puppeteer-intro/)**:
+  E2E Puppeteer examples for real life use cases, such as getting
+  useful info from the web pages or common login scenarios.
+- **[browserless](https://github.com/browserless/browserless)**: Headless
+  Chrome as a service letting you execute Puppeteer scripts remotely.
+- **[Puppeteer on AWS Lambda](https://github.com/jay-deshmukh/headless-chrome-with-puppeteer-on-AWS-lambda-with-serverless-framework)**:
+  Run puppeteer on AWS Lambda with Serverless framework
+- **[Apify SDK](https://github.com/apifytech/apify-js)**: The scalable web
+  crawling and scraping library for JavaScript. Automatically manages a pool of
+  Puppeteer browsers and provides error handling, task management, proxy
+  rotation and more.
+
+### Testing
+
+- **[angular-puppeteer-demo](https://github.com/Quramy/angular-puppeteer-demo)**:
+  Demo repository explaining how to use Puppeteer in Karma.
+- **[mocha-headless-chrome](https://github.com/direct-adv-interfaces/mocha-headless-chrome)**:
+  Tool which runs client-side mocha tests in the command line through headless
+  Chrome.
+- **[puppeteer-to-istanbul-example](https://github.com/bcoe/puppeteer-to-istanbul-example)**:
+  Demo repository demonstrating how to output Puppeteer coverage in Istanbul
+  format.
+- **[jest-puppeteer](https://github.com/smooth-code/jest-puppeteer)**: (almost)
+  Zero configuration tool for setting up and running Jest and Puppeteer. Also
+  includes an assertion library for Puppeteer.
+- **[puppeteer-har](https://github.com/Everettss/puppeteer-har)**: Generate HAR
+  file with puppeteer.
+- **[puppetry](https://puppetry.app/)**: A desktop app to build Puppeteer and
+  Jest driven tests without coding.
+- **[puppeteer-loadtest](https://github.com/svenkatreddy/puppeteer-loadtest)**:
+  command line interface for performing load test on Puppeteer scripts.
+- **[cucumber-puppeteer-example](https://github.com/mlampedx/cucumber-puppeteer-example)**:
+  Example repository demonstrating how to use Puppeeteer and Cucumber for
+  integration testing.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,13 +11,13 @@ Check out this repository and and install the package dependencies, using the fo
 npm install
 ```
 
-To build a version of Puppeteer to be used with the examples, run the following command:
+Then build a version of Puppeteer to be used with the examples:
 
 ```bash
 npm run build
 ```
 
-After both commands have succeeded, run an individual example using the following command:
+After both commands have succeeded, run an individual example like so:
 
 ```bash
 NODE_PATH=../ node examples/search.js

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,51 +1,24 @@
-# Running the examples
+# Puppeteer: Examples
 
-Assuming you have a checkout of the Puppeteer repo and install the dependencies:
+This is the official set of Puppeteer examples. For a list of curated examples and use-cases,
+including third-party ones, see [pptr.dev/examples](https://pptr.dev/examples).
 
-```bash npm2yarn
+## Run
+
+Check out this repository and and install the package dependencies, using the following command:
+
+```bash
 npm install
 ```
 
-Build the project:
+To build a version of Puppeteer to be used with the examples, run the following command:
 
-```bash npm2yarn
+```bash
 npm run build
 ```
 
-The examples can be run from the root folder like so:
+After both commands have succeeded, run an individual example using the following command:
 
 ```bash
 NODE_PATH=../ node examples/search.js
 ```
-
-## Larger examples
-
-More complex and use case driven examples can be found at [github.com/GoogleChromeLabs/puppeteer-examples](https://github.com/GoogleChromeLabs/puppeteer-examples).
-
-# Other resources
-
-Other useful tools, articles, and projects that use Puppeteer.
-
-## Rendering and web scraping
-
-- [Puppetron](https://github.com/cheeaun/puppetron) - Demo site that shows how to use Puppeteer and Headless Chrome to render pages. Inspired by [GoogleChrome/rendertron](https://github.com/GoogleChrome/rendertron).
-- [Thal](https://medium.com/@e_mad_ehsan/getting-started-with-puppeteer-and-chrome-headless-for-web-scrapping-6bf5979dee3e 'An article on medium') - Getting started with Puppeteer and Chrome Headless for Web Scraping.
-- [pupperender](https://github.com/LasaleFamine/pupperender) - Express middleware that checks the User-Agent header of incoming requests, and if it matches one of a configurable set of bots, render the page using Puppeteer. Useful for PWA rendering.
-- [headless-chrome-crawler](https://github.com/yujiosaka/headless-chrome-crawler) - Crawler that provides simple APIs to manipulate Headless Chrome and allows you to crawl dynamic websites.
-- [puppeteer-examples](https://github.com/checkly/puppeteer-examples) - Puppeteer Headless Chrome examples for real life use cases such as getting useful info from the web pages or common login scenarios.
-- [browserless](https://github.com/joelgriffith/browserless) - Headless Chrome as a service letting you execute Puppeteer scripts remotely. Provides a docker image with configuration for concurrency, launch arguments and more.
-- [Puppeteer on AWS Lambda](https://github.com/jay-deshmukh/headless-chrome-with-puppeteer-on-AWS-lambda-with-serverless-framework) - Running puppeteer on AWS Lambda with Serverless framework
-- [Apify SDK](https://github.com/apifytech/apify-js) - The scalable web crawling and scraping library for JavaScript. Automatically manages a pool of Puppeteer browsers and provides easy error handling, task management, proxy rotation and more.
-
-## Testing
-
-- [angular-puppeteer-demo](https://github.com/Quramy/angular-puppeteer-demo) - Demo repository explaining how to use Puppeteer in Karma.
-- [mocha-headless-chrome](https://github.com/direct-adv-interfaces/mocha-headless-chrome) - Tool which runs client-side **mocha** tests in the command line through headless Chrome.
-- [puppeteer-to-istanbul-example](https://github.com/bcoe/puppeteer-to-istanbul-example) - Demo repository demonstrating how to output Puppeteer coverage in Istanbul format.
-- [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer) - (almost) Zero configuration tool for setting up and running Jest and Puppeteer easily. Also includes an assertion library for Puppeteer.
-- [puppeteer-har](https://github.com/Everettss/puppeteer-har) - Generate HAR file with puppeteer.
-- [puppetry](https://puppetry.app/) - A desktop app to build Puppeteer/Jest driven tests without coding.
-- [puppeteer-loadtest](https://github.com/svenkatreddy/puppeteer-loadtest) - commandline interface for performing load test on puppeteer scripts.
-- [cucumber-puppeteer-example](https://github.com/mlampedx/cucumber-puppeteer-example) - Example repository demonstrating how to use Puppeeteer and Cucumber for integration testing.
-
-Also, see the [community list of Puppeteer resources](https://github.com/transitive-bullshit/awesome-puppeteer) for more examples.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -58,6 +58,7 @@ module.exports = {
         'guides/running-puppeteer-in-extensions',
       ],
     },
+    'examples',
     {
       type: 'category',
       label: 'Integrations',


### PR DESCRIPTION
That's a first stab on unifying the various example resources for Puppeteer.

To do so this PR creates a new docs page /examples and adds it to the sidebar as "Examples & Use Cases". This page at some time could potentially evolve into a full section, similar to Guides, but for a start it's simply meant to make the existing examples discoverable and maintainable.

This new page includes the resources list from https://developer.chrome.com/docs/puppeteer/examples, which is meant to be deleted and redirected to pptr.dev/examples soon. I did go over the list and check for dead links/redirects/deprecations. This list was also duplicated to https://github.com/puppeteer/puppeteer/tree/main/examples#other-resources, which I removed and instead also added a link to pptr.dev/examples while streamlining the instructions to run the samples.

Additionally the new page has explicit pointers to https://github.com/puppeteer/puppeteer/tree/main/examples
and https://github.com/puppeteer/examples which I'll both clean-up and extend with new examples and delete obsolete ones.