### PR TITLE
fix: handle requestservedfromcache during interception

### DIFF
--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -378,6 +378,10 @@ export abstract class HTTPRequest {
    */
   abstract failure(): {errorText: string} | null;
 
+  #canBeIntercepted(): boolean {
+    return !this.url().startsWith('data:') && !this._fromMemoryCache;
+  }
+
   /**
    * Continues request with optional request overrides.
    *
@@ -410,8 +414,7 @@ export abstract class HTTPRequest {
     overrides: ContinueRequestOverrides = {},
     priority?: number
   ): Promise<void> {
-    // Request interception is not supported for data: urls.
-    if (this.url().startsWith('data:')) {
+    if (!this.#canBeIntercepted()) {
       return;
     }
     assert(this.interception.enabled, 'Request Interception is not enabled!');
@@ -479,8 +482,7 @@ export abstract class HTTPRequest {
     response: Partial<ResponseForRequest>,
     priority?: number
   ): Promise<void> {
-    // Mocking responses for dataURL requests is not currently supported.
-    if (this.url().startsWith('data:')) {
+    if (!this.#canBeIntercepted()) {
       return;
     }
     assert(this.interception.enabled, 'Request Interception is not enabled!');
@@ -526,8 +528,7 @@ export abstract class HTTPRequest {
     errorCode: ErrorCode = 'failed',
     priority?: number
   ): Promise<void> {
-    // Request interception is not supported for data: urls.
-    if (this.url().startsWith('data:')) {
+    if (!this.#canBeIntercepted()) {
       return;
     }
     const errorReason = errorReasons[errorCode];

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -55,6 +55,7 @@ export class BidiHTTPResponse extends HTTPResponse {
 
   #initialize() {
     if (this.#data.fromCache) {
+      this.#request._fromMemoryCache = true;
       this.#request
         .frame()
         ?.page()

--- a/packages/puppeteer-core/src/cdp/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkEventManager.ts
@@ -6,7 +6,7 @@
 
 import type {Protocol} from 'devtools-protocol';
 
-import type {CdpHTTPRequest} from './HTTPRequest.js';
+import {CdpHTTPRequest} from './HTTPRequest.js';
 
 /**
  * @internal
@@ -213,5 +213,40 @@ export class NetworkEventManager {
 
   forgetQueuedEventGroup(networkRequestId: NetworkRequestId): void {
     this.#queuedEventGroupMap.delete(networkRequestId);
+  }
+
+  printState(): void {
+    function replacer(_key: unknown, value: unknown) {
+      if (value instanceof Map) {
+        return {
+          dataType: 'Map',
+          value: Array.from(value.entries()), // or with spread: value: [...value]
+        };
+      } else if (value instanceof CdpHTTPRequest) {
+        return {
+          dataType: 'CdpHTTPRequest',
+          value: `${value.id}: ${value.url()}`,
+        };
+      }
+      {
+        return value;
+      }
+    }
+    console.log(
+      'httpRequestsMap',
+      JSON.stringify(this.#httpRequestsMap, replacer, 2)
+    );
+    console.log(
+      'requestWillBeSentMap',
+      JSON.stringify(this.#requestWillBeSentMap, replacer, 2)
+    );
+    console.log(
+      'requestWillBeSentMap',
+      JSON.stringify(this.#responseReceivedExtraInfoMap, replacer, 2)
+    );
+    console.log(
+      'requestWillBeSentMap',
+      JSON.stringify(this.#requestPausedMap, replacer, 2)
+    );
   }
 }

--- a/packages/puppeteer-core/src/common/NetworkManagerEvents.ts
+++ b/packages/puppeteer-core/src/common/NetworkManagerEvents.ts
@@ -31,7 +31,7 @@ export namespace NetworkManagerEvent {
  */
 export interface NetworkManagerEvents extends Record<EventType, unknown> {
   [NetworkManagerEvent.Request]: HTTPRequest;
-  [NetworkManagerEvent.RequestServedFromCache]: HTTPRequest | undefined;
+  [NetworkManagerEvent.RequestServedFromCache]: HTTPRequest;
   [NetworkManagerEvent.Response]: HTTPResponse;
   [NetworkManagerEvent.RequestFailed]: HTTPRequest;
   [NetworkManagerEvent.RequestFinished]: HTTPRequest;


### PR DESCRIPTION
Previously, the request event would not be emitted for requests that will end up being served from cache when the interception is enabled.

This PR fixes the issue and also adds a check to not attempt interception calls for requests that are served from cache as those cannot be intercepted.