### PR TITLE
fix(browser): omit file path validation in uploadFile() in browser environments

### DIFF
--- a/packages/puppeteer-core/src/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/bidi/ElementHandle.ts
@@ -102,13 +102,15 @@ export class BidiElementHandle<
   ): Promise<void> {
     // Locate all files and confirm that they exist.
     const path = environment.value.path;
-    files = files.map(file => {
-      if (path.win32.isAbsolute(file) || path.posix.isAbsolute(file)) {
-        return file;
-      } else {
-        return path.resolve(file);
-      }
-    });
+    if (path) {
+      files = files.map(file => {
+        if (path.win32.isAbsolute(file) || path.posix.isAbsolute(file)) {
+          return file;
+        } else {
+          return path.resolve(file);
+        }
+      });
+    }
     await this.frame.setFiles(this, files);
   }
 

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -101,25 +101,30 @@ export class CdpElementHandle<
   @bindIsolatedHandle
   override async uploadFile(
     this: CdpElementHandle<HTMLInputElement>,
-    ...filePaths: string[]
+    ...files: string[]
   ): Promise<void> {
     const isMultiple = await this.evaluate(element => {
       return element.multiple;
     });
     assert(
-      filePaths.length <= 1 || isMultiple,
+      files.length <= 1 || isMultiple,
       'Multiple file uploads only work with <input type=file multiple>',
     );
 
     // Locate all files and confirm that they exist.
     const path = environment.value.path;
-    const files = filePaths.map(filePath => {
-      if (path.win32.isAbsolute(filePath) || path.posix.isAbsolute(filePath)) {
-        return filePath;
-      } else {
-        return path.resolve(filePath);
-      }
-    });
+    if (path) {
+      files = files.map(filePath => {
+        if (
+          path.win32.isAbsolute(filePath) ||
+          path.posix.isAbsolute(filePath)
+        ) {
+          return filePath;
+        } else {
+          return path.resolve(filePath);
+        }
+      });
+    }
 
     /**
      * The zero-length array is a special case, it seems that

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -16,7 +16,7 @@ export const isNode = !!(typeof process !== 'undefined' && process.version);
 
 export interface EnvironmentDependencies {
   fs: typeof FS;
-  path: typeof Path;
+  path?: typeof Path;
   ScreenRecorder: typeof ScreenRecorder;
 }
 
@@ -30,9 +30,6 @@ export const environment: {
   value: {
     get fs(): typeof FS {
       throw new Error('fs is not available in this environment');
-    },
-    get path(): typeof Path {
-      throw new Error('path is not available in this environment');
     },
     get ScreenRecorder(): typeof ScreenRecorder {
       throw new Error('ScreenRecorder is not available in this environment');


### PR DESCRIPTION
Filesystem access is not possible in the browser environments.