### PR TITLE
chore: cleanup EsLint plugins

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,7 @@ import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import importPlugin from 'eslint-plugin-import';
 import mocha from 'eslint-plugin-mocha';
-import eslintPluginRecommended from 'eslint-plugin-prettier/recommended';
+import eslintPrettierPluginRecommended from 'eslint-plugin-prettier/recommended';
 import rulesdir from 'eslint-plugin-rulesdir';
 import tsdoc from 'eslint-plugin-tsdoc';
 import globals from 'globals';
@@ -90,7 +90,7 @@ export default [
       'examples/puppeteer-in-extension/node_modules/**/*',
     ],
   },
-  eslintPluginRecommended,
+  eslintPrettierPluginRecommended,
   importPlugin.flatConfigs.typescript,
   {
     name: 'JavaScript rules',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,23 +5,20 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
 
-import {fixupConfigRules, fixupPluginRules} from '@eslint/compat';
 import {FlatCompat} from '@eslint/eslintrc';
 import js from '@eslint/js';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
-import _import from 'eslint-plugin-import';
+import importPlugin from 'eslint-plugin-import';
 import mocha from 'eslint-plugin-mocha';
+import eslintPluginRecommended from 'eslint-plugin-prettier/recommended';
 import rulesdir from 'eslint-plugin-rulesdir';
 import tsdoc from 'eslint-plugin-tsdoc';
 import globals from 'globals';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: import.meta.dirname,
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 });
@@ -30,9 +27,12 @@ rulesdir.RULES_DIR = 'tools/eslint/lib';
 
 function getThirdPartyPackages() {
   return fs
-    .readdirSync(path.join(__dirname, 'packages/puppeteer-core/third_party'), {
-      withFileTypes: true,
-    })
+    .readdirSync(
+      path.join(import.meta.dirname, 'packages/puppeteer-core/third_party'),
+      {
+        withFileTypes: true,
+      },
+    )
     .filter(dirent => {
       return dirent.isDirectory();
     })
@@ -90,15 +90,14 @@ export default [
       'examples/puppeteer-in-extension/node_modules/**/*',
     ],
   },
-  ...fixupConfigRules(
-    compat.extends('plugin:prettier/recommended', 'plugin:import/typescript'),
-  ),
+  eslintPluginRecommended,
+  importPlugin.flatConfigs.typescript,
   {
     name: 'JavaScript rules',
     plugins: {
       mocha,
       '@typescript-eslint': typescriptEslint,
-      import: fixupPluginRules(_import),
+      import: importPlugin,
       rulesdir,
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@babel/plugin-transform-modules-commonjs": "7.25.9",
         "@babel/plugin-transform-private-methods": "7.25.9",
         "@babel/plugin-transform-private-property-in-object": "7.25.9",
-        "@eslint/compat": "1.2.3",
         "@eslint/eslintrc": "3.2.0",
         "@eslint/js": "9.16.0",
         "@microsoft/api-extractor": "7.48.0",
@@ -7074,23 +7073,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/compat": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.3.tgz",
-      "integrity": "sha512-wlZhwlDFxkxIZ571aH0FoK4h4Vwx7P3HJx62Gp8hTc10bfpwT2x0nULuAHmQSJBOWPgPeVf+9YtnD4j50zVHmA==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": "^9.10.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
@@ -7185,6 +7167,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
       "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "@babel/plugin-transform-modules-commonjs": "7.25.9",
     "@babel/plugin-transform-private-methods": "7.25.9",
     "@babel/plugin-transform-private-property-in-object": "7.25.9",
-    "@eslint/compat": "1.2.3",
     "@eslint/eslintrc": "3.2.0",
     "@eslint/js": "9.16.0",
     "@microsoft/api-extractor": "7.48.0",


### PR DESCRIPTION
The fixer is no longer needed as the of the latest versions