### PR TITLE
feat: associate network requests with document IDs

### DIFF
--- a/docs/api/puppeteer.httprequest.documentid.md
+++ b/docs/api/puppeteer.httprequest.documentid.md
@@ -1,0 +1,21 @@
+---
+sidebar_label: HTTPRequest.documentId
+---
+
+# HTTPRequest.documentId() method
+
+Returns an opaque ID of the document associated with the request. When a new document gets loaded into a frame, a new documentId is genereated to identify the navigation request and all resource requests originated from this document.
+
+documentId is an empty string for requests related to workers.
+
+### Signature
+
+```typescript
+class HTTPRequest {
+  abstract documentId(): string;
+}
+```
+
+**Returns:**
+
+string

--- a/docs/api/puppeteer.httprequest.md
+++ b/docs/api/puppeteer.httprequest.md
@@ -143,6 +143,19 @@ The `ContinueRequestOverrides` that will be used if the interception is allowed 
 </td></tr>
 <tr><td>
 
+<span id="documentid">[documentId()](./puppeteer.httprequest.documentid.md)</span>
+
+</td><td>
+
+</td><td>
+
+Returns an opaque ID of the document associated with the request. When a new document gets loaded into a frame, a new documentId is genereated to identify the navigation request and all resource requests originated from this document.
+
+documentId is an empty string for requests related to workers.
+
+</td></tr>
+<tr><td>
+
 <span id="enqueueinterceptaction">[enqueueInterceptAction(pendingHandler)](./puppeteer.httprequest.enqueueinterceptaction.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -169,6 +169,16 @@ export abstract class HTTPRequest {
   abstract url(): string;
 
   /**
+   * Returns an opaque ID of the document associated with the request. When a
+   * new document gets loaded into a frame, a new documentId is genereated to
+   * identify the navigation request and all resource requests originated from
+   * this document.
+   *
+   * documentId is an empty string for requests related to workers.
+   */
+  abstract documentId(): string;
+
+  /**
    * The `ContinueRequestOverrides` that will be used
    * if the interception is allowed to continue (ie, `abort()` and
    * `respond()` aren't called).

--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -108,6 +108,10 @@ export class BidiHTTPRequest extends HTTPRequest {
     }
   }
 
+  override documentId(): string {
+    throw new UnsupportedOperation('Not supported in WebDriver BiDi');
+  }
+
   override url(): string {
     return this.#request.url;
   }

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -41,6 +41,7 @@ export class CdpHTTPRequest extends HTTPRequest {
   #headers: Record<string, string> = {};
   #frame: Frame | null;
   #initiator?: Protocol.Network.Initiator;
+  #documentId = '';
 
   override get client(): CDPSession {
     return this.#client;
@@ -97,12 +98,17 @@ export class CdpHTTPRequest extends HTTPRequest {
     this.#frame = frame;
     this._redirectChain = redirectChain;
     this.#initiator = data.initiator;
+    this.#documentId = data.loaderId ?? '';
 
     this.interception.enabled = allowInterception;
 
     for (const [key, value] of Object.entries(data.request.headers)) {
       this.#headers[key.toLowerCase()] = value;
     }
+  }
+
+  override documentId(): string {
+    return this.#documentId;
   }
 
   override url(): string {

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -41,7 +41,7 @@ export class CdpHTTPRequest extends HTTPRequest {
   #headers: Record<string, string> = {};
   #frame: Frame | null;
   #initiator?: Protocol.Network.Initiator;
-  #documentId = '';
+  #documentId: string;
 
   override get client(): CDPSession {
     return this.#client;

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -426,6 +426,13 @@
     "comment": "Flaky with both CDP and WebDriver BiDi. Needs investigation."
   },
   {
+    "testIdPattern": "[network.spec] network Request.documentId returns same documentId for navigation and resource requests",
+    "platforms": ["darwin"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "Not supported by WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[network.spec] network Request.initiator should return the initiator",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],


### PR DESCRIPTION
This would be useful to identify which requests are related to the current navigation.