### PR TITLE
feat: improve `screencast` options

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1196,8 +1196,6 @@ Required response data to fulfill a request with.
 
 </td><td>
 
-**_(Experimental)_**
-
 </td></tr>
 <tr><td>
 
@@ -1537,6 +1535,15 @@ Represents the source scheme of the origin that originally set the cookie. A val
 Defines experiment options for Puppeteer.
 
 See individual properties for more information.
+
+</td></tr>
+<tr><td>
+
+<span id="fileformat">[FileFormat](./puppeteer.fileformat.md)</span>
+
+</td><td>
+
+**_(Experimental)_**
 
 </td></tr>
 <tr><td>

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1196,6 +1196,8 @@ Required response data to fulfill a request with.
 
 </td><td>
 
+**_(Experimental)_**
+
 </td></tr>
 <tr><td>
 
@@ -1542,8 +1544,6 @@ See individual properties for more information.
 <span id="fileformat">[FileFormat](./puppeteer.fileformat.md)</span>
 
 </td><td>
-
-**_(Experimental)_**
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.fileformat.md
+++ b/docs/api/puppeteer.fileformat.md
@@ -1,0 +1,11 @@
+---
+sidebar_label: FileFormat
+---
+
+# FileFormat type
+
+### Signature
+
+```typescript
+export type FileFormat = 'gif' | 'webm' | 'mp4';
+```

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -929,7 +929,7 @@ Removes script that injected into page by Page.evaluateOnNewDocument.
 
 **Remarks:**
 
-All recordings will be [WebM](https://www.webmproject.org/) format using the [VP9](https://www.webmproject.org/vp9/) video codec. The FPS is 30.
+By default, all recordings will be [WebM](https://www.webmproject.org/) format using the [VP9](https://www.webmproject.org/vp9/) video codec, with a frame rate of 30 FPS.
 
 You must have [ffmpeg](https://ffmpeg.org/) installed on your system.
 

--- a/docs/api/puppeteer.page.screencast.md
+++ b/docs/api/puppeteer.page.screencast.md
@@ -49,7 +49,7 @@ Promise&lt;[ScreenRecorder](./puppeteer.screenrecorder.md)&gt;
 
 ## Remarks
 
-All recordings will be [WebM](https://www.webmproject.org/) format using the [VP9](https://www.webmproject.org/vp9/) video codec. The FPS is 30.
+By default, all recordings will be [WebM](https://www.webmproject.org/) format using the [VP9](https://www.webmproject.org/vp9/) video codec, with a frame rate of 30 FPS.
 
 You must have [ffmpeg](https://ffmpeg.org/) installed on your system.
 

--- a/docs/api/puppeteer.screencastoptions.md
+++ b/docs/api/puppeteer.screencastoptions.md
@@ -35,6 +35,27 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="colors">colors</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Specifies the maximum number of [palette](https://ffmpeg.org/ffmpeg-filters.html#palettegen) colors to quantize, with GIF limited to `256`. Restrict the palette to only necessary colors to reduce output file size.
+
+</td><td>
+
+`256`
+
+</td></tr>
+<tr><td>
+
 <span id="crop">crop</span>
 
 </td><td>
@@ -50,6 +71,27 @@ Default
 Specifies the region of the viewport to crop.
 
 </td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="delay">delay</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Specifies the delay between iterations of a loop, in ms. `-1` is a special value to re-use the previous delay.
+
+</td><td>
+
+`-1`
 
 </td></tr>
 <tr><td>
@@ -75,6 +117,69 @@ Required if `ffmpeg` is not in your PATH.
 </td></tr>
 <tr><td>
 
+<span id="format">format</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+[FileFormat](./puppeteer.fileformat.md)
+
+</td><td>
+
+Specifies the output file format.
+
+</td><td>
+
+`webm`
+
+</td></tr>
+<tr><td>
+
+<span id="fps">fps</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Specifies the frame rate in frames per second.
+
+</td><td>
+
+`30` (`20` for GIF)
+
+</td></tr>
+<tr><td>
+
+<span id="loop">loop</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Specifies the number of times to loop playback, from `0` to `Infinity`.
+
+</td><td>
+
+`0`
+
+</td></tr>
+<tr><td>
+
 <span id="path">path</span>
 
 </td><td>
@@ -83,13 +188,34 @@ Required if `ffmpeg` is not in your PATH.
 
 </td><td>
 
-\`$&#123;string&#125;.webm\`
+\`$&#123;string&#125;.gif\` \| \`$&#123;string&#125;.webm\` \| \`$&#123;string&#125;.mp4\`
 
 </td><td>
 
 File path to save the screencast to.
 
 </td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="quality">quality</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Specifies the recording [quality](https://trac.ffmpeg.org/wiki/Encode/VP9#constantq) Constant Rate Factor between `0`–`63`. Lower values mean better quality.
+
+</td><td>
+
+`30`
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.screencastoptions.md
+++ b/docs/api/puppeteer.screencastoptions.md
@@ -188,7 +188,7 @@ Specifies the number of times to loop playback, from `0` to `Infinity`. A value 
 
 </td><td>
 
-\`$&#123;string&#125;.gif\` \| \`$&#123;string&#125;.webm\` \| \`$&#123;string&#125;.mp4\`
+\`$&#123;string&#125;.$&#123;[FileFormat](./puppeteer.fileformat.md)&#125;\`
 
 </td><td>
 

--- a/docs/api/puppeteer.screencastoptions.md
+++ b/docs/api/puppeteer.screencastoptions.md
@@ -171,11 +171,11 @@ number
 
 </td><td>
 
-Specifies the number of times to loop playback, from `0` to `Infinity`.
+Specifies the number of times to loop playback, from `0` to `Infinity`. A value of `0` or `undefined` will disable looping.
 
 </td><td>
 
-`0`
+`undefined`
 
 </td></tr>
 <tr><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -316,15 +316,18 @@ export interface ScreenshotOptions {
 
 /**
  * @public
- * @experimental
  */
 export type FileFormat = 'gif' | 'webm' | 'mp4';
 
+/**
+ * @public
+ * @experimental
+ */
 export interface ScreencastOptions {
   /**
    * File path to save the screencast to.
    */
-  path?: `${string}.gif` | `${string}.webm` | `${string}.mp4`;
+  path?: `${string}.${FileFormat}`;
   /**
    * Specifies the output file format.
    *

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -322,7 +322,13 @@ export interface ScreencastOptions {
   /**
    * File path to save the screencast to.
    */
-  path?: `${string}.webm`;
+  path?: `${string}.gif` | `${string}.webm`;
+  /**
+   * Specifies the output file format.
+   *
+   * @defaultValue `webm`
+   */
+  format?: 'gif' | 'webm';
   /**
    * Specifies the region of the viewport to crop.
    */

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -318,13 +318,13 @@ export interface ScreenshotOptions {
  * @public
  * @experimental
  */
-export type FileFormat = 'gif' | 'webm';
+export type FileFormat = 'gif' | 'webm' | 'mp4';
 
 export interface ScreencastOptions {
   /**
    * File path to save the screencast to.
    */
-  path?: `${string}.gif` | `${string}.webm`;
+  path?: `${string}.gif` | `${string}.webm` | `${string}.mp4`;
   /**
    * Specifies the output file format.
    *

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -354,6 +354,42 @@ export interface ScreencastOptions {
    */
   speed?: number;
   /**
+   * Specifies the frame rate in frames per second.
+   *
+   * @defaultValue `30` (`20` for GIF)
+   */
+  fps?: number;
+  /**
+   * Specifies the number of times to loop playback, from `0` to `Infinity`.
+   *
+   * @defaultValue `0`
+   */
+  loop?: number;
+  /**
+   * Specifies the delay between iterations of a loop, in ms.
+   * `-1` is a special value to re-use the previous delay.
+   *
+   * @defaultValue `-1`
+   */
+  delay?: number;
+  /**
+   * Specifies the recording
+   * {@link https://trac.ffmpeg.org/wiki/Encode/VP9#constantq | quality}
+   * Constant Rate Factor between `0`–`63`. Lower values mean better quality.
+   *
+   * @defaultValue `30`
+   */
+  quality?: number;
+  /**
+   * Specifies the maximum number of
+   * {@link https://ffmpeg.org/ffmpeg-filters.html#palettegen | palette}
+   * colors to quantize, with GIF limited to `256`.
+   * Restrict the palette to only necessary colors to reduce output file size.
+   *
+   * @defaultValue `256`
+   */
+  colors?: number;
+  /**
    * Path to the {@link https://ffmpeg.org/ | ffmpeg}.
    *
    * Required if `ffmpeg` is not in your PATH.
@@ -2355,8 +2391,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *
    * @remarks
    *
-   * All recordings will be {@link https://www.webmproject.org/ | WebM} format using
-   * the {@link https://www.webmproject.org/vp9/ | VP9} video codec. The FPS is 30.
+   * By default, all recordings will be {@link https://www.webmproject.org/ | WebM} format using
+   * the {@link https://www.webmproject.org/vp9/ | VP9} video codec, with a frame rate of 30 FPS.
    *
    * You must have {@link https://ffmpeg.org/ | ffmpeg} installed on your system.
    */

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -318,6 +318,8 @@ export interface ScreenshotOptions {
  * @public
  * @experimental
  */
+export type FileFormat = 'gif' | 'webm';
+
 export interface ScreencastOptions {
   /**
    * File path to save the screencast to.
@@ -328,7 +330,7 @@ export interface ScreencastOptions {
    *
    * @defaultValue `webm`
    */
-  format?: 'gif' | 'webm';
+  format?: FileFormat;
   /**
    * Specifies the region of the viewport to crop.
    */

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -361,8 +361,9 @@ export interface ScreencastOptions {
   fps?: number;
   /**
    * Specifies the number of times to loop playback, from `0` to `Infinity`.
+   * A value of `0` or `undefined` will disable looping.
    *
-   * @defaultValue `0`
+   * @defaultValue `undefined`
    */
   loop?: number;
   /**

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -234,7 +234,7 @@ export class ScreenRecorder extends PassThrough {
           // input.
           [
             '-vf',
-            `fps=${fps},split[s0][s1];[s0]palettegen=stats_mode=diff:max_colors=${colors}[p];[s1][p]paletteuse`,
+            `fps=${fps},split[s0][s1];[s0]palettegen=stats_mode=diff:max_colors=${colors}[p];[s1][p]paletteuse=dither=bayer`,
           ],
           // Sets the number of times to loop playback.
           ['-loop', `${loop}`],

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -248,7 +248,7 @@ export class ScreenRecorder extends PassThrough {
         if (loop === Infinity) {
           loop = 0;
         }
-        if (!Math.sign(delay)) {
+        if (delay !== -1) {
           delay /= 10;
         } // ms to cs
         return [

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -125,7 +125,7 @@ export class ScreenRecorder extends PassThrough {
       colors,
     );
     const vf = formatArgs.indexOf('-vf');
-    if (~vf) {
+    if (vf !== -1) {
       filters.push(formatArgs.splice(vf, 2).at(-1) ?? '');
     }
 

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -6,8 +6,8 @@
 
 import type {ChildProcessWithoutNullStreams} from 'node:child_process';
 import {spawn, spawnSync} from 'node:child_process';
-import {PassThrough} from 'node:stream';
 import os from 'node:os';
+import {PassThrough} from 'node:stream';
 
 import debug from 'debug';
 
@@ -105,14 +105,29 @@ export class ScreenRecorder extends PassThrough {
     const filters = [
       `crop='min(${width},iw):min(${height},ih):0:0'`,
       `pad=${width}:${height}:0:0`,
-    ]
-    if (speed) filters.push(`setpts=${1 / speed}*PTS`);
-    if (crop) filters.push(`crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`);
-    if (scale) filters.push(`scale=iw*${scale}:-1:flags=lanczos`);
+    ];
+    if (speed) {
+      filters.push(`setpts=${1 / speed}*PTS`);
+    }
+    if (crop) {
+      filters.push(`crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`);
+    }
+    if (scale) {
+      filters.push(`scale=iw*${scale}:-1:flags=lanczos`);
+    }
 
-    const formatArgs = this.#getFormatArgs(format, fps, loop, delay, quality, colors);
+    const formatArgs = this.#getFormatArgs(
+      format,
+      fps,
+      loop,
+      delay,
+      quality,
+      colors,
+    );
     const vf = formatArgs.indexOf('-vf');
-    if (~vf) filters.push(formatArgs.splice(vf, 2).at(-1) ?? '');
+    if (~vf) {
+      filters.push(formatArgs.splice(vf, 2).at(-1) ?? '');
+    }
 
     this.#process = spawn(
       path,
@@ -220,7 +235,7 @@ export class ScreenRecorder extends PassThrough {
       ['-crf', `${quality}`],
       // Sets the quality and how efficient the compression will be.
       ['-deadline', 'realtime', '-cpu-used', `${os.cpus().length / 2}`],
-    ]
+    ];
     switch (format) {
       case 'webm':
         return [
@@ -230,8 +245,12 @@ export class ScreenRecorder extends PassThrough {
         ].flat();
       case 'gif':
         fps = DEFAULT_FPS === fps ? 20 : 'source_fps';
-        if (loop === Infinity) loop = 0;
-        if (!Math.sign(delay)) delay /= 10; // ms to cs
+        if (loop === Infinity) {
+          loop = 0;
+        }
+        if (!Math.sign(delay)) {
+          delay /= 10;
+        } // ms to cs
         return [
           // Sets the frame rate and uses a custom palette generated from the
           // input.

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -235,7 +235,12 @@ export class ScreenRecorder extends PassThrough {
       // Sets the quality. Lower the better.
       ['-crf', `${quality}`],
       // Sets the quality and how efficient the compression will be.
-      ['-deadline', 'realtime', '-cpu-used', `${os.cpus().length / 2}`],
+      [
+        '-deadline',
+        'realtime',
+        '-cpu-used',
+        `${Math.min(os.cpus().length / 2, 8)}`,
+      ],
     ];
     switch (format) {
       case 'webm':

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -7,6 +7,7 @@
 import type {ChildProcessWithoutNullStreams} from 'node:child_process';
 import {spawn, spawnSync} from 'node:child_process';
 import {PassThrough} from 'node:stream';
+import os from 'node:os';
 
 import debug from 'debug';
 
@@ -191,7 +192,7 @@ export class ScreenRecorder extends PassThrough {
           // Sets the quality. Lower the better.
           ['-crf', `${CRF_VALUE}`],
           // Sets the quality and how efficient the compression will be.
-          ['-deadline', 'realtime', '-cpu-used', '8'],
+          ['-deadline', 'realtime', '-cpu-used', `${os.cpus().length / 2}`],
         ].flat();
       case 'gif':
         return [

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -88,6 +88,7 @@ export class ScreenRecorder extends PassThrough {
 
     format ??= 'webm';
     fps ??= DEFAULT_FPS;
+    // Maps 0 to -1 as ffmpeg maps 0 to infinity.
     loop ||= -1;
     delay ??= -1;
     quality ??= CRF_VALUE;
@@ -249,8 +250,9 @@ export class ScreenRecorder extends PassThrough {
           loop = 0;
         }
         if (delay !== -1) {
+          // ms to cs
           delay /= 10;
-        } // ms to cs
+        }
         return [
           // Sets the frame rate and uses a custom palette generated from the
           // input.

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -213,17 +213,20 @@ export class ScreenRecorder extends PassThrough {
     quality: number,
     colors: number,
   ) {
+    const libvpx = [
+      // Sets the codec to use.
+      ['-c:v', 'vp9'],
+      // Sets the quality. Lower the better.
+      ['-crf', `${quality}`],
+      // Sets the quality and how efficient the compression will be.
+      ['-deadline', 'realtime', '-cpu-used', `${os.cpus().length / 2}`],
+    ]
     switch (format) {
       case 'webm':
         return [
-          // Sets the codec to use.
-          ['-c:v', 'vp9'],
+          ...libvpx,
           // Sets the format
           ['-f', 'webm'],
-          // Sets the quality. Lower the better.
-          ['-crf', `${CRF_VALUE}`],
-          // Sets the quality and how efficient the compression will be.
-          ['-deadline', 'realtime', '-cpu-used', `${os.cpus().length / 2}`],
         ].flat();
       case 'gif':
         fps = DEFAULT_FPS === fps ? 20 : 'source_fps';
@@ -242,6 +245,14 @@ export class ScreenRecorder extends PassThrough {
           ['-final_delay', `${delay}`],
           // Sets the format
           ['-f', 'gif'],
+        ].flat();
+      case 'mp4':
+        return [
+          ...libvpx,
+          // Fragment file during stream to avoid errors.
+          ['-movflags', 'hybrid_fragmented'],
+          // Sets the format
+          ['-f', 'mp4'],
         ].flat();
     }
   }

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -81,7 +81,7 @@ export class ScreenRecorder extends PassThrough {
     ]
     if (speed) filters.push(`setpts=${1 / speed}*PTS`);
     if (crop) filters.push(`crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`);
-    if (scale) filters.push(`scale=iw*${scale}:-1`);
+    if (scale) filters.push(`scale=iw*${scale}:-1:flags=lanczos`);
 
     const formatArgs = this.#getFormatArgs(format ?? 'webm');
     const vf = formatArgs.indexOf('-vf');

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -42,6 +42,11 @@ export interface ScreenRecorderOptions {
   speed?: number;
   crop?: BoundingBox;
   format?: FileFormat;
+  fps?: number;
+  loop?: number;
+  delay?: number;
+  quality?: number;
+  colors?: number;
   scale?: number;
   path?: string;
 }
@@ -57,6 +62,8 @@ export class ScreenRecorder extends PassThrough {
   #controller = new AbortController();
   #lastFrame: Promise<readonly [Buffer, number]>;
 
+  #fps: number;
+
   /**
    * @internal
    */
@@ -64,11 +71,30 @@ export class ScreenRecorder extends PassThrough {
     page: Page,
     width: number,
     height: number,
-    {speed, scale, crop, format, path}: ScreenRecorderOptions = {},
+    {
+      speed,
+      scale,
+      crop,
+      format,
+      fps,
+      loop,
+      delay,
+      quality,
+      colors,
+      path,
+    }: ScreenRecorderOptions = {},
   ) {
     super({allowHalfOpen: false});
 
+    format ??= 'webm';
+    fps ??= DEFAULT_FPS;
+    loop ||= -1;
+    delay ??= -1;
+    quality ??= CRF_VALUE;
+    colors ??= 256;
     path ??= 'ffmpeg';
+
+    this.#fps = fps;
 
     // Tests if `ffmpeg` exists.
     const {error} = spawnSync(path);
@@ -84,7 +110,7 @@ export class ScreenRecorder extends PassThrough {
     if (crop) filters.push(`crop=${crop.width}:${crop.height}:${crop.x}:${crop.y}`);
     if (scale) filters.push(`scale=iw*${scale}:-1:flags=lanczos`);
 
-    const formatArgs = this.#getFormatArgs(format ?? 'webm');
+    const formatArgs = this.#getFormatArgs(format, fps, loop, delay, quality, colors);
     const vf = formatArgs.indexOf('-vf');
     if (~vf) filters.push(formatArgs.splice(vf, 2).at(-1) ?? '');
 
@@ -115,7 +141,7 @@ export class ScreenRecorder extends PassThrough {
         // VP9 tries to use all available threads?
         ['-threads', '1'],
         // Specifies the frame rate we are giving ffmpeg.
-        ['-framerate', `${DEFAULT_FPS}`],
+        ['-framerate', `${fps}`],
         // Disable bitrate.
         ['-b:v', '0'],
         // Specifies the encoding and format we are using.
@@ -165,9 +191,7 @@ export class ScreenRecorder extends PassThrough {
         concatMap(([{timestamp: previousTimestamp, buffer}, {timestamp}]) => {
           return from(
             Array<Buffer>(
-              Math.round(
-                DEFAULT_FPS * Math.max(timestamp - previousTimestamp, 0),
-              ),
+              Math.round(fps * Math.max(timestamp - previousTimestamp, 0)),
             ).fill(buffer),
           );
         }),
@@ -181,7 +205,14 @@ export class ScreenRecorder extends PassThrough {
     );
   }
 
-  #getFormatArgs(format: FileFormat) {
+  #getFormatArgs(
+    format: FileFormat,
+    fps: number | 'source_fps',
+    loop: number,
+    delay: number,
+    quality: number,
+    colors: number,
+  ) {
     switch (format) {
       case 'webm':
         return [
@@ -195,13 +226,20 @@ export class ScreenRecorder extends PassThrough {
           ['-deadline', 'realtime', '-cpu-used', `${os.cpus().length / 2}`],
         ].flat();
       case 'gif':
+        fps = DEFAULT_FPS === fps ? 20 : 'source_fps';
+        if (loop === Infinity) loop = 0;
+        if (!Math.sign(delay)) delay /= 10; // ms to cs
         return [
           // Sets the frame rate and uses a custom palette generated from the
           // input.
           [
             '-vf',
-            'fps=5,split[s0][s1];[s0]palettegen=stats_mode=diff[p];[s1][p]paletteuse',
+            `fps=${fps},split[s0][s1];[s0]palettegen=stats_mode=diff:max_colors=${colors}[p];[s1][p]paletteuse`,
           ],
+          // Sets the number of times to loop playback.
+          ['-loop', `${loop}`],
+          // Sets the delay between iterations of a loop.
+          ['-final_delay', `${delay}`],
           // Sets the format
           ['-f', 'gif'],
         ].flat();
@@ -239,7 +277,7 @@ export class ScreenRecorder extends PassThrough {
       Array<Buffer>(
         Math.max(
           1,
-          Math.round((DEFAULT_FPS * (performance.now() - timestamp)) / 1000),
+          Math.round((this.#fps * (performance.now() - timestamp)) / 1000),
         ),
       )
         .fill(buffer)

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -25,7 +25,7 @@ import {
 } from '../../third_party/rxjs/rxjs.js';
 import {CDPSessionEvent} from '../api/CDPSession.js';
 import type {BoundingBox} from '../api/ElementHandle.js';
-import type {Page} from '../api/Page.js';
+import type {Page, FileFormat} from '../api/Page.js';
 import {debugError, fromEmitterEvent} from '../common/util.js';
 import {guarded} from '../util/decorators.js';
 import {asyncDisposeSymbol} from '../util/disposable.js';
@@ -41,7 +41,7 @@ const debugFfmpeg = debug('puppeteer:ffmpeg');
 export interface ScreenRecorderOptions {
   speed?: number;
   crop?: BoundingBox;
-  format?: 'gif' | 'webm';
+  format?: FileFormat;
   scale?: number;
   path?: string;
 }
@@ -181,7 +181,7 @@ export class ScreenRecorder extends PassThrough {
     );
   }
 
-  #getFormatArgs(format: 'webm' | 'gif') {
+  #getFormatArgs(format: FileFormat) {
     switch (format) {
       case 'webm':
         return [

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -276,7 +276,7 @@ export class ScreenRecorder extends PassThrough {
         return [
           ...libvpx,
           // Fragment file during stream to avoid errors.
-          ['-movflags', 'hybrid_fragmented'],
+          ['-movflags', 'delay_moov+hybrid_fragmented'],
           // Sets the format
           ['-f', 'mp4'],
         ].flat();

--- a/test/src/cdp/screencast.spec.ts
+++ b/test/src/cdp/screencast.spec.ts
@@ -93,6 +93,7 @@ describe('Screencasts', function () {
 
       await expect(page.screencast({format: 'gif'})).rejects.toBeDefined();
       await expect(page.screencast({format: 'webm'})).rejects.toBeDefined();
+      await expect(page.screencast({format: 'mp4'})).rejects.toBeDefined();
 
       await expect(page.screencast({fps: 0})).rejects.toBeDefined();
       await expect(page.screencast({fps: -1})).rejects.toBeDefined();

--- a/test/src/cdp/screencast.spec.ts
+++ b/test/src/cdp/screencast.spec.ts
@@ -91,6 +91,26 @@ describe('Screencasts', function () {
         page.screencast({crop: {x: 0, y: 0, height: 1, width: 10000}}),
       ).rejects.toBeDefined();
 
+      await expect(page.screencast({format: 'gif'})).rejects.toBeDefined();
+      await expect(page.screencast({format: 'webm'})).rejects.toBeDefined();
+
+      await expect(page.screencast({fps: 0})).rejects.toBeDefined();
+      await expect(page.screencast({fps: -1})).rejects.toBeDefined();
+
+      await expect(page.screencast({loop: 0})).rejects.toBeDefined();
+      await expect(page.screencast({loop: -1})).rejects.toBeDefined();
+      await expect(page.screencast({loop: Infinity})).rejects.toBeDefined();
+      await expect(page.screencast({loop: false})).rejects.toBeDefined();
+
+      await expect(page.screencast({delay: 0})).rejects.toBeDefined();
+      await expect(page.screencast({delay: -1})).rejects.toBeDefined();
+
+      await expect(page.screencast({quality: 0})).rejects.toBeDefined();
+      await expect(page.screencast({quality: -1})).rejects.toBeDefined();
+
+      await expect(page.screencast({colors: 0})).rejects.toBeDefined();
+      await expect(page.screencast({colors: -1})).rejects.toBeDefined();
+
       await expect(
         page.screencast({ffmpegPath: 'non-existent-path'}),
       ).rejects.toBeDefined();

--- a/test/src/cdp/screencast.spec.ts
+++ b/test/src/cdp/screencast.spec.ts
@@ -101,7 +101,6 @@ describe('Screencasts', function () {
       await expect(page.screencast({loop: 0})).rejects.toBeDefined();
       await expect(page.screencast({loop: -1})).rejects.toBeDefined();
       await expect(page.screencast({loop: Infinity})).rejects.toBeDefined();
-      await expect(page.screencast({loop: false})).rejects.toBeDefined();
 
       await expect(page.screencast({delay: 0})).rejects.toBeDefined();
       await expect(page.screencast({delay: -1})).rejects.toBeDefined();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Adds missing options to `screencast`/`ffmpeg`, and addresses undocumented existing options.

Also fixes multiple bugs in the existing code (see `commit`s…)

Closes #12735

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Adds missing options to `screencast`/`ffmpeg` to better control output, particularly GIFs, along with additional formats. This can avoid having to run `ffmpeg` a second time, only to tweak the final desired output—potentially drastically decreasing, for example, CI run time.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

See also:

#11084

_[High quality GIF with FFmpeg](https://blog.pkh.me/p/21-high-quality-gif-with-ffmpeg.html)_

_[A guide to upscaling or downscaling video with FFmpeg](https://write.corbpie.com/a-guide-to-upscaling-or-downscaling-video-with-ffmpeg)_

_[Elements to Keep in Mind When Optimizing GIFs](https://gifyard.com/elements-for-optimizing-gifs)_

https://github.com/sindresorhus/Gifski/issues/161#issuecomment-552681700

[FFmpeg Filters Documentation](https://ffmpeg.org/ffmpeg-filters.html#palettegen)

