### PR TITLE
feat: add apt cleanup commands to reduce Docker image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,8 @@ ENV DBUS_SESSION_BUS_ADDRESS=autolaunch:
 RUN apt-get update \
     && apt-get install -y --no-install-recommends fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros \
     fonts-kacst fonts-freefont-ttf dbus dbus-x11
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add pptruser.
 RUN groupadd -r pptruser && useradd -u $PPTRUSER_UID -rm -g pptruser -G audio,video pptruser

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ ENV DBUS_SESSION_BUS_ADDRESS=autolaunch:
 # installs, work.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros \
-    fonts-kacst fonts-freefont-ttf dbus dbus-x11
+    fonts-kacst fonts-freefont-ttf dbus dbus-x11 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Type: Build optimization
- Category: Docker image size reduction


**Did you add tests for your changes?**
- No tests needed
- Just Standard Docker best practices


**If relevant, did you update the documentation?**
- No, not required.

**Summary**
- PR optimizes the Dockerfile
- Add apt-get clean to remove package cache
- Add rm -rf /var/lib/apt/lists/* to remove package lists
- "Docker image size by removing unnecessary files that are cached during the package installation process. This is a widely accepted Docker best practice that helps create smaller, more efficient images"

**Does this PR introduce a breaking change?**
- No, it won't
- Only reduces final image size