### PR TITLE
fix(webdriver): support interception after continueWithAuth

### DIFF
--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -744,6 +744,21 @@ describe('network', function () {
       expect(response.status()).toBe(200);
     });
 
+    it('should work with interception', async () => {
+      const {page, server} = await getTestState();
+      await page.setRequestInterception(true);
+      page.on('request', async req => {
+        await req.continue();
+      });
+      server.setAuth('/empty.html', 'user', 'pass');
+      await page.authenticate({
+        username: 'user',
+        password: 'pass',
+      });
+      const response = (await page.goto(server.EMPTY_PAGE))!;
+      expect(response.status()).toBe(200);
+    });
+
     it('should error if authentication is required but not enabled', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
Closes https://github.com/puppeteer/puppeteer/issues/14152

Due to inconsistencies between Chrome and Firefox implementations for interception with authRequired event, Puppeteer did not account for the fact that a request continuedWithAuth can be intercepted again. For now, we treat such as requests as a redirect and since only headers can be used to differentiate such requests we check for the authorization header to detect interceptions after continueWithAuth.