### PR TITLE
docs: fix handling of the slash

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -43,6 +43,7 @@ const config = {
   favicon: 'img/favicon.ico',
   organizationName: 'puppeteer',
   projectName: 'puppeteer',
+  trailingSlash: false,
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],


### PR DESCRIPTION
It looks like our manual fixes for slash does not work with Algolia search. Trying to fix it by setting trailingSlash to false. Related https://github.com/puppeteer/puppeteer/issues/13842