### PR TITLE
ci: do not use fork for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,4 +18,3 @@ jobs:
           token: ${{ secrets.BROWSER_AUTOMATION_BOT_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          fork: true


### PR DESCRIPTION
We would need to give the bot permissions for the repo so the fork option would not be needed.