### PR TITLE
feat: allow listing installed browsers

### DIFF
--- a/docs/browsers-api/index.md
+++ b/docs/browsers-api/index.md
@@ -23,6 +23,8 @@ Built-in per-command `help` will provide all documentation you need to use the C
 npx @puppeteer/browsers --help # help for all commands
 npx @puppeteer/browsers install --help # help for the install command
 npx @puppeteer/browsers launch --help # help for the launch command
+npx @puppeteer/browsers clear --help # help for the clear command
+npx @puppeteer/browsers list --help # help for the list command
 ```
 
 You can specify the version of the `@puppeteer/browsers` when using
@@ -35,6 +37,18 @@ npx @puppeteer/browsers@latest --help
 npx @puppeteer/browsers@2.4.1 --help
 # Always install the latest version and automatically confirm the installation.
 npx --yes @puppeteer/browsers@latest --help
+```
+
+To clear all installed browsers, use the `clear` command:
+
+```bash
+npx @puppeteer/browsers clear
+```
+
+To list all installed browsers, use the `list` command:
+
+```bash
+npx @puppeteer/browsers list
 ```
 
 Some example to give an idea of what the CLI looks like (use the `--help` command for more examples):

--- a/packages/browsers/README.md
+++ b/packages/browsers/README.md
@@ -19,6 +19,8 @@ Built-in per-command `help` will provide all documentation you need to use the C
 npx @puppeteer/browsers --help # help for all commands
 npx @puppeteer/browsers install --help # help for the install command
 npx @puppeteer/browsers launch --help # help for the launch command
+npx @puppeteer/browsers clear --help # help for the clear command
+npx @puppeteer/browsers list --help # help for the list command
 ```
 
 You can specify the version of the `@puppeteer/browsers` when using
@@ -31,6 +33,18 @@ npx @puppeteer/browsers@latest --help
 npx @puppeteer/browsers@2.4.1 --help
 # Always install the latest version and automatically confirm the installation.
 npx --yes @puppeteer/browsers@latest --help
+```
+
+To clear all installed browsers, use the `clear` command:
+
+```bash
+npx @puppeteer/browsers clear
+```
+
+To list all installed browsers, use the `list` command:
+
+```bash
+npx @puppeteer/browsers list
 ```
 
 Some example to give an idea of what the CLI looks like (use the `--help` command for more examples):

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -54,6 +54,10 @@ interface ClearArgs {
   path?: string;
 }
 
+interface ListArgs {
+  path?: string;
+}
+
 /**
  * @public
  */
@@ -394,6 +398,35 @@ export class CLI {
               console.log(`${cacheDir} cleared.`);
             },
           );
+        },
+      )
+      .command(
+        'list',
+        'List all installed browsers in the cache directory',
+        yargs => {
+          this.#definePathParameter(yargs);
+          yargs.example(
+            '$0 list',
+            'List all installed browsers in the cache directory',
+          );
+          if (this.#allowCachePathOverride) {
+            yargs.example(
+              '$0 list --path /tmp/my-browser-cache',
+              'List browsers installed in the specified cache directory',
+            );
+          }
+        },
+        async argv => {
+          const args = argv as unknown as ListArgs;
+          const cacheDir = args.path ?? this.#cachePath;
+          const cache = new Cache(cacheDir);
+          const browsers = cache.getInstalledBrowsers();
+
+          for (const browser of browsers) {
+            console.log(
+              `${browser.browser}@${browser.buildId} (${browser.platform}) ${browser.executablePath}`,
+            );
+          }
         },
       )
       .demandCommand(1)

--- a/packages/browsers/test/src/list.spec.ts
+++ b/packages/browsers/test/src/list.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2023 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {CLI} from '../../lib/cjs/CLI.js';
+
+import {
+  createMockedReadlineInterface,
+  setupTestServer,
+  getServerUrl,
+} from './utils.js';
+import {testChromeBuildId} from './versions.js';
+
+describe('list command', function () {
+  this.timeout(90000);
+
+  setupTestServer();
+
+  let tmpDir = '/tmp/puppeteer-browsers-test';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'puppeteer-browsers-test'));
+  });
+
+  afterEach(async () => {
+    await new CLI(tmpDir, createMockedReadlineInterface('yes')).run([
+      'npx',
+      '@puppeteer/browsers',
+      'clear',
+      `--path=${tmpDir}`,
+      `--base-url=${getServerUrl()}`,
+    ]);
+  });
+
+  it('should show no browsers for empty cache', async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (message: string) => {
+      logs.push(message);
+    };
+
+    try {
+      await new CLI(tmpDir).run([
+        'npx',
+        '@puppeteer/browsers',
+        'list',
+        `--path=${tmpDir}`,
+      ]);
+
+      assert.strictEqual(logs.length, 0);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it('should list installed browsers', async () => {
+    await new CLI(tmpDir).run([
+      'npx',
+      '@puppeteer/browsers',
+      'install',
+      `chrome@${testChromeBuildId}`,
+      `--path=${tmpDir}`,
+      '--platform=linux',
+      `--base-url=${getServerUrl()}`,
+    ]);
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (message: string) => {
+      logs.push(message);
+    };
+
+    try {
+      await new CLI(tmpDir).run([
+        'npx',
+        '@puppeteer/browsers',
+        'list',
+        `--path=${tmpDir}`,
+      ]);
+
+      assert.match(
+        logs.join('\n'),
+        new RegExp(`chrome@${testChromeBuildId} \\(linux\\) .+chrome`),
+      );
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  it('should handle invalid cache directory', async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (message: string) => {
+      logs.push(message);
+    };
+
+    const invalidDir = path.join(tmpDir, 'nonexistent');
+    try {
+      await new CLI(invalidDir).run([
+        'npx',
+        '@puppeteer/browsers',
+        'list',
+        `--path=${invalidDir}`,
+      ]);
+
+      assert.strictEqual(logs.length, 0);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This adds a mode for `puppeteer/browsers` to `list` all installed browsers in the cache.

**Did you add tests for your changes?**

Sure! A `list.spec.ts` file has been added.

**If relevant, did you update the documentation?**

Yes, the `README.md` has been updated. (I also added some info on the `clear` command which was missing.)

**Summary**

Example:

```
➜ npx @puppeteer/browsers list
chrome@133.0.6886.0 (mac_arm) /Users/werner/Documents/Software/puppeteer/packages/browsers/chrome/mac_arm-133.0.6886.0/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing
```

It prints the type of browser, its version, platform, and the path.

This allows better maintenance of the currently installed versions, as the default cache directory is determined programmatically, and it's hard to understand what browsers are installed otherwise.

**Does this PR introduce a breaking change?**

No.