### PR TITLE
Updated website/versioned_docs/version-24.10.1/webdriver-bidi.md

### DIFF
--- a/website/versioned_docs/version-24.10.1/webdriver-bidi.md
+++ b/website/versioned_docs/version-24.10.1/webdriver-bidi.md
@@ -57,6 +57,7 @@ await chromeBrowser.close();
 - CDP-specific features
 
   - HTTPRequest.client()
+  - HTTPRequest.resourceType()
   - Page.createCDPSession()
 
 - Accessibility


### PR DESCRIPTION
Closes: #13937

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Lists 'request.resourceType()' as not supported over WebDriver BiDi.

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

Yes

**Summary**

Added `HTTPRequest.resourceType()` to the list of Puppeteer features not supported over WebDriver BiDi for Firefox 139.0.4, as this was previously undocumented in https://pptr.dev/webdriver-bidi#puppeteer-features-not-supported-over-webdriver-bidi.

<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

**Other information**
