### PR TITLE
feat: expose CDPSession.detached

### DIFF
--- a/docs/api/puppeteer.cdpsession.connection.md
+++ b/docs/api/puppeteer.cdpsession.connection.md
@@ -4,6 +4,8 @@ sidebar_label: CDPSession.connection
 
 # CDPSession.connection() method
 
+The underlying connection for this session, if any.
+
 ### Signature
 
 ```typescript

--- a/docs/api/puppeteer.cdpsession.md
+++ b/docs/api/puppeteer.cdpsession.md
@@ -37,6 +37,44 @@ await client.send('Animation.setPlaybackRate', {
 });
 ```
 
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="detached">detached</span>
+
+</td><td>
+
+`readonly`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+True if the session has been detached, false otherwise.
+
+</td></tr>
+</tbody></table>
+
 ## Methods
 
 <table><thead><tr><th>
@@ -59,6 +97,8 @@ Description
 </td><td>
 
 </td><td>
+
+The underlying connection for this session, if any.
 
 </td></tr>
 <tr><td>

--- a/packages/puppeteer-core/src/api/CDPSession.ts
+++ b/packages/puppeteer-core/src/api/CDPSession.ts
@@ -96,7 +96,19 @@ export abstract class CDPSession extends EventEmitter<CDPSessionEvents> {
     super();
   }
 
+  /**
+   * The underlying connection for this session, if any.
+   *
+   * @public
+   */
   abstract connection(): Connection | undefined;
+
+  /**
+   * True if the session has been detached, false otherwise.
+   *
+   * @public
+   */
+  abstract get detached(): boolean;
 
   /**
    * Parent session in terms of CDP's auto-attach mechanism.

--- a/packages/puppeteer-core/src/bidi/CDPSession.ts
+++ b/packages/puppeteer-core/src/bidi/CDPSession.ts
@@ -60,6 +60,10 @@ export class BidiCdpSession extends CDPSession {
     return undefined;
   }
 
+  override get detached(): boolean {
+    return this.#detached;
+  }
+
   override async send<T extends keyof ProtocolMapping.Commands>(
     method: T,
     params?: ProtocolMapping.Commands[T]['paramsType'][0],

--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -74,7 +74,7 @@ export class CdpCDPSession extends CDPSession {
     return this.#connection;
   }
 
-  get #closed(): boolean {
+  override get detached(): boolean {
     return this.#connection._closed || this.#detached;
   }
 
@@ -93,7 +93,7 @@ export class CdpCDPSession extends CDPSession {
     params?: ProtocolMapping.Commands[T]['paramsType'][0],
     options?: CommandOptions,
   ): Promise<ProtocolMapping.Commands[T]['returnType']> {
-    if (this.#closed) {
+    if (this.detached) {
       return Promise.reject(
         new TargetCloseError(
           `Protocol error (${method}): Session closed. Most likely the ${this.#targetType} has been closed.`,
@@ -144,7 +144,7 @@ export class CdpCDPSession extends CDPSession {
    * won't emit any events and can't be used to send messages.
    */
   override async detach(): Promise<void> {
-    if (this.#closed) {
+    if (this.detached) {
       throw new Error(
         `Session already detached. Most likely the ${this.#targetType} has been closed.`,
       );

--- a/packages/puppeteer-core/src/cdp/DeviceRequestPrompt.test.ts
+++ b/packages/puppeteer-core/src/cdp/DeviceRequestPrompt.test.ts
@@ -24,6 +24,7 @@ class MockCDPSession extends EventEmitter<CDPSessionEvents> {
   connection() {
     return undefined;
   }
+  readonly detached = false;
   async detach() {}
   id() {
     return '1';

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -25,6 +25,7 @@ class MockCDPSession extends EventEmitter<CDPSessionEvents> {
   connection() {
     return undefined;
   }
+  readonly detached = false;
   async detach() {}
   id() {
     return '1';

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -164,4 +164,22 @@ describe('Target.createCDPSession', function () {
     const client = await page.createCDPSession();
     expect(client.connection()).toBeTruthy();
   });
+
+  it('should keep the underlying connection after being detached', async () => {
+    const {page} = await getTestState();
+
+    const client = await page.createCDPSession();
+    const connection = client.connection();
+    await client.detach();
+    expect(client.connection()).toBe(connection);
+  });
+
+  it('should expose detached state', async () => {
+    const {page} = await getTestState();
+
+    const client = await page.createCDPSession();
+    expect(client.detached).toBe(false);
+    await client.detach();
+    expect(client.detached).toBe(true);
+  });
 });


### PR DESCRIPTION
Different perspective to #13613

**What kind of change does this PR introduce?**

Feature/Refactor: `CdpCDPSession.connection()` behavior contracted by test; add `CDPSession.detached`

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Code comments only.

**Summary**

#13591 and #13613 raised a question that `CdpCDPSession.connection()` behavior was not explicitly defined.

**Does this PR introduce a breaking change?**

No