### PR TITLE
chore(dependencies): update TypeScript to 5.5.4

### DIFF
--- a/docs/api/puppeteer.defaultargs.md
+++ b/docs/api/puppeteer.defaultargs.md
@@ -7,7 +7,7 @@ sidebar_label: defaultArgs
 ### Signature
 
 ```typescript
-defaultArgs: (options?: import("puppeteer-core/internal/puppeteer-core.js").BrowserLaunchArgumentOptions | undefined) => string[]
+defaultArgs: (options?: import("puppeteer-core/internal/puppeteer-core.js").BrowserLaunchArgumentOptions) => string[]
 ```
 
 ## Parameters
@@ -31,7 +31,7 @@ options
 
 </td><td>
 
-import("puppeteer-core/internal/puppeteer-core.js").[BrowserLaunchArgumentOptions](./puppeteer.browserlaunchargumentoptions.md) \| undefined
+import("puppeteer-core/internal/puppeteer-core.js").[BrowserLaunchArgumentOptions](./puppeteer.browserlaunchargumentoptions.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.executablepath.md
+++ b/docs/api/puppeteer.executablepath.md
@@ -8,9 +8,7 @@ sidebar_label: executablePath
 
 ```typescript
 executablePath: (
-  channel?:
-    | import('puppeteer-core/internal/puppeteer-core.js').ChromeReleaseChannel
-    | undefined
+  channel?: import('puppeteer-core/internal/puppeteer-core.js').ChromeReleaseChannel
 ) => string;
 ```
 
@@ -35,7 +33,7 @@ channel
 
 </td><td>
 
-import("puppeteer-core/internal/puppeteer-core.js").[ChromeReleaseChannel](./puppeteer.chromereleasechannel.md) \| undefined
+import("puppeteer-core/internal/puppeteer-core.js").[ChromeReleaseChannel](./puppeteer.chromereleasechannel.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.launch.md
+++ b/docs/api/puppeteer.launch.md
@@ -8,9 +8,7 @@ sidebar_label: launch
 
 ```typescript
 launch: (
-  options?:
-    | import('puppeteer-core/internal/puppeteer-core.js').PuppeteerLaunchOptions
-    | undefined
+  options?: import('puppeteer-core/internal/puppeteer-core.js').PuppeteerLaunchOptions
 ) => Promise<import('puppeteer-core/internal/puppeteer-core.js').Browser>;
 ```
 
@@ -35,7 +33,7 @@ options
 
 </td><td>
 
-import("puppeteer-core/internal/puppeteer-core.js").[PuppeteerLaunchOptions](./puppeteer.puppeteerlaunchoptions.md) \| undefined
+import("puppeteer-core/internal/puppeteer-core.js").[PuppeteerLaunchOptions](./puppeteer.puppeteerlaunchoptions.md)
 
 </td><td>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "spdx-satisfies": "5.0.1",
         "tsd": "0.31.2",
         "tsx": "4.19.1",
-        "typescript": "5.4.5",
+        "typescript": "5.5.4",
         "wireit": "0.14.9"
       }
     },
@@ -15267,9 +15267,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "spdx-satisfies": "5.0.1",
     "tsd": "0.31.2",
     "tsx": "4.19.1",
-    "typescript": "5.4.5",
+    "typescript": "5.5.4",
     "wireit": "0.14.9"
   },
   "overrides": {


### PR DESCRIPTION
Update to the latest possible version that work without issues.

The  ApiExtractor is having some problems with the latest `5.6` version.
That can be seen on this issue - https://github.com/microsoft/rushstack/issues/4919