### PR TITLE
fix(browsers): correctly import yargs for esm module

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -10,7 +10,7 @@ import * as readline from 'readline';
 import ProgressBar from 'progress';
 import type * as Yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
-import yargs from 'yargs/yargs';
+import yargs from 'yargs';
 
 import {
   resolveBuildId,

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -9,8 +9,8 @@ import * as readline from 'readline';
 
 import ProgressBar from 'progress';
 import type * as Yargs from 'yargs';
-import {hideBin} from 'yargs/helpers';
 import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers';
 
 import {
   resolveBuildId,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR changes the way to import `yargs`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No, would be happy to know how to add a test for it.

**If relevant, did you update the documentation?**

No doc update is needed.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This is to work around https://github.com/yargs/yargs/issues/2418, which prevents any application that uses `puppeteer` from being built using single file bundlers like `ncc`.

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**