### PR TITLE
fix: do not throw an error when a navigation is aborted

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -406,11 +406,7 @@ export class BidiFrame extends Frame {
                 raceWith(
                   fromEmitterEvent(navigation, 'fragment'),
                   fromEmitterEvent(navigation, 'failed'),
-                  fromEmitterEvent(navigation, 'aborted').pipe(
-                    map(({url}) => {
-                      throw new Error(`Navigation aborted: ${url}`);
-                    }),
-                  ),
+                  fromEmitterEvent(navigation, 'aborted'),
                 ),
                 switchMap(() => {
                   if (navigation.request) {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1251,18 +1251,25 @@
     "comment": "https://github.com/w3c/webdriver-bidi/issues/502"
   },
   {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should work when a page redirects on DOMContentLoaded",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "https://github.com/puppeteer/puppeteer/issues/12929 and https://github.com/w3c/webdriver-bidi/issues/763"
+  },
+  {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work when navigating to a URL with a client redirect",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome"],
     "expectations": ["FAIL"],
-    "comment": "In CDP implementation, we sometimes get the client redirect response."
+    "comment": "In CDP implementation, we get the client redirect response."
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work when navigating to a URL with a client redirect",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
-    "comment": "https://github.com/puppeteer/puppeteer/issues/12929"
+    "comment": "https://github.com/puppeteer/puppeteer/issues/12929 and https://github.com/w3c/webdriver-bidi/issues/763"
   },
   {
     "testIdPattern": "[navigation.spec] navigation Page.goto should work when page calls history API in beforeunload",

--- a/test/assets/client-redirect-DOMContentLoaded.html
+++ b/test/assets/client-redirect-DOMContentLoaded.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    window.location = "/empty.html";
+  });
+</script>

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -325,6 +325,14 @@ describe('navigation', function () {
       expect(response.ok()).toBe(true);
       expect(response.url()).toBe(server.PREFIX + '/client-redirect.html');
     });
+    it('should work when a page redirects on DOMContentLoaded', async () => {
+      const {page, server} = await getTestState();
+
+      const response = (await page.goto(
+        server.PREFIX + '/client-redirect-DOMContentLoaded.html',
+      ))!;
+      expect(response.ok()).toBe(true);
+    });
     it('should work when navigating to data url', async () => {
       const {page} = await getTestState();
 


### PR DESCRIPTION
Inspired by https://github.com/w3c/webdriver-bidi/issues/878 It looks like we should not be throwing an error when a navigation is aborted.