### PR TITLE
docs: drop redundant launch flag --disable-setuid-sandbox

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -261,7 +261,7 @@ Chrome with the `--no-sandbox` argument:
 
 ```ts
 const browser = await puppeteer.launch({
-  args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  args: ['--no-sandbox'],
 });
 ```
 
@@ -564,10 +564,10 @@ before_script:
     xdg-utils wget
 ```
 
-Next, you have to use `'--no-sandbox'` mode and also
-`'--disable-setuid-sandbox'` when launching Puppeteer. This can be done by
+Next, you have to use `'--no-sandbox'` mode
+when launching Puppeteer. This can be done by
 passing them as an arguments to your `.launch()` call:
-`puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });`.
+`puppeteer.launch({ args: ['--no-sandbox'] });`.
 
 ## Running Puppeteer on Google Cloud Run
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

When `--no-sandbox` is passed, all chromium sandboxes are disabled and `--disable-setuid-sandbox` is a no-op. See
https://source.chromium.org/chromium/chromium/src/+/main:content/browser/zygote_host/zygote_host_impl_linux.cc;l=122?q=kDisableSetuidSandbox, the only place where `kDisableSetuidSandbox` is used other than redirecting cli options: if `kNoSandbox` is enabled then `ZygoteHostImpl::Init` bails out early, and the code path concerning `--disable-setuid-sandbox` is unreachable anyway.

**Did you add tests for your changes?**

Not needed.

**If relevant, did you update the documentation?**

Yes.

**Summary**

See first subsection.

**Does this PR introduce a breaking change?**

No.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
