### PR TITLE
test: set up fixed test domains

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2674,20 +2674,6 @@
     "comment": "Firefox does not support multiple sessions in BiDi."
   },
   {
-    "testIdPattern": "[oopif.spec] OOPIF should retrieve body for OOPIF document requests",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Chrome-specific test (uses DNS mapping); does not work with Firefox."
-  },
-  {
-    "testIdPattern": "[oopif.spec] OOPIF should wait for inner OOPIFs",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "Chrome-specific test (uses DNS mapping); does not work with Firefox."
-  },
-  {
     "testIdPattern": "[page.spec] Page Page.addScriptTag should throw when added with content to the CSP page",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome"],

--- a/test/assets/inner-frame1.html
+++ b/test/assets/inner-frame1.html
@@ -3,7 +3,7 @@
   window.addEventListener('DOMContentLoaded', () => {
     const iframe = document.createElement('iframe');
     const url = new URL(location.href);
-    url.hostname = 'inner-frame2.test';
+    url.hostname = 'domain1.test';
     url.pathname = '/inner-frame2.html';
     iframe.src = url.toString();
     document.body.appendChild(iframe);

--- a/test/assets/main-frame.html
+++ b/test/assets/main-frame.html
@@ -3,7 +3,7 @@
   window.addEventListener('DOMContentLoaded', () => {
     const iframe = document.createElement('iframe');
     const url = new URL(location.href);
-    url.hostname = 'inner-frame1.test';
+    url.hostname = 'domain2.test';
     url.pathname = '/inner-frame1.html';
     iframe.src = url.toString();
     document.body.appendChild(iframe);

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -94,6 +94,12 @@ const defaultBrowserOptions = Object.assign(
     headless: headless === 'shell' ? ('shell' as const) : isHeadless,
     dumpio: !!process.env['DUMPIO'],
     protocol,
+    args: [
+      `--host-resolver-rules=MAP domain1.test 127.0.0.1,MAP domain2.test 127.0.0.1,MAP domain3.test 127.0.0.1`,
+    ],
+    extraPrefsFirefox: {
+      'network.dns.localDomains': `domain1.test,domain2.test,domain3.test`,
+    },
   } satisfies LaunchOptions,
   extraLaunchOptions,
 );


### PR DESCRIPTION
- adds domain1.test, domain2.test, domain3.test that all map to 127.0.0.1 across browsers.
- configures these domains for all tests

Closes https://github.com/puppeteer/puppeteer/issues/13353