### PR TITLE
Use Buffer.from for base64 decoding

### DIFF
--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -250,9 +250,7 @@ export async function getReadableFromProtocolStream(
     async pull(controller) {
       function getUnit8Array(data: string, isBase64: boolean): Uint8Array {
         if (isBase64) {
-          return Uint8Array.from(atob(data), m => {
-            return m.codePointAt(0)!;
-          });
+          return Buffer.from(data, 'base64');
         }
         const encoder = new TextEncoder();
         return encoder.encode(data);


### PR DESCRIPTION
This PR replaces this code

```js
          return Uint8Array.from(atob(data), m => {
            return m.codePointAt(0)!;
          });
```

with 

```js
return Buffer.from(data, 'base64');
```

In an attempt to reduce CPU usage (And presumably also improve latency, but I haven't tested that).

See https://github.com/puppeteer/puppeteer/issues/13747 for more information

Fixes https://github.com/puppeteer/puppeteer/issues/13747