### PR TITLE
test: add a webgl test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -649,6 +649,13 @@
     "comment": "Firefox is currently only able to install signed extensions."
   },
   {
+    "testIdPattern": "[webgl.spec] webgl Create webgl context should work",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"],
+    "comment": "tests chrome-specific flags"
+  },
+  {
     "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails Network redirects should report SecurityDetails",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/src/webgl.spec.ts
+++ b/test/src/webgl.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import expect from 'expect';
+
+import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+
+describe('webgl', function () {
+  setupTestBrowserHooks();
+
+  describe('Create webgl context', function () {
+    it('should work', async () => {
+      const {page} = await getTestState();
+
+      const promise = page.evaluate(() => {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl');
+        if (!gl) {
+          throw new Error('WebGL context not created');
+        }
+        return true;
+      });
+      await promise;
+      await expect(promise).resolves.toBe(true);
+    });
+  });
+});

--- a/test/src/webgl.spec.ts
+++ b/test/src/webgl.spec.ts
@@ -1,21 +1,25 @@
 /**
  * @license
- * Copyright 2024 Google Inc.
+ * Copyright 2025 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import expect from 'expect';
 
-import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+import {setupSeparateTestBrowserHooks} from './mocha-utils.js';
 
 describe('webgl', function () {
-  setupTestBrowserHooks();
+  const state = setupSeparateTestBrowserHooks({
+    args: [
+      '--disable-gpu',
+      '--enable-features=AllowSwiftShaderFallback,AllowSoftwareGLFallbackDueToCrashes',
+      '--enable-unsafe-swiftshader',
+    ],
+  });
 
   describe('Create webgl context', function () {
     it('should work', async () => {
-      const {page} = await getTestState();
-
-      const promise = page.evaluate(() => {
+      const promise = state.page.evaluate(() => {
         const canvas = document.createElement('canvas');
         const gl = canvas.getContext('webgl');
         if (!gl) {

--- a/test/src/webgl.spec.ts
+++ b/test/src/webgl.spec.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import expect from 'expect';
-
 import {setupSeparateTestBrowserHooks} from './mocha-utils.js';
 
 describe('webgl', function () {
   const state = setupSeparateTestBrowserHooks({
     args: [
+      // Current flags that enable software rendering.
       '--disable-gpu',
       '--enable-features=AllowSwiftShaderFallback,AllowSoftwareGLFallbackDueToCrashes',
       '--enable-unsafe-swiftshader',
@@ -19,16 +18,13 @@ describe('webgl', function () {
 
   describe('Create webgl context', function () {
     it('should work', async () => {
-      const promise = state.page.evaluate(() => {
+      await state.page.evaluate(() => {
         const canvas = document.createElement('canvas');
         const gl = canvas.getContext('webgl');
         if (!gl) {
           throw new Error('WebGL context not created');
         }
-        return true;
       });
-      await promise;
-      await expect(promise).resolves.toBe(true);
     });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It add a webgl test to make sure webgl can be ran for library authors that needs webgl in github actions.

**Did you add tests for your changes?**
Only a test was added at this point.

**If relevant, did you update the documentation?**

**Summary**
See explanation above.

**Does this PR introduce a breaking change?**
Nope.

**Other information**

I'm maintaining maplibre-gl-js which uses webgl in the browser to render maps.
Our CI is extensive and uses puppeteer to test the code that runs in the browser.
We need webgl testing support to make sure our maps looks the same after every code change.
We have extensive tests that relay.
Currently we can't upgrade to latest version of puppeteer due to breaking change in chrome and the way webgl was used to be avialable.

- See #14060