### PR TITLE
fix: correctly resolve OOPIF response bodies

### DIFF
--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -46,6 +46,10 @@ export class CdpHTTPRequest extends HTTPRequest {
     return this.#client;
   }
 
+  override set client(newClient: CDPSession) {
+    this.#client = newClient;
+  }
+
   constructor(
     client: CDPSession,
     frame: Frame | null,

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -5,7 +5,6 @@
  */
 import type {Protocol} from 'devtools-protocol';
 
-import type {CDPSession} from '../api/CDPSession.js';
 import type {Frame} from '../api/Frame.js';
 import {HTTPResponse, type RemoteAddress} from '../api/HTTPResponse.js';
 import {ProtocolError} from '../common/Errors.js';
@@ -19,7 +18,6 @@ import type {CdpHTTPRequest} from './HTTPRequest.js';
  * @internal
  */
 export class CdpHTTPResponse extends HTTPResponse {
-  #client: CDPSession;
   #request: CdpHTTPRequest;
   #contentPromise: Promise<Uint8Array> | null = null;
   #bodyLoadedDeferred = Deferred.create<void, Error>();
@@ -34,13 +32,11 @@ export class CdpHTTPResponse extends HTTPResponse {
   #timing: Protocol.Network.ResourceTiming | null;
 
   constructor(
-    client: CDPSession,
     request: CdpHTTPRequest,
     responsePayload: Protocol.Network.Response,
     extraInfo: Protocol.Network.ResponseReceivedExtraInfoEvent | null,
   ) {
     super();
-    this.#client = client;
     this.#request = request;
 
     this.#remoteAddress = {
@@ -128,7 +124,9 @@ export class CdpHTTPResponse extends HTTPResponse {
         .valueOrThrow()
         .then(async () => {
           try {
-            const response = await this.#client.send(
+            // Use CDPSession from corresponding request to retrieve body, as it's client
+            // might have been updated (e.g. for an adopted OOPIF).
+            const response = await this.#request.client.send(
               'Network.getResponseBody',
               {
                 requestId: this.#request.id,

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -725,11 +725,11 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     client: CDPSession,
     request: CdpHTTPRequest,
   ): void {
-    // Document requests for OOPIFs will in the parent frame but are adopted by their
-    // child frame, so loadingFinished and loadingFailed for these requests will be fired
-    // on the child session. In this case we reassign the request CDPSession to ensure all
-    // subsequent actions are called on the correct session (e.g. retrieving response body
-    // in HTTPResponse).
+    // Document requests for OOPIFs start in the parent frame but are adopted by their
+    // child frame, meaning their loadingFinished and loadingFailed events are fired on
+    // the child session. In this case we reassign the request CDPSession to ensure all
+    // subsequent actions use the correct session (e.g. retrieving response body in
+    // HTTPResponse).
     if (client !== request.client && request.isNavigationRequest()) {
       request.client = client;
     }

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -514,17 +514,12 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   #handleRequestRedirect(
-    client: CDPSession,
+    _client: CDPSession,
     request: CdpHTTPRequest,
     responsePayload: Protocol.Network.Response,
     extraInfo: Protocol.Network.ResponseReceivedExtraInfoEvent | null,
   ): void {
-    const response = new CdpHTTPResponse(
-      client,
-      request,
-      responsePayload,
-      extraInfo,
-    );
+    const response = new CdpHTTPResponse(request, responsePayload, extraInfo);
     request._response = response;
     request._redirectChain.push(request);
     response._resolveBody(
@@ -536,7 +531,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   #emitResponseEvent(
-    client: CDPSession,
+    _client: CDPSession,
     responseReceived: Protocol.Network.ResponseReceivedEvent,
     extraInfo: Protocol.Network.ResponseReceivedExtraInfoEvent | null,
   ): void {
@@ -568,7 +563,6 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     }
 
     const response = new CdpHTTPResponse(
-      client,
       request,
       responseReceived.response,
       extraInfo,
@@ -627,10 +621,10 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
         event,
       );
       if (queuedEvents.loadingFinishedEvent) {
-        this.#emitLoadingFinished(queuedEvents.loadingFinishedEvent);
+        this.#emitLoadingFinished(client, queuedEvents.loadingFinishedEvent);
       }
       if (queuedEvents.loadingFailedEvent) {
-        this.#emitLoadingFailed(queuedEvents.loadingFailedEvent);
+        this.#emitLoadingFailed(client, queuedEvents.loadingFailedEvent);
       }
       return;
     }
@@ -654,7 +648,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   #onLoadingFinished(
-    _client: CDPSession,
+    client: CDPSession,
     event: Protocol.Network.LoadingFinishedEvent,
   ): void {
     // If the response event for this request is still waiting on a
@@ -665,17 +659,22 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     if (queuedEvents) {
       queuedEvents.loadingFinishedEvent = event;
     } else {
-      this.#emitLoadingFinished(event);
+      this.#emitLoadingFinished(client, event);
     }
   }
 
-  #emitLoadingFinished(event: Protocol.Network.LoadingFinishedEvent): void {
+  #emitLoadingFinished(
+    client: CDPSession,
+    event: Protocol.Network.LoadingFinishedEvent,
+  ): void {
     const request = this.#networkEventManager.getRequest(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
     // @see https://crbug.com/750469
     if (!request) {
       return;
     }
+
+    this.#maybeReassignOOPIFRequestClient(client, request);
 
     // Under certain conditions we never get the Network.responseReceived
     // event from protocol. @see https://crbug.com/883475
@@ -687,7 +686,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   #onLoadingFailed(
-    _client: CDPSession,
+    client: CDPSession,
     event: Protocol.Network.LoadingFailedEvent,
   ): void {
     // If the response event for this request is still waiting on a
@@ -698,17 +697,21 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     if (queuedEvents) {
       queuedEvents.loadingFailedEvent = event;
     } else {
-      this.#emitLoadingFailed(event);
+      this.#emitLoadingFailed(client, event);
     }
   }
 
-  #emitLoadingFailed(event: Protocol.Network.LoadingFailedEvent): void {
+  #emitLoadingFailed(
+    client: CDPSession,
+    event: Protocol.Network.LoadingFailedEvent,
+  ): void {
     const request = this.#networkEventManager.getRequest(event.requestId);
     // For certain requestIds we never receive requestWillBeSent event.
     // @see https://crbug.com/750469
     if (!request) {
       return;
     }
+    this.#maybeReassignOOPIFRequestClient(client, request);
     request._failureText = event.errorText;
     const response = request.response();
     if (response) {
@@ -716,5 +719,19 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     }
     this.#forgetRequest(request, true);
     this.emit(NetworkManagerEvent.RequestFailed, request);
+  }
+
+  #maybeReassignOOPIFRequestClient(
+    client: CDPSession,
+    request: CdpHTTPRequest,
+  ): void {
+    // Document requests for OOPIFs will in the parent frame but are adopted by their
+    // child frame, so loadingFinished and loadingFailed for these requests will be fired
+    // on the child session. In this case we reassign the request CDPSession to ensure all
+    // subsequent actions are called on the correct session (e.g. retrieving response body
+    // in HTTPResponse).
+    if (client !== request.client && request.isNavigationRequest()) {
+      request.client = client;
+    }
   }
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3514,5 +3514,12 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[oopif.spec] should retrieve body for OOPIF document requests",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Response body retrieval not yet supported in WebDriver BiDi implementations"
   }
 ]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3516,7 +3516,7 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[oopif.spec] should retrieve body for OOPIF document requests",
+    "testIdPattern": "[oopif.spec] OOPIF should retrieve body for OOPIF document requests",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
     "expectations": ["FAIL"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -591,6 +591,13 @@
     "comment": "chrome-headless-shell does not have a PDF viewer"
   },
   {
+    "testIdPattern": "[oopif.spec] OOPIF should retrieve body for OOPIF document requests",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Response body retrieval not yet supported in WebDriver BiDi implementations"
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.addScriptTag should throw when added with content to the CSP page",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -2646,6 +2653,13 @@
     "comment": "Firefox does not support multiple sessions in BiDi."
   },
   {
+    "testIdPattern": "[oopif.spec] OOPIF should retrieve body for OOPIF document requests",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "Chrome-specific test (uses DNS mapping); does not work with Firefox."
+  },
+  {
     "testIdPattern": "[oopif.spec] OOPIF should wait for inner OOPIFs",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -3514,12 +3528,5 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[oopif.spec] OOPIF should retrieve body for OOPIF document requests",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Response body retrieval not yet supported in WebDriver BiDi implementations"
   }
 ]

--- a/test/assets/oopif-response.html
+++ b/test/assets/oopif-response.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<h1>I'm an OOPIF!</h1>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

**Summary**

Fix for https://github.com/puppeteer/puppeteer/issues/13307. I've raised it as a draft initially as there's a potential edge case that this may need to account for in `#maybeReassignOOPIFRequestClient` - namely, if we end up with different sessions for a document request on the main frame (top-level page). Is this something you're aware can happen? If so, what do you think would be the best way of making this info available for this check in `NetworkManager`, i.e. does the `CDPSession` that just received a `Network.loadingFinished` or `Network.loadingFailed` event belong to the 'main' target or not?

**Does this PR introduce a breaking change?**

No

**Other information**
