### PR TITLE
docs: better documentation for interception multiple headers

### DIFF
--- a/docs/api/puppeteer.responseforrequest.md
+++ b/docs/api/puppeteer.responseforrequest.md
@@ -79,7 +79,7 @@ Record&lt;string, string \| string\[\] \| unknown&gt;
 
 Optional response headers.
 
-The record values will be converted to string following: Arrays' values will be mapped to String (Used when you need multiple headers with same name). Non-arrays will be converted to String.
+The record values will be converted to string following: Arrays' values will be mapped to String (Used when you need multiple headers with the same name). Non-arrays will be converted to String.
 
 </td><td>
 

--- a/docs/api/puppeteer.responseforrequest.md
+++ b/docs/api/puppeteer.responseforrequest.md
@@ -73,11 +73,13 @@ string
 
 </td><td>
 
-Record&lt;string, unknown&gt;
+Record&lt;string, string \| string\[\] \| unknown&gt;
 
 </td><td>
 
-Optional response headers. All values are converted to strings.
+Optional response headers.
+
+The record values will be converted to string following: Arrays' values will be mapped to String (Used when you need multiple headers with same name). Non-arrays will be converted to String.
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -43,9 +43,14 @@ export interface InterceptResolutionState {
 export interface ResponseForRequest {
   status: number;
   /**
-   * Optional response headers. All values are converted to strings.
+   * Optional response headers.
+   *
+   * The record values will be converted to string following:
+   * Arrays' values will be mapped to String
+   * (Used when you need multiple headers with same name).
+   * Non-arrays will be converted to String.
    */
-  headers: Record<string, unknown>;
+  headers: Record<string, string | string[] | unknown>;
   contentType: string;
   body: string | Uint8Array;
 }

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -47,7 +47,7 @@ export interface ResponseForRequest {
    *
    * The record values will be converted to string following:
    * Arrays' values will be mapped to String
-   * (Used when you need multiple headers with same name).
+   * (Used when you need multiple headers with the same name).
    * Non-arrays will be converted to String.
    */
   headers: Record<string, string | string[] | unknown>;


### PR DESCRIPTION
Closes #9518
Should we make a breaking change to make sure the type is correct and we don't do the conversion ourselfs, else it's impossible to type correctly as currently all IDE and TS will report only `unknown`. This is only for documentation purpose.  