### PR TITLE
chore: update nightly expectations for Firefox after Bug_1898158

### DIFF
--- a/test/CanaryTestExpectations.json
+++ b/test/CanaryTestExpectations.json
@@ -40,5 +40,19 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["PASS"],
     "comment": "Works in Nightly"
+  },
+  {
+    "testIdPattern": "[requestinterception.spec] request interception Request.continue should redirect in a way non-observable to page",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["PASS"],
+    "comment": "Works in Nightly"
+  },
+  {
+    "testIdPattern": "[requestinterception-experimental.spec] cooperative request interception Request.continue should redirect in a way non-observable to page",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["PASS"],
+    "comment": "Works in Nightly"
   }
 ]


### PR DESCRIPTION
Sync nightly expectations for Bug_1898158 which added support for the URL parameter to network.continueRequest