### PR TITLE
fix(webdriver): convert console method to type

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -61,6 +61,21 @@ import {BidiFrameRealm} from './Realm.js';
 import {rewriteNavigationError} from './util.js';
 import {BidiWebWorker} from './WebWorker.js';
 
+// TODO: Remove this and map CDP the correct method.
+// Requires breaking change.
+function convertConsoleMessageLevel(method: string): ConsoleMessageType {
+  switch (method) {
+    case 'group':
+      return 'startGroup';
+    case 'groupCollapsed':
+      return 'startGroupCollapsed';
+    case 'groupEnd':
+      return 'endGroup';
+    default:
+      return method as ConsoleMessageType;
+  }
+}
+
 export class BidiFrame extends Frame {
   static from(
     parent: BidiPage | BidiFrame,
@@ -174,7 +189,7 @@ export class BidiFrame extends Frame {
         this.page().trustedEmitter.emit(
           PageEvent.Console,
           new ConsoleMessage(
-            entry.method as ConsoleMessageType,
+            convertConsoleMessageLevel(entry.method),
             text,
             args,
             getStackTraceLocations(entry.stackTrace)

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2660,6 +2660,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[page.spec] Page Page.Events.Console should work for different console API calls with group functions",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "We don't normalize the values for CDP as it's being deprecated"
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.Events.Console should work for different console API calls with logging functions",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -3410,12 +3417,5 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.Events.Console should work for different console API calls with group functions",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "cdp"],
-    "expectations": ["FAIL"],
-    "comment": "We don't normalize the values for CDP as it's being deprecated"
   }
 ]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3410,5 +3410,12 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[page.spec] Page Page.Events.Console should work for different console API calls with group functions",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "cdp"],
+    "expectations": ["FAIL"],
+    "comment": "We don't normalize the values for CDP as it's being deprecated"
   }
 ]

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -478,6 +478,27 @@ describe('Page', function () {
       ).toEqual(['timeEnd']);
       expect(messages[0]!.text()).toContain('calling console.time');
     });
+    it('should work for different console API calls with group functions', async () => {
+      const {page} = await getTestState();
+
+      const messages: ConsoleMessage[] = [];
+      page.on('console', msg => {
+        return messages.push(msg);
+      });
+      // All console events will be reported before `page.evaluate` is finished.
+      await page.evaluate(() => {
+        console.group('calling console.group');
+        console.groupEnd();
+      });
+      expect(
+        messages.map(msg => {
+          return msg.type();
+        })
+      ).toEqual(['startGroup', 'endGroup']);
+
+      // We should be able to check both messages, but Chrome report text
+      expect(messages[0]!.text()).toContain('calling console.group');
+    });
     it('should not fail for window object', async () => {
       const {page} = await getTestState();
 


### PR DESCRIPTION
I went with this approach for now, as I consider the other a breaking change.

Closes #13109