### PR TITLE
feat: emulateTimezone via BiDi

### DIFF
--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -363,7 +363,7 @@ export class BidiPage extends Page {
   }
 
   override async emulateTimezone(timezoneId?: string): Promise<void> {
-    return await this.#cdpEmulationManager.emulateTimezone(timezoneId);
+    return await this.#frame.browsingContext.setTimezoneOverride(timezoneId);
   }
 
   override async emulateIdleState(overrides?: {

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -585,6 +585,11 @@ export class BrowsingContext extends EventEmitter<{
     return context.#reason!;
   })
   async setTimezoneOverride(timezoneId?: string): Promise<void> {
+    if (timezoneId?.startsWith('GMT')) {
+      // CDP requires `GMT` prefix before timezone offset, while BiDi does not. Remove the
+      // `GMT` for interop between CDP and BiDi.
+      timezoneId = timezoneId?.replace('GMT', '');
+    }
     await this.userContext.browser.session.send(
       'emulation.setTimezoneOverride',
       {

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -584,6 +584,20 @@ export class BrowsingContext extends EventEmitter<{
     // SAFETY: Disposal implies this exists.
     return context.#reason!;
   })
+  async setTimezoneOverride(timezoneId?: string): Promise<void> {
+    await this.userContext.browser.session.send(
+      'emulation.setTimezoneOverride',
+      {
+        timezone: timezoneId ?? null,
+        contexts: [this.id],
+      },
+    );
+  }
+
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
   async getCookies(
     options: GetCookiesOptions = {},
   ): Promise<Bidi.Network.Cookie[]> {

--- a/packages/puppeteer-core/src/bidi/core/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/core/Connection.ts
@@ -119,6 +119,10 @@ export interface Commands {
     params: Bidi.Emulation.SetGeolocationOverrideParameters;
     returnType: Bidi.EmptyResult;
   };
+  'emulation.setTimezoneOverride': {
+    params: Bidi.Emulation.SetTimezoneOverrideParameters;
+    returnType: Bidi.EmptyResult;
+  };
 
   'permissions.setPermission': {
     params: Bidi.Permissions.SetPermissionParameters;

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -279,6 +279,12 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[emulation.spec] Emulation Page.emulateTimezone should support timezone offset",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"]
+  },
+  {
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should replace symbols with undefined",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -282,7 +282,8 @@
     "testIdPattern": "[emulation.spec] Emulation Page.emulateTimezone should support timezone offset",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
-    "expectations": ["FAIL"]
+    "expectations": ["FAIL"],
+    "comment": "Firefox does not support timezone emulation yet"
   },
   {
     "testIdPattern": "[evaluation.spec] Evaluation specs Page.evaluate should replace symbols with undefined",

--- a/test/src/emulation.spec.ts
+++ b/test/src/emulation.spec.ts
@@ -450,6 +450,27 @@ describe('Emulation', () => {
       );
     });
 
+    it('should support timezone offset', async () => {
+      const {page} = await getTestState();
+
+      await page.evaluate(() => {
+        (globalThis as any).date = new Date(1479579154987);
+      });
+      await page.emulateTimezone('GMT+10:00');
+      expect(
+        await page.evaluate(() => {
+          return (globalThis as any).date.toString();
+        }),
+      ).toBe('Sun Nov 20 2016 04:12:34 GMT+1000 (GMT+10:00)');
+
+      await page.emulateTimezone('GMT-12:34');
+      expect(
+        await page.evaluate(() => {
+          return (globalThis as any).date.toString();
+        }),
+      ).toBe('Sat Nov 19 2016 05:38:34 GMT-1234 (GMT-12:34)');
+    });
+
     it('should throw for invalid timezone IDs', async () => {
       const {page} = await getTestState();
 

--- a/test/src/emulation.spec.ts
+++ b/test/src/emulation.spec.ts
@@ -457,11 +457,21 @@ describe('Emulation', () => {
       await page.emulateTimezone('Foo/Bar').catch(error_ => {
         return (error = error_);
       });
-      expect(error.message).toBe('Invalid timezone ID: Foo/Bar');
+      expect(error.message).atLeastOneToContain([
+        'Invalid timezone ID: Foo/Bar', // CDP
+        'invalid argument', // BiDi.
+      ]);
+      // Assert the error message is informative.
+      expect(error.message).toContain('Foo/Bar');
       await page.emulateTimezone('Baz/Qux').catch(error_ => {
         return (error = error_);
       });
-      expect(error.message).toBe('Invalid timezone ID: Baz/Qux');
+      expect(error.message).atLeastOneToContain([
+        'Invalid timezone ID: Baz/Qux', // CDP
+        'invalid argument', // BiDi.
+      ]);
+      // Assert the error message is informative.
+      expect(error.message).toContain('Baz/Qux');
     });
   });
 


### PR DESCRIPTION
In BiDi, use BiDi instead of CDP shortcut for `emulateTimezone`.