### PR TITLE
feat: implement ElementHandle.backendNodeId

### DIFF
--- a/docs/api/puppeteer.elementhandle.backendnodeid.md
+++ b/docs/api/puppeteer.elementhandle.backendnodeid.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ElementHandle.backendNodeId
+---
+
+# ElementHandle.backendNodeId() method
+
+When connected using Chrome DevTools Protocol, it returns a DOM.BackendNodeId for the element.
+
+### Signature
+
+```typescript
+class ElementHandle {
+  abstract backendNodeId(): Promise<number>;
+}
+```
+
+**Returns:**
+
+Promise&lt;number&gt;

--- a/docs/api/puppeteer.elementhandle.md
+++ b/docs/api/puppeteer.elementhandle.md
@@ -172,6 +172,17 @@ await name.autofill({
 </td></tr>
 <tr><td>
 
+<span id="backendnodeid">[backendNodeId()](./puppeteer.elementhandle.backendnodeid.md)</span>
+
+</td><td>
+
+</td><td>
+
+When connected using Chrome DevTools Protocol, it returns a DOM.BackendNodeId for the element.
+
+</td></tr>
+<tr><td>
+
 <span id="boundingbox">[boundingBox()](./puppeteer.elementhandle.boundingbox.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -1561,6 +1561,12 @@ export abstract class ElementHandle<
    * ```
    */
   abstract autofill(data: AutofillData): Promise<void>;
+
+  /**
+   * When connected using Chrome DevTools Protocol, it returns a
+   * DOM.BackendNodeId for the element.
+   */
+  abstract backendNodeId(): Promise<number>;
 }
 
 /**

--- a/packages/puppeteer-core/src/cdp/ElementHandle.ts
+++ b/packages/puppeteer-core/src/cdp/ElementHandle.ts
@@ -37,6 +37,7 @@ export class CdpElementHandle<
   ElementType extends Node = Element,
 > extends ElementHandle<ElementType> {
   protected declare readonly handle: CdpJSHandle<ElementType>;
+  #backendNodeId?: number;
 
   constructor(
     world: IsolatedWorld,
@@ -200,5 +201,16 @@ export class CdpElementHandle<
         ElementHandle<Node>
       >;
     });
+  }
+
+  override async backendNodeId(): Promise<number> {
+    if (this.#backendNodeId) {
+      return this.#backendNodeId;
+    }
+    const {node} = await this.client.send('DOM.describeNode', {
+      objectId: this.handle.id,
+    });
+    this.#backendNodeId = node.backendNodeId;
+    return this.#backendNodeId;
   }
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -912,6 +912,13 @@
     "comment": "times out flakily"
   },
   {
+    "testIdPattern": "[backendNodeId.spec] ElementHandle.backendNodeId should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "CDP-specific"
+  },
+  {
     "testIdPattern": "[bfcache.spec] BFCache can call a function exposed on a page restored from bfcache",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],

--- a/test/src/cdp/backendNodeId.spec.ts
+++ b/test/src/cdp/backendNodeId.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import expect from 'expect';
+
+import {getTestState, setupTestBrowserHooks} from '../mocha-utils.js';
+
+describe('ElementHandle.backendNodeId', function () {
+  setupTestBrowserHooks();
+
+  it('should work', async () => {
+    const {page} = await getTestState();
+    using handle = await page.evaluateHandle('document');
+    const id = await handle.asElement()!.backendNodeId();
+    expect(id).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
When run over CDP, the getter will provide the https://chromedevtools.github.io/devtools-protocol/tot/DOM/#type-BackendNodeId for the element handle which allows identifying the element in other CDP sessions.

Closes https://github.com/puppeteer/puppeteer/issues/9284