### PR TITLE
fix(extensions): handle attachToTarget command correctly

### DIFF
--- a/examples/puppeteer-in-extension/background.js
+++ b/examples/puppeteer-in-extension/background.js
@@ -31,6 +31,11 @@ globalThis.testConnect = async url => {
   const title = await page.evaluate(() => {
     return document.title;
   });
-  await browser.disconnect();
-  return title;
+  const frame = await page.waitForFrame(frame => {
+    return frame.url().endsWith('iframe.html');
+  });
+  const frameTitle = await frame.evaluate(() => {
+    return document.title;
+  });
+  return title + '|' + frameTitle;
 };

--- a/examples/puppeteer-in-extension/iframe.html
+++ b/examples/puppeteer-in-extension/iframe.html
@@ -1,0 +1,1 @@
+<!doctype html> <title>Iframe</title>

--- a/examples/puppeteer-in-extension/playground.html
+++ b/examples/puppeteer-in-extension/playground.html
@@ -1,1 +1,3 @@
-<!doctype html> <title>Playground</title>
+<!doctype html>
+<title>Playground</title>
+<iframe src="iframe.html"></iframe>

--- a/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
+++ b/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
@@ -130,6 +130,13 @@ export class ExtensionTransport implements ConnectionTransport {
               sessionId: 'pageTargetSessionId',
             },
           });
+          this.#dispatchResponse({
+            id: parsed.id,
+            sessionId: parsed.sessionId,
+            method: parsed.method,
+            result: {},
+          });
+          return;
         } else if (!parsed.sessionId) {
           this.#dispatchResponse({
             method: 'Target.attachedToTarget',
@@ -138,14 +145,14 @@ export class ExtensionTransport implements ConnectionTransport {
               sessionId: 'tabTargetSessionId',
             },
           });
+          this.#dispatchResponse({
+            id: parsed.id,
+            sessionId: parsed.sessionId,
+            method: parsed.method,
+            result: {},
+          });
+          return;
         }
-        this.#dispatchResponse({
-          id: parsed.id,
-          sessionId: parsed.sessionId,
-          method: parsed.method,
-          result: {},
-        });
-        return;
       }
     }
     if (parsed.sessionId === 'pageTargetSessionId') {

--- a/test/installation/assets/puppeteer/puppeteer-in-extension.js
+++ b/test/installation/assets/puppeteer/puppeteer-in-extension.js
@@ -33,8 +33,10 @@ try {
     return await globalThis.testConnect(url);
   }, `http://localhost:${port}/playground.html`);
 
-  if (result !== 'Playground') {
-    throw new Error('Unexpected playground.html page title: ' + result);
+  if (result !== 'Playground|Iframe') {
+    throw new Error(
+      'Unexpected playground.html+iframe.html page titles: ' + result
+    );
   }
 } finally {
   await browser.close();


### PR DESCRIPTION
The command should fall-through and only be intercepted if it is for the dummy extension targets.

Refs: #13089