### PR TITLE
feat: browser level cookies API

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -667,6 +667,13 @@ Description
 </td></tr>
 <tr><td>
 
+<span id="convertcookiespartitionkeyfrompuppeteertocdp">[convertCookiesPartitionKeyFromPuppeteerToCdp(partitionKey)](./puppeteer.convertcookiespartitionkeyfrompuppeteertocdp.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="defaultargs">[defaultArgs(options)](./puppeteer.defaultargs.md)</span>
 
 </td><td>
@@ -778,6 +785,15 @@ Launcher options that only apply to Chrome.
 <span id="cdpsessionevents">[CDPSessionEvents](./puppeteer.cdpsessionevents.md)</span>
 
 </td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="chromecookiepartitionkey">[ChromeCookiePartitionKey](./puppeteer.chromecookiepartitionkey.md)</span>
+
+</td><td>
+
+Represents a cookie partition key in Chrome.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.cookies.md
+++ b/docs/api/puppeteer.browser.cookies.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: Browser.cookies
+---
+
+# Browser.cookies() method
+
+Returns all cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
+
+### Signature
+
+```typescript
+class Browser {
+  cookies(): Promise<Cookie[]>;
+}
+```
+
+**Returns:**
+
+Promise&lt;[Cookie](./puppeteer.cookie.md)\[\]&gt;

--- a/docs/api/puppeteer.browser.deletecookie.md
+++ b/docs/api/puppeteer.browser.deletecookie.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: Browser.deleteCookie
+---
+
+# Browser.deleteCookie() method
+
+Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
+
+### Signature
+
+```typescript
+class Browser {
+  deleteCookie(...cookies: Cookie[]): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+cookies
+
+</td><td>
+
+[Cookie](./puppeteer.cookie.md)\[\]
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browser.deletecookie.md
+++ b/docs/api/puppeteer.browser.deletecookie.md
@@ -4,7 +4,7 @@ sidebar_label: Browser.deleteCookie
 
 # Browser.deleteCookie() method
 
-Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
+Removes cookies from the default [BrowserContext](./puppeteer.browsercontext.md).
 
 ### Signature
 

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -154,6 +154,17 @@ Closes this [browser](./puppeteer.browser.md) and all associated [pages](./puppe
 </td></tr>
 <tr><td>
 
+<span id="cookies">[cookies()](./puppeteer.browser.cookies.md)</span>
+
+</td><td>
+
+</td><td>
+
+Returns all cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
+
+</td></tr>
+<tr><td>
+
 <span id="createbrowsercontext">[createBrowserContext(options)](./puppeteer.browser.createbrowsercontext.md)</span>
 
 </td><td>
@@ -178,6 +189,17 @@ Gets the default [browser context](./puppeteer.browsercontext.md).
 **Remarks:**
 
 The default [browser context](./puppeteer.browsercontext.md) cannot be closed.
+
+</td></tr>
+<tr><td>
+
+<span id="deletecookie">[deleteCookie(cookies)](./puppeteer.browser.deletecookie.md)</span>
+
+</td><td>
+
+</td><td>
+
+Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
 
 </td></tr>
 <tr><td>
@@ -245,6 +267,17 @@ Non-visible [pages](./puppeteer.page.md), such as `"background_page"`, will not 
 </td><td>
 
 Gets the associated [ChildProcess](https://nodejs.org/api/child_process.html#class-childprocess).
+
+</td></tr>
+<tr><td>
+
+<span id="setcookie">[setCookie(cookies)](./puppeteer.browser.setcookie.md)</span>
+
+</td><td>
+
+</td><td>
+
+Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -199,7 +199,7 @@ The default [browser context](./puppeteer.browsercontext.md) cannot be closed.
 
 </td><td>
 
-Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
+Removes cookies from the default [BrowserContext](./puppeteer.browsercontext.md).
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.setcookie.md
+++ b/docs/api/puppeteer.browser.setcookie.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: Browser.setCookie
+---
+
+# Browser.setCookie() method
+
+Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
+
+### Signature
+
+```typescript
+class Browser {
+  setCookie(...cookies: Cookie[]): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+cookies
+
+</td><td>
+
+[Cookie](./puppeteer.cookie.md)\[\]
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browsercontext.cookies.md
+++ b/docs/api/puppeteer.browsercontext.cookies.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: BrowserContext.cookies
+---
+
+# BrowserContext.cookies() method
+
+Gets all cookies in the browser context.
+
+### Signature
+
+```typescript
+class BrowserContext {
+  abstract cookies(): Promise<Cookie[]>;
+}
+```
+
+**Returns:**
+
+Promise&lt;[Cookie](./puppeteer.cookie.md)\[\]&gt;

--- a/docs/api/puppeteer.browsercontext.deletecookie.md
+++ b/docs/api/puppeteer.browsercontext.deletecookie.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: BrowserContext.deleteCookie
+---
+
+# BrowserContext.deleteCookie() method
+
+Removes cookie in the browser context
+
+### Signature
+
+```typescript
+class BrowserContext {
+  deleteCookie(...cookies: Cookie[]): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+cookies
+
+</td><td>
+
+[Cookie](./puppeteer.cookie.md)\[\]
+
+</td><td>
+
+[cookie](./puppeteer.cookie.md) to remove
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browsercontext.md
+++ b/docs/api/puppeteer.browsercontext.md
@@ -150,6 +150,28 @@ The [default browser context](./puppeteer.browser.defaultbrowsercontext.md) cann
 </td></tr>
 <tr><td>
 
+<span id="cookies">[cookies()](./puppeteer.browsercontext.cookies.md)</span>
+
+</td><td>
+
+</td><td>
+
+Gets all cookies in the browser context.
+
+</td></tr>
+<tr><td>
+
+<span id="deletecookie">[deleteCookie(cookies)](./puppeteer.browsercontext.deletecookie.md)</span>
+
+</td><td>
+
+</td><td>
+
+Removes cookie in the browser context
+
+</td></tr>
+<tr><td>
+
 <span id="newpage">[newPage()](./puppeteer.browsercontext.newpage.md)</span>
 
 </td><td>
@@ -183,6 +205,17 @@ Gets a list of all open [pages](./puppeteer.page.md) inside this [browser contex
 **Remarks:**
 
 Non-visible [pages](./puppeteer.page.md), such as `"background_page"`, will not be listed here. You can find them using [Target.page()](./puppeteer.target.page.md).
+
+</td></tr>
+<tr><td>
+
+<span id="setcookie">[setCookie(cookies)](./puppeteer.browsercontext.setcookie.md)</span>
+
+</td><td>
+
+</td><td>
+
+Sets a cookie in the browser context.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browsercontext.setcookie.md
+++ b/docs/api/puppeteer.browsercontext.setcookie.md
@@ -1,0 +1,48 @@
+---
+sidebar_label: BrowserContext.setCookie
+---
+
+# BrowserContext.setCookie() method
+
+Sets a cookie in the browser context.
+
+### Signature
+
+```typescript
+class BrowserContext {
+  abstract setCookie(...cookies: Cookie[]): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+cookies
+
+</td><td>
+
+[Cookie](./puppeteer.cookie.md)\[\]
+
+</td><td>
+
+[cookie](./puppeteer.cookie.md) to set
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.chromecookiepartitionkey.md
+++ b/docs/api/puppeteer.chromecookiepartitionkey.md
@@ -1,0 +1,74 @@
+---
+sidebar_label: ChromeCookiePartitionKey
+---
+
+# ChromeCookiePartitionKey interface
+
+Represents a cookie partition key in Chrome.
+
+### Signature
+
+```typescript
+export interface ChromeCookiePartitionKey
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="hascrosssiteancestor">hasCrossSiteAncestor</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Indicates if the cookie has any ancestors that are cross-site to the topLevelSite.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="toplevelsite">topLevelSite</span>
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+The site of the top-level URL the browser was visiting at the start of the request to the endpoint that set the cookie.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.convertcookiespartitionkeyfrompuppeteertocdp.md
+++ b/docs/api/puppeteer.convertcookiespartitionkeyfrompuppeteertocdp.md
@@ -1,0 +1,44 @@
+---
+sidebar_label: convertCookiesPartitionKeyFromPuppeteerToCdp
+---
+
+# convertCookiesPartitionKeyFromPuppeteerToCdp() function
+
+### Signature
+
+```typescript
+export declare function convertCookiesPartitionKeyFromPuppeteerToCdp(
+  partitionKey: ChromeCookiePartitionKey | string | undefined,
+): Protocol.Network.CookiePartitionKey | undefined;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+partitionKey
+
+</td><td>
+
+[ChromeCookiePartitionKey](./puppeteer.chromecookiepartitionkey.md) \| string \| undefined
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Protocol.Network.CookiePartitionKey \| undefined

--- a/docs/api/puppeteer.cookie.md
+++ b/docs/api/puppeteer.cookie.md
@@ -113,7 +113,7 @@ Cookie name.
 
 </td><td>
 
-string
+[ChromeCookiePartitionKey](./puppeteer.chromecookiepartitionkey.md) \| string
 
 </td><td>
 

--- a/docs/api/puppeteer.cookieparam.md
+++ b/docs/api/puppeteer.cookieparam.md
@@ -119,7 +119,7 @@ Cookie name.
 
 </td><td>
 
-string
+[ChromeCookiePartitionKey](./puppeteer.chromecookiepartitionkey.md) \| string
 
 </td><td>
 

--- a/docs/api/puppeteer.deletecookiesrequest.md
+++ b/docs/api/puppeteer.deletecookiesrequest.md
@@ -79,7 +79,7 @@ Name of the cookies to remove.
 
 </td><td>
 
-string
+[ChromeCookiePartitionKey](./puppeteer.chromecookiepartitionkey.md) \| string
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -439,7 +439,7 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
   }
 
   /**
-   * Sets cookies in the default {@link BrowserContext}.
+   * Removes cookies from the default {@link BrowserContext}.
    */
   async deleteCookie(...cookies: Cookie[]): Promise<void> {
     return await this.defaultBrowserContext().deleteCookie(...cookies);

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -15,6 +15,7 @@ import {
   raceWith,
 } from '../../third_party/rxjs/rxjs.js';
 import type {ProtocolType} from '../common/ConnectOptions.js';
+import type {Cookie} from '../common/Cookie.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {
@@ -24,7 +25,6 @@ import {
   timeout,
   fromAbortSignal,
 } from '../common/util.js';
-import type {Cookie} from '../puppeteer-core.js';
 import {asyncDisposeSymbol, disposeSymbol} from '../util/disposable.js';
 
 import type {BrowserContext} from './BrowserContext.js';

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -24,6 +24,7 @@ import {
   timeout,
   fromAbortSignal,
 } from '../common/util.js';
+import type {Cookie} from '../puppeteer-core.js';
 import {asyncDisposeSymbol, disposeSymbol} from '../util/disposable.js';
 
 import type {BrowserContext} from './BrowserContext.js';
@@ -423,6 +424,26 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * process running.
    */
   abstract disconnect(): Promise<void>;
+
+  /**
+   * Returns all cookies in the default {@link BrowserContext}.
+   */
+  async cookies(): Promise<Cookie[]> {
+    return await this.defaultBrowserContext().cookies();
+  }
+  /**
+   * Sets cookies in the default {@link BrowserContext}.
+   */
+  async setCookie(...cookies: Cookie[]): Promise<void> {
+    return await this.defaultBrowserContext().setCookie(...cookies);
+  }
+
+  /**
+   * Sets cookies in the default {@link BrowserContext}.
+   */
+  async deleteCookie(...cookies: Cookie[]): Promise<void> {
+    return await this.defaultBrowserContext().deleteCookie(...cookies);
+  }
 
   /**
    * Whether Puppeteer is connected to this {@link Browser | browser}.

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -10,6 +10,7 @@ import {
   merge,
   raceWith,
 } from '../../third_party/rxjs/rxjs.js';
+import type {Cookie} from '../common/Cookie.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {
   debugError,
@@ -242,6 +243,32 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
    * closed.
    */
   abstract close(): Promise<void>;
+
+  /**
+   * Gets all cookies in the browser context.
+   */
+  abstract cookies(): Promise<Cookie[]>;
+
+  /**
+   * Sets a cookie in the browser context.
+   * @param cookies - {@link Cookie | cookie} to set
+   */
+  abstract setCookie(...cookies: Cookie[]): Promise<void>;
+
+  /**
+   * Removes cookie in the browser context
+   * @param cookies - {@link Cookie | cookie} to remove
+   */
+  async deleteCookie(...cookies: Cookie[]): Promise<void> {
+    return await this.setCookie(
+      ...cookies.map(cookie => {
+        return {
+          ...cookie,
+          expires: 1,
+        };
+      }),
+    );
+  }
 
   /**
    * Whether this {@link BrowserContext | browser context} is closed.

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -27,6 +27,7 @@ import {
   BidiPage,
   bidiToPuppeteerCookie,
   cdpSpecificCookiePropertiesFromPuppeteerToBidi,
+  convertCookiesExpiryCdpToBiDi,
   convertCookiesSameSiteCdpToBiDi,
 } from './Page.js';
 import {BidiWorkerTarget} from './Target.js';
@@ -309,7 +310,7 @@ export class BidiBrowserContext extends BrowserContext {
           ...(cookie.sameSite !== undefined
             ? {sameSite: convertCookiesSameSiteCdpToBiDi(cookie.sameSite)}
             : {}),
-          ...(cookie.expires !== undefined ? {expiry: cookie.expires} : {}),
+          ...{expiry: convertCookiesExpiryCdpToBiDi(cookie.expires)},
           // Chrome-specific properties.
           ...cdpSpecificCookiePropertiesFromPuppeteerToBidi(
             cookie,

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -12,6 +12,7 @@ import type {BrowserContextEvents} from '../api/BrowserContext.js';
 import {BrowserContext, BrowserContextEvent} from '../api/BrowserContext.js';
 import {PageEvent, type Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
+import type {Cookie} from '../common/Cookie.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
@@ -22,7 +23,12 @@ import type {BidiBrowser} from './Browser.js';
 import type {BrowsingContext} from './core/BrowsingContext.js';
 import {UserContext} from './core/UserContext.js';
 import type {BidiFrame} from './Frame.js';
-import {BidiPage} from './Page.js';
+import {
+  BidiPage,
+  bidiToPuppeteerCookie,
+  cdpSpecificCookiePropertiesFromPuppeteerToBidi,
+  convertCookiesSameSiteCdpToBiDi,
+} from './Page.js';
 import {BidiWorkerTarget} from './Target.js';
 import {BidiFrameTarget, BidiPageTarget} from './Target.js';
 import type {BidiWebWorker} from './WebWorker.js';
@@ -280,5 +286,44 @@ export class BidiBrowserContext extends BrowserContext {
       return undefined;
     }
     return this.userContext.id;
+  }
+
+  override async cookies(): Promise<Cookie[]> {
+    const cookies = await this.userContext.getCookies();
+    return cookies.map(bidiToPuppeteerCookie);
+  }
+
+  override async setCookie(...cookies: Cookie[]): Promise<void> {
+    await Promise.all(
+      cookies.map(async cookie => {
+        const bidiCookie: Bidi.Storage.PartialCookie = {
+          domain: cookie.domain,
+          name: cookie.name,
+          value: {
+            type: 'string',
+            value: cookie.value,
+          },
+          ...(cookie.path !== undefined ? {path: cookie.path} : {}),
+          ...(cookie.httpOnly !== undefined ? {httpOnly: cookie.httpOnly} : {}),
+          ...(cookie.secure !== undefined ? {secure: cookie.secure} : {}),
+          ...(cookie.sameSite !== undefined
+            ? {sameSite: convertCookiesSameSiteCdpToBiDi(cookie.sameSite)}
+            : {}),
+          ...(cookie.expires !== undefined ? {expiry: cookie.expires} : {}),
+          // Chrome-specific properties.
+          ...cdpSpecificCookiePropertiesFromPuppeteerToBidi(
+            cookie,
+            'sameParty',
+            'sourceScheme',
+            'priority',
+            'url',
+          ),
+        };
+        return await this.userContext.setCookie(
+          bidiCookie,
+          cookie.partitionKey,
+        );
+      }),
+    );
   }
 }

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -28,6 +28,7 @@ import {
   bidiToPuppeteerCookie,
   cdpSpecificCookiePropertiesFromPuppeteerToBidi,
   convertCookiesExpiryCdpToBiDi,
+  convertCookiesPartitionKeyFromPuppeteerToBiDi,
   convertCookiesSameSiteCdpToBiDi,
 } from './Page.js';
 import {BidiWorkerTarget} from './Target.js';
@@ -322,7 +323,7 @@ export class BidiBrowserContext extends BrowserContext {
         };
         return await this.userContext.setCookie(
           bidiCookie,
-          cookie.partitionKey,
+          convertCookiesPartitionKeyFromPuppeteerToBiDi(cookie.partitionKey),
         );
       }),
     );

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -734,6 +734,10 @@ export class BidiPage extends Page {
         !String.prototype.startsWith.call(cookieUrl || '', 'data:'),
         `Data URL page can not have cookie "${cookie.name}"`,
       );
+      assert(
+        typeof cookie.partitionKey === 'string',
+        `BiDi only allows domain partition keys`,
+      );
 
       const normalizedUrl = URL.canParse(cookieUrl)
         ? new URL(cookieUrl)

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -922,7 +922,7 @@ function testUrlMatchCookie(cookie: Cookie, url: URL): boolean {
   return testUrlMatchCookiePath(cookie, normalizedUrl);
 }
 
-function bidiToPuppeteerCookie(bidiCookie: Bidi.Network.Cookie): Cookie {
+export function bidiToPuppeteerCookie(bidiCookie: Bidi.Network.Cookie): Cookie {
   const partitionKey = bidiCookie[CDP_SPECIFIC_PREFIX + 'partitionKey'];
 
   function getParitionKey(): {partitionKey?: string} {
@@ -985,7 +985,7 @@ function cdpSpecificCookiePropertiesFromBidiToPuppeteer(
  * Gets CDP-specific properties from the cookie, adds CDP-specific prefixes and returns
  * them as a new object which can be used in BiDi.
  */
-function cdpSpecificCookiePropertiesFromPuppeteerToBidi(
+export function cdpSpecificCookiePropertiesFromPuppeteerToBidi(
   cookieParam: CookieParam,
   ...propertyNames: Array<keyof CookieParam>
 ): Record<string, unknown> {
@@ -1004,7 +1004,7 @@ function convertCookiesSameSiteBiDiToCdp(
   return sameSite === 'strict' ? 'Strict' : sameSite === 'lax' ? 'Lax' : 'None';
 }
 
-function convertCookiesSameSiteCdpToBiDi(
+export function convertCookiesSameSiteCdpToBiDi(
   sameSite: CookieSameSite | undefined,
 ): Bidi.Network.SameSite {
   return sameSite === 'Strict'

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -758,7 +758,7 @@ export class BidiPage extends Page {
         ...(cookie.sameSite !== undefined
           ? {sameSite: convertCookiesSameSiteCdpToBiDi(cookie.sameSite)}
           : {}),
-        ...(cookie.expires !== undefined ? {expiry: cookie.expires} : {}),
+        ...{expiry: convertCookiesExpiryCdpToBiDi(cookie.expires)},
         // Chrome-specific properties.
         ...cdpSpecificCookiePropertiesFromPuppeteerToBidi(
           cookie,
@@ -1012,4 +1012,10 @@ export function convertCookiesSameSiteCdpToBiDi(
     : sameSite === 'Lax'
       ? Bidi.Network.SameSite.Lax
       : Bidi.Network.SameSite.None;
+}
+
+export function convertCookiesExpiryCdpToBiDi(
+  expiry: number | undefined,
+): number | undefined {
+  return [undefined, -1].includes(expiry) ? undefined : expiry;
 }

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -735,7 +735,7 @@ export class BidiPage extends Page {
         `Data URL page can not have cookie "${cookie.name}"`,
       );
       assert(
-        typeof cookie.partitionKey === 'string',
+        cookie.partitionKey === undefined || typeof cookie.partitionKey === 'string',
         `BiDi only allows domain partition keys`,
       );
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -735,10 +735,11 @@ export class BidiPage extends Page {
         !String.prototype.startsWith.call(cookieUrl || '', 'data:'),
         `Data URL page can not have cookie "${cookie.name}"`,
       );
+      // TODO: Support Chrome cookie partition keys
       assert(
         cookie.partitionKey === undefined ||
           typeof cookie.partitionKey === 'string',
-        `BiDi only allows domain partition keys`,
+        'BiDi only allows domain partition keys',
       );
 
       const normalizedUrl = URL.canParse(cookieUrl)

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -32,6 +32,7 @@ import type {
 } from '../cdp/NetworkManager.js';
 import {Tracing} from '../cdp/Tracing.js';
 import type {
+  ChromeCookiePartitionKey,
   Cookie,
   CookieParam,
   CookieSameSite,
@@ -735,7 +736,8 @@ export class BidiPage extends Page {
         `Data URL page can not have cookie "${cookie.name}"`,
       );
       assert(
-        cookie.partitionKey === undefined || typeof cookie.partitionKey === 'string',
+        cookie.partitionKey === undefined ||
+          typeof cookie.partitionKey === 'string',
         `BiDi only allows domain partition keys`,
       );
 
@@ -1022,4 +1024,13 @@ export function convertCookiesExpiryCdpToBiDi(
   expiry: number | undefined,
 ): number | undefined {
   return [undefined, -1].includes(expiry) ? undefined : expiry;
+}
+
+export function convertCookiesPartitionKeyFromPuppeteerToBiDi(
+  partitionKey: ChromeCookiePartitionKey | string | undefined,
+): string | undefined {
+  if (partitionKey === undefined || typeof partitionKey === 'string') {
+    return partitionKey;
+  }
+  return partitionKey.topLevelSite;
 }

--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -16,6 +16,7 @@ import {assert} from '../util/assert.js';
 
 import type {CdpBrowser} from './Browser.js';
 import type {Connection} from './Connection.js';
+import {convertCookiesPartitionKeyFromPuppeteerToCdp} from './Page.js';
 import type {CdpTarget} from './Target.js';
 
 /**
@@ -120,12 +121,9 @@ export class CdpBrowserContext extends BrowserContext {
       cookies: cookies.map(cookie => {
         return {
           ...cookie,
-          partitionKey: cookie.partitionKey
-            ? {
-                topLevelSite: cookie.partitionKey,
-                hasCrossSiteAncestor: false,
-              }
-            : undefined,
+          partitionKey: convertCookiesPartitionKeyFromPuppeteerToCdp(
+            cookie.partitionKey,
+          ),
         };
       }),
     });

--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -10,6 +10,7 @@ import {
 } from '../api/Browser.js';
 import {BrowserContext} from '../api/BrowserContext.js';
 import type {Page} from '../api/Page.js';
+import type {Cookie} from '../common/Cookie.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
 import {assert} from '../util/assert.js';
 
@@ -98,6 +99,40 @@ export class CdpBrowserContext extends BrowserContext {
   override async close(): Promise<void> {
     assert(this.#id, 'Default BrowserContext cannot be closed!');
     await this.#browser._disposeContext(this.#id);
+  }
+
+  override async cookies(): Promise<Cookie[]> {
+    const {cookies} = await this.#connection.send('Storage.getCookies', {
+      browserContextId: this.#id || undefined,
+    });
+    return cookies.map(cookie => {
+      return {
+        ...cookie,
+        // TODO: a breaking change is needed in Puppeteer types to support other
+        // partition keys.
+        partitionKey: cookie.partitionKey
+          ? cookie.partitionKey.topLevelSite
+          : undefined,
+      };
+    });
+  }
+
+  override async setCookie(...cookies: Cookie[]): Promise<void> {
+    return await this.#connection.send('Storage.setCookies', {
+      cookies: cookies.map(cookie => {
+        return {
+          ...cookie,
+          // TODO: a breaking change is needed in Puppeteer types to support other
+          // partition keys.
+          partitionKey: cookie.partitionKey
+            ? {
+                topLevelSite: cookie.partitionKey,
+                hasCrossSiteAncestor: false,
+              }
+            : undefined,
+        };
+      }),
+    });
   }
 
   public async setDownloadBehavior(

--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -108,8 +108,6 @@ export class CdpBrowserContext extends BrowserContext {
     return cookies.map(cookie => {
       return {
         ...cookie,
-        // TODO: a breaking change is needed in Puppeteer types to support other
-        // partition keys.
         partitionKey: cookie.partitionKey
           ? cookie.partitionKey.topLevelSite
           : undefined,
@@ -122,8 +120,6 @@ export class CdpBrowserContext extends BrowserContext {
       cookies: cookies.map(cookie => {
         return {
           ...cookie,
-          // TODO: a breaking change is needed in Puppeteer types to support other
-          // partition keys.
           partitionKey: cookie.partitionKey
             ? {
                 topLevelSite: cookie.partitionKey,

--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -106,14 +106,7 @@ export class CdpBrowserContext extends BrowserContext {
     const {cookies} = await this.#connection.send('Storage.getCookies', {
       browserContextId: this.#id || undefined,
     });
-    return cookies.map(cookie => {
-      return {
-        ...cookie,
-        partitionKey: cookie.partitionKey
-          ? cookie.partitionKey.topLevelSite
-          : undefined,
-      };
-    });
+    return cookies;
   }
 
   override async setCookie(...cookies: Cookie[]): Promise<void> {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -611,7 +611,9 @@ export class CdpPage extends Page {
     for (const cookie of cookies) {
       const item = {
         ...cookie,
-        partitionKey: convertCookiesPartitionKeyFromPuppeteerToCdp(cookie.partitionKey),
+        partitionKey: convertCookiesPartitionKeyFromPuppeteerToCdp(
+          cookie.partitionKey,
+        ),
       };
       if (!cookie.url && pageURL.startsWith('http')) {
         item.url = pageURL;

--- a/packages/puppeteer-core/src/common/Cookie.ts
+++ b/packages/puppeteer-core/src/common/Cookie.ts
@@ -30,6 +30,23 @@ export type CookiePriority = 'Low' | 'Medium' | 'High';
 export type CookieSourceScheme = 'Unset' | 'NonSecure' | 'Secure';
 
 /**
+ * Represents a cookie partition key in Chrome.
+ *
+ * @public
+ */
+export interface ChromeCookiePartitionKey {
+  /**
+   * The site of the top-level URL the browser was visiting at the start of the request
+   * to the endpoint that set the cookie.
+   */
+  topLevelSite: string;
+  /**
+   * Indicates if the cookie has any ancestors that are cross-site to the topLevelSite.
+   */
+  hasCrossSiteAncestor?: boolean;
+}
+
+/**
  * Represents a cookie object.
  *
  * @public
@@ -162,7 +179,7 @@ export interface CookieParam {
    * source origin
    * (https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
    */
-  partitionKey?: string;
+  partitionKey?: ChromeCookiePartitionKey | string;
 }
 
 /**
@@ -192,5 +209,5 @@ export interface DeleteCookiesRequest {
    * cookie is available in. In Firefox, it matches the source origin
    * (https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
    */
-  partitionKey?: string;
+  partitionKey?: ChromeCookiePartitionKey | string;
 }

--- a/packages/puppeteer-core/src/common/Cookie.ts
+++ b/packages/puppeteer-core/src/common/Cookie.ts
@@ -111,7 +111,7 @@ export interface Cookie {
    * source origin
    * (https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
    */
-  partitionKey?: string;
+  partitionKey?: ChromeCookiePartitionKey | string;
   /**
    * True if cookie partition key is opaque. Supported only in Chrome.
    */

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3428,7 +3428,7 @@
   {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
     "platforms": ["linux"],
-    "parameters": ["cdp", "firefox", "headless"],
+    "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Firefox CDP does not support cookie settings"
   },

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -244,6 +244,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "BiDi partition key requires refactor (no longer string)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with string partition key",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "BiDi partition key requires refactor (no longer string)"
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.deleteCookie should delete cookie for specified URL regardless of the current page",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -1136,6 +1150,27 @@
     "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.deleteCookies should delete cookies",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"],
+    "comment": "Fails with fieldtrial testing config in Chrome"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.deleteCookies should delete cookies",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.setCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"],
+    "comment": "Fails with fieldtrial testing config in Chrome"
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -1145,9 +1180,23 @@
   {
     "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with string partition key",
     "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"],
+    "comment": "Fails with fieldtrial testing config in Chrome"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with string partition key",
+    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Firefox CDP does not support Storage.setCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set with undefined partition key",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"],
+    "comment": "Fails with fieldtrial testing config in Chrome"
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set with undefined partition key",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3426,6 +3426,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
+    "platforms": ["linux"],
+    "parameters": ["cdp", "firefox", "headless"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support cookie settings"
+  },
+  {
     "testIdPattern": "[devtools.spec] DevTools should expose DevTools as a page",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -251,13 +251,6 @@
     "comment": "The test relies on the default page partition key do not contain the source origin. This is not the case for Firefox."
   },
   {
-    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["FAIL"],
-    "comment": "Chromium-specific test. The sourceScheme property is chromium-specific."
-  },
-  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set secure same-site cookies from a frame",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome"],
@@ -1141,13 +1134,6 @@
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
-  },
-  {
-    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "expiry value `-1` not supported by BiDi"
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1129,6 +1129,34 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.cookies should find cookie created in page",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.cookies should find no cookies in new context",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "expiry value `-1` not supported by BiDi"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.setCookies (UnknownMethodError)"
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.cookies should get cookies from nested path",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -3410,13 +3438,6 @@
     "parameters": ["cdp", "chrome", "headless"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",
-    "platforms": ["darwin"],
-    "parameters": ["firefox", "headless", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "expiry value `-1` not supported by BiDi"
   },
   {
     "testIdPattern": "[devtools.spec] DevTools should expose DevTools as a page",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -244,6 +244,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.cookies should find partitioned cookie",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "BiDi partition key requires refactor (no longer string)"
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -1148,6 +1155,20 @@
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.cookies should find partitioned cookie",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.cookies should find partitioned cookie",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"],
+    "comment": "Fails with fieldtrial testing config in Chrome"
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.deleteCookies should delete cookies",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1136,7 +1136,7 @@
     "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
   },
   {
-    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set with undefined partition key",
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
@@ -1150,7 +1150,7 @@
     "comment": "Firefox CDP does not support Storage.setCookies (UnknownMethodError)"
   },
   {
-    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set with undefined partition key",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3427,7 +3427,7 @@
   },
   {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
-    "platforms": ["linux"],
+    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],
     "comment": "Firefox CDP does not support cookie settings"

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1136,7 +1136,21 @@
     "comment": "Firefox CDP does not support Storage.getCookies (UnknownMethodError)"
   },
   {
-    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set with undefined partition key",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.setCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with string partition key",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support Storage.setCookies (UnknownMethodError)"
+  },
+  {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should set cookie with chrome partition key",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
     "expectations": ["FAIL"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3412,6 +3412,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs BrowserContext.setCookie should work",
+    "platforms": ["darwin"],
+    "parameters": ["firefox", "headless", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "expiry value `-1` not supported by BiDi"
+  },
+  {
     "testIdPattern": "[devtools.spec] DevTools should expose DevTools as a page",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1241,6 +1241,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox CDP does not support cookie settings"
+  },
+  {
     "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with reasonable defaults",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],
@@ -3424,13 +3431,6 @@
     "parameters": ["cdp", "chrome", "headless"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[cookies.spec] Cookie specs Page.setCookie should set cookie with all available properties",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "firefox"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox CDP does not support cookie settings"
   },
   {
     "testIdPattern": "[devtools.spec] DevTools should expose DevTools as a page",

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -865,6 +865,33 @@ describe('Cookie specs', () => {
         },
       ]);
     });
+    it('should find partitioned cookie', async () => {
+      const {context} = await getTestState();
+      const topLevelSite = 'https://localhost:8000';
+      await context.setCookie({
+        name: 'infoCookie',
+        value: 'secret',
+        domain: 'localhost',
+        path: '/',
+        sameParty: false,
+        expires: -1,
+        size: 16,
+        httpOnly: false,
+        secure: false,
+        session: true,
+        partitionKey: {
+          topLevelSite: topLevelSite,
+          hasCrossSiteAncestor: false,
+        },
+        sourceScheme: 'NonSecure',
+      });
+      const cookies = await context.cookies();
+      expect(cookies.length).toEqual(1);
+      expect(cookies[0]?.partitionKey).toEqual({
+        topLevelSite: topLevelSite,
+        hasCrossSiteAncestor: false,
+      });
+    });
   });
   describe('BrowserContext.setCookie', function () {
     it('should set with undefined partition key', async () => {

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -867,7 +867,7 @@ describe('Cookie specs', () => {
     });
   });
   describe('BrowserContext.setCookie', function () {
-    it('should work', async () => {
+    it('should set with undefined partition key', async () => {
       const {page, context, server} = await getTestState();
       await context.setCookie({
         name: 'infoCookie',
@@ -880,6 +880,61 @@ describe('Cookie specs', () => {
         httpOnly: false,
         secure: false,
         session: true,
+        sourceScheme: 'NonSecure',
+      });
+
+      await page.goto(server.EMPTY_PAGE);
+
+      expect(
+        await page.evaluate(() => {
+          return document.cookie;
+        }),
+      ).toEqual('infoCookie=secret');
+    });
+
+    it("should set cookie with string partition key", async () => {
+      const {page, context, server} = await getTestState();
+      await context.setCookie({
+        name: 'infoCookie',
+        value: 'secret',
+        domain: 'localhost',
+        path: '/',
+        sameParty: false,
+        expires: -1,
+        size: 16,
+        httpOnly: false,
+        secure: false,
+        session: true,
+        partitionKey: "https://localhost:8000",
+        sourceScheme: 'NonSecure',
+      });
+
+      await page.goto(server.EMPTY_PAGE);
+
+      expect(
+        await page.evaluate(() => {
+          return document.cookie;
+        }),
+      ).toEqual('infoCookie=secret');
+    });
+
+    it("should set cookie with chrome partition key", async () => {
+      const {page, context, server} = await getTestState();
+      await context.setCookie({
+        name: 'infoCookie',
+        value: 'secret',
+        domain: 'localhost',
+        path: '/',
+        sameParty: false,
+        expires: -1,
+        size: 16,
+        httpOnly: false,
+        secure: false,
+        session: true,
+        partitionKey: {
+          topLevelSite: "https://localhost:8000",
+          hasCrossSiteAncestor: false,
+        },
         sourceScheme: 'NonSecure',
       });
 

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -892,7 +892,7 @@ describe('Cookie specs', () => {
       ).toEqual('infoCookie=secret');
     });
 
-    it("should set cookie with string partition key", async () => {
+    it('should set cookie with string partition key', async () => {
       const {page, context, server} = await getTestState();
       await context.setCookie({
         name: 'infoCookie',
@@ -905,7 +905,7 @@ describe('Cookie specs', () => {
         httpOnly: false,
         secure: false,
         session: true,
-        partitionKey: "https://localhost:8000",
+        partitionKey: 'https://localhost:8000',
         sourceScheme: 'NonSecure',
       });
 
@@ -918,7 +918,7 @@ describe('Cookie specs', () => {
       ).toEqual('infoCookie=secret');
     });
 
-    it("should set cookie with chrome partition key", async () => {
+    it('should set cookie with chrome partition key', async () => {
       const {page, context, server} = await getTestState();
       await context.setCookie({
         name: 'infoCookie',
@@ -932,7 +932,7 @@ describe('Cookie specs', () => {
         secure: false,
         session: true,
         partitionKey: {
-          topLevelSite: "https://localhost:8000",
+          topLevelSite: 'https://localhost:8000',
           hasCrossSiteAncestor: false,
         },
         sourceScheme: 'NonSecure',

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -892,4 +892,62 @@ describe('Cookie specs', () => {
       ).toEqual('infoCookie=secret');
     });
   });
+
+  describe('BrowserContext.deleteCookies', () => {
+    it('should delete cookies', async () => {
+      const {page, context, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+      await context.setCookie(
+        {
+          name: 'cookie1',
+          value: '1',
+          domain: 'localhost',
+          path: '/',
+          sameParty: false,
+          expires: -1,
+          size: 16,
+          httpOnly: false,
+          secure: false,
+          session: true,
+          sourceScheme: 'NonSecure',
+        },
+        {
+          name: 'cookie2',
+          value: '2',
+          domain: 'localhost',
+          path: '/',
+          sameParty: false,
+          expires: -1,
+          size: 16,
+          httpOnly: false,
+          secure: false,
+          session: true,
+          sourceScheme: 'NonSecure',
+        },
+      );
+      expect(
+        await page.evaluate(() => {
+          return document.cookie;
+        }),
+      ).toEqual('cookie1=1; cookie2=2');
+      await context.deleteCookie({
+        name: 'cookie1',
+        value: '1',
+        domain: 'localhost',
+        path: '/',
+        sameParty: false,
+        expires: -1,
+        size: 16,
+        httpOnly: false,
+        secure: false,
+        session: true,
+        sourceScheme: 'NonSecure',
+      });
+      expect(
+        await page.evaluate(() => {
+          return document.cookie;
+        }),
+      ).toEqual('cookie2=2');
+    });
+  });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feature - supporting cookies API in the browser context level (and the browser level for the default context).

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Yes

**Summary**

Up until now, the cookies API was only exposed via the Page interface. This only supported setting cookies for the current domain, which is sometimes not what users are looking for.

This is brought up in issue #645 and a part of puppeteer v24 (#12921)

**Does this PR introduce a breaking change?**

No, this is backward compatible. 

**Other information**
