### PR TITLE
fix: report a helpful error if waiting fails

### DIFF
--- a/packages/puppeteer-core/src/common/QueryHandler.ts
+++ b/packages/puppeteer-core/src/common/QueryHandler.ts
@@ -12,6 +12,7 @@ import type PuppeteerUtil from '../injected/injected.js';
 import {isErrorLike} from '../util/ErrorLike.js';
 import {interpolateFunction, stringifyFunction} from '../util/Function.js';
 
+import {TimeoutError} from './Errors.js';
 import {transposeIterableHandle} from './HandleIterator.js';
 import {LazyArg} from './LazyArg.js';
 import type {Awaitable, AwaitableIterable} from './types.js';
@@ -209,8 +210,11 @@ export class QueryHandler {
       if (error.name === 'AbortError') {
         throw error;
       }
-      error.message = `Waiting for selector \`${selector}\` failed: ${error.message}`;
-      throw error;
+      const waitForSelectorError = new (
+        error instanceof TimeoutError ? TimeoutError : Error
+      )(`Waiting for selector \`${selector}\` failed`);
+      waitForSelectorError.cause = error;
+      throw waitForSelectorError;
     }
   }
 }

--- a/packages/puppeteer-core/src/common/WaitTask.ts
+++ b/packages/puppeteer-core/src/common/WaitTask.ts
@@ -38,6 +38,7 @@ export class WaitTask<T = unknown> {
   #args: unknown[];
 
   #timeout?: NodeJS.Timeout;
+  #genericError = new Error('Waiting failed');
   #timeoutError?: TimeoutError;
 
   #result = Deferred.create<HandleFor<T>>();
@@ -162,7 +163,8 @@ export class WaitTask<T = unknown> {
       }
       const badError = this.getBadError(error);
       if (badError) {
-        await this.terminate(badError);
+        this.#genericError.cause = badError;
+        await this.terminate(this.#genericError);
       }
     }
   }

--- a/test/src/ariaqueryhandler.spec.ts
+++ b/test/src/ariaqueryhandler.spec.ts
@@ -439,10 +439,9 @@ describe('AriaQueryHandler', () => {
       await detachFrame(page, 'frame1');
       await waitPromise;
       expect(waitError).toBeTruthy();
-      expect(waitError.message).atLeastOneToContain([
-        'waitForFunction failed: frame got detached.',
-        'Browsing context already closed.',
-      ]);
+      expect(waitError.message).toBe(
+        'Waiting for selector `does-not-exist` failed',
+      );
     });
 
     it('should survive cross-process navigation', async () => {
@@ -612,7 +611,7 @@ describe('AriaQueryHandler', () => {
           return error;
         });
       expect(error.message).toContain(
-        'Waiting for selector `[role="button"]` failed: Waiting failed: 10ms exceeded',
+        'Waiting for selector `[role="button"]` failed',
       );
       expect(error).toBeInstanceOf(TimeoutError);
     });
@@ -626,8 +625,7 @@ describe('AriaQueryHandler', () => {
         timeout: 10,
       });
       await expect(promise).rejects.toMatchObject({
-        message:
-          'Waiting for selector `[role="main"]` failed: Waiting failed: 10ms exceeded',
+        message: 'Waiting for selector `[role="main"]` failed',
       });
     });
 
@@ -677,9 +675,7 @@ describe('AriaQueryHandler', () => {
       await page.waitForSelector('aria/zombo', {timeout: 10}).catch(error_ => {
         return (error = error_);
       });
-      expect(error!.stack).toContain(
-        'Waiting for selector `zombo` failed: Waiting failed: 10ms exceeded',
-      );
+      expect(error!.stack).toContain('Waiting for selector `zombo` failed');
     });
   });
 

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -74,10 +74,7 @@ describe('Launcher specs', function () {
             });
           await remote.disconnect();
           const error = await watchdog;
-          expect(error.message).atLeastOneToContain([
-            'Waiting for selector `div` failed: Waiting failed: Frame detached',
-            'Waiting for selector `div` failed: Browsing context already closed: User context was closed: Session already ended.',
-          ]);
+          expect(error.message).toBe('Waiting for selector `div` failed');
         } finally {
           await close();
         }


### PR DESCRIPTION
Noticed that errors thrown by WaitTask do not have a stacktrace pointing to where the WaitTask started. Attempting to fix it revealed some error message rewriting that is no longer needed with Error.cause. So this PR fixes the stack traces and cleans up error messages.