### PR TITLE
fix(browsers): correctly handle LINUX_ARM in chromium data

### DIFF
--- a/packages/browsers/src/browser-data/chromium.ts
+++ b/packages/browsers/src/browser-data/chromium.ts
@@ -27,11 +27,11 @@ function archive(platform: BrowserPlatform, buildId: string): string {
 
 function folder(platform: BrowserPlatform): string {
   switch (platform) {
+    case BrowserPlatform.LINUX_ARM:
     case BrowserPlatform.LINUX:
       return 'Linux_x64';
     case BrowserPlatform.MAC_ARM:
       return 'Mac_Arm';
-    case BrowserPlatform.LINUX_ARM:
     case BrowserPlatform.MAC:
       return 'Mac';
     case BrowserPlatform.WIN32:


### PR DESCRIPTION
Fixes https://github.com/puppeteer/puppeteer/pull/13646/files/3ef182b5e9102def33dd85be25f1b74c76304c8c#r2210577594