### PR TITLE
ci: turn off experimental in daily jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,7 +30,6 @@ jobs:
           - 1-2
           - 2-2
         configs:
-          - experimental
           - stable
         exclude:
           - os: windows-latest


### PR DESCRIPTION
we do not have capacity to investigate potential issues with experimental flags.