### PR TITLE
chore: sync preference change to disable Firefox screenshot feature

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -314,9 +314,6 @@ function defaultProfilePreferences(
     // Disable installing any distribution extensions or add-ons.
     'extensions.installDistroAddons': false,
 
-    // Disabled screenshots extension
-    'extensions.screenshots.disabled': true,
-
     // Turn off extension updates so they do not bother tests
     'extensions.update.enabled': false,
 
@@ -375,6 +372,9 @@ function defaultProfilePreferences(
     // Can be removed once Firefox 89 is no longer supported
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1710839
     'remote.enabled': true,
+
+    // Disabled screenshots component
+    'screenshots.browser.component.enabled': false,
 
     // Don't do network connections for mitm priming
     'security.certerrors.mitm.priming.enabled': false,


### PR DESCRIPTION
Sync changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1948366