### PR TITLE
test: disable a flaky test for Firefox

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -3106,6 +3106,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[screenshot.spec] Screenshots ElementHandle.screenshot should run in parallel with page.close()",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "Started to be flaky"
+  },
+  {
     "testIdPattern": "[screenshot.spec] Screenshots Page.screenshot should clip clip bigger than the viewport without \"captureBeyondViewport\"",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "firefox"],


### PR DESCRIPTION
Started to flaky mostly on Windows and Mac recently.

Issue https://github.com/puppeteer/puppeteer/issues/13360