### PR TITLE
documentation - adding double quotes around the suggested path on Windows

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,7 +87,7 @@ following errors in the browser output:
 You can use icacls to set permissions manually:
 
 ```powershell
-icacls %USERPROFILE%/.cache/puppeteer/chrome /grant *S-1-15-2-1:(OI)(CI)(RX)
+icacls "%USERPROFILE%/.cache/puppeteer/chrome" /grant *S-1-15-2-1:(OI)(CI)(RX)
 ```
 
 :::note

--- a/website/versioned_docs/version-24.0.0/troubleshooting.md
+++ b/website/versioned_docs/version-24.0.0/troubleshooting.md
@@ -87,7 +87,7 @@ following errors in the browser output:
 You can use icacls to set permissions manually:
 
 ```powershell
-icacls %USERPROFILE%/.cache/puppeteer/chrome /grant *S-1-15-2-1:(OI)(CI)(RX)
+icacls "%USERPROFILE%/.cache/puppeteer/chrome" /grant *S-1-15-2-1:(OI)(CI)(RX)
 ```
 
 :::note


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Update documentation

**Did you add tests for your changes?**

No, not necessary

**If relevant, did you update the documentation?**

No

**Summary**

If you run the proposed command as is and there is a space in the file path, the command will fail. Adding double quotes prevents the command from failing. The double quotes still work regardless if there is or is not a space in the file path so it should just be the default suggestion.

https://pptr.dev/troubleshooting#chrome-reports-sandbox-errors-on-windows
![image](https://github.com/user-attachments/assets/ed9c0828-5357-4f33-b3a9-c71fd9d611c7)

![image](https://github.com/user-attachments/assets/72355d1b-b48a-4b69-aab3-8209da0a4955)

![image](https://github.com/user-attachments/assets/7c9de710-2b94-4c64-9599-6be8d3dee178)

**Does this PR introduce a breaking change?**

No

**Other information**

N/A
