### PR TITLE
feat: remove --disable-component-update from default args

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -212,7 +212,6 @@ export class ChromeLauncher extends BrowserLauncher {
       '--disable-breakpad',
       '--disable-client-side-phishing-detection',
       '--disable-component-extensions-with-background-pages',
-      '--disable-component-update',
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',


### PR DESCRIPTION
Chrome for Testing that ships with Puppeteer by default automatically disables component updates. This PR removes the --disable-component-update to allow built-in components to initialize properly (without updating them).

If you use Chrome and not Chrome for Testing, you might want to add this argument to your launch args.

Closes #13010