### PR TITLE
chore: sync Firefox contentblocking preference change from Bug 1977066

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -218,7 +218,7 @@ function defaultProfilePreferences(
     // Prevent various error message on the console
     // jest-puppeteer asserts that no error message is emitted by the console
     'browser.contentblocking.features.standard':
-      '-tp,tpPrivate,cookieBehavior0,-cm,-fp',
+      '-tp,tpPrivate,cookieBehavior0,-cryptoTP,-fp',
 
     // Enable the dump function: which sends messages to the system
     // console


### PR DESCRIPTION
The "cm" value is no longer recognized since Firefox 139 and can be safely updated to the new expected value.