### PR TITLE
feat: add debugging highlight to ElementHandle.click()

### DIFF
--- a/docs/api/puppeteer.clickoptions.md
+++ b/docs/api/puppeteer.clickoptions.md
@@ -37,6 +37,25 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="debughighlight">debugHighlight</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+**_(Experimental)_** An experimental debugging feature. If true, inserts an element into the page to highlight the click location for 10 seconds. Might not work on all pages and does not persist across navigations.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="offset">offset</span>
 
 </td><td>


### PR DESCRIPTION
This PR adds an option for debugging clicks called debugHighlight. If set to to true, it will insert an animated element at the location that was clicked. It is experimental and might not work on all pages. The highlight would not persist across navigations.