### PR TITLE
fix: CdpCDPSession.connection() to return undefined after onClosed

### DIFF
--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -71,6 +71,16 @@ export class CdpCDPSession extends CDPSession {
   }
 
   override connection(): Connection | undefined {
+    if (this.#closed) {
+      return undefined;
+    }
+    return this.#connection;
+  }
+
+  /**
+   * @internal
+   */
+  get _connection(): Connection {
     return this.#connection;
   }
 

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -45,7 +45,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
   #networkManager: NetworkManager;
   #timeoutSettings: TimeoutSettings;
   #isolatedWorlds = new Set<string>();
-  #client: CDPSession;
+  #client: CdpCDPSession;
   #scriptsToEvaluateOnNewDocument = new Map<string, CdpPreloadScript>();
   #bindings = new Set<Binding>();
 
@@ -73,7 +73,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     return this.#networkManager;
   }
 
-  get client(): CDPSession {
+  get client(): CdpCDPSession {
     return this.#client;
   }
 
@@ -83,6 +83,10 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     timeoutSettings: TimeoutSettings,
   ) {
     super();
+    assert(
+      client instanceof CdpCDPSession,
+      'client is not an instance of CdpCDPSession.',
+    );
     this.#client = client;
     this.#page = page;
     this.#networkManager = new NetworkManager(this);
@@ -104,7 +108,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
       return;
     }
 
-    if (this.client.connection()?._closed) {
+    if (this.#client._connection?._closed) {
       // On connection disconnected remove all frames
       this.#removeFramesRecursively(mainFrame);
       return;
@@ -133,11 +137,11 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
    * its frame tree and ID.
    */
   async swapFrameTree(client: CDPSession): Promise<void> {
-    this.#client = client;
     assert(
-      this.#client instanceof CdpCDPSession,
-      'CDPSession is not an instance of CDPSessionImpl.',
+      client instanceof CdpCDPSession,
+      'client is not an instance of CdpCDPSession.',
     );
+    this.#client = client;
     const frame = this._frameTree.getMainFrame();
     if (frame) {
       this.#frameNavigatedReceived.add(this.#client.target()._targetId);

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -6,6 +6,7 @@
 
 import expect from 'expect';
 import type {Target} from 'puppeteer-core/internal/api/Target.js';
+import {Connection} from 'puppeteer-core/internal/cdp/Connection.js';
 import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
 
 import {getTestState, setupTestBrowserHooks} from '../mocha-utils.js';
@@ -163,5 +164,14 @@ describe('Target.createCDPSession', function () {
 
     const client = await page.createCDPSession();
     expect(client.connection()).toBeTruthy();
+  });
+
+  it('should not return a connection if the session is disposed', async () => {
+    const {page} = await getTestState();
+    const client = await page.createCDPSession();
+    expect(client.connection()).toBeTruthy();
+    await client.detach();
+    expect(client.connection()).toBeUndefined();
+    expect(Connection.fromSession(client)).toBeUndefined();
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix

**Did you add tests for your changes?**

~The tests should not be impacted.~
Yes

**If relevant, did you update the documentation?**

N/A

**Summary**

Restores `CdpCDPSession.connection()` behavior to return `undefined` after `onClosed` as it was before #13591

**Does this PR introduce a breaking change?**

It fix-reverts one
