### PR TITLE
docs: usage of deprecated "name" method in documentation of Page.waitForFrame() method

### DIFF
--- a/docs/api/puppeteer.page.waitforframe.md
+++ b/docs/api/puppeteer.page.waitforframe.md
@@ -65,6 +65,11 @@ Promise&lt;[Frame](./puppeteer.frame.md)&gt;
 
 ```ts
 const frame = await page.waitForFrame(async frame => {
-  return frame.name() === 'Test';
+  const frameElement = await frame.frameElement();
+  if (!frameElement) {
+    return false;
+  }
+  const name = await frameElement.evaluate(el => el.getAttribute('name'));
+  return name === 'test';
 });
 ```

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1912,7 +1912,12 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *
    * ```ts
    * const frame = await page.waitForFrame(async frame => {
-   *   return frame.name() === 'Test';
+   *   const frameElement = await frame.frameElement();
+   *   if (!frameElement) {
+   *     return false;
+   *   }
+   *   const name = await frameElement.evaluate(el => el.getAttribute('name'));
+   *   return name === 'test';
    * });
    * ```
    */


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Updates example documentation of Page.waitForFrame() to not use deprecated method frame.name()

**Did you add tests for your changes?**

No code changes, so no added tests

**If relevant, did you update the documentation?**

Yes, updated documentation example

**Summary**

Makes requested change to documentation in #13705 Updates the Page.waitForFrame() method documentation with proper access of frame's name attribute, removes deprecated frame.name() method example.

**Does this PR introduce a breaking change?**

No

**Other information**
