### PR TITLE
fix: revert the use of structuredClone

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2494,7 +2494,6 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
     await this.bringToFront();
 
-    // TODO: use structuredClone after Node 16 support is dropped.
     const options = {
       ...userOptions,
       clip: userOptions.clip

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2494,7 +2494,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
     await this.bringToFront();
 
-    const options = structuredClone(userOptions) as ScreenshotOptions;
+    // TODO: use structuredClone after Node 16 support is dropped.
+    const options = {
+      ...userOptions,
+      clip: userOptions.clip
+        ? {
+            ...userOptions.clip,
+          }
+        : undefined,
+    };
     if (options.type === undefined && options.path !== undefined) {
       const filePath = options.path;
       // Note we cannot use Node.js here due to browser compatibility.


### PR DESCRIPTION
In some cases users pass down unserializable properties that are not part of the Puppeteer API.

Closes https://github.com/puppeteer/puppeteer/issues/13042