### PR TITLE
feat: support network requests for workers

### DIFF
--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -337,6 +337,7 @@ export class CdpPage extends Page {
         session.target().type(),
         this.#addConsoleMessage.bind(this),
         this.#handleException.bind(this),
+        this.#frameManager.networkManager,
       );
       this.#workers.set(session.id(), worker);
       this.emit(PageEvent.WorkerCreated, worker);

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -297,6 +297,7 @@ export class WorkerTarget extends CdpTarget {
           this.type(),
           () => {} /* consoleAPICalled */,
           () => {} /* exceptionThrown */,
+          undefined /* networkManager */,
         );
       });
     }

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -15,6 +15,7 @@ import {debugError} from '../common/util.js';
 import {ExecutionContext} from './ExecutionContext.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import {CdpJSHandle} from './JSHandle.js';
+import type {NetworkManager} from './NetworkManager.js';
 
 /**
  * @internal
@@ -48,6 +49,7 @@ export class CdpWebWorker extends WebWorker {
     targetType: TargetType,
     consoleAPICalled: ConsoleAPICalledCallback,
     exceptionThrown: ExceptionThrownCallback,
+    networkManager?: NetworkManager,
   ) {
     super(url);
     this.#id = targetId;
@@ -79,6 +81,7 @@ export class CdpWebWorker extends WebWorker {
     });
 
     // This might fail if the target is closed before we receive all execution contexts.
+    networkManager?.addClient(this.#client).catch(debugError);
     this.#client.send('Runtime.enable').catch(debugError);
   }
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1745,6 +1745,13 @@
     "expectations": ["PASS"]
   },
   {
+    "testIdPattern": "[worker.spec] Workers should retrieve body for main worker requests",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Getting request bodies is not supported"
+  },
+  {
     "testIdPattern": "[CDPSession.spec] Target.createCDPSession should send events",
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome", "headless"],


### PR DESCRIPTION
This PR integrates worker network requests with the page's network manager making worker requests show up on the page. With PlzDedicatedWorker shipping in Chromium workers are set up differently and that caused a regression with `waitForNetworkIdle` because the worker fetch request would be finished in the worker target so the `waitForNetworkIdle` would not see it and treat it as pending.

Related https://crbug.com/404184783