### PR TITLE
fix: return the parent's handle for accessibility text nodes instead of the text node

### DIFF
--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -775,10 +775,12 @@ describe('Accessibility', function () {
         using parentNodeHandle = await parentSnapshot!.elementHandle();
         using textNodeHandle = await snapshot!.elementHandle();
         expect(parentNodeHandle).toEqual(textNodeHandle);
-        
-        expect( await textNodeHandle?.evaluate(button => {
+
+        expect(
+          await textNodeHandle?.evaluate(button => {
             return button.innerHTML;
-          })).toEqual('<b>Hello, </b> world!');
+          }),
+        ).toEqual('<b>Hello, </b> world!');
       });
     });
   });


### PR DESCRIPTION
It's better to return the parent for the Node as then it allows for easier automation. 
Mimicking other query selectors.