### PR TITLE
feat: support LaunchOptions in executablePath()

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -681,13 +681,6 @@ Description
 </td></tr>
 <tr><td>
 
-<span id="executablepath">[executablePath(channel)](./puppeteer.executablepath.md)</span>
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
 <span id="launch">[launch(options)](./puppeteer.launch.md)</span>
 
 </td><td>
@@ -1345,6 +1338,13 @@ Description
 </td><td>
 
 The default cooperative request interception resolution priority
+
+</td></tr>
+<tr><td>
+
+<span id="executablepath">[executablePath](./puppeteer.executablepath.md)</span>
+
+</td><td>
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browserlauncher.executablepath.md
+++ b/docs/api/puppeteer.browserlauncher.executablepath.md
@@ -8,7 +8,10 @@ sidebar_label: BrowserLauncher.executablePath
 
 ```typescript
 class BrowserLauncher {
-  abstract executablePath(channel?: ChromeReleaseChannel): string;
+  abstract executablePath(
+    channel?: ChromeReleaseChannel,
+    validatePath?: boolean,
+  ): string;
 }
 ```
 
@@ -34,6 +37,19 @@ channel
 </td><td>
 
 [ChromeReleaseChannel](./puppeteer.chromereleasechannel.md)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+<tr><td>
+
+validatePath
+
+</td><td>
+
+boolean
 
 </td><td>
 

--- a/docs/api/puppeteer.browserlauncher.md
+++ b/docs/api/puppeteer.browserlauncher.md
@@ -78,7 +78,7 @@ Description
 </td></tr>
 <tr><td>
 
-<span id="executablepath">[executablePath(channel)](./puppeteer.browserlauncher.executablepath.md)</span>
+<span id="executablepath">[executablePath(channel, validatePath)](./puppeteer.browserlauncher.executablepath.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.executablepath.md
+++ b/docs/api/puppeteer.executablepath.md
@@ -2,43 +2,14 @@
 sidebar_label: executablePath
 ---
 
-# executablePath() function
+# executablePath variable
 
 ### Signature
 
 ```typescript
-executablePath: (channel?: PuppeteerCore.ChromeReleaseChannel) => string;
+executablePath: {
+    (channel: PuppeteerCore.ChromeReleaseChannel): string;
+    (options: PuppeteerCore.LaunchOptions): string;
+    (): string;
+}
 ```
-
-## Parameters
-
-<table><thead><tr><th>
-
-Parameter
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-channel
-
-</td><td>
-
-[PuppeteerCore.ChromeReleaseChannel](./puppeteer.chromereleasechannel.md)
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-</tbody></table>
-**Returns:**
-
-string

--- a/docs/api/puppeteer.puppeteernode.defaultargs.md
+++ b/docs/api/puppeteer.puppeteernode.defaultargs.md
@@ -45,4 +45,4 @@ _(Optional)_ Set of configurable options to set on the browser.
 
 string\[\]
 
-The default flags that Chromium will be launched with.
+The default arguments that the browser will be launched with.

--- a/docs/api/puppeteer.puppeteernode.executablepath.md
+++ b/docs/api/puppeteer.puppeteernode.executablepath.md
@@ -4,13 +4,15 @@ sidebar_label: PuppeteerNode.executablePath
 
 # PuppeteerNode.executablePath() method
 
-The default executable path.
+<h2 id="executablePath">executablePath(): string</h2>
+
+The default executable path for a given ChromeReleaseChannel.
 
 ### Signature
 
 ```typescript
 class PuppeteerNode {
-  executablePath(channel?: ChromeReleaseChannel): string;
+  executablePath(channel: ChromeReleaseChannel): string;
 }
 ```
 
@@ -39,10 +41,67 @@ channel
 
 </td><td>
 
-_(Optional)_
+</td></tr>
+</tbody></table>
+**Returns:**
+
+string
+
+<h2 id="executablePath-1">executablePath(): string</h2>
+
+The default executable path given LaunchOptions.
+
+### Signature
+
+```typescript
+class PuppeteerNode {
+  executablePath(options: LaunchOptions): string;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+[LaunchOptions](./puppeteer.launchoptions.md)
+
+</td><td>
 
 </td></tr>
 </tbody></table>
+**Returns:**
+
+string
+
+<h2 id="executablePath-2">executablePath(): string</h2>
+
+The default executable path.
+
+### Signature
+
+```typescript
+class PuppeteerNode {
+  executablePath(): string;
+}
+```
+
 **Returns:**
 
 string

--- a/docs/api/puppeteer.puppeteernode.md
+++ b/docs/api/puppeteer.puppeteernode.md
@@ -159,6 +159,28 @@ This method attaches Puppeteer to an existing browser instance.
 
 </td><td>
 
+The default executable path for a given ChromeReleaseChannel.
+
+</td></tr>
+<tr><td>
+
+<span id="executablepath">[executablePath(options)](./puppeteer.puppeteernode.executablepath.md)</span>
+
+</td><td>
+
+</td><td>
+
+The default executable path given LaunchOptions.
+
+</td></tr>
+<tr><td>
+
+<span id="executablepath">[executablePath()](./puppeteer.puppeteernode.executablepath.md)</span>
+
+</td><td>
+
+</td><td>
+
 The default executable path.
 
 </td></tr>

--- a/packages/browsers/src/browser-data/chrome.ts
+++ b/packages/browsers/src/browser-data/chrome.ts
@@ -186,14 +186,12 @@ export function resolveSystemExecutablePath(
           return '/opt/google/chrome/chrome';
         case ChromeReleaseChannel.BETA:
           return '/opt/google/chrome-beta/chrome';
+        case ChromeReleaseChannel.CANARY:
+          return '/opt/google/chrome-canary/chrome';
         case ChromeReleaseChannel.DEV:
           return '/opt/google/chrome-unstable/chrome';
       }
   }
-
-  throw new Error(
-    `Unable to detect browser executable path for '${channel}' on ${platform}.`,
-  );
 }
 
 export function compareVersions(a: string, b: string): number {

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -99,15 +99,13 @@ describe('Chrome', () => {
       ),
       '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
     );
-    assert.throws(() => {
-      assert.strictEqual(
-        resolveSystemExecutablePath(
-          BrowserPlatform.LINUX,
-          ChromeReleaseChannel.CANARY,
-        ),
-        path.join('chrome-linux', 'chrome'),
-      );
-    }, new Error(`Unable to detect browser executable path for 'canary' on linux.`));
+    assert.strictEqual(
+      resolveSystemExecutablePath(
+        BrowserPlatform.LINUX,
+        ChromeReleaseChannel.CANARY,
+      ),
+      '/opt/google/chrome-canary/chrome',
+    );
   });
 
   it('should resolve milestones', async () => {

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -225,7 +225,10 @@ export abstract class BrowserLauncher {
     return browser;
   }
 
-  abstract executablePath(channel?: ChromeReleaseChannel): string;
+  abstract executablePath(
+    channel?: ChromeReleaseChannel,
+    validatePath?: boolean,
+  ): string;
 
   abstract defaultArgs(object: LaunchOptions): string[];
 
@@ -413,10 +416,13 @@ export abstract class BrowserLauncher {
   /**
    * @internal
    */
-  protected resolveExecutablePath(headless?: boolean | 'shell'): string {
+  resolveExecutablePath(
+    headless?: boolean | 'shell',
+    validatePath = true,
+  ): string {
     let executablePath = this.puppeteer.configuration.executablePath;
     if (executablePath) {
-      if (!existsSync(executablePath)) {
+      if (validatePath && !existsSync(executablePath)) {
         throw new Error(
           `Tried to find the browser at the configured path (${executablePath}), but no executable was found.`,
         );
@@ -451,7 +457,7 @@ export abstract class BrowserLauncher {
       buildId: this.puppeteer.browserVersion,
     });
 
-    if (!existsSync(executablePath)) {
+    if (validatePath && !existsSync(executablePath)) {
       const configVersion =
         this.puppeteer.configuration?.[this.browser]?.version;
       if (configVersion) {

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -123,7 +123,9 @@ export class ChromeLauncher extends BrowserLauncher {
         channel || !this.puppeteer._isPuppeteerCore,
         `An \`executablePath\` or \`channel\` must be specified for \`puppeteer-core\``,
       );
-      chromeExecutable = this.executablePath(channel, options.headless ?? true);
+      chromeExecutable = channel
+        ? this.executablePath(channel)
+        : this.resolveExecutablePath(options.headless ?? true);
     }
 
     return {
@@ -264,7 +266,7 @@ export class ChromeLauncher extends BrowserLauncher {
 
   override executablePath(
     channel?: ChromeReleaseChannel,
-    headless?: boolean | 'shell',
+    validatePath = true,
   ): string {
     if (channel) {
       return computeSystemExecutablePath({
@@ -272,7 +274,7 @@ export class ChromeLauncher extends BrowserLauncher {
         channel: convertPuppeteerChannelToBrowsersChannel(channel),
       });
     } else {
-      return this.resolveExecutablePath(headless);
+      return this.resolveExecutablePath(undefined, validatePath);
     }
   }
 }

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -140,7 +140,7 @@ export class FirefoxLauncher extends BrowserLauncher {
       );
       firefoxExecutable = executablePath;
     } else {
-      firefoxExecutable = this.executablePath();
+      firefoxExecutable = this.executablePath(undefined);
     }
 
     return {
@@ -191,8 +191,11 @@ export class FirefoxLauncher extends BrowserLauncher {
     }
   }
 
-  override executablePath(): string {
-    return this.resolveExecutablePath();
+  override executablePath(_: unknown, validatePath = true): string {
+    return this.resolveExecutablePath(
+      undefined,
+      /* validatePath=*/ validatePath,
+    );
   }
 
   override defaultArgs(options: LaunchOptions = {}): string[] {

--- a/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
@@ -52,8 +52,8 @@ describe('PuppeteerNode', () => {
           cacheDirectory: tmpDir,
         },
       });
-      expect(puppeteer.executablePath('chrome-canary').toLowerCase()).toContain(
-        'canary',
+      expect(puppeteer.executablePath('chrome').toLowerCase()).toContain(
+        'chrome',
       );
     });
 

--- a/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import fs from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, it, beforeEach, afterEach} from 'node:test';
+
+import expect from 'expect';
+
+import {PuppeteerNode} from './PuppeteerNode.js';
+
+describe('PuppeteerNode', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(join(tmpdir(), 'puppeteer-unit-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmdirSync(tmpDir);
+  });
+
+  describe('executablePath()', () => {
+    it('returns the default path', () => {
+      const puppeteer = new PuppeteerNode({
+        isPuppeteerCore: false,
+        configuration: {
+          cacheDirectory: tmpDir,
+        },
+      });
+      expect(puppeteer.executablePath()).toContain('chrome');
+    });
+
+    it('returns the default path based on the default browser configuration', () => {
+      const puppeteer = new PuppeteerNode({
+        isPuppeteerCore: false,
+        configuration: {
+          cacheDirectory: tmpDir,
+          defaultBrowser: 'firefox',
+        },
+      });
+      expect(puppeteer.executablePath().toLowerCase()).toContain('firefox');
+    });
+
+    it('returns the default path for a given Chrome channel', () => {
+      const puppeteer = new PuppeteerNode({
+        isPuppeteerCore: false,
+        configuration: {
+          cacheDirectory: tmpDir,
+        },
+      });
+      expect(puppeteer.executablePath('chrome-canary').toLowerCase()).toContain(
+        'canary',
+      );
+    });
+
+    it('returns the default path for chrome-headless-shell', () => {
+      const puppeteer = new PuppeteerNode({
+        isPuppeteerCore: false,
+        configuration: {
+          cacheDirectory: tmpDir,
+        },
+      });
+      expect(
+        puppeteer
+          .executablePath({
+            headless: 'shell',
+          })
+          .toLowerCase(),
+      ).toContain('chrome-headless-shell');
+    });
+  });
+
+  describe('defaultArgs()', () => {
+    it('returns the default args without arguments', () => {
+      const puppeteer = new PuppeteerNode({
+        isPuppeteerCore: false,
+        configuration: {
+          cacheDirectory: tmpDir,
+        },
+      });
+      expect(puppeteer.defaultArgs()).toBeInstanceOf(Array);
+    });
+  });
+});

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -317,19 +317,29 @@ if (
   process.env['MOCHA_WORKER_ID'] === '0'
 ) {
   console.log(
-    `Running unit tests with:
+    `Running tests with:
   -> product: ${processVariables.product}
   -> binary: ${
     processVariables.defaultBrowserOptions.executablePath ||
-    path.relative(process.cwd(), puppeteer.executablePath())
+    path.relative(
+      process.cwd(),
+      puppeteer.executablePath({
+        headless: isHeadless
+          ? processVariables.headless === 'shell'
+            ? 'shell'
+            : true
+          : false,
+      }),
+    )
   }
   -> mode: ${
-    processVariables.isHeadless
-      ? processVariables.headless === 'true'
-        ? '--headless=new'
-        : '--headless'
+    isHeadless
+      ? processVariables.headless === 'shell'
+        ? 'shell'
+        : 'new headless'
       : 'headful'
-  }`,
+  }
+  -> protocol: ${protocol}`,
   );
 }
 

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -336,7 +336,7 @@ if (
     isHeadless
       ? processVariables.headless === 'shell'
         ? 'shell'
-        : 'new headless'
+        : 'headless'
       : 'headful'
   }
   -> protocol: ${protocol}`,


### PR DESCRIPTION
This allows determining the correct path based on the headless attribute and potentially other launch options later.

Drive-by: add the standard path for Chrome Canary on Linux.

Closes https://github.com/puppeteer/puppeteer/issues/13308