### PR TITLE
test: remove trace config assertions

### DIFF
--- a/test/src/tracing.spec.ts
+++ b/test/src/tracing.spec.ts
@@ -51,11 +51,6 @@ describe('Tracing', function () {
     const traceJson = JSON.parse(
       fs.readFileSync(outputFile, {encoding: 'utf8'}),
     );
-    const traceConfig = JSON.parse(traceJson.metadata['trace-config']);
-    expect(traceConfig.included_categories).toEqual([
-      'disabled-by-default-devtools.timeline.frame',
-    ]);
-    expect(traceConfig.excluded_categories).toEqual(['*']);
     expect(traceJson.traceEvents).not.toContainEqual(
       expect.objectContaining({
         cat: 'toplevel',


### PR DESCRIPTION
Close https://github.com/puppeteer/puppeteer/issues/13963

Chrome no longer includes the trace config in the JSON format.