### PR TITLE
ci: simplify test suites format

### DIFF
--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -2,45 +2,31 @@
   "testSuites": [
     {
       "id": "chrome-headless",
-      "platforms": ["linux", "win32", "darwin"],
-      "parameters": ["chrome", "headless", "cdp"],
-      "expectedLineCoverage": 93
+      "parameters": ["chrome", "headless", "cdp"]
     },
     {
       "id": "chrome-headful",
-      "platforms": ["linux"],
-      "parameters": ["chrome", "headful", "cdp"],
-      "expectedLineCoverage": 93
+      "parameters": ["chrome", "headful", "cdp"]
     },
     {
       "id": "chrome-headless-shell",
-      "platforms": ["linux"],
-      "parameters": ["chrome", "chrome-headless-shell", "cdp"],
-      "expectedLineCoverage": 93
+      "parameters": ["chrome", "chrome-headless-shell", "cdp"]
     },
     {
       "id": "firefox-headless",
-      "platforms": ["linux", "darwin"],
-      "parameters": ["firefox", "headless", "webDriverBiDi"],
-      "expectedLineCoverage": 56
+      "parameters": ["firefox", "headless", "webDriverBiDi"]
     },
     {
       "id": "firefox-headful",
-      "platforms": ["linux"],
-      "parameters": ["firefox", "headful", "webDriverBiDi"],
-      "expectedLineCoverage": 56
+      "parameters": ["firefox", "headful", "webDriverBiDi"]
     },
     {
       "id": "firefox-cdp",
-      "platforms": ["linux"],
-      "parameters": ["firefox", "headless", "cdp"],
-      "expectedLineCoverage": 80
+      "parameters": ["firefox", "headless", "cdp"]
     },
     {
       "id": "chrome-bidi",
-      "platforms": ["linux"],
-      "parameters": ["chrome", "headless", "webDriverBiDi"],
-      "expectedLineCoverage": 56
+      "parameters": ["chrome", "headless", "webDriverBiDi"]
     }
   ],
   "parameterDefinitions": {

--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -20,7 +20,6 @@ import {
   zPlatform,
   zTestSuiteFile,
   type MochaResults,
-  type Platform,
   type TestExpectation,
   type TestSuite,
   type TestSuiteFile,
@@ -89,14 +88,11 @@ const {
   })
   .parseSync();
 
-function getApplicableTestSuites(
-  parsedSuitesFile: TestSuiteFile,
-  platform: Platform
-): TestSuite[] {
+function getApplicableTestSuites(parsedSuitesFile: TestSuiteFile): TestSuite[] {
   let applicableSuites: TestSuite[] = [];
 
   if (!testSuiteId) {
-    applicableSuites = filterByPlatform(parsedSuitesFile.testSuites, platform);
+    applicableSuites = parsedSuitesFile.testSuites;
   } else {
     const testSuite = parsedSuitesFile.testSuites.find(suite => {
       return suite.id === testSuiteId;
@@ -105,12 +101,6 @@ function getApplicableTestSuites(
     if (!testSuite) {
       console.error(`Test suite ${testSuiteId} is not defined`);
       process.exit(1);
-    }
-
-    if (!testSuite.platforms.includes(platform)) {
-      console.warn(
-        `Test suite ${testSuiteId} is not enabled for your platform. Running it anyway.`
-      );
     }
 
     applicableSuites = [testSuite];
@@ -135,7 +125,7 @@ async function main() {
     readJSON(path.join(process.cwd(), 'test', 'TestSuites.json'))
   );
 
-  const applicableSuites = getApplicableTestSuites(parsedSuitesFile, platform);
+  const applicableSuites = getApplicableTestSuites(parsedSuitesFile);
 
   console.log('Planning to run the following test suites', applicableSuites);
   if (statsPath) {
@@ -238,13 +228,7 @@ async function main() {
         'npx',
         [
           ...(useCoverage
-            ? [
-                'c8',
-                '--check-coverage',
-                '--lines',
-                String(suite.expectedLineCoverage),
-                'npx',
-              ]
+            ? ['c8', '--check-coverage', '--lines', '90', 'npx']
             : []),
           'mocha',
           ...mochaArgs.map(String),

--- a/tools/mocha-runner/src/types.ts
+++ b/tools/mocha-runner/src/types.ts
@@ -14,9 +14,7 @@ export type Platform = z.infer<typeof zPlatform>;
 
 export const zTestSuite = z.object({
   id: z.string(),
-  platforms: z.array(zPlatform),
   parameters: z.array(z.string()),
-  expectedLineCoverage: z.number(),
 });
 
 export type TestSuite = z.infer<typeof zTestSuite>;


### PR DESCRIPTION
- removes platforms that are outdated and not actually used (ci.yml determines if a test suite is run).
- also removes expectedLineCoverage which is mostly not used and does not make much sense with how our codebase is structured.