### PR TITLE
fix: standardize error handling for closed connections

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -111,6 +111,15 @@ The constructor for this class is marked as internal. Third-party code should no
 </td></tr>
 <tr><td>
 
+<span id="connectionclosederror">[ConnectionClosedError](./puppeteer.connectionclosederror.md)</span>
+
+</td><td>
+
+Thrown if underlying protocol connection has been closed.
+
+</td></tr>
+<tr><td>
+
 <span id="consolemessage">[ConsoleMessage](./puppeteer.consolemessage.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.connectionclosederror.md
+++ b/docs/api/puppeteer.connectionclosederror.md
@@ -1,0 +1,15 @@
+---
+sidebar_label: ConnectionClosedError
+---
+
+# ConnectionClosedError class
+
+Thrown if underlying protocol connection has been closed.
+
+### Signature
+
+```typescript
+export declare class ConnectionClosedError extends ProtocolError
+```
+
+**Extends:** [ProtocolError](./puppeteer.protocolerror.md)

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -9,10 +9,10 @@ import type * as Bidi from 'chromium-bidi/lib/cjs/protocol/protocol.js';
 import {CallbackRegistry} from '../common/CallbackRegistry.js';
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {debug} from '../common/Debug.js';
+import {ConnectionClosedError} from '../common/Errors.js';
 import type {EventsWithWildcard} from '../common/EventEmitter.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
-import {assert} from '../util/assert.js';
 
 import {BidiCdpSession} from './CDPSession.js';
 import type {
@@ -100,8 +100,9 @@ export class BidiConnection
     params: Commands[T]['params'],
     timeout?: number,
   ): Promise<{result: Commands[T]['returnType']}> {
-    assert(!this.#closed, 'Protocol error: Connection closed.');
-
+    if (this.#closed) {
+      return Promise.reject(new ConnectionClosedError('Connection closed.'));
+    }
     return this.#callbacks.create(method, timeout ?? this.#timeout, id => {
       const stringifiedMessage = JSON.stringify({
         id,

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -16,7 +16,7 @@ import {
 import {CallbackRegistry} from '../common/CallbackRegistry.js';
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import {debug} from '../common/Debug.js';
-import {TargetCloseError} from '../common/Errors.js';
+import {ConnectionClosedError, TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {createProtocolErrorMessage} from '../util/ErrorLike.js';
 
@@ -131,7 +131,7 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
     options?: CommandOptions,
   ): Promise<ProtocolMapping.Commands[T]['returnType']> {
     if (this.#closed) {
-      return Promise.reject(new Error('Protocol error: Connection closed.'));
+      return Promise.reject(new ConnectionClosedError('Connection closed.'));
     }
     return callbacks.create(method, options?.timeout ?? this.#timeout, id => {
       const stringifiedMessage = JSON.stringify({

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -1139,7 +1139,7 @@ export class CdpPage extends Page {
     const connection = this.#primaryTargetClient.connection();
     assert(
       connection,
-      'Protocol error: Connection closed. Most likely the page has been closed.',
+      'Connection closed. Most likely the page has been closed.',
     );
     const runBeforeUnload = !!options.runBeforeUnload;
     if (runBeforeUnload) {

--- a/packages/puppeteer-core/src/common/Errors.ts
+++ b/packages/puppeteer-core/src/common/Errors.ts
@@ -89,3 +89,10 @@ export class UnsupportedOperation extends PuppeteerError {}
  * @internal
  */
 export class TargetCloseError extends ProtocolError {}
+
+/**
+ * Thrown if underlying protocol connection has been closed.
+ *
+ * @public
+ */
+export class ConnectionClosedError extends ProtocolError {}

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -10,7 +10,9 @@ import path from 'node:path';
 import {TestServer} from '@pptr/testserver';
 import expect from 'expect';
 import type * as MochaBase from 'mocha';
-import puppeteer from 'puppeteer/lib/cjs/puppeteer/puppeteer.js';
+import puppeteer, {
+  ConnectionClosedError,
+} from 'puppeteer/lib/cjs/puppeteer/puppeteer.js';
 import type {Browser} from 'puppeteer-core/internal/api/Browser.js';
 import type {BrowserContext} from 'puppeteer-core/internal/api/BrowserContext.js';
 import type {Page} from 'puppeteer-core/internal/api/Page.js';
@@ -530,7 +532,7 @@ const closeLaunched = (storage: Array<() => Promise<void>>) => {
     } catch (error) {
       // If the browser was closed by other means, swallow the error
       // and mark the browser as closed.
-      if ((error as Error)?.message.includes('Connection closed')) {
+      if (error instanceof ConnectionClosedError) {
         storage.splice(0, storage.length);
         return;
       }


### PR DESCRIPTION
Adds ConnectionClosedError class.

Closes https://github.com/puppeteer/puppeteer/issues/14123