### PR TITLE
chore: use `goog:` prefix for BiDi+ commands

### DIFF
--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -60,15 +60,15 @@ export class BidiBrowser extends Browser {
   ];
   static readonly subscribeCdpEvents: Bidi.Cdp.EventNames[] = [
     // Coverage
-    'cdp.Debugger.scriptParsed',
-    'cdp.CSS.styleSheetAdded',
-    'cdp.Runtime.executionContextsCleared',
+    'goog:cdp.Debugger.scriptParsed',
+    'goog:cdp.CSS.styleSheetAdded',
+    'goog:cdp.Runtime.executionContextsCleared',
     // Tracing
-    'cdp.Tracing.tracingComplete',
+    'goog:cdp.Tracing.tracingComplete',
     // TODO: subscribe to all CDP events in the future.
-    'cdp.Network.requestWillBeSent',
-    'cdp.Debugger.scriptParsed',
-    'cdp.Page.screencastFrame',
+    'goog:cdp.Network.requestWillBeSent',
+    'goog:cdp.Debugger.scriptParsed',
+    'goog:cdp.Page.screencastFrame',
   ];
 
   static async create(opts: BidiBrowserOptions): Promise<BidiBrowser> {

--- a/packages/puppeteer-core/src/bidi/CDPSession.ts
+++ b/packages/puppeteer-core/src/bidi/CDPSession.ts
@@ -41,7 +41,7 @@ export class BidiCdpSession extends CDPSession {
     } else {
       (async () => {
         try {
-          const {result} = await connection.send('cdp.getSession', {
+          const {result} = await connection.send('goog:cdp.getSession', {
             context: frame._id,
           });
           this.#sessionId.resolve(result.session!);
@@ -77,7 +77,7 @@ export class BidiCdpSession extends CDPSession {
     }
     const session = await this.#sessionId.valueOrThrow();
     const {result} = await this.#connection.send(
-      'cdp.sendCommand',
+      'goog:cdp.sendCommand',
       {
         method: method,
         params: params,

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -15,7 +15,11 @@ import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 
 import {BidiCdpSession} from './CDPSession.js';
-import type {BidiEvents, Commands as BidiCommands, Connection,} from './core/Connection.js';
+import type {
+  BidiEvents,
+  Commands as BidiCommands,
+  Connection,
+} from './core/Connection.js';
 
 const debugProtocolSend = debug('puppeteer:webDriverBiDi:SEND ►');
 const debugProtocolReceive = debug('puppeteer:webDriverBiDi:RECV ◀');

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -28,15 +28,15 @@ const debugProtocolReceive = debug('puppeteer:webDriverBiDi:RECV ◀');
  * @internal
  */
 export interface Commands extends BidiCommands {
-  'cdp.sendCommand': {
+  'goog:cdp.sendCommand': {
     params: Bidi.Cdp.SendCommandParameters;
     returnType: Bidi.Cdp.SendCommandResult;
   };
-  'cdp.getSession': {
+  'goog:cdp.getSession': {
     params: Bidi.Cdp.GetSessionParameters;
     returnType: Bidi.Cdp.GetSessionResult;
   };
-  'cdp.resolveRealm': {
+  'goog:cdp.resolveRealm': {
     params: Bidi.Cdp.ResolveRealmParameters;
     returnType: Bidi.Cdp.ResolveRealmResult;
   };
@@ -141,9 +141,11 @@ export class BidiConnection
           return;
         case 'event':
           if (isCdpEvent(object)) {
+            // Remove `goog:` prefix from BiDi+ events.
+            const eventName = object.params.event.replaceAll('goog:', '');
             BidiCdpSession.sessions
               .get(object.params.session)
-              ?.emit(object.params.event, object.params.params);
+              ?.emit(eventName, object.params.params);
             return;
           }
           // SAFETY: We know the method and parameter still match here.
@@ -208,5 +210,5 @@ function createProtocolError(object: Bidi.ErrorResponse): string {
 }
 
 function isCdpEvent(event: Bidi.ChromiumBidi.Event): event is Bidi.Cdp.Event {
-  return event.method.startsWith('cdp.');
+  return event.method.startsWith('goog:cdp.');
 }

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -15,11 +15,7 @@ import {debugError} from '../common/util.js';
 import {assert} from '../util/assert.js';
 
 import {BidiCdpSession} from './CDPSession.js';
-import type {
-  Commands as BidiCommands,
-  BidiEvents,
-  Connection,
-} from './core/Connection.js';
+import type {BidiEvents, Commands as BidiCommands, Connection,} from './core/Connection.js';
 
 const debugProtocolSend = debug('puppeteer:webDriverBiDi:SEND ►');
 const debugProtocolReceive = debug('puppeteer:webDriverBiDi:RECV ◀');
@@ -141,11 +137,9 @@ export class BidiConnection
           return;
         case 'event':
           if (isCdpEvent(object)) {
-            // Remove `goog:` prefix from BiDi+ events.
-            const eventName = object.params.event.replaceAll('goog:', '');
             BidiCdpSession.sessions
               .get(object.params.session)
-              ?.emit(eventName, object.params.params);
+              ?.emit(object.params.event, object.params.params);
             return;
           }
           // SAFETY: We know the method and parameter still match here.

--- a/packages/puppeteer-core/src/bidi/core/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/core/Realm.ts
@@ -125,7 +125,7 @@ export abstract class Realm extends EventEmitter<{
   async resolveExecutionContextId(): Promise<number> {
     if (!this.executionContextId) {
       const {result} = await (this.session.connection as BidiConnection).send(
-        'cdp.resolveRealm',
+        'goog:cdp.resolveRealm',
         {realm: this.id},
       );
       this.executionContextId = result.executionContextId;


### PR DESCRIPTION
Addressing https://github.com/GoogleChromeLabs/chromium-bidi/issues/2841