### PR TITLE
ci: fix last release sha

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:firefox:headless": "wireit",
     "validate-licenses": "node --experimental-strip-types tools/third_party/validate-licenses.ts",
     "unit": "npm run unit --workspaces --if-present",
-    "changelog": "node --experimental-strip-types tools/merge-changelogs.ts"
+    "changelog": "node --experimental-strip-types tools/merge-changelogs.ts",
+    "release-please-dry-run": "release-please release-pr --token=$GITHUB_TOKEN --repo-url=puppeteer/puppeteer --dry-run"
   },
   "wireit": {
     "build": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "30e5b1a58edb8b1d94acdff00d64c76e76cf02a3",
+  "last-release-sha": "0b006175eea0c58957715b2c1cd7e56aec5170f1",
   "packages": {
     "packages/puppeteer": {
       "component": "puppeteer",


### PR DESCRIPTION
Changes the latest release sha to recover after manually editing tags due to a broken publish job.