### PR TITLE
feat: pass custom arguments to browser on launch

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -373,8 +373,15 @@ export class CLI {
                 cacheDir: args.path ?? this.#cachePath,
                 platform: args.platform,
               });
+          // Pass any extra arguments after '--' directly to the browser executable
+          let extraArgs: string[] = [];
+          const extraArgsIndex = process.argv.indexOf('--');
+          if (extraArgsIndex !== -1) {
+            extraArgs = process.argv.splice(extraArgsIndex + 1);
+          }
           launch({
             executablePath,
+            args: extraArgs,
             detached: args.detached,
           });
         },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature #13037

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

I don't think it's relevant, I don't see any place where the command-line tools are documented. Only the Javascript APIs seem to be documented in docs/

**Summary**

Allow passing additional arguments directly to the browser on launch. This feature was requested in #13037 

**Does this PR introduce a breaking change?**

No

**Other information**

I tried to work with yargs to pull the additional arguments out, and in fact, yargs does support a mechanism of passing "extra" arguments, i.e. anything after "--". However, the TS types did not allow me to access yargs' `argv._` and even when I do access it (by casting yargs' `argv` to any), I've lost reference to the position of "--" and so I'd need to process the arguments based on their position, which is very confusing.

Instead I've taken the approach of looking at `process.argv` directly instead. This way, it is very clear which arguments are handled by yargs, and which arguments are handled by the browser process itself.

If there's another approach that would be more straightforward using yargs, or there is a desire to *not* use `process.argv` directly, I can take a look at an alternative solution.