### PR TITLE
chore: use relative paths in tsconfig

### DIFF
--- a/packages/browsers/tsconfig.json
+++ b/packages/browsers/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "references": [
-    {"path": "src/tsconfig.esm.json"},
-    {"path": "src/tsconfig.cjs.json"}
+    {"path": "./src/tsconfig.esm.json"},
+    {"path": "./src/tsconfig.cjs.json"}
   ]
 }

--- a/packages/puppeteer-core/tsconfig.json
+++ b/packages/puppeteer-core/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "references": [
-    {"path": "src/tsconfig.esm.json"},
-    {"path": "src/tsconfig.cjs.json"}
+    {"path": "./src/tsconfig.esm.json"},
+    {"path": "./CHANGELOG.mdsrc/tsconfig.cjs.json"}
   ]
 }

--- a/packages/puppeteer-core/tsconfig.json
+++ b/packages/puppeteer-core/tsconfig.json
@@ -3,6 +3,6 @@
   "files": [],
   "references": [
     {"path": "./src/tsconfig.esm.json"},
-    {"path": "./CHANGELOG.mdsrc/tsconfig.cjs.json"}
+    {"path": "./src/tsconfig.cjs.json"}
   ]
 }

--- a/packages/puppeteer/tsconfig.json
+++ b/packages/puppeteer/tsconfig.json
@@ -10,7 +10,7 @@
     }
   },
   "references": [
-    {"path": "src/tsconfig.esm.json"},
-    {"path": "src/tsconfig.cjs.json"}
+    {"path": "./src/tsconfig.esm.json"},
+    {"path": "./src/tsconfig.cjs.json"}
   ]
 }


### PR DESCRIPTION
Small change to make it more explicit where there are coming from. Also allows to quickly jump in IDEs