### PR TITLE
test: add a test extension for Firefox

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -642,13 +642,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[webExtension.spec] webExtension can install and uninstall an extension",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox is currently only able to install signed extensions."
-  },
-  {
     "testIdPattern": "[webgl.spec] webgl Create webgl context should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/assets/simple-extension-firefox/content-script.js
+++ b/test/assets/simple-extension-firefox/content-script.js
@@ -1,0 +1,2 @@
+console.log('hey from the content-script');
+self.thisIsTheContentScript = true;

--- a/test/assets/simple-extension-firefox/index.js
+++ b/test/assets/simple-extension-firefox/index.js
@@ -1,0 +1,2 @@
+// Mock script for background extension
+globalThis.MAGIC = 42;

--- a/test/assets/simple-extension-firefox/manifest.json
+++ b/test/assets/simple-extension-firefox/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Simple extension",
+  "version": "0.1",
+  "background": {
+    "scripts": ["index.js"]
+  },
+  "content_scripts": [{
+    "matches": ["<all_urls>"],
+    "css": [],
+    "js": ["content-script.js"]
+  }],
+  "permissions": ["background", "activeTab"],
+  "manifest_version": 3
+}

--- a/test/src/webExtension.spec.ts
+++ b/test/src/webExtension.spec.ts
@@ -11,6 +11,10 @@ import expect from 'expect';
 import {getTestState, launch, setupTestBrowserHooks} from './mocha-utils.js';
 
 const EXTENSION_PATH = path.join(__dirname, '/../assets/simple-extension');
+const EXTENSION_FIREFOX_PATH = path.join(
+  __dirname,
+  '/../assets/simple-extension-firefox',
+);
 const EXPECTED_ID = 'mbljndkcfjhaffohbnmoedabegpolpmd';
 
 describe('webExtension', function () {
@@ -22,7 +26,10 @@ describe('webExtension', function () {
     });
 
     const options = Object.assign({}, defaultBrowserOptions);
-
+    const extensionPath = isChrome ? EXTENSION_PATH : EXTENSION_FIREFOX_PATH;
+    // For Chrome, since the `key` field is present in the
+    // manifest, this should always have the same ID.
+    const expectedId = isChrome ? EXPECTED_ID : /temporary-addon/;
     if (isChrome) {
       options.enableExtensions = true;
       options.pipe = true;
@@ -30,12 +37,11 @@ describe('webExtension', function () {
 
     const {browser, close} = await launch(options);
     try {
-      // Install an extension. Since the `key` field is present in the
-      // manifest, this should always have the same ID.
-      expect(await browser.installExtension(EXTENSION_PATH)).toBe(EXPECTED_ID);
+      const id = await browser.installExtension(extensionPath);
+      expect(id).toMatch(expectedId);
 
       // Check we can uninstall the extension.
-      await browser.uninstallExtension(EXPECTED_ID);
+      await browser.uninstallExtension(id);
     } finally {
       await close();
     }


### PR DESCRIPTION
Fixing the test which seems to work now:

- Firefox currently requires a slightly different data in the manifest (background scripts instead of workers).
- Firefox generates an ID with a temporary add-on suffix.