### PR TITLE
docs: fix typos in browser-management.md

### DIFF
--- a/docs/guides/browser-management.md
+++ b/docs/guides/browser-management.md
@@ -1,6 +1,6 @@
 # Browser management
 
-Usually, you start working with Puppeteer by either launching [launching](https://pptr.dev/api/puppeteer.puppeteernode.launch) or [connecting](https://pptr.dev/api/puppeteer.puppeteernode.connect) to a browser.
+Usually, you start working with Puppeteer by either [launching](https://pptr.dev/api/puppeteer.puppeteernode.launch) or [connecting](https://pptr.dev/api/puppeteer.puppeteernode.connect) to a browser.
 
 ## Launching a browser
 
@@ -60,7 +60,7 @@ await context.overridePermissions('https://html5demos.com', ['geolocation']);
 
 ## Connecting to a running browser
 
-If you launched a browser outside of Puppeteer, you can connect to it using [`connect`](https://pptr.dev/api/puppeteer.puppeteernode.connect/) method. Usually, you can grab a WebSocket endpoint URL from the browser output:
+If you launched a browser outside of Puppeteer, you can connect to it using the [`connect`](https://pptr.dev/api/puppeteer.puppeteernode.connect/) method. Usually, you can grab a WebSocket endpoint URL from the browser output:
 
 ```ts
 const browser = await puppeteer.connect({


### PR DESCRIPTION
This commit fixes several typos in the `browser-management.md` file:

* It removes the extra "launching";
* Adds "the" before specifying the connect method

**What kind of change does this PR introduce?**

Documentation update

**Did you add tests for your changes?**

No tests needed, as this is documentation-only

**If relevant, did you update the documentation?**

I did, fixing a few typos. An existing PR exists but the creator hasn't yet accepted the agreement

**Summary**

The current page has some typos that I noticed; this PR fixes that

**Does this PR introduce a breaking change?**

Nope, no breaking changes

**Other information**
