### PR TITLE
feat: Add Browser.installExtension and Browser.uninstallExtension

### DIFF
--- a/docs/api/puppeteer.browser.installextension.md
+++ b/docs/api/puppeteer.browser.installextension.md
@@ -4,7 +4,7 @@ sidebar_label: Browser.installExtension
 
 # Browser.installExtension() method
 
-Installs an extension and returns the ID. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+Installs an extension and returns the ID. In Chrome, this is only available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
 
 ### Signature
 

--- a/docs/api/puppeteer.browser.installextension.md
+++ b/docs/api/puppeteer.browser.installextension.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: Browser.installExtension
+---
+
+# Browser.installExtension() method
+
+Installs an extension and returns the ID. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+
+### Signature
+
+```typescript
+class Browser {
+  abstract installExtension(path: string): Promise<string>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+path
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Promise&lt;string&gt;

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -223,6 +223,17 @@ Disconnects Puppeteer from this [browser](./puppeteer.browser.md), but leaves th
 </td></tr>
 <tr><td>
 
+<span id="installextension">[installExtension(path)](./puppeteer.browser.installextension.md)</span>
+
+</td><td>
+
+</td><td>
+
+Installs an extension and returns the ID. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+
+</td></tr>
+<tr><td>
+
 <span id="isconnected">[isConnected()](./puppeteer.browser.isconnected.md)</span>
 
 </td><td>
@@ -314,6 +325,17 @@ Gets the [target](./puppeteer.target.md) associated with the [default browser co
 Gets all active [targets](./puppeteer.target.md).
 
 In case of multiple [browser contexts](./puppeteer.browsercontext.md), this returns all [targets](./puppeteer.target.md) in all [browser contexts](./puppeteer.browsercontext.md).
+
+</td></tr>
+<tr><td>
+
+<span id="uninstallextension">[uninstallExtension(id)](./puppeteer.browser.uninstallextension.md)</span>
+
+</td><td>
+
+</td><td>
+
+Uninstalls an extension. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -229,7 +229,7 @@ Disconnects Puppeteer from this [browser](./puppeteer.browser.md), but leaves th
 
 </td><td>
 
-Installs an extension and returns the ID. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+Installs an extension and returns the ID. In Chrome, this is only available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
 
 </td></tr>
 <tr><td>
@@ -335,7 +335,7 @@ In case of multiple [browser contexts](./puppeteer.browsercontext.md), this retu
 
 </td><td>
 
-Uninstalls an extension. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+Uninstalls an extension. In Chrome, this is only available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.uninstallextension.md
+++ b/docs/api/puppeteer.browser.uninstallextension.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: Browser.uninstallExtension
+---
+
+# Browser.uninstallExtension() method
+
+Uninstalls an extension. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+
+### Signature
+
+```typescript
+class Browser {
+  abstract uninstallExtension(id: string): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+id
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browser.uninstallextension.md
+++ b/docs/api/puppeteer.browser.uninstallextension.md
@@ -4,7 +4,7 @@ sidebar_label: Browser.uninstallExtension
 
 # Browser.uninstallExtension() method
 
-Uninstalls an extension. Available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+Uninstalls an extension. In Chrome, this is only available if the browser was created using `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
 
 ### Signature
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -462,15 +462,16 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
   }
 
   /**
-   * Installs an extension and returns the ID. Available if the browser was
-   * created using `pipe: true` and the `--enable-unsafe-extension-debugging`
-   * flag is set.
+   * Installs an extension and returns the ID. In Chrome, this is only
+   * available if the browser was created using `pipe: true` and the
+   * `--enable-unsafe-extension-debugging` flag is set.
    */
   abstract installExtension(path: string): Promise<string>;
 
   /**
-   * Uninstalls an extension. Available if the browser was created using
-   * `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+   * Uninstalls an extension. In Chrome, this is only available if the browser
+   * was created using `pipe: true` and the
+   * `--enable-unsafe-extension-debugging` flag is set.
    */
   abstract uninstallExtension(id: string): Promise<void>;
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -462,6 +462,19 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
   }
 
   /**
+   * Installs an extension and returns the ID. Available if the browser was
+   * created using `pipe: true` and the `--enable-unsafe-extension-debugging`
+   * flag is set.
+   */
+  abstract installExtension(path: string): Promise<string>;
+
+  /**
+   * Uninstalls an extension. Available if the browser was created using
+   * `pipe: true` and the `--enable-unsafe-extension-debugging` flag is set.
+   */
+  abstract uninstallExtension(id: string): Promise<void>;
+
+  /**
    * Whether Puppeteer is connected to this {@link Browser | browser}.
    *
    * @deprecated Use {@link Browser | Browser.connected}.

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -242,6 +242,14 @@ export class BidiBrowser extends Browser {
     return this.defaultBrowserContext().newPage();
   }
 
+  override installExtension(path: string): Promise<string> {
+    return this.#browserCore.installExtension(path);
+  }
+
+  override async uninstallExtension(id: string): Promise<void> {
+    await this.#browserCore.uninstallExtension(id);
+  }
+
   override targets(): Target[] {
     return [
       this.#target,

--- a/packages/puppeteer-core/src/bidi/core/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/core/Browser.ts
@@ -232,7 +232,9 @@ export class Browser extends EventEmitter<{
   async installExtension(path: string): Promise<string> {
     const {
       result: {extension},
-    } = await this.session.send('webExtension.install', {extensionData: {type: 'path', path}});
+    } = await this.session.send('webExtension.install', {
+      extensionData: {type: 'path', path},
+    });
     return extension;
   }
 

--- a/packages/puppeteer-core/src/bidi/core/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/core/Browser.ts
@@ -225,6 +225,25 @@ export class Browser extends EventEmitter<{
     return this.#createUserContext(context);
   }
 
+  @throwIfDisposed<Browser>(browser => {
+    // SAFETY: By definition of `disposed`, `#reason` is defined.
+    return browser.#reason!;
+  })
+  async installExtension(path: string): Promise<string> {
+    const {
+      result: {extension},
+    } = await this.session.send('webExtension.install', {extensionData: {type: 'path', path}});
+    return extension;
+  }
+
+  @throwIfDisposed<Browser>(browser => {
+    // SAFETY: By definition of `disposed`, `#reason` is defined.
+    return browser.#reason!;
+  })
+  async uninstallExtension(id: string): Promise<void> {
+    await this.session.send('webExtension.uninstall', {extension: id});
+  }
+
   override [disposeSymbol](): void {
     this.#reason ??=
       'Browser was disconnected, probably because the session ended.';

--- a/packages/puppeteer-core/src/bidi/core/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/core/Connection.ts
@@ -183,6 +183,14 @@ export interface Commands {
     params: Bidi.Network.ProvideResponseParameters;
     returnType: Bidi.EmptyResult;
   };
+  'webExtension.install': {
+    params: Bidi.WebExtension.InstallParameters;
+    returnType: Bidi.WebExtension.InstallResult;
+  };
+  'webExtension.uninstall': {
+    params: Bidi.WebExtension.UninstallParameters;
+    returnType: Bidi.EmptyResult;
+  };
 }
 
 /**

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -360,6 +360,15 @@ export class CdpBrowser extends BrowserBase {
     return page;
   }
 
+  override async installExtension(path: string): Promise<string> {
+    const {id} = await this.#connection.send('Extensions.loadUnpacked', { path });
+    return id;
+  }
+
+  override uninstallExtension(id: string): Promise<void> {
+    return this.#connection.send('Extensions.uninstall', { id });
+  }
+
   override targets(): CdpTarget[] {
     return Array.from(
       this.#targetManager.getAvailableTargets().values(),

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -361,12 +361,12 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async installExtension(path: string): Promise<string> {
-    const {id} = await this.#connection.send('Extensions.loadUnpacked', { path });
+    const {id} = await this.#connection.send('Extensions.loadUnpacked', {path});
     return id;
   }
 
   override uninstallExtension(id: string): Promise<void> {
-    return this.#connection.send('Extensions.uninstall', { id });
+    return this.#connection.send('Extensions.uninstall', {id});
   }
 
   override targets(): CdpTarget[] {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -649,6 +649,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox is currently only able to install signed extensions."
+  },
+  {
     "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails Network redirects should report SecurityDetails",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -1703,24 +1710,17 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome", "chrome-headless-shell"],
+    "expectations": ["FAIL"],
+    "comment": "Extensions are not supported in shell mode."
+  },
+  {
     "testIdPattern": "[worker.spec] Workers Page.workers",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "chrome-headless-shell", "cdp"],
-    "expectations": ["FAIL"],
-    "comment": "Extensions are not supported in shell mode."
-  },
-  {
-    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox is currently only able to install signed extensions."
   }
 ]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1718,7 +1718,7 @@
   },
   {
     "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
-    "platforms": ["darwin"],
+    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["FAIL"],
     "comment": "Firefox is currently only able to install signed extensions."

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1708,5 +1708,19 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
+    "platforms": ["darwin"],
+    "parameters": ["chrome", "chrome-headless-shell", "cdp"],
+    "expectations": ["FAIL"],
+    "comment": "Extensions are not supported in shell mode."
+  },
+  {
+    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
+    "platforms": ["darwin"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox is currently only able to install signed extensions."
   }
 ]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1711,7 +1711,7 @@
   },
   {
     "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
-    "platforms": ["darwin"],
+    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "chrome-headless-shell", "cdp"],
     "expectations": ["FAIL"],
     "comment": "Extensions are not supported in shell mode."

--- a/test/assets/simple-extension/manifest.json
+++ b/test/assets/simple-extension/manifest.json
@@ -1,4 +1,5 @@
 {
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkdj/foSvjYv+9rAjepZIQ3ghb4630EA+xEuUal77xb/NVKcHEamKHEsDKMLTSsmA0qv8biWEqSiZ5JQIdO7KagYCkFOFjHlyPkHgMCmLo14x6sqzQh1XGlALIWiLJXEA3/Z2Kde+dt0iQEbn0B9PBLo+2yghwxlS+YeP3k9YVEpvtq6Yj8v4JUqVT+8rF0A9GIHUvga30wFUpi2W1Fpiqpu+3DbOUn4LXDSgyK8q9h4H21rnAa9Y0tGkxf2Tl7Hy+Q2JuibUa6GrRKojY0TRaFv5H0Y33CtnvIbYFct/6ZpvJCTT1HmDm5yUR1aUY5PGGVREmj5PMbmPK4EwybYckQIDAQAB",
   "name": "Simple extension",
   "version": "0.1",
   "background": {

--- a/test/src/webExtension.spec.ts
+++ b/test/src/webExtension.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+
+import expect from 'expect';
+
+import {getTestState, launch, setupTestBrowserHooks} from './mocha-utils.js';
+
+const EXTENSION_PATH = path.join(__dirname, '/../assets/simple-extension');
+const EXPECTED_ID = 'mbljndkcfjhaffohbnmoedabegpolpmd';
+
+describe('webExtension', function () {
+  setupTestBrowserHooks();
+
+  it.only('can install and uninstall an extension', async () => {
+    const {defaultBrowserOptions, isChrome} = await getTestState({
+      skipLaunch: true,
+    });
+
+    const options = Object.assign({}, defaultBrowserOptions);
+
+    if (isChrome) {
+      options.ignoreDefaultArgs = ['--disable-extensions'];
+      options.args = ['--enable-unsafe-extension-debugging'].concat(
+        options.args || [],
+      );
+      options.pipe = true;
+    }
+
+    const {browser, close} = await launch(options);
+    try {
+      // Install an extension. Since the `key` field is present in the
+      // manifest, this should always have the same ID.
+      expect(await browser.installExtension(EXTENSION_PATH)).toBe(EXPECTED_ID);
+
+      // Check we can uninstall the extension.
+      await browser.uninstallExtension(EXPECTED_ID);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/test/src/webExtension.spec.ts
+++ b/test/src/webExtension.spec.ts
@@ -16,7 +16,7 @@ const EXPECTED_ID = 'mbljndkcfjhaffohbnmoedabegpolpmd';
 describe('webExtension', function () {
   setupTestBrowserHooks();
 
-  it.only('can install and uninstall an extension', async () => {
+  it('can install and uninstall an extension', async () => {
     const {defaultBrowserOptions, isChrome} = await getTestState({
       skipLaunch: true,
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A new feature, in particular new methods on `Browser` to install and uninstall a browser extension.

**Did you add tests for your changes?**

I wasn't able to identify any relevant test files for this type of change.

**If relevant, did you update the documentation?**

Used the `npm run docs` command. I will also open a follow-up PR with updates to https://pptr.dev/guides/chrome-extensions.

**Summary**

New CDP and WebDriver BiDi commands have been added for installing web extensions. This PR adds new methods to allow developers to use this capability.

**Does this PR introduce a breaking change?**

NA

**Other information**

NA