### PR TITLE
refactor: add `node:` when importing node internal modules

### DIFF
--- a/docs/api/puppeteer.page.exposefunction.md
+++ b/docs/api/puppeteer.page.exposefunction.md
@@ -106,7 +106,7 @@ An example of adding a `window.readfile` function into the page:
 
 ```ts
 import puppeteer from 'puppeteer';
-import fs from 'fs';
+import fs from 'node:fs';
 
 (async () => {
   const browser = await puppeteer.launch();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -222,6 +222,8 @@ export default [
         },
       ],
 
+      'import/enforce-node-protocol-usage': 'error',
+
       '@stylistic/func-call-spacing': 'error',
       '@stylistic/semi': 'error',
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -222,7 +222,8 @@ export default [
         },
       ],
 
-      'import/enforce-node-protocol-usage': 'error',
+      // TODO: enable with next version
+      // 'import/enforce-node-protocol-usage': 'error',
 
       '@stylistic/func-call-spacing': 'error',
       '@stylistic/semi': 'error',

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {stdin as input, stdout as output} from 'process';
-import * as readline from 'readline';
+import {stdin as input, stdout as output} from 'node:process';
+import * as readline from 'node:readline';
 
 import ProgressBar from 'progress';
 import type * as Yargs from 'yargs';

--- a/packages/browsers/src/Cache.ts
+++ b/packages/browsers/src/Cache.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import debug from 'debug';
 

--- a/packages/browsers/src/browser-data/chrome-headless-shell.ts
+++ b/packages/browsers/src/browser-data/chrome-headless-shell.ts
@@ -3,7 +3,7 @@
  * Copyright 2023 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import path from 'path';
+import path from 'node:path';
 
 import {BrowserPlatform} from './types.js';
 

--- a/packages/browsers/src/browser-data/chrome.ts
+++ b/packages/browsers/src/browser-data/chrome.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'path';
+import path from 'node:path';
 
 import semver from 'semver';
 

--- a/packages/browsers/src/browser-data/chromedriver.ts
+++ b/packages/browsers/src/browser-data/chromedriver.ts
@@ -3,7 +3,7 @@
  * Copyright 2023 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import path from 'path';
+import path from 'node:path';
 
 import {BrowserPlatform} from './types.js';
 

--- a/packages/browsers/src/browser-data/chromium.ts
+++ b/packages/browsers/src/browser-data/chromium.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'path';
+import path from 'node:path';
 
 import {getText} from '../httpUtil.js';
 

--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {getJSON} from '../httpUtil.js';
 

--- a/packages/browsers/src/detectPlatform.ts
+++ b/packages/browsers/src/detectPlatform.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import os from 'os';
+import os from 'node:os';
 
 import {BrowserPlatform} from './browser-data/browser-data.js';
 

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ChildProcessByStdio} from 'child_process';
-import {spawnSync, spawn} from 'child_process';
-import {createReadStream} from 'fs';
-import {mkdir, readdir} from 'fs/promises';
-import * as path from 'path';
-import type {Readable, Transform, Writable} from 'stream';
-import {Stream} from 'stream';
+import type {ChildProcessByStdio} from 'node:child_process';
+import {spawnSync, spawn} from 'node:child_process';
+import {createReadStream} from 'node:fs';
+import {mkdir, readdir} from 'node:fs/promises';
+import * as path from 'node:path';
+import type {Readable, Transform, Writable} from 'node:stream';
+import {Stream} from 'node:stream';
 
 import debug from 'debug';
 

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {createWriteStream} from 'fs';
-import * as http from 'http';
-import * as https from 'https';
-import {URL, urlToHttpOptions} from 'url';
+import {createWriteStream} from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import {URL, urlToHttpOptions} from 'node:url';
 
 import {ProxyAgent} from 'proxy-agent';
 

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {spawnSync} from 'child_process';
-import {existsSync, readFileSync} from 'fs';
-import {mkdir, unlink} from 'fs/promises';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
+import {existsSync, readFileSync} from 'node:fs';
+import {mkdir, unlink} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   Browser,

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -309,7 +309,7 @@ export class Process {
       this.#browserProcess.stderr?.pipe(process.stderr);
       this.#browserProcess.stdout?.pipe(process.stdout);
     }
-    // subscribeToProcessEvent('exit', this.#onDriverProcessExit);
+    subscribeToProcessEvent('exit', this.#onDriverProcessExit);
     if (opts.handleSIGINT) {
       subscribeToProcessEvent('SIGINT', this.#onDriverProcessSignal);
     }

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import childProcess from 'child_process';
-import {accessSync} from 'fs';
-import os from 'os';
-import readline from 'readline';
+import childProcess from 'node:child_process';
+import {accessSync} from 'node:fs';
+import os from 'node:os';
+import readline from 'node:readline';
 
 import {
   type Browser,
@@ -309,7 +309,7 @@ export class Process {
       this.#browserProcess.stderr?.pipe(process.stderr);
       this.#browserProcess.stdout?.pipe(process.stdout);
     }
-    subscribeToProcessEvent('exit', this.#onDriverProcessExit);
+    // subscribeToProcessEvent('exit', this.#onDriverProcessExit);
     if (opts.handleSIGINT) {
       subscribeToProcessEvent('SIGINT', this.#onDriverProcessSignal);
     }

--- a/packages/browsers/test/src/Cache.spec.ts
+++ b/packages/browsers/test/src/Cache.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {Browser, Cache} from '../../lib/cjs/main.js';
 

--- a/packages/browsers/test/src/chrome-headless-shell/chrome-headless-shell-data.spec.ts
+++ b/packages/browsers/test/src/chrome-headless-shell/chrome-headless-shell-data.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import path from 'path';
+import assert from 'node:assert';
+import path from 'node:path';
 
 import {BrowserPlatform} from '../../../lib/cjs/browser-data/browser-data.js';
 import {

--- a/packages/browsers/test/src/chrome-headless-shell/cli.spec.ts
+++ b/packages/browsers/test/src/chrome-headless-shell/cli.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {CLI} from '../../../lib/cjs/CLI.js';
 import {

--- a/packages/browsers/test/src/chrome-headless-shell/install.spec.ts
+++ b/packages/browsers/test/src/chrome-headless-shell/install.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   install,

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import path from 'path';
+import assert from 'node:assert';
+import path from 'node:path';
 
 import {
   BrowserPlatform,

--- a/packages/browsers/test/src/chrome/cli.spec.ts
+++ b/packages/browsers/test/src/chrome/cli.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {CLI} from '../../../lib/cjs/CLI.js';
 import {

--- a/packages/browsers/test/src/chrome/install.spec.ts
+++ b/packages/browsers/test/src/chrome/install.spec.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import http from 'http';
-import https from 'https';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   install,

--- a/packages/browsers/test/src/chrome/launch.spec.ts
+++ b/packages/browsers/test/src/chrome/launch.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   CDP_WEBSOCKET_ENDPOINT_REGEX,

--- a/packages/browsers/test/src/chromedriver/chromedriver-data.spec.ts
+++ b/packages/browsers/test/src/chromedriver/chromedriver-data.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import path from 'path';
+import assert from 'node:assert';
+import path from 'node:path';
 
 import {BrowserPlatform} from '../../../lib/cjs/browser-data/browser-data.js';
 import {

--- a/packages/browsers/test/src/chromedriver/cli.spec.ts
+++ b/packages/browsers/test/src/chromedriver/cli.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {CLI} from '../../../lib/cjs/CLI.js';
 import {

--- a/packages/browsers/test/src/chromedriver/install.spec.ts
+++ b/packages/browsers/test/src/chromedriver/install.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   install,

--- a/packages/browsers/test/src/chromium/chromium-data.spec.ts
+++ b/packages/browsers/test/src/chromium/chromium-data.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import path from 'path';
+import assert from 'node:assert';
+import path from 'node:path';
 
 import {BrowserPlatform} from '../../../lib/cjs/browser-data/browser-data.js';
 import {

--- a/packages/browsers/test/src/chromium/launch.spec.ts
+++ b/packages/browsers/test/src/chromium/launch.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   CDP_WEBSOCKET_ENDPOINT_REGEX,

--- a/packages/browsers/test/src/fileUtil.spec.ts
+++ b/packages/browsers/test/src/fileUtil.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   internalConstantsForTesting,

--- a/packages/browsers/test/src/firefox/cli.spec.ts
+++ b/packages/browsers/test/src/firefox/cli.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import sinon from 'sinon';
 

--- a/packages/browsers/test/src/firefox/firefox-data.spec.ts
+++ b/packages/browsers/test/src/firefox/firefox-data.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {BrowserPlatform} from '../../../lib/cjs/browser-data/browser-data.js';
 import {

--- a/packages/browsers/test/src/firefox/install.spec.ts
+++ b/packages/browsers/test/src/firefox/install.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {install, Browser, BrowserPlatform} from '../../../lib/cjs/main.js';
 import {setupTestServer, getServerUrl, clearCache} from '../utils.js';

--- a/packages/browsers/test/src/firefox/launch.spec.ts
+++ b/packages/browsers/test/src/firefox/launch.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   computeExecutablePath,

--- a/packages/browsers/test/src/list.spec.ts
+++ b/packages/browsers/test/src/list.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {CLI} from '../../lib/cjs/CLI.js';
 

--- a/packages/browsers/test/src/uninstall.spec.ts
+++ b/packages/browsers/test/src/uninstall.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   install,

--- a/packages/browsers/test/src/utils.ts
+++ b/packages/browsers/test/src/utils.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {execSync} from 'child_process';
-import os from 'os';
-import path from 'path';
-import * as readline from 'readline';
-import {Writable, Readable} from 'stream';
+import {execSync} from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import * as readline from 'node:readline';
+import {Writable, Readable} from 'node:stream';
 
 import {TestServer} from '@pptr/testserver';
 

--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -3,8 +3,8 @@
  * Copyright 2024 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {spawn} from 'child_process';
-import {normalize, join} from 'path';
+import {spawn} from 'node:child_process';
+import {normalize, join} from 'node:path';
 
 import {
   createBuilder,

--- a/packages/ng-schematics/src/schematics/utils/files.ts
+++ b/packages/ng-schematics/src/schematics/utils/files.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {relative, resolve} from 'path';
+import {relative, resolve} from 'node:path';
 
 import {getSystemPath, normalize, strings} from '@angular-devkit/core';
 import type {Rule} from '@angular-devkit/schematics';

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {get} from 'https';
+import {get} from 'node:https';
 
 import type {Tree} from '@angular-devkit/schematics';
 

--- a/packages/ng-schematics/test/src/utils.ts
+++ b/packages/ng-schematics/test/src/utils.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import https from 'node:https';
-import {before, after} from 'node:test';
 import {join} from 'node:path';
+import {before, after} from 'node:test';
 
 import type {JsonObject} from '@angular-devkit/core';
 import {

--- a/packages/ng-schematics/test/src/utils.ts
+++ b/packages/ng-schematics/test/src/utils.ts
@@ -3,9 +3,9 @@
  * Copyright 2024 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import https from 'https';
+import https from 'node:https';
 import {before, after} from 'node:test';
-import {join} from 'path';
+import {join} from 'node:path';
 
 import type {JsonObject} from '@angular-devkit/core';
 import {

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /// <reference types="node"  preserve="true"/>
-import type {ChildProcess} from 'child_process';
+import type {ChildProcess} from 'node:child_process';
 
 import type {Protocol} from 'devtools-protocol';
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1508,7 +1508,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *
    * ```ts
    * import puppeteer from 'puppeteer';
-   * import fs from 'fs';
+   * import fs from 'node:fs';
    *
    * (async () => {
    *   const browser = await puppeteer.launch();

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ChildProcess} from 'child_process';
+import type {ChildProcess} from 'node:child_process';
 
 import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ChildProcess} from 'child_process';
+import type {ChildProcess} from 'node:child_process';
 
 import type {Protocol} from 'devtools-protocol';
 

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type FS from 'fs';
-import type Path from 'path';
+import type FS from 'node:fs';
+import type Path from 'node:path';
 
 import type {ScreenRecorder} from './node/ScreenRecorder.js';
 

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -3,9 +3,9 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {existsSync} from 'fs';
-import {tmpdir} from 'os';
-import {join} from 'path';
+import {existsSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 
 import {
   Browser as InstalledBrowser,

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {mkdtemp} from 'fs/promises';
-import os from 'os';
-import path from 'path';
+import {mkdtemp} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   computeSystemExecutablePath,

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import {rename, unlink, mkdtemp} from 'fs/promises';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import {rename, unlink, mkdtemp} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import {Browser as SupportedBrowsers, createProfile} from '@puppeteer/browsers';
 

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ChildProcessWithoutNullStreams} from 'child_process';
-import {spawn, spawnSync} from 'child_process';
-import {PassThrough} from 'stream';
+import type {ChildProcessWithoutNullStreams} from 'node:child_process';
+import {spawn, spawnSync} from 'node:child_process';
+import {PassThrough} from 'node:stream';
 
 import debug from 'debug';
 

--- a/packages/puppeteer-core/src/node/util/fs.ts
+++ b/packages/puppeteer-core/src/node/util/fs.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 const rmOptions = {
   force: true,

--- a/packages/puppeteer-core/src/puppeteer-core.ts
+++ b/packages/puppeteer-core/src/puppeteer-core.ts
@@ -6,8 +6,8 @@
 
 export * from './index.js';
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {environment} from './environment.js';
 

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {homedir} from 'os';
-import {join} from 'path';
+import {homedir} from 'node:os';
+import {join} from 'node:path';
 
 import {cosmiconfigSync} from 'cosmiconfig';
 import type {

--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -4,23 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {readFile, readFileSync} from 'fs';
+import assert from 'node:assert';
+import {readFile, readFileSync} from 'node:fs';
 import {
   createServer as createHttpServer,
   type IncomingMessage,
   type RequestListener,
   type Server as HttpServer,
   type ServerResponse,
-} from 'http';
+} from 'node:http';
 import {
   createServer as createHttpsServer,
   type Server as HttpsServer,
   type ServerOptions as HttpsServerOptions,
-} from 'https';
+} from 'node:https';
 import type {AddressInfo} from 'net';
-import {join} from 'path';
-import type {Duplex} from 'stream';
+import {join} from 'node:path';
+import type {Duplex} from 'node:stream';
 import {gzip} from 'zlib';
 
 import {getType as getMimeType} from 'mime';

--- a/packages/testserver/src/index.ts
+++ b/packages/testserver/src/index.ts
@@ -18,7 +18,7 @@ import {
   type Server as HttpsServer,
   type ServerOptions as HttpsServerOptions,
 } from 'node:https';
-import type {AddressInfo} from 'net';
+import type {AddressInfo} from 'node:net';
 import {join} from 'node:path';
 import type {Duplex} from 'node:stream';
 import {gzip} from 'zlib';

--- a/test/installation/assets/puppeteer/configuration/puppeteer.config.ts
+++ b/test/installation/assets/puppeteer/configuration/puppeteer.config.ts
@@ -1,5 +1,5 @@
 import {type Configuration} from 'puppeteer';
-import {join} from 'path';
+import {join} from 'node:path';
 
 export default {
   cacheDirectory: join(__dirname, '.cache', 'puppeteer'),

--- a/test/installation/src/browsers.spec.ts
+++ b/test/installation/src/browsers.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {spawnSync} from 'child_process';
+import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
 
 import {configureSandbox} from './sandbox.js';
 

--- a/test/installation/src/constants.ts
+++ b/test/installation/src/constants.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {dirname, join, resolve} from 'path';
-import {fileURLToPath} from 'url';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {globSync} from 'glob';
 

--- a/test/installation/src/puppeteer-cli.spec.ts
+++ b/test/installation/src/puppeteer-cli.spec.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {spawnSync} from 'child_process';
-import {existsSync} from 'fs';
-import {readdir} from 'fs/promises';
-import {join} from 'path';
+import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {readdir} from 'node:fs/promises';
+import {join} from 'node:path';
 
 import {configureSandbox} from './sandbox.js';
 

--- a/test/installation/src/puppeteer-configuration.spec.ts
+++ b/test/installation/src/puppeteer-configuration.spec.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {spawnSync} from 'child_process';
-import {existsSync, readFileSync} from 'fs';
-import {readdir, writeFile} from 'fs/promises';
-import {join} from 'path';
+import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
+import {existsSync, readFileSync} from 'node:fs';
+import {readdir, writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
 
 import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';

--- a/test/installation/src/puppeteer-firefox.spec.ts
+++ b/test/installation/src/puppeteer-firefox.spec.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {spawnSync} from 'child_process';
-import {existsSync} from 'fs';
-import {readdir} from 'fs/promises';
-import {platform} from 'os';
-import {join} from 'path';
+import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {readdir} from 'node:fs/promises';
+import {platform} from 'node:os';
+import {join} from 'node:path';
 
 import {configureSandbox} from './sandbox.js';
 import {readAsset} from './util.js';

--- a/test/installation/src/puppeteer-typescript.spec.ts
+++ b/test/installation/src/puppeteer-typescript.spec.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {readFile, writeFile} from 'fs/promises';
-import {platform} from 'os';
-import {join} from 'path';
+import {readFile, writeFile} from 'node:fs/promises';
+import {platform} from 'node:os';
+import {join} from 'node:path';
 
 import {configureSandbox} from './sandbox.js';
 import {execFile, readAsset} from './util.js';

--- a/test/installation/src/puppeteer-webpack.spec.ts
+++ b/test/installation/src/puppeteer-webpack.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {readFile, rm, writeFile} from 'fs/promises';
-import {join} from 'path';
+import {readFile, rm, writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
 
 import {configureSandbox} from './sandbox.js';
 import {execFile, readAsset} from './util.js';

--- a/test/installation/src/puppeteer.spec.ts
+++ b/test/installation/src/puppeteer.spec.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
-import {spawnSync} from 'child_process';
-import {readdirSync} from 'fs';
-import fs from 'fs';
-import {readdir} from 'fs/promises';
-import {platform} from 'os';
-import {join} from 'path';
+import assert from 'node:assert';
+import {spawnSync} from 'node:child_process';
+import {readdirSync} from 'node:fs';
+import fs from 'node:fs';
+import {readdir} from 'node:fs/promises';
+import {platform} from 'node:os';
+import {join} from 'node:path';
 
 import {TestServer} from '@pptr/testserver';
 

--- a/test/installation/src/sandbox.ts
+++ b/test/installation/src/sandbox.ts
@@ -3,10 +3,10 @@
  * Copyright 2022 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import crypto from 'crypto';
-import {mkdtemp, rm, writeFile} from 'fs/promises';
-import {tmpdir} from 'os';
-import {join} from 'path';
+import crypto from 'node:crypto';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 
 import {
   PUPPETEER_CORE_PACKAGE_PATH,

--- a/test/installation/src/util.ts
+++ b/test/installation/src/util.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ExecFileOptions} from 'child_process';
-import {execFile as execFileAsync} from 'child_process';
-import {readFile} from 'fs/promises';
-import {join} from 'path';
+import type {ExecFileOptions} from 'node:child_process';
+import {execFile as execFileAsync} from 'node:child_process';
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
 import {promisify} from 'util';
 
 import {ASSETS_DIR} from './constants.js';

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
+import assert from 'node:assert';
 
 import expect from 'expect';
 import type {SerializedAXNode} from 'puppeteer-core/internal/cdp/Accessibility.js';

--- a/test/src/ariaqueryhandler.spec.ts
+++ b/test/src/ariaqueryhandler.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
+import assert from 'node:assert';
 
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'path';
+import path from 'node:path';
 
 import expect from 'expect';
 

--- a/test/src/cdp/interventionHeaders.spec.ts
+++ b/test/src/cdp/interventionHeaders.spec.ts
@@ -3,7 +3,7 @@
  * Copyright 2024 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type {IncomingMessage} from 'http';
+import type {IncomingMessage} from 'node:http';
 
 import expect from 'expect';
 

--- a/test/src/cdp/pdf.spec.ts
+++ b/test/src/cdp/pdf.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {readFile, unlink} from 'fs/promises';
+import {readFile, unlink} from 'node:fs/promises';
 
 import expect from 'expect';
 

--- a/test/src/cdp/prerender.spec.ts
+++ b/test/src/cdp/prerender.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {statSync} from 'fs';
+import {statSync} from 'node:fs';
 
 import expect from 'expect';
 

--- a/test/src/cdp/screencast.spec.ts
+++ b/test/src/cdp/screencast.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {statSync} from 'fs';
+import {statSync} from 'node:fs';
 
 import expect from 'expect';
 

--- a/test/src/download.spec.ts
+++ b/test/src/download.spec.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {mkdtemp, rm} from 'fs/promises';
-import {tmpdir} from 'os';
-import {join} from 'path';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 
 import expect from 'expect';
 

--- a/test/src/drag-and-drop.spec.ts
+++ b/test/src/drag-and-drop.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
+import assert from 'node:assert';
 
 import expect from 'expect';
 

--- a/test/src/fixtures.spec.ts
+++ b/test/src/fixtures.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {spawn, execSync} from 'child_process';
-import path from 'path';
+import {spawn, execSync} from 'node:child_process';
+import path from 'node:path';
 
 import expect from 'expect';
 

--- a/test/src/golden-utils.ts
+++ b/test/src/golden-utils.ts
@@ -3,9 +3,9 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import assert from 'assert';
-import fs from 'fs';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {diffLines} from 'diff';
 import jpeg from 'jpeg-js';

--- a/test/src/headful.spec.ts
+++ b/test/src/headful.spec.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {mkdtemp} from 'fs/promises';
-import os from 'os';
-import path from 'path';
+import {mkdtemp} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import expect from 'expect';
 import type {LaunchOptions} from 'puppeteer-core/internal/node/LaunchOptions.js';

--- a/test/src/input.spec.ts
+++ b/test/src/input.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from 'path';
+import path from 'node:path';
 
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';

--- a/test/src/keyboard.spec.ts
+++ b/test/src/keyboard.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import os from 'os';
+import os from 'node:os';
 
 import expect from 'expect';
 import type {KeyInput} from 'puppeteer-core/internal/common/USKeyboardLayout.js';

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -3,12 +3,12 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import assert from 'assert';
-import fs from 'fs';
-import {mkdtemp, readFile, writeFile} from 'fs/promises';
-import os from 'os';
-import path from 'path';
-import type {TLSSocket} from 'tls';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import {mkdtemp, readFile, writeFile} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type {TLSSocket} from 'node:tls';
 
 import expect from 'expect';
 import {TimeoutError} from 'puppeteer';

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {TestServer} from '@pptr/testserver';
 import expect from 'expect';

--- a/test/src/mouse.spec.ts
+++ b/test/src/mouse.spec.ts
@@ -3,7 +3,7 @@
  * Copyright 2018 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import os from 'os';
+import os from 'node:os';
 
 import expect from 'expect';
 import {MouseButton} from 'puppeteer-core/internal/api/Input.js';

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ServerResponse} from 'http';
+import type {ServerResponse} from 'node:http';
 
 import expect from 'expect';
 import {type Frame, TimeoutError} from 'puppeteer';

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import type {ServerResponse} from 'http';
-import path from 'path';
+import fs from 'node:fs';
+import type {ServerResponse} from 'node:http';
+import path from 'node:path';
 
 import expect from 'expect';
 import type {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -3,10 +3,10 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import assert from 'assert';
-import fs from 'fs';
-import type {ServerResponse} from 'http';
-import path from 'path';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import type {ServerResponse} from 'node:http';
+import path from 'node:path';
 
 import expect from 'expect';
 import {KnownDevices, TimeoutError} from 'puppeteer';

--- a/test/src/proxy.spec.ts
+++ b/test/src/proxy.spec.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Server} from 'http';
-import http from 'http';
-import type {AddressInfo} from 'net';
-import os from 'os';
+import type {Server} from 'node:http';
+import http from 'node:http';
+import type {AddressInfo} from 'node:net';
+import os from 'node:os';
 
 import type {TestServer} from '@pptr/testserver';
 import expect from 'expect';

--- a/test/src/queryhandler.spec.ts
+++ b/test/src/queryhandler.spec.ts
@@ -3,7 +3,7 @@
  * Copyright 2018 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import assert from 'assert';
+import assert from 'node:assert';
 
 import expect from 'expect';
 import {Puppeteer} from 'puppeteer-core';

--- a/test/src/requestinterception-experimental.spec.ts
+++ b/test/src/requestinterception-experimental.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import expect from 'expect';
 import {

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import expect from 'expect';
 import type {HTTPRequest} from 'puppeteer-core/internal/api/HTTPRequest.js';

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
+import assert from 'node:assert';
 
 import expect from 'expect';
 

--- a/test/src/stacktrace.spec.ts
+++ b/test/src/stacktrace.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from 'assert';
+import assert from 'node:assert';
 
 import expect from 'expect';
 

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ServerResponse} from 'http';
+import type {ServerResponse} from 'node:http';
 
 import expect from 'expect';
 import {type Target, TimeoutError} from 'puppeteer';

--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import expect from 'expect';
 import * as utils from 'puppeteer-core/internal/common/util.js';

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {access, constants, rm, watch} from 'fs/promises';
-import {tmpdir} from 'os';
-import {basename, dirname} from 'path';
+import {access, constants, rm, watch} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {basename, dirname} from 'node:path';
 
 import expect from 'expect';
 import type {Frame} from 'puppeteer-core/internal/api/Frame.js';

--- a/tools/chmod.ts
+++ b/tools/chmod.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 /**
  * Calls chmod with the mode in argv[2] on paths in argv[3...length-1].

--- a/tools/cp.ts
+++ b/tools/cp.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 /**
  * Copies single file in argv[2] to argv[3]

--- a/tools/docgen/src/custom_markdown_documenter.ts
+++ b/tools/docgen/src/custom_markdown_documenter.ts
@@ -11,7 +11,7 @@
 // https://github.com/microsoft/rushstack/blob/main/apps/api-documenter/src/documenters/MarkdownDocumenter.ts
 // This file has been edited to morph into Docusaurus's expected inputs.
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import type {DocumenterConfig} from '@microsoft/api-documenter/lib/documenters/DocumenterConfig.js';
 import {CustomMarkdownEmitter as ApiFormatterMarkdownEmitter} from '@microsoft/api-documenter/lib/markdown/CustomMarkdownEmitter.js';

--- a/tools/generate_module_package_json.ts
+++ b/tools/generate_module_package_json.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {mkdirSync, writeFileSync} from 'fs';
-import {dirname} from 'path';
+import {mkdirSync, writeFileSync} from 'node:fs';
+import {dirname} from 'node:path';
 
 /**
  * Outputs the dummy package.json file to the path specified

--- a/tools/merge-changelogs.ts
+++ b/tools/merge-changelogs.ts
@@ -9,7 +9,7 @@
  * changelog file.
  */
 
-import {readFileSync, writeFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'node:fs';
 
 interface Version {
   version: string;

--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {spawn} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
 import fs from 'node:fs';
-import {spawn} from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 

--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {randomUUID} from 'crypto';
-import fs from 'fs';
+import {randomUUID} from 'node:crypto';
+import fs from 'node:fs';
 import {spawn} from 'node:child_process';
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import {globSync} from 'glob';
 import yargs from 'yargs';

--- a/tools/mocha-runner/src/utils.ts
+++ b/tools/mocha-runner/src/utils.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type {
   MochaTestResult,


### PR DESCRIPTION
This should be a no-op change that is supported on Node v18.

Also it allowed me to just build and link then run some Deno tests, that were leaking things.

Will enforce this with next release of `eslint-plugin-import`