### PR TITLE
fix: switch to global command id generation

### DIFF
--- a/packages/puppeteer-core/src/common/CallbackRegistry.ts
+++ b/packages/puppeteer-core/src/common/CallbackRegistry.ts
@@ -11,6 +11,8 @@ import {createIncrementalIdGenerator} from '../util/incremental-id-generator.js'
 import {ProtocolError, TargetCloseError} from './Errors.js';
 import {debugError} from './util.js';
 
+const idGenerator = createIncrementalIdGenerator();
+
 /**
  * Manages callbacks and their IDs for the protocol request/response communication.
  *
@@ -18,7 +20,7 @@ import {debugError} from './util.js';
  */
 export class CallbackRegistry {
   #callbacks = new Map<number, Callback>();
-  #idGenerator = createIncrementalIdGenerator();
+  #idGenerator = idGenerator;
 
   create(
     label: string,

--- a/packages/puppeteer-core/src/util/incremental-id-generator.ts
+++ b/packages/puppeteer-core/src/util/incremental-id-generator.ts
@@ -10,6 +10,9 @@
 export function createIncrementalIdGenerator(): GetIdFn {
   let id = 0;
   return (): number => {
+    if (id === Number.MAX_SAFE_INTEGER) {
+      id = 0;
+    }
     return ++id;
   };
 }


### PR DESCRIPTION
Some CDP error messages are not attributed to the command's sessionId resulting in potential conflicts.