### PR TITLE
chore(deps): bump chromium-bidi v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19120,7 +19120,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.7.0",
-        "chromium-bidi": "1.0.0",
+        "chromium-bidi": "1.1.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1380148",
         "puppeteer-core": "24.1.0",
@@ -19141,7 +19141,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.7.0",
-        "chromium-bidi": "1.0.0",
+        "chromium-bidi": "1.1.0",
         "debug": "^4.4.0",
         "devtools-protocol": "0.0.1380148",
         "typed-query-selector": "^2.12.0",
@@ -19166,9 +19166,9 @@
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-1.0.0.tgz",
-      "integrity": "sha512-fbuPNi0hzljgtBslYdb14nwMSwqUPc07HcLC7AHzoqLtEW7YALNCWTQtfhTk5qJc/Nv5n/FN87FXn5LUvw4LUQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-1.1.0.tgz",
+      "integrity": "sha512-HislCEczCuamWm3+55Lig9XKmMF13K+BGKum9rwtDAzgUAHT4h5jNwhDmD4U20VoVUG8ujnv9UZ89qiIf5uF8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",
@@ -19209,9 +19209,9 @@
       "license": "MIT"
     },
     "packages/puppeteer/node_modules/chromium-bidi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-1.0.0.tgz",
-      "integrity": "sha512-fbuPNi0hzljgtBslYdb14nwMSwqUPc07HcLC7AHzoqLtEW7YALNCWTQtfhTk5qJc/Nv5n/FN87FXn5LUvw4LUQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-1.1.0.tgz",
+      "integrity": "sha512-HislCEczCuamWm3+55Lig9XKmMF13K+BGKum9rwtDAzgUAHT4h5jNwhDmD4U20VoVUG8ujnv9UZ89qiIf5uF8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -142,7 +142,7 @@
   "dependencies": {
     "@puppeteer/browsers": "2.7.0",
     "debug": "^4.4.0",
-    "chromium-bidi": "1.0.0",
+    "chromium-bidi": "1.1.0",
     "devtools-protocol": "0.0.1380148",
     "typed-query-selector": "^2.12.0",
     "ws": "^8.18.0"

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -124,7 +124,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.7.0",
-    "chromium-bidi": "1.0.0",
+    "chromium-bidi": "1.1.0",
     "cosmiconfig": "^9.0.0",
     "devtools-protocol": "0.0.1380148",
     "puppeteer-core": "24.1.0",


### PR DESCRIPTION
NPM with Dependabot seems to have issue, updating the package-lock correctly. 