### PR TITLE
fix(webdriver): partially handle client-side redirects in page.goto

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -329,6 +329,10 @@ export class BidiFrame extends Frame {
             return;
           }
 
+          if (error.message.includes('navigation canceled')) {
+            return;
+          }
+
           throw error;
         }),
     ]).catch(

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -482,6 +482,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should work when navigating to a URL with a client redirect",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "https://github.com/puppeteer/puppeteer/issues/12929"
+  },
+  {
     "testIdPattern": "[network.spec] network Network Events Page.Events.RequestServedFromCache *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/assets/client-redirect.html
+++ b/test/assets/client-redirect.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+  window.location = "/empty.html"
+</script>

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -315,6 +315,16 @@ describe('navigation', function () {
       const response = (await page.goto(server.EMPTY_PAGE))!;
       expect(response.ok()).toBe(true);
     });
+
+    it('should work when navigating to a URL with a client redirect', async () => {
+      const {page, server} = await getTestState();
+
+      const response = (await page.goto(
+        server.PREFIX + '/client-redirect.html'
+      ))!;
+      expect(response.ok()).toBe(true);
+      expect(response.url()).toBe(server.EMPTY_PAGE);
+    });
     it('should work when navigating to data url', async () => {
       const {page} = await getTestState();
 


### PR DESCRIPTION
This CL partially solves the issue in that the client-side redirect does not cause an error any more but there is still a difference between BiDi and CDP in that the navigation request returned is the first one in BiDi and the second one in CDP.

See https://github.com/puppeteer/puppeteer/issues/12929