### PR TITLE
fix: revert "refactor: allow importing chromium-bidi ESM"

### DIFF
--- a/docs/guides/running-puppeteer-in-extensions.md
+++ b/docs/guides/running-puppeteer-in-extensions.md
@@ -59,8 +59,8 @@ export default {
     dir: 'out',
   },
   // If you do not need to use WebDriver BiDi protocol,
-  // exclude chromium-bidi/lib/* to minimize the bundle size.
-  external: ['chromium-bidi/*'],
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       // Indicate that we target a browser environment.

--- a/docs/guides/running-puppeteer-in-the-browser.md
+++ b/docs/guides/running-puppeteer-in-the-browser.md
@@ -49,8 +49,8 @@ export default {
     dir: 'out',
   },
   // If you do not need to use WebDriver BiDi protocol,
-  // exclude chromium-bidi/lib/* to minimize the bundle size.
-  external: ['chromium-bidi/*'],
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       // Indicate that we target a browser environment.

--- a/examples/puppeteer-in-browser/rollup.config.mjs
+++ b/examples/puppeteer-in-browser/rollup.config.mjs
@@ -12,8 +12,8 @@ export default {
     dir: 'out',
   },
   // If you do not need to use WebDriver BiDi protocol,
-  // exclude chromium-bidi/* to minimize the bundle size.
-  external: ['chromium-bidi/*'],
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       browser: true,

--- a/examples/puppeteer-in-extension/rollup.config.mjs
+++ b/examples/puppeteer-in-extension/rollup.config.mjs
@@ -12,8 +12,8 @@ export default {
     dir: 'out',
   },
   // If you do not need to use WebDriver BiDi protocol,
-  // exclude chromium-bidi/* to minimize the bundle size.
-  external: ['chromium-bidi/*'],
+  // exclude chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js to minimize the bundle size.
+  external: ['chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js'],
   plugins: [
     nodeResolve({
       browser: true,

--- a/package.json
+++ b/package.json
@@ -205,10 +205,5 @@
     "tools/doctest",
     "tools/docgen",
     "tools/mocha-runner"
-  ],
-  "tsd": {
-    "compilerOptions": {
-      "module": "NodeNext"
-    }
-  }
+  ]
 }

--- a/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as BidiMapper from 'chromium-bidi/bidiMapper/BidiMapper.js';
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as BidiMapper from 'chromium-bidi/lib/cjs/bidiMapper/BidiMapper.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
 import type {CDPEvents, CDPSession} from '../api/CDPSession.js';

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -6,7 +6,7 @@
 
 import type {ChildProcess} from 'node:child_process';
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {BrowserEvents} from '../api/Browser.js';
 import {

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {Permission} from '../api/Browser.js';
 import {WEB_PERMISSION_TO_PROTOCOL_PERMISSION} from '../api/Browser.js';

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {CallbackRegistry} from '../common/CallbackRegistry.js';
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';

--- a/packages/puppeteer-core/src/bidi/Deserializer.ts
+++ b/packages/puppeteer-core/src/bidi/Deserializer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {debugError} from '../common/util.js';
 

--- a/packages/puppeteer-core/src/bidi/ElementHandle.ts
+++ b/packages/puppeteer-core/src/bidi/ElementHandle.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {
   bindIsolatedHandle,

--- a/packages/puppeteer-core/src/bidi/ExposedFunction.ts
+++ b/packages/puppeteer-core/src/bidi/ExposedFunction.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../common/EventEmitter.js';
 import type {Awaitable, FlattenHandle} from '../common/types.js';

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {Observable} from '../../third_party/rxjs/rxjs.js';
 import {

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -3,7 +3,7 @@
  * Copyright 2020 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type {Protocol} from 'devtools-protocol';
 
 import type {CDPSession} from '../api/CDPSession.js';

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -3,7 +3,7 @@
  * Copyright 2020 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type {Protocol} from 'devtools-protocol';
 
 import type {Frame} from '../api/Frame.js';

--- a/packages/puppeteer-core/src/bidi/Input.ts
+++ b/packages/puppeteer-core/src/bidi/Input.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {Point} from '../api/ElementHandle.js';
 import {

--- a/packages/puppeteer-core/src/bidi/JSHandle.ts
+++ b/packages/puppeteer-core/src/bidi/JSHandle.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {ElementHandle} from '../api/ElementHandle.js';
 import {JSHandle} from '../api/JSHandle.js';

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import type Protocol from 'devtools-protocol';
 
 import {firstValueFrom, from, raceWith} from '../../third_party/rxjs/rxjs.js';

--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -3,7 +3,7 @@
  * Copyright 2024 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {JSHandle} from '../api/JSHandle.js';
 import {Realm} from '../api/Realm.js';

--- a/packages/puppeteer-core/src/bidi/Serializer.ts
+++ b/packages/puppeteer-core/src/bidi/Serializer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {isDate, isPlainObject, isRegExp} from '../common/util.js';
 

--- a/packages/puppeteer-core/src/bidi/core/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/core/Browser.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {inertIfDisposed, throwIfDisposed} from '../../util/decorators.js';

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {inertIfDisposed, throwIfDisposed} from '../../util/decorators.js';

--- a/packages/puppeteer-core/src/bidi/core/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/core/Connection.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {EventEmitter} from '../../common/EventEmitter.js';
 

--- a/packages/puppeteer-core/src/bidi/core/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/core/Realm.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {inertIfDisposed, throwIfDisposed} from '../../util/decorators.js';

--- a/packages/puppeteer-core/src/bidi/core/Request.ts
+++ b/packages/puppeteer-core/src/bidi/core/Request.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {inertIfDisposed} from '../../util/decorators.js';

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {

--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {assert} from '../../util/assert.js';

--- a/packages/puppeteer-core/src/bidi/core/UserPrompt.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserPrompt.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {EventEmitter} from '../../common/EventEmitter.js';
 import {inertIfDisposed, throwIfDisposed} from '../../util/decorators.js';

--- a/packages/puppeteer-core/src/bidi/util.ts
+++ b/packages/puppeteer-core/src/bidi/util.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as Bidi from 'chromium-bidi/protocol/protocol.js';
+import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import {ProtocolError, TimeoutError} from '../common/Errors.js';
 import {PuppeteerURL} from '../common/util.js';

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Session} from 'chromium-bidi/protocol/protocol.js';
+import type {Session} from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 import type {
   IsPageTargetCallback,

--- a/packages/puppeteer-core/src/index-browser.ts
+++ b/packages/puppeteer-core/src/index-browser.ts
@@ -5,7 +5,7 @@
  */
 
 export type {Protocol} from 'devtools-protocol';
-export type {Session} from 'chromium-bidi/protocol/protocol.js';
+export type {Session} from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 
 export * from './api/api.js';
 export * from './cdp/cdp.js';

--- a/packages/puppeteer-core/src/tsconfig.cjs.json
+++ b/packages/puppeteer-core/src/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "outDir": "../lib/cjs/puppeteer"
   },
   "references": [{"path": "../third_party/tsconfig.cjs.json"}]

--- a/test-d/ElementHandle.test-d.ts
+++ b/test-d/ElementHandle.test-d.ts
@@ -8,419 +8,1003 @@ import {expectNotType, expectType} from 'tsd';
 
 declare const handle: ElementHandle;
 
-const test = async () => {
+{
   {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(await handle.$('a'));
-    expectNotType<ElementHandle<Element> | null>(await handle.$('a'));
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(await handle.$('a'));
+      expectNotType<ElementHandle<Element> | null>(await handle.$('a'));
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('a#id'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('a#id'));
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('a.class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('a.class'));
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('a[attr=value]'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('a[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('a:psuedo-class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('a:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('a:func(arg)'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('a:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(await handle.$('a#id'));
-    expectNotType<ElementHandle<Element> | null>(await handle.$('a#id'));
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(await handle.$('div'));
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div'));
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div#id'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div#id'));
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div.class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div.class'));
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div[attr=value]'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div:psuedo-class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div:func(arg)'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('a.class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('a.class'));
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('some-custom'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('some-custom#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('some-custom.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('some-custom[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('some-custom:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('some-custom:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('a[attr=value]'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('a[attr=value]'),
-    );
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$(''));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('#id'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('.class'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('[attr=value]'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$(':pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$(':func(arg)'));
+    }
   }
   {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('a:psuedo-class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('a:pseudo-class'),
-    );
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div > a'));
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a#id'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a.class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a[attr=value]'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a:psuedo-class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a:func(arg)'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('a:func(arg)'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('a:func(arg)'));
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div > div'));
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div#id'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div.class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div[attr=value]'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div:psuedo-class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div:func(arg)'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div:func(arg)'),
+      );
+    }
   }
+  {
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('div > #id'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('div > .class'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > [attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > :pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > :func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div > a'));
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a#id'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a.class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a[attr=value]'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a:psuedo-class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLAnchorElement> | null>(
+        await handle.$('div > a:func(arg)'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > a:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div'),
+      );
+      expectNotType<ElementHandle<Element> | null>(await handle.$('div > div'));
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div#id'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div.class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div[attr=value]'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div:psuedo-class'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<HTMLDivElement> | null>(
+        await handle.$('div > div:func(arg)'),
+      );
+      expectNotType<ElementHandle<Element> | null>(
+        await handle.$('div > div:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom#id'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom.class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom[attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom:pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > some-custom:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('div > #id'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(await handle.$('div > .class'));
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > [attr=value]'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > :pseudo-class'),
+      );
+    }
+    {
+      expectType<ElementHandle<Element> | null>(
+        await handle.$('div > :func(arg)'),
+      );
+    }
+  }
+}
 
+{
   {
-    expectType<ElementHandle<HTMLDivElement> | null>(await handle.$('div'));
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div'));
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(await handle.$$('a'));
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('a'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('a#id'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('a#id'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('a.class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('a.class'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('a[attr=value]'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('a[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('a:psuedo-class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('a:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('a:func(arg)'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('a:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLDivElement> | null>(await handle.$('div#id'));
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div#id'));
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(await handle.$$('div'));
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('div'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div#id'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('div#id'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div.class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div[attr=value]'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div:psuedo-class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div:func(arg)'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div.class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div.class'));
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$('some-custom'));
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('some-custom#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('some-custom.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('some-custom[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('some-custom:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('some-custom:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div[attr=value]'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div[attr=value]'),
-    );
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$(''));
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$('#id'));
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$('.class'));
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$(':pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$(':func(arg)'));
+    }
   }
   {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div:psuedo-class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div:pseudo-class'),
-    );
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('div > a'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a#id'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a.class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a[attr=value]'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a:psuedo-class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a:func(arg)'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a:func(arg)'),
+      );
+    }
   }
   {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div:func(arg)'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div:func(arg)'),
-    );
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div#id'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div.class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div[attr=value]'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div:psuedo-class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div:func(arg)'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div:func(arg)'),
+      );
+    }
   }
+  {
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$('div > #id'));
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > .class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > [attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > :pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > :func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(await handle.$$('div > a'));
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a#id'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a.class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a[attr=value]'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a:psuedo-class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLAnchorElement>>>(
+        await handle.$$('div > a:func(arg)'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > a:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div#id'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div.class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div[attr=value]'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div:psuedo-class'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<HTMLDivElement>>>(
+        await handle.$$('div > div:func(arg)'),
+      );
+      expectNotType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > div:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom#id'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom.class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom[attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom:pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > some-custom:func(arg)'),
+      );
+    }
+  }
+  {
+    {
+      expectType<Array<ElementHandle<Element>>>(await handle.$$('div > #id'));
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > .class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > [attr=value]'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > :pseudo-class'),
+      );
+    }
+    {
+      expectType<Array<ElementHandle<Element>>>(
+        await handle.$$('div > :func(arg)'),
+      );
+    }
+  }
+}
 
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('some-custom'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('some-custom#id'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('some-custom.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('some-custom[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('some-custom:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('some-custom:func(arg)'),
-    );
-  }
+{
+  expectType<void>(
+    await handle.$eval(
+      'a',
+      (element, int) => {
+        expectType<HTMLAnchorElement>(element);
+        expectType<number>(int);
+      },
+      1,
+    ),
+  );
+  expectType<void>(
+    await handle.$eval(
+      'div',
+      (element, int, str) => {
+        expectType<HTMLDivElement>(element);
+        expectType<number>(int);
+        expectType<string>(str);
+      },
+      1,
+      '',
+    ),
+  );
+  expectType<number>(
+    await handle.$eval(
+      'a',
+      (element, value) => {
+        expectType<HTMLAnchorElement>(element);
+        return value;
+      },
+      1,
+    ),
+  );
+  expectType<number>(
+    await handle.$eval(
+      'some-element',
+      (element, value) => {
+        expectType<Element>(element);
+        return value;
+      },
+      1,
+    ),
+  );
+  expectType<HTMLAnchorElement>(
+    await handle.$eval('a', element => {
+      return element;
+    }),
+  );
+  expectType<unknown>(await handle.$eval('a', 'document'));
+}
 
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$(''));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('#id'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('.class'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('[attr=value]'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$(':pseudo-class'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$(':func(arg)'));
-  }
+{
+  expectType<void>(
+    await handle.$$eval(
+      'a',
+      (elements, int) => {
+        expectType<HTMLAnchorElement[]>(elements);
+        expectType<number>(int);
+      },
+      1,
+    ),
+  );
+  expectType<void>(
+    await handle.$$eval(
+      'div',
+      (elements, int, str) => {
+        expectType<HTMLDivElement[]>(elements);
+        expectType<number>(int);
+        expectType<string>(str);
+      },
+      1,
+      '',
+    ),
+  );
+  expectType<number>(
+    await handle.$$eval(
+      'a',
+      (elements, value) => {
+        expectType<HTMLAnchorElement[]>(elements);
+        return value;
+      },
+      1,
+    ),
+  );
+  expectType<number>(
+    await handle.$$eval(
+      'some-element',
+      (elements, value) => {
+        expectType<Element[]>(elements);
+        return value;
+      },
+      1,
+    ),
+  );
+  expectType<HTMLAnchorElement[]>(
+    await handle.$$eval('a', elements => {
+      return elements;
+    }),
+  );
+  expectType<unknown>(await handle.$$eval('a', 'document'));
+}
 
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div > a'));
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a#id'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div > a#id'));
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a.class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a[attr=value]'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a:psuedo-class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a:func(arg)'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a:func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div > div'));
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div#id'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div#id'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div.class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div[attr=value]'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div:psuedo-class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div:func(arg)'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div:func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom#id'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom:func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('div > #id'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('div > .class'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > [attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > :pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > :func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div > a'));
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a#id'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div > a#id'));
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a.class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a[attr=value]'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a:psuedo-class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLAnchorElement> | null>(
-      await handle.$('div > a:func(arg)'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > a:func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div'),
-    );
-    expectNotType<ElementHandle<Element> | null>(await handle.$('div > div'));
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div#id'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div#id'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div.class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div[attr=value]'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div:psuedo-class'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<HTMLDivElement> | null>(
-      await handle.$('div > div:func(arg)'),
-    );
-    expectNotType<ElementHandle<Element> | null>(
-      await handle.$('div > div:func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom#id'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom.class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom[attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom:pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > some-custom:func(arg)'),
-    );
-  }
-
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('div > #id'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(await handle.$('div > .class'));
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > [attr=value]'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > :pseudo-class'),
-    );
-  }
-  {
-    expectType<ElementHandle<Element> | null>(
-      await handle.$('div > :func(arg)'),
-    );
-  }
-
+{
   {
     expectType<ElementHandle<HTMLAnchorElement> | null>(
       await handle.waitForSelector('a'),
@@ -442,5 +1026,4 @@ const test = async () => {
       await handle.waitForSelector('some-custom'),
     );
   }
-};
-void test();
+}

--- a/test-d/JSHandle.test-d.ts
+++ b/test-d/JSHandle.test-d.ts
@@ -7,8 +7,8 @@ import type {ElementHandle, JSHandle} from 'puppeteer';
 import {expectNotAssignable, expectNotType, expectType} from 'tsd';
 
 declare const handle: JSHandle;
-declare const handle2: JSHandle<{test: number}>;
-const test = async () => {
+
+{
   expectType<unknown>(await handle.evaluate('document'));
   expectType<number>(
     await handle.evaluate(() => {
@@ -32,7 +32,9 @@ const test = async () => {
       return '';
     }, ''),
   );
+}
 
+{
   expectType<JSHandle>(await handle.evaluateHandle('document'));
   expectType<JSHandle<number>>(
     await handle.evaluateHandle(() => {
@@ -56,7 +58,11 @@ const test = async () => {
       return document.body;
     }),
   );
+}
 
+declare const handle2: JSHandle<{test: number}>;
+
+{
   {
     expectType<JSHandle<number>>(await handle2.getProperty('test'));
     expectNotType<JSHandle<unknown>>(await handle2.getProperty('test'));
@@ -72,11 +78,11 @@ const test = async () => {
       await handle2.getProperty('key-doesnt-exist'),
     );
   }
+}
 
+{
   void handle.evaluate((value, other) => {
     expectType<unknown>(value);
     expectType<{test: number}>(other);
   }, handle2);
-};
-
-void test();
+}

--- a/tools/patch.mjs
+++ b/tools/patch.mjs
@@ -42,7 +42,7 @@ file = fs.readFileSync(genTypes, 'utf-8');
 file = file.replaceAll('#private;', '');
 
 file = file.replaceAll(
-  `import { Session } from 'chromium-bidi/protocol/protocol.js';`,
+  `import { Session } from 'chromium-bidi/lib/cjs/protocol/protocol.js';`,
   'type Session = any;',
 );
 file = file.replaceAll(


### PR DESCRIPTION
Reverts puppeteer/puppeteer#13784 because it does not work with Jest due to dynamic imports.

Closes https://github.com/puppeteer/puppeteer/issues/13847