### PR TITLE
docs: drop obsolete troubleshooting tip about --disable-dev-shm-usage

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -612,24 +612,7 @@ If you want to run the stuff in the background, you need to "**enable CPU always
 
 #### Tips
 
-By default, Docker runs a container with a `/dev/shm` shared memory space 64MB.
-This is [typically too small](https://github.com/c0b/chrome-in-docker/issues/1)
-for Chrome and will cause Chrome to crash when rendering large pages. To fix,
-run the container with `docker run --shm-size=1gb` to increase the size of
-`/dev/shm`. Since Chrome 65, this is no longer necessary. Instead, launch the
-browser with the `--disable-dev-shm-usage` flag:
-
-```ts
-const browser = await puppeteer.launch({
-  args: ['--disable-dev-shm-usage'],
-});
-```
-
-This will write shared memory files into `/tmp` instead of `/dev/shm`. See
-[crbug.com/736452](https://bugs.chromium.org/p/chromium/issues/detail?id=736452)
-for more details.
-
-Seeing other weird errors when launching Chrome? Try running your container with
+Seeing weird errors when launching Chrome? Try running your container with
 `docker run --cap-add=SYS_ADMIN` when developing locally. Since the Dockerfile
 adds a `pptr` user as a non-privileged user, it may not have all the necessary
 privileges.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

`--disable-dev-shm-usage` is already a default launch option for chrome, so this tip is obsolete.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Not needed.

**If relevant, did you update the documentation?**

Yes.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

When fixing some puppeteer chrome tests in docker containers for GHC, I looked into the default launch options and noticed that `--disable-dev-shm-usage` is already there. Though the troubleshooting guide still mention it and I assume it's obsolete, but feel free to close if it's my misunderstanding.

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
