### PR TITLE
docs: switch to Browser.cookies, document Browser.deleteCookie

### DIFF
--- a/docs/guides/cookies.md
+++ b/docs/guides/cookies.md
@@ -15,6 +15,8 @@ import puppeteer from 'puppeteer';
 
 const browser = await puppeteer.launch();
 
+const context = await browser.createBrowserContext();
+
 const page = await browser.newPage();
 
 await page.goto('https://example.com');
@@ -36,6 +38,8 @@ Puppeteer can also write cookies directly into the browser's storage:
 import puppeteer from 'puppeteer';
 
 const browser = await puppeteer.launch();
+
+const context = await browser.createBrowserContext();
 
 // Sets two cookies for the localhost domain.
 await browser.setCookie(
@@ -69,6 +73,42 @@ console.log(await context.cookies()); // print available cookies.
 ## Deleting cookies
 
 [Browser.deleteCookie()](https://pptr.dev/api/puppeteer.browser.deletecookie) method allows deleting cookies from storage.
+
+```ts
+import puppeteer from 'puppeteer';
+
+const browser = await puppeteer.launch();
+
+const context = await browser.createBrowserContext();
+
+// Deletes two cookies for the localhost domain.
+await browser.deleteCookie(
+  {
+    name: 'cookie1',
+    value: '1',
+    domain: 'localhost',
+    path: '/',
+    sameParty: false,
+    expires: -1,
+    httpOnly: false,
+    secure: false,
+    sourceScheme: 'NonSecure',
+  },
+  {
+    name: 'cookie2',
+    value: '2',
+    domain: 'localhost',
+    path: '/',
+    sameParty: false,
+    expires: -1,
+    httpOnly: false,
+    secure: false,
+    sourceScheme: 'NonSecure',
+  },
+);
+
+console.log(await context.cookies()); // print available cookies.
+```
 
 In addition to the `Browser` methods operating on the default browser
 context, the same methods are available on the

--- a/docs/guides/cookies.md
+++ b/docs/guides/cookies.md
@@ -75,8 +75,6 @@ import puppeteer from 'puppeteer';
 
 const browser = await puppeteer.launch();
 
-const context = await browser.createBrowserContext();
-
 // Deletes two cookies for the localhost domain.
 await browser.deleteCookie(
   {
@@ -103,7 +101,7 @@ await browser.deleteCookie(
   },
 );
 
-console.log(await context.cookies()); // print available cookies.
+console.log(await browser.cookies()); // print available cookies.
 ```
 
 In addition to the `Browser` methods operating on the default browser

--- a/docs/guides/cookies.md
+++ b/docs/guides/cookies.md
@@ -15,8 +15,6 @@ import puppeteer from 'puppeteer';
 
 const browser = await puppeteer.launch();
 
-const context = await browser.createBrowserContext();
-
 const page = await browser.newPage();
 
 await page.goto('https://example.com');
@@ -27,7 +25,7 @@ await page.evaluate(() => {
   document.cookie = 'myCookie = MyCookieValue';
 });
 
-console.log(await context.cookies()); // print available cookies.
+console.log(await browser.cookies()); // print available cookies.
 ```
 
 ## Setting cookies
@@ -38,8 +36,6 @@ Puppeteer can also write cookies directly into the browser's storage:
 import puppeteer from 'puppeteer';
 
 const browser = await puppeteer.launch();
-
-const context = await browser.createBrowserContext();
 
 // Sets two cookies for the localhost domain.
 await browser.setCookie(
@@ -67,7 +63,7 @@ await browser.setCookie(
   },
 );
 
-console.log(await context.cookies()); // print available cookies.
+console.log(await browser.cookies()); // print available cookies.
 ```
 
 ## Deleting cookies


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

docs bugfix

**Did you add tests for your changes?**

n/a

**If relevant, did you update the documentation?**

Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Followup to #13334

- The `context` identifier is missing in the code examples
- The `Browser.deleteCookie` method doesn't have a code example

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

Trying to help out others upgrading away from the deprecated `page.cookies` and `page.deleteCookies` APIs:

- https://github.com/puppeteer/puppeteer/pull/13316#issuecomment-2522457638