### PR TITLE
chore: extract extra browser creation in hook

### DIFF
--- a/packages/puppeteer-core/src/util/Deferred.ts
+++ b/packages/puppeteer-core/src/util/Deferred.ts
@@ -62,6 +62,7 @@ export class Deferred<T, V extends Error = Error> {
   #value: T | V | TimeoutError | undefined;
   // SAFETY: This is ensured by #taskPromise.
   #resolve!: (value: void) => void;
+  // TODO: Switch to Promise.withResolvers with Node 22
   #taskPromise = new Promise<void>(resolve => {
     this.#resolve = resolve;
   });

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2618,13 +2618,6 @@
     "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1878166"
   },
   {
-    "testIdPattern": "[oopif.spec] OOPIF should support wait for navigation for transitions from local to OOPIF",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "chrome"],
-    "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
     "testIdPattern": "[oopif.spec] OOPIF should wait for inner OOPIFs",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -2991,13 +2984,6 @@
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome"],
     "expectations": ["FAIL", "PASS"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[requestinterception-experimental.spec] request interception Page.setRequestInterception should load fonts if cache enabled",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "chrome"],
-    "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {

--- a/test/src/acceptInsecureCerts.spec.ts
+++ b/test/src/acceptInsecureCerts.spec.ts
@@ -9,36 +9,15 @@ import type {TLSSocket} from 'tls';
 import expect from 'expect';
 import type {HTTPResponse} from 'puppeteer-core/internal/api/HTTPResponse.js';
 
-import {launch} from './mocha-utils.js';
+import {setupSeparateTestBrowserHooks} from './mocha-utils.js';
 
-describe('acceptInsecureCerts', function () {
+describe('acceptInsecureCerts', async () => {
   /* Note that this test creates its own browser rather than use
    * the one provided by the test set-up as we need one
    * with acceptInsecureCerts set to true
    */
-  let state: Awaited<ReturnType<typeof launch>>;
-
-  before(async () => {
-    state = await launch(
-      {acceptInsecureCerts: true},
-      {
-        after: 'all',
-        createContext: false,
-      },
-    );
-  });
-
-  after(async () => {
-    await state.close();
-  });
-
-  beforeEach(async () => {
-    state.context = await state.browser.createBrowserContext();
-    state.page = await state.context.newPage();
-  });
-
-  afterEach(async () => {
-    await state.context.close();
+  const state = setupSeparateTestBrowserHooks({
+    acceptInsecureCerts: true,
   });
 
   describe('Response.securityDetails', function () {

--- a/test/src/browser.spec.ts
+++ b/test/src/browser.spec.ts
@@ -75,7 +75,7 @@ describe('Browser specs', function () {
       expect(remoteBrowser.process()).toBe(null);
     });
     it('should keep connected after the last page is closed', async () => {
-      const {browser, close} = await launch({}, {createContext: false});
+      const {browser, close} = await launch({});
       try {
         const pages = await browser.pages();
         await Promise.all(

--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -22,7 +22,7 @@ describe('TargetManager', () => {
       ],
     },
     {
-      createContext: false,
+      createPage: false,
     },
   ) as Awaited<ReturnType<typeof launch>> & {
     browser: CdpBrowser;

--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -13,13 +13,18 @@ import {attachFrame} from '../utils.js';
 
 describe('TargetManager', () => {
   /* We use a special browser for this test as we need the --site-per-process flag */
-  const state = setupSeparateTestBrowserHooks({
-    args: [
-      '--site-per-process',
-      '--remote-debugging-port=21222',
-      '--host-rules=MAP * 127.0.0.1',
-    ],
-  }) as Awaited<ReturnType<typeof launch>> & {
+  const state = setupSeparateTestBrowserHooks(
+    {
+      args: [
+        '--site-per-process',
+        '--remote-debugging-port=21222',
+        '--host-rules=MAP * 127.0.0.1',
+      ],
+    },
+    {
+      createContext: false,
+    },
+  ) as Awaited<ReturnType<typeof launch>> & {
     browser: CdpBrowser;
   };
 

--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -7,36 +7,21 @@
 import expect from 'expect';
 import type {CdpBrowser} from 'puppeteer-core/internal/cdp/Browser.js';
 
-import {getTestState, launch} from '../mocha-utils.js';
+import type {launch} from '../mocha-utils.js';
+import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
 import {attachFrame} from '../utils.js';
 
 describe('TargetManager', () => {
   /* We use a special browser for this test as we need the --site-per-process flag */
-  let state: Awaited<ReturnType<typeof launch>> & {
+  const state = setupSeparateTestBrowserHooks({
+    args: [
+      '--site-per-process',
+      '--remote-debugging-port=21222',
+      '--host-rules=MAP * 127.0.0.1',
+    ],
+  }) as Awaited<ReturnType<typeof launch>> & {
     browser: CdpBrowser;
   };
-
-  beforeEach(async () => {
-    const {defaultBrowserOptions} = await getTestState({
-      skipLaunch: true,
-    });
-    state = (await launch(
-      Object.assign({}, defaultBrowserOptions, {
-        args: (defaultBrowserOptions.args || []).concat([
-          '--site-per-process',
-          '--remote-debugging-port=21222',
-          '--host-rules=MAP * 127.0.0.1',
-        ]),
-      }),
-      {createPage: false},
-    )) as Awaited<ReturnType<typeof launch>> & {
-      browser: CdpBrowser;
-    };
-  });
-
-  afterEach(async () => {
-    await state.close();
-  });
 
   // CDP-specific test.
   it('should handle targets', async () => {

--- a/test/src/cdp/bfcache.spec.ts
+++ b/test/src/cdp/bfcache.spec.ts
@@ -7,100 +7,86 @@
 import expect from 'expect';
 import {PageEvent} from 'puppeteer-core';
 
-import {launch} from '../mocha-utils.js';
+import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
 import {waitEvent} from '../utils.js';
 
 describe('BFCache', function () {
+  const state = setupSeparateTestBrowserHooks({
+    acceptInsecureCerts: true,
+  });
+
   it('can navigate to a BFCached page', async () => {
-    const {httpsServer, page, close} = await launch({
-      acceptInsecureCerts: true,
-    });
+    const {httpsServer, page} = state;
 
-    try {
-      page.setDefaultTimeout(3000);
+    page.setDefaultTimeout(3000);
 
-      await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');
+    await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');
 
-      await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
+    await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
 
-      expect(page.url()).toContain('target.html');
+    expect(page.url()).toContain('target.html');
 
-      await Promise.all([page.waitForNavigation(), page.goBack()]);
+    await Promise.all([page.waitForNavigation(), page.goBack()]);
 
-      expect(
-        await page.evaluate(() => {
-          return document.body.innerText;
-        }),
-      ).toBe('BFCachednext');
-    } finally {
-      await close();
-    }
+    expect(
+      await page.evaluate(() => {
+        return document.body.innerText;
+      }),
+    ).toBe('BFCachednext');
   });
 
   it('can call a function exposed on a page restored from bfcache', async () => {
-    const {httpsServer, page, close} = await launch({
-      acceptInsecureCerts: true,
-    });
+    const {httpsServer, page} = state;
     let message = '';
-    try {
-      page.setDefaultTimeout(3000);
-      await page.exposeFunction('ping', (msg: string) => {
-        message = msg;
-      });
-      await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');
+    page.setDefaultTimeout(3000);
+    await page.exposeFunction('ping', (msg: string) => {
+      message = msg;
+    });
+    await page.goto(httpsServer.PREFIX + '/cached/bfcache/index.html');
 
-      await page.evaluate(async () => {
-        await (window as any).ping('1');
-      });
-      expect(message).toBe('1');
+    await page.evaluate(async () => {
+      await (window as any).ping('1');
+    });
+    expect(message).toBe('1');
 
-      await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
+    await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
 
-      expect(page.url()).toContain('target.html');
+    expect(page.url()).toContain('target.html');
 
-      await page.evaluate(async () => {
-        await (window as any).ping('2');
-      });
-      expect(message).toBe('2');
+    await page.evaluate(async () => {
+      await (window as any).ping('2');
+    });
+    expect(message).toBe('2');
 
-      await Promise.all([page.waitForNavigation(), page.goBack()]);
-      await page.evaluate(async () => {
-        await (window as any).ping('3');
-      });
-      expect(message).toBe('3');
-      expect(
-        await page.evaluate(() => {
-          return document.body.innerText;
-        }),
-      ).toBe('BFCachednext');
-    } finally {
-      await close();
-    }
+    await Promise.all([page.waitForNavigation(), page.goBack()]);
+    await page.evaluate(async () => {
+      await (window as any).ping('3');
+    });
+    expect(message).toBe('3');
+    expect(
+      await page.evaluate(() => {
+        return document.body.innerText;
+      }),
+    ).toBe('BFCachednext');
   });
 
   it('can navigate to a BFCached page containing an OOPIF and a worker', async () => {
-    const {httpsServer, page, close} = await launch({
-      acceptInsecureCerts: true,
-    });
-    try {
-      page.setDefaultTimeout(3000);
-      const [worker1] = await Promise.all([
-        waitEvent(page, PageEvent.WorkerCreated),
-        page.goto(
-          httpsServer.PREFIX + '/cached/bfcache/worker-iframe-container.html',
-        ),
-      ]);
-      expect(await worker1.evaluate('1 + 1')).toBe(2);
-      await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
+    const {httpsServer, page} = state;
+    page.setDefaultTimeout(3000);
+    const [worker1] = await Promise.all([
+      waitEvent(page, PageEvent.WorkerCreated),
+      page.goto(
+        httpsServer.PREFIX + '/cached/bfcache/worker-iframe-container.html',
+      ),
+    ]);
+    expect(await worker1.evaluate('1 + 1')).toBe(2);
+    await Promise.all([page.waitForNavigation(), page.locator('a').click()]);
 
-      const [worker2] = await Promise.all([
-        waitEvent(page, PageEvent.WorkerCreated),
-        page.waitForNavigation(),
-        page.goBack(),
-      ]);
-      expect(await worker2.evaluate('1 + 1')).toBe(2);
-    } finally {
-      await close();
-    }
+    const [worker2] = await Promise.all([
+      waitEvent(page, PageEvent.WorkerCreated),
+      page.waitForNavigation(),
+      page.goBack(),
+    ]);
+    expect(await worker2.evaluate('1 + 1')).toBe(2);
   });
 });

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -52,7 +52,7 @@ describe('extensions', function () {
   });
 
   async function launchBrowser(options: typeof extensionOptions) {
-    const {browser, close} = await launch(options, {createContext: false});
+    const {browser, close} = await launch(options);
     browsers.push(close);
     return browser;
   }

--- a/test/src/chromiumonly.spec.ts
+++ b/test/src/chromiumonly.spec.ts
@@ -88,7 +88,7 @@ describe('Chromium-Specific Launcher tests', function () {
 
   describe('Puppeteer.launch |pipe| option', function () {
     it('should support the pipe option', async () => {
-      const {browser, close} = await launch({pipe: true}, {createPage: false});
+      const {browser, close} = await launch({pipe: true});
       try {
         expect(await browser.pages()).toHaveLength(1);
         expect(browser.wsEndpoint()).toBe('');

--- a/test/src/headful.spec.ts
+++ b/test/src/headful.spec.ts
@@ -40,7 +40,7 @@ describe('headful tests', function () {
   });
 
   async function launchBrowser(options: any) {
-    const {browser, close} = await launch(options, {createContext: false});
+    const {browser, close} = await launch(options);
     browsers.push(close);
     return browser;
   }

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -203,6 +203,52 @@ export const setupTestBrowserHooks = (): void => {
   });
 };
 
+export const setupSeparateTestBrowserHooks = (
+  launchOptions: Readonly<PuppeteerLaunchOptions>,
+  options: {
+    createContext?: boolean;
+    createPage?: boolean;
+  } = {},
+): Awaited<ReturnType<typeof launch>> => {
+  const {createContext = true, createPage = true} = options;
+  const state: Awaited<ReturnType<typeof launch>> = {} as any;
+  before(async () => {
+    const browserState = await launch(launchOptions, {
+      after: 'all',
+      ...options,
+    });
+    // Trick to keep the correct reference
+    const props = Object.entries(browserState).reduce((acc, entries) => {
+      const [key, value] = entries;
+      acc[key] = {
+        value,
+        writable: true,
+      };
+      return acc;
+    }, {} as PropertyDescriptorMap);
+    Object.defineProperties(state, props);
+  });
+
+  if (createContext) {
+    beforeEach(async () => {
+      state.context = await state.browser.createBrowserContext();
+      if (createPage) {
+        state.page = await state.context.newPage();
+      }
+    });
+
+    afterEach(async () => {
+      await state.context.close();
+    });
+  }
+
+  after(async () => {
+    await state.close();
+  });
+
+  return state;
+};
+
 export const getTestState = async (
   options: {
     skipLaunch?: boolean;
@@ -342,13 +388,15 @@ export const mochaHooks: Mocha.RootHookObject = {
   },
 
   async afterEach(this: Mocha.Context): Promise<void> {
+    const timeout = this.timeout();
+    this.timeout(0);
     if (browserCleanups.length > 0) {
       (this.test as Mocha.Hook).error(browserNotClosedError);
       await Deferred.race([
         closeLaunched(browserCleanups)(),
         Deferred.create({
           message: `Failed in after Hook`,
-          timeout: this.timeout() - 1000,
+          timeout: timeout - 1000,
         }),
       ]);
     }
@@ -481,7 +529,7 @@ export const launch = async (
     close: () => Promise<void>;
   }
 > => {
-  const {after = 'each', createContext = true, createPage = true} = options;
+  const {after = 'each', createContext = false, createPage = true} = options;
   const initState = await getTestState({
     skipLaunch: true,
   });

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -211,15 +211,10 @@ export const setupSeparateTestBrowserHooks = (
     mergeArgs?: boolean;
   } = {},
 ): Awaited<ReturnType<typeof launch>> => {
-  const {createContext = true, createPage = true, mergeArgs = true} = options;
+  const {createContext = true, createPage = true} = options;
 
   const state: Awaited<ReturnType<typeof launch>> = {} as any;
   before(async () => {
-    const {defaultBrowserOptions} = await getTestState({
-      skipLaunch: true,
-    });
-    const launchOptionsMerged = {};
-
     const browserState = await launch(launchOptions, {
       after: 'all',
       ...options,

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -885,9 +885,14 @@ describe('network', function () {
     });
 
     it('Cross-origin set-cookie', async () => {
-      const {page, httpsServer, close} = await launch({
-        acceptInsecureCerts: true,
-      });
+      const {page, httpsServer, close} = await launch(
+        {
+          acceptInsecureCerts: true,
+        },
+        {
+          createContext: true,
+        },
+      );
       try {
         await page.goto(httpsServer.PREFIX + '/empty.html');
 

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -21,7 +21,7 @@ describe('Tracing', function () {
    * individual test, which isn't the default behaviour of getTestState()
    */
   beforeEach(async () => {
-    testState = await launch({});
+    testState = await launch({}, {createContext: true});
     outputFile = path.join(__dirname, 'trace.json');
   });
 


### PR DESCRIPTION
Creates a wrapper function similar to the original setUpBrowser.
This remove the need to set it per test and shows that a couple of places were not reusing a browser.
Also changes the defaults `launch` to not create a Context and Page, as almost all test use `browser.newPage` so we were creating them for no reson.