### PR TITLE
fix: export the PuppeteerLaunchOptions type

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1712,6 +1712,17 @@ The sizes of each format are as follows:
 </td></tr>
 <tr><td>
 
+<span id="puppeteerlaunchoptions">[PuppeteerLaunchOptions](./puppeteer.puppeteerlaunchoptions.md)</span>
+
+</td><td>
+
+**Deprecated:**
+
+Use [LaunchOptions](./puppeteer.launchoptions.md).
+
+</td></tr>
+<tr><td>
+
 <span id="puppeteerlifecycleevent">[PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.puppeteerlaunchoptions.md
+++ b/docs/api/puppeteer.puppeteerlaunchoptions.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: PuppeteerLaunchOptions
+---
+
+# PuppeteerLaunchOptions type
+
+> Warning: This API is now obsolete.
+>
+> Use [LaunchOptions](./puppeteer.launchoptions.md).
+
+### Signature
+
+```typescript
+export type PuppeteerLaunchOptions = LaunchOptions;
+```
+
+**References:** [LaunchOptions](./puppeteer.launchoptions.md)

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -145,3 +145,9 @@ export type BrowserLaunchArgumentOptions = LaunchOptions;
  * @public
  */
 export type PuppeteerNodeLaunchOptions = LaunchOptions;
+
+/**
+ * @deprecated Use {@link LaunchOptions}.
+ * @public
+ */
+export type PuppeteerLaunchOptions = LaunchOptions;


### PR DESCRIPTION
In https://github.com/puppeteer/puppeteer/pull/13332 the alias for PuppeteerLaunchOptions was accidentally removed.