### PR TITLE
fix: re-export node reference removed by TS 5.5

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,7 @@ module.exports = {
       'error',
       'always',
       {
-        markers: ['*'],
+        markers: ['*', '/'],
       },
     ],
     eqeqeq: ['error'],

--- a/packages/puppeteer-core/api-extractor.json
+++ b/packages/puppeteer-core/api-extractor.json
@@ -14,6 +14,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
+    "omitTrimmingComments": true,
     "alphaTrimmedFilePath": "lib/types.d.ts"
   },
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -3,7 +3,7 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+/// <reference types="node"  preserve="true"/>
 import type {ChildProcess} from 'child_process';
 
 import type {Protocol} from 'devtools-protocol';


### PR DESCRIPTION
Closes https://github.com/puppeteer/puppeteer/pull/13198
Closes https://github.com/puppeteer/puppeteer/issues/13193