### PR TITLE
feat: get rendered fonts for element

### DIFF
--- a/docs/api/puppeteer.elementhandle.md
+++ b/docs/api/puppeteer.elementhandle.md
@@ -406,6 +406,15 @@ If `key` is a single character and no modifier keys besides `Shift` are being he
 </td></tr>
 <tr><td>
 
+<span id="renderedfonts">[renderedFonts()](./puppeteer.elementhandle.renderedfonts.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="screenshot">[screenshot(options)](./puppeteer.elementhandle.screenshot.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.elementhandle.renderedfonts.md
+++ b/docs/api/puppeteer.elementhandle.renderedfonts.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: ElementHandle.renderedFonts
+---
+
+# ElementHandle.renderedFonts() method
+
+### Signature
+
+```typescript
+class ElementHandle {
+  abstract renderedFonts(): Promise<PlatformFontUsage[]>;
+}
+```
+
+**Returns:**
+
+Promise&lt;PlatformFontUsage\[\]&gt;

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -7,6 +7,7 @@
 import type {Protocol} from 'devtools-protocol';
 
 import type {Frame} from '../api/Frame.js';
+import type {PlatformFontUsage} from '../common/fonts.js';
 import {getQueryHandlerAndSelector} from '../common/GetQueryHandler.js';
 import {LazyArg} from '../common/LazyArg.js';
 import type {
@@ -1561,6 +1562,8 @@ export abstract class ElementHandle<
    * ```
    */
   abstract autofill(data: AutofillData): Promise<void>;
+
+  abstract renderedFonts(): Promise<PlatformFontUsage[]>;
 }
 
 /**

--- a/packages/puppeteer-core/src/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/bidi/ElementHandle.ts
@@ -11,6 +11,7 @@ import {
   ElementHandle,
   type AutofillData,
 } from '../api/ElementHandle.js';
+import type {PlatformFontUsage} from '../common/fonts.js';
 import type {AwaitableIterable} from '../common/types.js';
 import {environment} from '../environment.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
@@ -131,5 +132,9 @@ export class BidiElementHandle<
       // TODO: maybe change ownership since the default ownership is probably none.
       return Promise.resolve(BidiElementHandle.from(node, this.realm));
     });
+  }
+
+  override renderedFonts(): Promise<PlatformFontUsage[]> {
+    throw new Error('not supported in BiDi');
   }
 }

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -12,6 +12,7 @@ import {
   ElementHandle,
   type AutofillData,
 } from '../api/ElementHandle.js';
+import type {PlatformFontUsage} from '../common/fonts.js';
 import type {AwaitableIterable} from '../common/types.js';
 import {debugError} from '../common/util.js';
 import {environment} from '../environment.js';
@@ -200,5 +201,21 @@ export class CdpElementHandle<
         ElementHandle<Node>
       >;
     });
+  }
+
+  override async renderedFonts(): Promise<PlatformFontUsage[]> {
+    await this.client.send('DOM.getDocument', {depth: -1});
+    const nodeInfo = await this.client.send('DOM.requestNode', {
+      objectId: this.id as string,
+    });
+    const nodeId = nodeInfo.nodeId;
+    await this.client.send('CSS.enable');
+    const platformFonts = await this.client.send(
+      'CSS.getPlatformFontsForNode',
+      {
+        nodeId,
+      },
+    );
+    return platformFonts.fonts;
   }
 }

--- a/packages/puppeteer-core/src/common/fonts.ts
+++ b/packages/puppeteer-core/src/common/fonts.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * Information about amount of glyphs that were rendered with given font.
+ * See https://chromedevtools.github.io/devtools-protocol/tot/CSS/#type-PlatformFontUsage
+ *
+ * @public
+ */
+export interface PlatformFontUsage {
+  /**
+   * Font's family name reported by platform.
+   */
+  familyName: string;
+  /**
+   * Font's PostScript name reported by the platform.
+   */
+  postScriptName: string;
+  /**
+   * Indicates whether the font was downloaded or resolved locally.
+   */
+  isCustomFont: boolean;
+  /**
+   * Amount of glyphs that were rendered with this font.
+   */
+  glyphCount: number;
+}

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -328,6 +328,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[elementhandle.spec] ElementHandle spces ElementHandle.renderedFonts should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "BiDi does not offer support for this functionality"
+  },
+  {
     "testIdPattern": "[elementhandle.spec] ElementHandle specs ElementHandle.boundingBox should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/assets/credit-card.html
+++ b/test/assets/credit-card.html
@@ -19,7 +19,7 @@
         </tr>
         <tr>
           <td>
-            <label for="number">Card Number</label>
+            <label for="number" id="cardnumber">Card Number</label>
           </td>
           <td>
             <input size="40" id="number" name="card_number" />

--- a/test/src/elementhandle.spec.ts
+++ b/test/src/elementhandle.spec.ts
@@ -1205,4 +1205,19 @@ describe('ElementHandle specs', function () {
       expect(handle.disposed).toBeFalsy();
     });
   });
+
+  describe('ElementHandle.renderedFonts', () => {
+    it('should work', async () => {
+      const {server, page} = await getTestState();
+      await page.goto(server.PREFIX + '/credit-card.html');
+      using handle = await page.evaluateHandle(() => {
+        return document.querySelector('#cardnumber');
+      });
+
+      expect(handle).toBeInstanceOf(ElementHandle);
+      const fonts = await (handle as ElementHandle).renderedFonts();
+      expect(fonts.length).toEqual(1);
+      expect(fonts[0]?.isCustomFont).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
feature

**Did you add tests for your changes?**
Yes
**If relevant, did you update the documentation?**
Yes
**Summary**
Adds the ability to get the rendered fonts (and some metadata) for text nodes, based on element handle. 
Solves #9757 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
