### PR TITLE
docs: incorrect field used for browser selection

### DIFF
--- a/docs/webdriver-bidi.md
+++ b/docs/webdriver-bidi.md
@@ -25,14 +25,14 @@ Below is an example of launching Firefox or Chrome with WebDriver BiDi:
 import puppeteer from 'puppeteer';
 
 const firefoxBrowser = await puppeteer.launch({
-  product: 'firefox', // WebDriver BiDi is used by default.
+  browser: 'firefox', // WebDriver BiDi is used by default.
 });
 const page = await firefoxBrowser.newPage();
 ...
 await firefoxBrowser.close();
 
 const chromeBrowser = await puppeteer.launch({
-  product: 'chrome',
+  browser: 'chrome',
   protocol: 'webDriverBiDi', // CDP would be used by default for Chrome.
 });
 const page = await chromeBrowser.newPage();


### PR DESCRIPTION
The browser should be specified in the 'browser' field, but the example mistakenly placed it in the 'product' field.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This commit fixes the example in the file `docs/webdriver-bidi.md`.
The browser selection should be put in the 'browser' field.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No.

**If relevant, did you update the documentation?**

Yes and the commit only updates the documentation.

**Summary**

I followed the example to launch Firefox. However, I found that Chrome is always launched.
After digging into the source code of puppeteer, I found that the browser selection should be put in the 'browser' field.

The original documentation may be confusing, so I made this change.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
