### PR TITLE
fix: correctly handle errors in the ExtensionTransport

### DIFF
--- a/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
+++ b/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
@@ -178,7 +178,11 @@ export class ExtensionTransport implements ConnectionTransport {
           id: parsed.id,
           sessionId: parsed.sessionId ?? 'pageTargetSessionId',
           method: parsed.method,
-          error: err,
+          error: {
+            code: err?.code,
+            data: err?.data,
+            message: err?.message ?? 'CDP error had no message',
+          },
         });
       });
   }


### PR DESCRIPTION
chrome.debugger API returns Error objects which are not serialized correctly by default. This PR extracts error fields into an object that Puppeteer expects.