### PR TITLE
#14080 : docs: unify code examples to use plain JavaScript

### DIFF
--- a/website/versioned_docs/version-24.17.0/api/puppeteer.elementhandle.__eval.md
+++ b/website/versioned_docs/version-24.17.0/api/puppeteer.elementhandle.__eval.md
@@ -102,9 +102,15 @@ HTML:
 
 JavaScript:
 
-```ts
+```js
 const feedHandle = await page.$('.feed');
-expect(
-  await feedHandle.$$eval('.tweet', nodes => nodes.map(n => n.innerText)),
-).toEqual(['Hello!', 'Hi!']);
+
+const tweets = await feedHandle.$$eval('.tweet', nodes => {
+  return nodes.map(n => n.innerText);
+});
+
+console.log(tweets); // ['Hello!', 'Hi!']
+
+const assert = require('assert');
+assert.deepStrictEqual(tweets, ['Hello!', 'Hi!']);
 ```

--- a/website/versioned_docs/version-24.17.0/guides/page-interactions.md
+++ b/website/versioned_docs/version-24.17.0/guides/page-interactions.md
@@ -127,9 +127,9 @@ other locator functions such as `.click()` or `.fill()` on the function locator.
 ```ts
 await page
   .locator(() => {
-    let resolve!: (node: HTMLCanvasElement) => void;
+    let resolve;
     const promise = new Promise(res => {
-      return (resolve = res);
+      return resolve = res;
     });
     const observer = new MutationObserver(records => {
       for (const record of records) {
@@ -138,7 +138,7 @@ await page
         }
       }
     });
-    observer.observe(document);
+    observer.observe(document, { childList: true, subtree: true });
     return promise;
   })
   .wait();


### PR DESCRIPTION
Some documentation examples currently include TypeScript-specific syntax and Jest/Playwright-Test assertions without explanation, which is confusing since most examples are in plain JavaScript.

Changes:
- Replaced TypeScript example in guides/page-interactions with equivalent JS.
- Converted ElementHandle.__eval example from Jest `expect(...).toEqual(...)` to Node.js `assert.deepStrictEqual(...)`.

This ensures consistency across docs and avoids mixing JS with TS/Jest snippets unless explicitly stated.
