### PR TITLE
fix: browser management docs typo

### DIFF
--- a/docs/guides/browser-management.md
+++ b/docs/guides/browser-management.md
@@ -1,6 +1,6 @@
 # Browser management
 
-Usually, you start working with Puppeteer by either launching [launching](https://pptr.dev/api/puppeteer.puppeteernode.launch) or [connecting](https://pptr.dev/api/puppeteer.puppeteernode.connect) to a browser.
+Usually, you start working with Puppeteer by either [launching](https://pptr.dev/api/puppeteer.puppeteernode.launch) or [connecting](https://pptr.dev/api/puppeteer.puppeteernode.connect) to a browser.
 
 ## Launching a browser
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR fixes the typo in the browser management docs

**Did you add tests for your changes?**

No. Was not needed.

**Summary**

This PR corrects a typo in the Puppeteer documentation. The word "launching" appeared twice in the sentence about starting to work with Puppeteer, and the duplicate has been removed.

**Does this PR introduce a breaking change?**

No

**Other information**
