### PR TITLE
feat: Add `enableExtensions` launch option

### DIFF
--- a/docs/api/puppeteer.launchoptions.md
+++ b/docs/api/puppeteer.launchoptions.md
@@ -159,6 +159,25 @@ If true, pipes the browser process stdout and stderr to `process.stdout` and `pr
 </td></tr>
 <tr><td>
 
+<span id="enableextensions">enableExtensions</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean \| string\[\]
+
+</td><td>
+
+If `true`, avoids passing default arguments to the browser that would prevent extensions from being enabled. Passing a list of strings will load the provided paths as unpacked extensions.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="env">env</span>
 
 </td><td>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,11 +83,11 @@ enforce running Chrome/Chromium with certain extensions.
 Puppeteer passes `--disable-extensions` flag by default and will fail to launch
 when such policies are active.
 
-To work around this, try running without the flag:
+To work around this, set the `enableExtensions` option:
 
 ```ts
 const browser = await puppeteer.launch({
-  ignoreDefaultArgs: ['--disable-extensions'],
+  enableExtensions: true,
 });
 ```
 

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -74,6 +74,7 @@ export abstract class BrowserLauncher {
   async launch(options: LaunchOptions = {}): Promise<Browser> {
     const {
       dumpio = false,
+      enableExtensions = false,
       env = process.env,
       handleSIGINT = true,
       handleSIGTERM = true,
@@ -207,6 +208,20 @@ export abstract class BrowserLauncher {
         throw new TimeoutError(error.message);
       }
       throw error;
+    }
+
+    if (Array.isArray(enableExtensions)) {
+      if (this.#browser === 'chrome' && !usePipe) {
+        throw new Error(
+          'To use `enableExtensions` with a list of paths in Chrome, you must be connected with `--remote-debugging-pipe` (`pipe: true`).',
+        );
+      }
+
+      await Promise.all([
+        enableExtensions.map(path => {
+          return browser.installExtension(path);
+        }),
+      ]);
     }
 
     if (waitForInitialPage) {

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -211,6 +211,12 @@ export abstract class BrowserLauncher {
     }
 
     if (Array.isArray(enableExtensions)) {
+      if (this.#browser === 'chrome' && !usePipe) {
+        throw new Error(
+          'To use `enableExtensions` with a list of paths in Chrome, you must be connected with `--remote-debugging-pipe` (`pipe: true`).',
+        );
+      }
+
       // In Chrome, extensions are installed using the default args instead.
       if (this.#browser !== 'chrome') {
         await Promise.all([

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -211,17 +211,14 @@ export abstract class BrowserLauncher {
     }
 
     if (Array.isArray(enableExtensions)) {
-      if (this.#browser === 'chrome' && !usePipe) {
-        throw new Error(
-          'To use `enableExtensions` with a list of paths in Chrome, you must be connected with `--remote-debugging-pipe` (`pipe: true`).',
-        );
+      // In Chrome, extensions are installed using the default args instead.
+      if (this.#browser !== 'chrome') {
+        await Promise.all([
+          enableExtensions.map(path => {
+            return browser.installExtension(path);
+          }),
+        ]);
       }
-
-      await Promise.all([
-        enableExtensions.map(path => {
-          return browser.installExtension(path);
-        }),
-      ]);
     }
 
     if (waitForInitialPage) {

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -217,14 +217,11 @@ export abstract class BrowserLauncher {
         );
       }
 
-      // In Chrome, extensions are installed using the default args instead.
-      if (this.#browser !== 'chrome') {
-        await Promise.all([
-          enableExtensions.map(path => {
-            return browser.installExtension(path);
-          }),
-        ]);
-      }
+      await Promise.all([
+        enableExtensions.map(path => {
+          return browser.installExtension(path);
+        }),
+      ]);
     }
 
     if (waitForInitialPage) {

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -213,7 +213,6 @@ export class ChromeLauncher extends BrowserLauncher {
       '--disable-crash-reporter', // No crash reporting in CfT.
       '--disable-default-apps',
       '--disable-dev-shm-usage',
-      '--disable-extensions',
       '--disable-hang-monitor',
       '--disable-infobars',
       '--disable-ipc-flooding-protection',
@@ -240,6 +239,7 @@ export class ChromeLauncher extends BrowserLauncher {
       headless = !devtools,
       args = [],
       userDataDir,
+      enableExtensions = false,
     } = options;
     if (userDataDir) {
       chromeArguments.push(`--user-data-dir=${path.resolve(userDataDir)}`);
@@ -254,6 +254,11 @@ export class ChromeLauncher extends BrowserLauncher {
         '--mute-audio',
       );
     }
+    chromeArguments.push(
+      enableExtensions
+        ? '--enable-unsafe-extension-debugging'
+        : '--disable-extensions',
+    );
     if (
       args.every(arg => {
         return arg.startsWith('-');

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -254,15 +254,11 @@ export class ChromeLauncher extends BrowserLauncher {
         '--mute-audio',
       );
     }
-    if (enableExtensions) {
-      chromeArguments.push('--enable-unsafe-extension-debugging');
-
-      if (Array.isArray(enableExtensions)) {
-        chromeArguments.push(`--load-extension=${enableExtensions.join(',')}`);
-      }
-    } else {
-      chromeArguments.push('--disable-extensions');
-    }
+    chromeArguments.push(
+      enableExtensions
+        ? '--enable-unsafe-extension-debugging'
+        : '--disable-extensions',
+    );
     if (
       args.every(arg => {
         return arg.startsWith('-');

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -254,11 +254,18 @@ export class ChromeLauncher extends BrowserLauncher {
         '--mute-audio',
       );
     }
-    chromeArguments.push(
-      enableExtensions
-        ? '--enable-unsafe-extension-debugging'
-        : '--disable-extensions',
-    );
+    if (enableExtensions) {
+      chromeArguments.push('--enable-unsafe-extension-debugging');
+
+      if (Array.isArray(enableExtensions)) {
+        chromeArguments.push(
+          '--disable-extensions',
+          `--disable-extensions-except=${enableExtensions.join(',')}`,
+        );
+      }
+    } else {
+      chromeArguments.push('--disable-extensions');
+    }
     if (
       args.every(arg => {
         return arg.startsWith('-');

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -258,10 +258,7 @@ export class ChromeLauncher extends BrowserLauncher {
       chromeArguments.push('--enable-unsafe-extension-debugging');
 
       if (Array.isArray(enableExtensions)) {
-        chromeArguments.push(
-          '--disable-extensions',
-          `--disable-extensions-except=${enableExtensions.join(',')}`,
-        );
+        chromeArguments.push(`--load-extension=${enableExtensions.join(',')}`);
       }
     } else {
       chromeArguments.push('--disable-extensions');

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -44,6 +44,12 @@ export interface LaunchOptions extends ConnectOptions {
    */
   ignoreDefaultArgs?: boolean | string[];
   /**
+   * If `true`, avoids passing default arguments to the browser that would
+   * prevent extensions from being enabled. Passing a list of strings will
+   * load the provided paths as unpacked extensions.
+   */
+  enableExtensions?: boolean | string[];
+  /**
    * Close the browser process on `Ctrl+C`.
    * @defaultValue `true`
    */

--- a/test/installation/assets/puppeteer/puppeteer-in-extension.js
+++ b/test/installation/assets/puppeteer/puppeteer-in-extension.js
@@ -9,8 +9,8 @@ const pathToExtension = path.join(
 
 const browser = await puppeteer.launch({
   headless: true,
+  enableExtensions: true,
   args: [
-    `--disable-extensions-except=${pathToExtension}`,
     `--load-extension=${pathToExtension}`,
     '--silent-debugger-extension-api',
   ],

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -21,10 +21,8 @@ const extensionPath = path.join(
 describe('extensions', function () {
   const state = setupSeparateTestBrowserHooks(
     {
-      args: [
-        `--disable-extensions-except=${extensionPath}`,
-        `--load-extension=${extensionPath}`,
-      ],
+      enableExtensions: true,
+      args: [`--load-extension=${extensionPath}`],
     },
     {createContext: false},
   );

--- a/test/src/webExtension.spec.ts
+++ b/test/src/webExtension.spec.ts
@@ -24,10 +24,7 @@ describe('webExtension', function () {
     const options = Object.assign({}, defaultBrowserOptions);
 
     if (isChrome) {
-      options.ignoreDefaultArgs = ['--disable-extensions'];
-      options.args = ['--enable-unsafe-extension-debugging'].concat(
-        options.args || [],
-      );
+      options.enableExtensions = true;
       options.pipe = true;
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A new launch option (`enableExtensions`) which can be set to `string[]`, `true` or `false`:

- `string[]` - load the provided list of paths as unpacked extensions.
- `true` - avoids passing default args that would disable extensions. Further extension installation is allowed.
- `false` - disables extensions entirely.

**Known issues**

- In Chrome, passing a `string[]` or `true` removes the `--disable-extensions` flag which means other extensions may run.
- In Chrome, `pipe: true` must also be provided if a `string[]` is passed.
- In Firefox, there is no known command line flag to disable addons so they are always enabled.
- In Firefox, passing a `string[]` uses WebDriver BiDi commands which have not yet reached stable.

**Did you add tests for your changes?**

Covered by existing tests.

**If relevant, did you update the documentation?**

Yes

**Summary**

This avoids developers needing to manually change the flags when wanting to install extensions.

**Does this PR introduce a breaking change?**

No

**Other information**
