### PR TITLE
fix: handle shadow DOM in Frame.frameElement

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -363,6 +363,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[frame.spec] Frame specs Frame.prototype.frameElement should handle shadow roots",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "https://github.com/w3c/webdriver-bidi/issues/794"
+  },
+  {
     "testIdPattern": "[idle_override.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -1574,6 +1581,13 @@
     "parameters": ["cdp", "firefox"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[frame.spec] Frame specs Frame.prototype.frameElement should handle shadow roots",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["SKIP"],
+    "comment": "not supported"
   },
   {
     "testIdPattern": "[idle_override.spec] Emulate idle state changing idle state emulation causes change of the IdleDetector state",

--- a/test/src/frame.spec.ts
+++ b/test/src/frame.spec.ts
@@ -320,5 +320,26 @@ describe('Frame specs', function () {
       });
       expect(name2).toBe('theFrameName');
     });
+
+    it('should handle shadow roots', async () => {
+      const {page} = await getTestState();
+      await page.setContent(`
+        <div id="shadow-host"></div>
+        <script>
+          const host = document.getElementById('shadow-host');
+          const shadowRoot = host.attachShadow({ mode: 'closed' });
+          const frame = document.createElement('iframe');
+          frame.srcdoc = '<p>Inside frame</p>';
+          shadowRoot.appendChild(frame);
+        </script>
+      `);
+      const frame = page.frames()[1]!;
+      using frameElement = (await frame.frameElement())!;
+      expect(
+        await frameElement.evaluate(el => {
+          return el.tagName.toLocaleLowerCase();
+        })
+      ).toBe('iframe');
+    });
   });
 });


### PR DESCRIPTION
This PR provides a CDP-specific implementation for frameElement that works around the issue of frame owner elements not being findable in shadow roots.
 
Refs: #13155