### PR TITLE
fix: stop calling bringToFront when taking page screenshots

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2511,8 +2511,6 @@ export abstract class Page extends EventEmitter<PageEvents> {
   ): Promise<Uint8Array | string> {
     using _guard = await this.browserContext().startScreenshot();
 
-    await this.bringToFront();
-
     const options = {
       ...userOptions,
       clip: userOptions.clip


### PR DESCRIPTION
With https://crrev.com/c/5899683 (M131) it should not be longer needer to make sure background tabs are brought to front before taking a screenshot.