### PR TITLE
fix: default to RAF polling if visible||hidden is set

### DIFF
--- a/packages/puppeteer-core/src/common/QueryHandler.ts
+++ b/packages/puppeteer-core/src/common/QueryHandler.ts
@@ -162,9 +162,7 @@ export class QueryHandler {
     })();
 
     const {visible = false, hidden = false, timeout, signal} = options;
-    const polling =
-      options.polling ??
-      (visible || hidden ? PollingOptions.RAF : PollingOptions.MUTATION);
+    const polling = visible || hidden ? PollingOptions.RAF : options.polling;
 
     try {
       signal?.throwIfAborted();

--- a/test/src/waittask.spec.ts
+++ b/test/src/waittask.spec.ts
@@ -408,6 +408,7 @@ describe('waittask specs', function () {
     });
 
     // MutationPoller currently does not support shadow DOM.
+    // See https://github.com/puppeteer/puppeteer/issues/13163.
     it.skip('should work when node is added in a shadow root', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
The regression is caused by the visible flag no longer changing the polling type to RAF. This PR solves the case reported in the related bug when changes within shadow roots are tracked with visible=true.

The underlying and more general issue is that MutationPoller does not consider shadow roots at all. There is a related [spec issue](https://github.com/whatwg/dom/issues/1287) to support shadow roots in MutationObserver used by MutationPoller but as long as it is not supported we need a client side solution.

This PR adds a test for the shadow root mutation case as well as a test when visibility is changed without DOM mutations.
Existing tests using visible and hidden flags all seem to also cause a DOM mutation.

Refs: #13152