### PR TITLE
test: Re-enable test "[page.spec] Page Page.pdf should respect timeout" for Firefox.

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -531,13 +531,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[page.spec] Page Page.pdf should respect timeout",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["SKIP"],
-    "comment": "https://github.com/puppeteer/puppeteer/issues/12152"
-  },
-  {
     "testIdPattern": "[page.spec] Page Page.setBypassCSP *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],


### PR DESCRIPTION
Fixes https://github.com/puppeteer/puppeteer/issues/12152.

The test is not failing anymore but I also fixed an issue we had under such a condition on https://bugzilla.mozilla.org/show_bug.cgi?id=1841125.

Not sure if we can already merge (because I don't know when the test actually started to pass), but lets see what the test results show.