### PR TITLE
fix: writable stream in PipeTransport should handle errors

### DIFF
--- a/packages/puppeteer-core/src/node/PipeTransport.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.ts
@@ -47,7 +47,7 @@ export class PipeTransport implements ConnectionTransport {
       // NodeJS event emitters don't support `*` so we need to typecast
       // As long as we don't use it we should be OK.
       new EventEmitter(
-        pipeRead as unknown as EventEmitter<Record<string, any>>,
+        pipeWrite as unknown as EventEmitter<Record<string, any>>,
       ),
     );
     pipeWriteEmitter.on('error', debugError);


### PR DESCRIPTION
Without an error handler it can lead to crashes.