### PR TITLE
chore: disable crash reporting by default

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -210,6 +210,7 @@ export class ChromeLauncher extends BrowserLauncher {
       '--disable-breakpad',
       '--disable-client-side-phishing-detection',
       '--disable-component-extensions-with-background-pages',
+      '--disable-crash-reporter', // No crash reporting in CfT.
       '--disable-default-apps',
       '--disable-dev-shm-usage',
       '--disable-extensions',
@@ -223,8 +224,8 @@ export class ChromeLauncher extends BrowserLauncher {
       '--disable-sync',
       '--enable-automation',
       '--export-tagged-pdf',
-      '--generate-pdf-document-outline',
       '--force-color-profile=srgb',
+      '--generate-pdf-document-outline',
       '--metrics-recording-only',
       '--no-first-run',
       '--password-store=basic',


### PR DESCRIPTION
Crash reporting is disabled in Chrome for Testing used with Puppeteer by default. We could also use available flags to ensure that crashpad processes do not start. There seems to be still some open issues with these flags as they seem to only affect the main process:

Related https://github.com/puppeteer/puppeteer/issues/2778#issuecomment-2321326769, https://github.com/puppeteer/puppeteer/issues/13419