### PR TITLE
test: skip a test for headless shell on windows

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1780,6 +1780,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[mouse.spec] Mouse should select the text with mouse",
+    "platforms": ["win32"],
+    "parameters": ["cdp", "chrome", "chrome-headless-shell"],
+    "expectations": ["FAIL"],
+    "comment": "TODO: started to fail with Chrome headless shell 135 on Windows"
+  },
+  {
     "testIdPattern": "[network.spec] network Network Events Page.Events.Request",
     "platforms": ["linux"],
     "parameters": ["cdp", "chrome", "headless"],


### PR DESCRIPTION
Seems to be failing consistently on Windows after M135 roll.