### PR TITLE
feat: `screencast` image options

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -615,6 +615,13 @@ All the events a [browser instance](./puppeteer.browser.md) may emit.
 </td></tr>
 <tr><td>
 
+<span id="imageformat">[ImageFormat](./puppeteer.imageformat.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="interceptresolutionaction">[InterceptResolutionAction](./puppeteer.interceptresolutionaction.md)</span>
 
 </td><td>
@@ -1541,6 +1548,20 @@ See individual properties for more information.
 </td></tr>
 <tr><td>
 
+<span id="fileformat">[FileFormat](./puppeteer.fileformat.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="filepath">[FilePath](./puppeteer.filepath.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="flattenhandle">[FlattenHandle](./puppeteer.flattenhandle.md)</span>
 
 </td><td>
@@ -1563,13 +1584,6 @@ See individual properties for more information.
 <tr><td>
 
 <span id="handler">[Handler](./puppeteer.handler.md)</span>
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="imageformat">[ImageFormat](./puppeteer.imageformat.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.fileformat.md
+++ b/docs/api/puppeteer.fileformat.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: FileFormat
+---
+
+# FileFormat type
+
+### Signature
+
+```typescript
+export type FileFormat = VideoFormat | Exclude<ImageFormat, 'webp'>;
+```
+
+**References:** [VideoFormat](./puppeteer.videoformat.md), [ImageFormat](./puppeteer.imageformat.md)

--- a/docs/api/puppeteer.filepath.md
+++ b/docs/api/puppeteer.filepath.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: FilePath
+---
+
+# FilePath type
+
+### Signature
+
+```typescript
+export type FilePath = `${string}.${FileFormat}`;
+```
+
+**References:** [FileFormat](./puppeteer.fileformat.md)

--- a/docs/api/puppeteer.imageformat.md
+++ b/docs/api/puppeteer.imageformat.md
@@ -2,10 +2,60 @@
 sidebar_label: ImageFormat
 ---
 
-# ImageFormat type
+# ImageFormat enum
 
 ### Signature
 
 ```typescript
-export type ImageFormat = 'png' | 'jpeg' | 'webp';
+export declare enum ImageFormat
 ```
+
+## Enumeration Members
+
+<table><thead><tr><th>
+
+Member
+
+</th><th>
+
+Value
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+jpeg
+
+</td><td>
+
+`"jpeg"`
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+png
+
+</td><td>
+
+`"png"`
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+webp
+
+</td><td>
+
+`"webp"`
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.screencastoptions.md
+++ b/docs/api/puppeteer.screencastoptions.md
@@ -127,7 +127,7 @@ Required if `ffmpeg` is not in your PATH.
 
 </td><td>
 
-[VideoFormat](./puppeteer.videoformat.md)
+[FileFormat](./puppeteer.fileformat.md)
 
 </td><td>
 
@@ -211,7 +211,7 @@ Specifies whether to overwrite output file, or exit immediately if it already ex
 
 </td><td>
 
-\`$&#123;string&#125;.$&#123;[VideoFormat](./puppeteer.videoformat.md)&#125;\`
+[FilePath](./puppeteer.filepath.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.screenshotoptions.md
+++ b/docs/api/puppeteer.screenshotoptions.md
@@ -224,7 +224,7 @@ Quality of the image, between 0-100. Not applicable to `png` images.
 
 </td><td>
 
-[ImageFormat](./puppeteer.imageformat.md)
+\`$&#123;[ImageFormat](./puppeteer.imageformat.md)&#125;\`
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -258,7 +258,11 @@ export interface ScreenshotClip extends BoundingBox {
 /**
  * @public
  */
-export type ImageFormat = 'png' | 'jpeg' | 'webp';
+export enum ImageFormat {
+  png = 'png',
+  jpeg = 'jpeg',
+  webp = 'webp',
+}
 
 /**
  * @public
@@ -276,7 +280,7 @@ export interface ScreenshotOptions {
   /**
    * @defaultValue `'png'`
    */
-  type?: ImageFormat;
+  type?: `${ImageFormat}`;
   /**
    * Quality of the image, between 0-100. Not applicable to `png` images.
    */
@@ -326,13 +330,23 @@ export interface ScreenshotOptions {
 
 /**
  * @public
+ */
+export type FileFormat = VideoFormat | Exclude<ImageFormat, 'webp'>;
+
+/**
+ * @public
+ */
+export type FilePath = `${string}.${FileFormat}`;
+
+/**
+ * @public
  * @experimental
  */
 export interface ScreencastOptions {
   /**
    * File path to save the screencast to.
    */
-  path?: `${string}.${VideoFormat}`;
+  path?: FilePath;
   /**
    * Specifies whether to overwrite output file,
    * or exit immediately if it already exists.
@@ -345,7 +359,7 @@ export interface ScreencastOptions {
    *
    * @defaultValue `'webm'`
    */
-  format?: VideoFormat;
+  format?: FileFormat;
   /**
    * Specifies the region of the viewport to crop.
    */
@@ -2481,7 +2495,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       void recorder.stop();
       throw error;
     }
-    if (options.path) {
+    if (options.path && !(options.format ?? '' in ImageFormat)) {
       const {createWriteStream} = environment.value.fs;
       const stream = createWriteStream(options.path, 'binary');
       recorder.pipe(stream);

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -272,6 +272,8 @@ export class ScreenRecorder extends PassThrough {
     // Sets the format
     const image = ['-f', 'image2'];
     switch (format) {
+      default:
+        return [];
       case 'webm':
         return [
           ...libvpx,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

A follow-up to the suggested refactor in https://github.com/puppeteer/puppeteer/pull/13708#issuecomment-2835505747, separating out part of—and dependent on—#13708.

**Did you add tests for your changes?**

Yes, see #13708.

**If relevant, did you update the documentation?**

Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Adds `png`/`jpeg` support to output `format` options for `screencast`/`ffmpeg`, to generate a folder full of frames in the corresponding image format. Along with their corresponding `quality` option.

Follow up to https://github.com/puppeteer/puppeteer/pull/13708#issuecomment-2835505747.

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Related to: #13708, #11084, #13645 and #13676.

See also:

[How can I extract a good quality JPEG image from a video file with ffmpeg?](https://stackoverflow.com/questions/10225403/how-can-i-extract-a-good-quality-jpeg-image-from-a-video-file-with-ffmpeg/10234065#10234065)