### PR TITLE
test: prepare for chromium-bidi roll

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -2201,8 +2201,8 @@
     "testIdPattern": "[navigation.spec] navigation Page.goBack should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["TIMEOUT"],
-    "comment": "Bug in chromium-bidi that causes navigation events to not be emitted. See https://github.com/GoogleChromeLabs/chromium-bidi/issues/2894"
+    "expectations": ["PASS", "TIMEOUT"],
+    "comment": "Bug in chromium-bidi that causes navigation events to not be emitted. See https://github.com/GoogleChromeLabs/chromium-bidi/issues/2894. PASS|TIMEOUT for chromium-bidi roll."
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goBack should work with HistoryAPI",
@@ -2301,6 +2301,13 @@
     "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "https://github.com/GoogleChromeLabs/chromium-bidi/issues/2856 historyUpdated from beforeunload incorrectly comes before navigationStarted"
+  },
+  {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should work when reload causes history API in beforeunload",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "https://github.com/GoogleChromeLabs/chromium-bidi/issues/2856 historyUpdated from beforeunload incorrectly comes before navigationStarted. PASS|FAIL for chromium-bidi roll"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work with anchor navigation",


### PR DESCRIPTION
In preparation for the chromium-bidi release in https://github.com/GoogleChromeLabs/chromium-bidi/pull/2897