### PR TITLE
fix(webdriver): provide proper exception while accessing response in BiDi

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1209,13 +1209,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[network.spec] network Response.buffer should throw if the response does not have a body",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "https://github.com/GoogleChromeLabs/chromium-bidi/issues/3570"
-  },
-  {
     "testIdPattern": "[network.spec] network Response.text should throw when requesting body of redirected response",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],


### PR DESCRIPTION
Fix "[network.spec] network Response.buffer should throw if the response does not have a body"