### PR TITLE
build: use download cli instead of relying on postinstall

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -53,11 +53,9 @@ jobs:
       - name: Build packages
         run: npm run build
       - name: Install browsers
-        run: npm run postinstall
-        env:
-          PUPPETEER_CHROME_VERSION: canary
-          PUPPETEER_CHROME_HEADLESS_SHELL_VERSION: canary
-          PUPPETEER_FIREFOX_SKIP_DOWNLOAD: true
+        run: |
+          npx puppeteer browsers install chrome@canary
+          npx puppeteer browsers install chrome-headless-shell@canary
       - name: Apply Canary expectations
         run: node tools/merge-canary-test-expectations.mjs
       - name: Run all tests (for non-Linux)
@@ -66,7 +64,6 @@ jobs:
         env:
           PUPPETEER_CHROME_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_VERSION: canary
-          PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
           PUPPETEER_TEST_EXPERIMENTAL_CHROME_FEATURES: ${{ matrix.configs == 'experimental' }}
       - name: Run all tests (for Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -116,11 +113,8 @@ jobs:
       - name: Build packages
         run: npm run build
       - name: Install browsers
-        run: npm run postinstall
-        env:
-          PUPPETEER_CHROME_SKIP_DOWNLOAD: true
-          PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
-          PUPPETEER_FIREFOX_VERSION: nightly
+        run: |
+          npx puppeteer browsers install firefox@nightly
       - name: Apply Canary expectations
         run: node tools/merge-canary-test-expectations.mjs
       - name: Run all tests (for non-Linux)


### PR DESCRIPTION
cli download would not fail  if browser downloads fail like postinstall in https://github.com/puppeteer/puppeteer/actions/runs/10629126470/job/29466329118