### PR TITLE
ci: scope build more

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -51,7 +51,7 @@ jobs:
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@eea3c9f0385a39e6eb4ff6a6daa273311381d436 # setup-github-actions-caching/v2.0.2
       - name: Build packages
-        run: npm run build
+        run: npm run build -w @puppeteer-test/test
       - name: Install browsers
         run: npm run postinstall
         env:
@@ -114,7 +114,7 @@ jobs:
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@eea3c9f0385a39e6eb4ff6a6daa273311381d436 # setup-github-actions-caching/v2.0.2
       - name: Build packages
-        run: npm run build
+        run: npm run build -w @puppeteer-test/test
       - name: Install browsers
         run: npm run postinstall
         env:


### PR DESCRIPTION
Sometimes WireIt would fail so reducing the chance is due to other packages.