### PR TITLE
chore: remove setting of the "remote.active-protocol" preference for Firefox

### DIFF
--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -32,13 +32,9 @@ export class FirefoxLauncher extends BrowserLauncher {
   ): Record<string, unknown> {
     return {
       ...extraPrefsFirefox,
-      // Only enable the WebDriver BiDi protocol
-      'remote.active-protocols': 1,
       // Force all web content to use a single content process. TODO: remove
       // this once Firefox supports mouse event dispatch from the main frame
-      // context. Once this happens, webContentIsolationStrategy should only
-      // be set for CDP. See
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1773393
+      // context. See https://bugzilla.mozilla.org/show_bug.cgi?id=1773393.
       'fission.webContentIsolationStrategy': 0,
     };
   }


### PR DESCRIPTION
With Firefox 141 the CDP code base is removed and we should as well stop setting the given preference because it no longer exists.

@OrKoN not sure if there are as well other pieces that we have to remove. Would you mind checking? Happy to take care of them as well.

Also when do we want to remove CDP support for Firefox in Puppeteer? Note that the upcoming Firefox 140 ESR will still be around for another year. Do you still want to support it? Or did you already stop the CDP support? I cannot fully remember.