### PR TITLE
ci: run stale only once per day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    # The action processes up to 30 issues at once, so we need to run more frequently.
-    - cron: '*/60 * * * *'
+    # The job successfuly goes though all the current issues
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 # Declare default permissions as read only.


### PR DESCRIPTION
As you can see from the latest run we only need to run it once per day as the latest version batches the opened issued and goes though them all internally - https://github.com/puppeteer/puppeteer/actions/runs/13898913266/job/38885785304