### PR TITLE
fix: support default download callback option in install()

### DIFF
--- a/docs/browsers-api/browsers.installoptions.md
+++ b/docs/browsers-api/browsers.installoptions.md
@@ -136,11 +136,11 @@ Determines the path to download browsers to.
 
 </td><td>
 
-(downloadedBytes: number, totalBytes: number) =&gt; void
+'default' \| ((downloadedBytes: number, totalBytes: number) =&gt; void)
 
 </td><td>
 
-Provides information about the progress of the download.
+Provides information about the progress of the download. If set to 'default', the default callback implementing a progress bar will be used.
 
 </td><td>
 

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -7,8 +7,6 @@
 import {stdin as input, stdout as output} from 'node:process';
 import * as readline from 'node:readline';
 
-import type * as ProgressBar from 'progress';
-import ProgressBarClass from 'progress';
 import type * as Yargs from 'yargs';
 
 import {
@@ -498,10 +496,7 @@ export class CLI {
       buildId: args.browser.buildId,
       platform: args.platform,
       cacheDir: args.path ?? this.#cachePath,
-      downloadProgressCallback: await makeProgressCallback(
-        args.browser.name,
-        args.browser.buildId,
-      ),
+      downloadProgressCallback: 'default',
       baseUrl: args.baseUrl,
       buildIdAlias:
         originalBuildId !== args.browser.buildId ? originalBuildId : undefined,
@@ -516,39 +511,4 @@ export class CLI {
       })}`,
     );
   }
-}
-
-/**
- * @public
- */
-export function makeProgressCallback(
-  browser: Browser,
-  buildId: string,
-): (downloadedBytes: number, totalBytes: number) => void {
-  let progressBar: ProgressBar;
-
-  let lastDownloadedBytes = 0;
-  return (downloadedBytes: number, totalBytes: number) => {
-    if (!progressBar) {
-      progressBar = new ProgressBarClass(
-        `Downloading ${browser} ${buildId} - ${toMegabytes(
-          totalBytes,
-        )} [:bar] :percent :etas `,
-        {
-          complete: '=',
-          incomplete: ' ',
-          width: 20,
-          total: totalBytes,
-        },
-      );
-    }
-    const delta = downloadedBytes - lastDownloadedBytes;
-    lastDownloadedBytes = downloadedBytes;
-    progressBar.tick(delta);
-  };
-}
-
-function toMegabytes(bytes: number) {
-  const mb = bytes / 1000 / 1000;
-  return `${Math.round(mb * 10) / 10} MB`;
 }

--- a/packages/browsers/src/main.ts
+++ b/packages/browsers/src/main.ts
@@ -25,6 +25,7 @@ export type {
 } from './install.js';
 export {
   install,
+  makeProgressCallback,
   getInstalledBrowsers,
   canDownload,
   uninstall,
@@ -40,6 +41,6 @@ export {
   createProfile,
   getVersionComparator,
 } from './browser-data/browser-data.js';
-export {CLI, makeProgressCallback} from './CLI.js';
+export {CLI} from './CLI.js';
 export {Cache, InstalledBrowser} from './Cache.js';
 export {BrowserTag} from './browser-data/types.js';

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -9,7 +9,6 @@ import {
   install,
   Browser,
   resolveBuildId,
-  makeProgressCallback,
   detectBrowserPlatform,
 } from '@puppeteer/browsers';
 import type {
@@ -46,7 +45,7 @@ async function downloadBrowser({
       cacheDir,
       platform,
       buildId,
-      downloadProgressCallback: await makeProgressCallback(browser, buildId),
+      downloadProgressCallback: 'default',
       baseUrl,
       buildIdAlias:
         buildId !== unresolvedBuildId ? unresolvedBuildId : undefined,


### PR DESCRIPTION
Using the `default` callback option allows Puppeteer to stop relying on on the makeProgressCallback function.