### PR TITLE
test: fix a flaky test

### DIFF
--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -974,12 +974,16 @@ describe('network', function () {
       const {page, server} = await getTestState();
 
       const cssRequests: HTTPRequest[] = [];
-      page.on('request', request => {
-        if (request.url().endsWith('css')) {
-          cssRequests.push(request);
-        }
+      const promise = new Promise<void>(resolve => {
+        page.on('request', request => {
+          if (request.url().endsWith('css')) {
+            cssRequests.push(request);
+            resolve();
+          }
+        });
       });
       await page.goto(server.PREFIX + '/one-style.html');
+      await promise;
       expect(cssRequests).toHaveLength(1);
       const request = cssRequests[0]!;
       expect(request.url()).toContain('one-style.css');


### PR DESCRIPTION
This PR adds explicit waiting for the CSS request as Canary runs indicate that the load event might be racing with the network events. Not 100% sure that this is the reason but explicitly waiting for the event would help rule out this possibility.