### PR TITLE
fix: dynamically import yargs and progress in CLI

### DIFF
--- a/docs/browsers-api/browsers.makeprogresscallback.md
+++ b/docs/browsers-api/browsers.makeprogresscallback.md
@@ -10,7 +10,7 @@ sidebar_label: makeProgressCallback
 export declare function makeProgressCallback(
   browser: Browser,
   buildId: string,
-): (downloadedBytes: number, totalBytes: number) => void;
+): Promise<(downloadedBytes: number, totalBytes: number) => void>;
 ```
 
 ## Parameters
@@ -53,4 +53,4 @@ string
 </tbody></table>
 **Returns:**
 
-(downloadedBytes: number, totalBytes: number) =&gt; void
+Promise&lt;(downloadedBytes: number, totalBytes: number) =&gt; void&gt;

--- a/packages/browsers/test/src/utils.ts
+++ b/packages/browsers/test/src/utils.ts
@@ -18,11 +18,18 @@ import {Cache} from '../../lib/cjs/main.js';
 export function createMockedReadlineInterface(
   input: string,
 ): readline.Interface {
-  const readable = Readable.from([input]);
+  const waitForQuestion = Promise.withResolvers<void>();
+  async function* readableGen() {
+    await waitForQuestion.promise;
+    yield input;
+  }
+
+  const readable = Readable.from(readableGen());
   const writable = new Writable({
     write(_chunk, _encoding, callback) {
       // Suppress the output to keep the test clean
       callback();
+      waitForQuestion.resolve();
     },
   });
 

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -46,7 +46,7 @@ async function downloadBrowser({
       cacheDir,
       platform,
       buildId,
-      downloadProgressCallback: makeProgressCallback(browser, buildId),
+      downloadProgressCallback: await makeProgressCallback(browser, buildId),
       baseUrl,
       buildIdAlias:
         buildId !== unresolvedBuildId ? unresolvedBuildId : undefined,


### PR DESCRIPTION
Issue: #13775

Importing the two deps make Esbuild not bundle.
Example: 
![image](https://github.com/user-attachments/assets/3b7ef6df-781e-4768-86fd-0a97f262d5a6)
