### PR TITLE
feat: add touch specifier (#13084)

### DIFF
--- a/docs/api/puppeteer.touchscreen.touchstart.md
+++ b/docs/api/puppeteer.touchscreen.touchstart.md
@@ -10,7 +10,7 @@ Dispatches a `touchstart` event.
 
 ```typescript
 class Touchscreen {
-  abstract touchStart(x: number, y: number): Promise<void>;
+  abstract touchStart(x: number, y: number): Promise<Touch>;
 }
 ```
 

--- a/packages/puppeteer-core/src/api/Input.ts
+++ b/packages/puppeteer-core/src/api/Input.ts
@@ -34,6 +34,14 @@ export interface KeyboardTypeOptions {
 /**
  * @public
  */
+export interface Touch {
+  move(x: number, y: number): Promise<void>;
+  end(): Promise<void>;
+}
+
+/**
+ * @public
+ */
 export type KeyPressOptions = KeyDownOptions & KeyboardTypeOptions;
 
 /**
@@ -495,7 +503,7 @@ export abstract class Touchscreen {
    * @param x - Horizontal position of the tap.
    * @param y - Vertical position of the tap.
    */
-  abstract touchStart(x: number, y: number): Promise<void>;
+  abstract touchStart(x: number, y: number): Promise<Touch>;
 
   /**
    * Dispatches a `touchMove` event.

--- a/packages/puppeteer-core/src/bidi/Input.ts
+++ b/packages/puppeteer-core/src/bidi/Input.ts
@@ -12,6 +12,7 @@ import {
   Mouse,
   MouseButton,
   Touchscreen,
+  type Touch,
   type KeyboardTypeOptions,
   type KeyDownOptions,
   type KeyPressOptions,
@@ -625,7 +626,7 @@ export class BidiTouchscreen extends Touchscreen {
     x: number,
     y: number,
     options: BidiTouchMoveOptions = {}
-  ): Promise<void> {
+  ): Promise<Touch> {
     await this.#page.mainFrame().browsingContext.performActions([
       {
         type: SourceActionsType.Pointer,
@@ -651,6 +652,17 @@ export class BidiTouchscreen extends Touchscreen {
         ],
       },
     ]);
+
+    const touch: Touch = {
+      move: async (x: number, y: number): Promise<void> => {
+        await this.touchMove(x, y, options);
+      },
+      end: async (): Promise<void> => {
+        await this.touchEnd();
+      }
+    };
+  
+    return touch;
   }
 
   override async touchMove(

--- a/packages/puppeteer-core/src/cdp/Input.ts
+++ b/packages/puppeteer-core/src/cdp/Input.ts
@@ -13,6 +13,7 @@ import {
   Mouse,
   MouseButton,
   Touchscreen,
+  type Touch,
   type KeyDownOptions,
   type KeyPressOptions,
   type KeyboardTypeOptions,
@@ -564,7 +565,7 @@ export class CdpTouchscreen extends Touchscreen {
     this.#client = client;
   }
 
-  override async touchStart(x: number, y: number): Promise<void> {
+  override async touchStart(x: number, y: number): Promise<Touch> {
     await this.#client.send('Input.dispatchTouchEvent', {
       type: 'touchStart',
       touchPoints: [
@@ -578,6 +579,17 @@ export class CdpTouchscreen extends Touchscreen {
       ],
       modifiers: this.#keyboard._modifiers,
     });
+
+    const touch: Touch = {
+      move: async (x: number, y: number): Promise<void> => {
+        await this.touchMove(x, y);
+      },
+      end: async (): Promise<void> => {
+        await this.touchEnd();
+      }
+    };
+
+    return touch;
   }
 
   override async touchMove(x: number, y: number): Promise<void> {

--- a/website/versioned_docs/version-23.4.0/api/puppeteer.touchscreen.touchstart.md
+++ b/website/versioned_docs/version-23.4.0/api/puppeteer.touchscreen.touchstart.md
@@ -10,7 +10,7 @@ Dispatches a `touchstart` event.
 
 ```typescript
 class Touchscreen {
-  abstract touchStart(x: number, y: number): Promise<void>;
+  abstract touchStart(x: number, y: number): Promise<Touch>;
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature added to specify which of the touches you want to move in [`TouchScreen.touchStart`](https://github.com/puppeteer/puppeteer/blob/280e6f82065a2cbbe696673934a9c10610a780c6/packages/puppeteer-core/src/api/Input.ts#L498)

**Did you add tests for your changes?**
No, the base tests were fine

**If relevant, did you update the documentation?**
Yes, Updated puppeteer.touchscreen.touchstart.md in docs/api and puppeteer.touchscreen.touchstart.md in website/versioned_docs/version-23.4.0/api/

**Summary**
Added feature for [this](https://github.com/puppeteer/puppeteer/issues/13084) pull request

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
