### PR TITLE
feat: add Browser.deleteMatchingCookies() method

### DIFF
--- a/docs/api/puppeteer.browser.deletematchingcookies.md
+++ b/docs/api/puppeteer.browser.deletematchingcookies.md
@@ -1,0 +1,51 @@
+---
+sidebar_label: Browser.deleteMatchingCookies
+---
+
+# Browser.deleteMatchingCookies() method
+
+Deletes cookies matching the provided filters from the default [BrowserContext](./puppeteer.browsercontext.md).
+
+### Signature
+
+```typescript
+class Browser {
+  deleteMatchingCookies(...filters: DeleteCookiesRequest[]): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+filters
+
+</td><td>
+
+[DeleteCookiesRequest](./puppeteer.deletecookiesrequest.md)\[\]
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;
+
+## Remarks
+
+Shortcut for [browser.defaultBrowserContext().deleteMatchingCookies()](./puppeteer.browsercontext.deletematchingcookies.md).

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -212,6 +212,21 @@ Shortcut for [browser.defaultBrowserContext().deleteCookie()](./puppeteer.browse
 </td></tr>
 <tr><td>
 
+<span id="deletematchingcookies">[deleteMatchingCookies(filters)](./puppeteer.browser.deletematchingcookies.md)</span>
+
+</td><td>
+
+</td><td>
+
+Deletes cookies matching the provided filters from the default [BrowserContext](./puppeteer.browsercontext.md).
+
+**Remarks:**
+
+Shortcut for [browser.defaultBrowserContext().deleteMatchingCookies()](./puppeteer.browsercontext.deletematchingcookies.md).
+
+</td></tr>
+<tr><td>
+
 <span id="disconnect">[disconnect()](./puppeteer.browser.disconnect.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.browsercontext.deletecookie.md
+++ b/docs/api/puppeteer.browsercontext.deletecookie.md
@@ -4,7 +4,7 @@ sidebar_label: BrowserContext.deleteCookie
 
 # BrowserContext.deleteCookie() method
 
-Removes cookie in the browser context
+Removes cookie in this browser context.
 
 ### Signature
 
@@ -39,7 +39,7 @@ cookies
 
 </td><td>
 
-[cookie](./puppeteer.cookie.md) to remove
+Complete [cookie](./puppeteer.cookie.md) object to be removed.
 
 </td></tr>
 </tbody></table>

--- a/docs/api/puppeteer.browsercontext.deletematchingcookies.md
+++ b/docs/api/puppeteer.browsercontext.deletematchingcookies.md
@@ -1,0 +1,49 @@
+---
+sidebar_label: BrowserContext.deleteMatchingCookies
+---
+
+# BrowserContext.deleteMatchingCookies() method
+
+Deletes cookies matching the provided filters in this browser context.
+
+### Signature
+
+```typescript
+class BrowserContext {
+  deleteMatchingCookies(...filters: DeleteCookiesRequest[]): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+filters
+
+</td><td>
+
+[DeleteCookiesRequest](./puppeteer.deletecookiesrequest.md)\[\]
+
+</td><td>
+
+[DeleteCookiesRequest](./puppeteer.deletecookiesrequest.md)
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browsercontext.md
+++ b/docs/api/puppeteer.browsercontext.md
@@ -167,7 +167,18 @@ Gets all cookies in the browser context.
 
 </td><td>
 
-Removes cookie in the browser context
+Removes cookie in this browser context.
+
+</td></tr>
+<tr><td>
+
+<span id="deletematchingcookies">[deleteMatchingCookies(filters)](./puppeteer.browsercontext.deletematchingcookies.md)</span>
+
+</td><td>
+
+</td><td>
+
+Deletes cookies matching the provided filters in this browser context.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.cookie.md
+++ b/docs/api/puppeteer.cookie.md
@@ -39,23 +39,6 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
-<span id="domain">domain</span>
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-Cookie domain.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
 <span id="expires">expires</span>
 
 </td><td>
@@ -67,59 +50,6 @@ number
 </td><td>
 
 Cookie expiration date as the number of seconds since the UNIX epoch. Set to `-1` for session cookies
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="httponly">httpOnly</span>
-
-</td><td>
-
-</td><td>
-
-boolean
-
-</td><td>
-
-True if cookie is http-only.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="name">name</span>
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-Cookie name.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="partitionkey">partitionKey</span>
-
-</td><td>
-
-`optional`
-
-</td><td>
-
-[CookiePartitionKey](./puppeteer.cookiepartitionkey.md) \| string
-
-</td><td>
-
-Cookie partition key. In Chrome, it is the top-level site the partitioned cookie is available in. In Firefox, it matches the source origin in the [PartitionKey](https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey).
 
 </td><td>
 
@@ -156,63 +86,6 @@ string
 </td><td>
 
 Cookie path.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="priority">priority</span>
-
-</td><td>
-
-`optional`
-
-</td><td>
-
-[CookiePriority](./puppeteer.cookiepriority.md)
-
-</td><td>
-
-Cookie Priority. Supported only in Chrome.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="sameparty">sameParty</span>
-
-</td><td>
-
-`optional`
-
-</td><td>
-
-boolean
-
-</td><td>
-
-True if cookie is SameParty. Supported only in Chrome.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="samesite">sameSite</span>
-
-</td><td>
-
-`optional`
-
-</td><td>
-
-[CookieSameSite](./puppeteer.cookiesamesite.md)
-
-</td><td>
-
-Cookie SameSite type.
 
 </td><td>
 
@@ -264,42 +137,6 @@ number
 </td><td>
 
 Cookie size.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="sourcescheme">sourceScheme</span>
-
-</td><td>
-
-`optional`
-
-</td><td>
-
-[CookieSourceScheme](./puppeteer.cookiesourcescheme.md)
-
-</td><td>
-
-Cookie source scheme type. Supported only in Chrome.
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-<span id="value">value</span>
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-Cookie value.
 
 </td><td>
 

--- a/docs/api/puppeteer.page.deletecookie.md
+++ b/docs/api/puppeteer.page.deletecookie.md
@@ -6,7 +6,7 @@ sidebar_label: Page.deleteCookie
 
 > Warning: This API is now obsolete.
 >
-> Page-level cookie API is deprecated. Use [Browser.deleteCookie()](./puppeteer.browser.deletecookie.md) or [BrowserContext.deleteCookie()](./puppeteer.browsercontext.deletecookie.md) instead.
+> Page-level cookie API is deprecated. Use [Browser.deleteCookie()](./puppeteer.browser.deletecookie.md), [BrowserContext.deleteCookie()](./puppeteer.browsercontext.deletecookie.md), [Browser.deleteMatchingCookies()](./puppeteer.browser.deletematchingcookies.md) or [BrowserContext.deleteMatchingCookies()](./puppeteer.browsercontext.deletematchingcookies.md) instead.
 
 ### Signature
 

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -489,7 +489,7 @@ By default, `page.pdf()` generates a pdf with modified colors for printing. Use 
 
 **Deprecated:**
 
-Page-level cookie API is deprecated. Use [Browser.deleteCookie()](./puppeteer.browser.deletecookie.md) or [BrowserContext.deleteCookie()](./puppeteer.browsercontext.deletecookie.md) instead.
+Page-level cookie API is deprecated. Use [Browser.deleteCookie()](./puppeteer.browser.deletecookie.md), [BrowserContext.deleteCookie()](./puppeteer.browsercontext.deletecookie.md), [Browser.deleteMatchingCookies()](./puppeteer.browser.deletematchingcookies.md) or [BrowserContext.deleteMatchingCookies()](./puppeteer.browsercontext.deletematchingcookies.md) instead.
 
 </td></tr>
 <tr><td>

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -15,7 +15,11 @@ import {
   raceWith,
 } from '../../third_party/rxjs/rxjs.js';
 import type {ProtocolType} from '../common/ConnectOptions.js';
-import type {Cookie, CookieData} from '../common/Cookie.js';
+import type {
+  Cookie,
+  CookieData,
+  DeleteCookiesRequest,
+} from '../common/Cookie.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
 import {EventEmitter, type EventType} from '../common/EventEmitter.js';
 import {
@@ -459,6 +463,22 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    */
   async deleteCookie(...cookies: Cookie[]): Promise<void> {
     return await this.defaultBrowserContext().deleteCookie(...cookies);
+  }
+
+  /**
+   * Deletes cookies matching the provided filters from the default
+   * {@link BrowserContext}.
+   *
+   * @remarks
+   *
+   * Shortcut for
+   * {@link BrowserContext.deleteMatchingCookies |
+   * browser.defaultBrowserContext().deleteMatchingCookies()}.
+   */
+  async deleteMatchingCookies(
+    ...filters: DeleteCookiesRequest[]
+  ): Promise<void> {
+    return await this.defaultBrowserContext().deleteMatchingCookies(...filters);
   }
 
   /**

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1472,7 +1472,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
   /**
    * @deprecated Page-level cookie API is deprecated. Use
-   * {@link Browser.deleteCookie} or {@link BrowserContext.deleteCookie}
+   * {@link Browser.deleteCookie}, {@link BrowserContext.deleteCookie},
+   * {@link Browser.deleteMatchingCookies} or {@link BrowserContext.deleteMatchingCookies}
    * instead.
    */
   abstract deleteCookie(...cookies: DeleteCookiesRequest[]): Promise<void>;

--- a/packages/puppeteer-core/src/common/Cookie.ts
+++ b/packages/puppeteer-core/src/common/Cookie.ts
@@ -58,18 +58,6 @@ export interface CookiePartitionKey {
  */
 export interface Cookie extends CookieData {
   /**
-   * Cookie name.
-   */
-  name: string;
-  /**
-   * Cookie value.
-   */
-  value: string;
-  /**
-   * Cookie domain.
-   */
-  domain: string;
-  /**
    * Cookie path.
    */
   path: string;
@@ -83,10 +71,6 @@ export interface Cookie extends CookieData {
    */
   size: number;
   /**
-   * True if cookie is http-only.
-   */
-  httpOnly: boolean;
-  /**
    * True if cookie is secure.
    */
   secure: boolean;
@@ -94,29 +78,6 @@ export interface Cookie extends CookieData {
    * True in case of session cookie.
    */
   session: boolean;
-  /**
-   * Cookie SameSite type.
-   */
-  sameSite?: CookieSameSite;
-  /**
-   * Cookie Priority. Supported only in Chrome.
-   */
-  priority?: CookiePriority;
-  /**
-   * True if cookie is SameParty. Supported only in Chrome.
-   */
-  sameParty?: boolean;
-  /**
-   * Cookie source scheme type. Supported only in Chrome.
-   */
-  sourceScheme?: CookieSourceScheme;
-  /**
-   * Cookie partition key. In Chrome, it is the top-level site the
-   * partitioned cookie is available in. In Firefox, it matches the
-   * source origin in the
-   * {@link https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey | PartitionKey }.
-   */
-  partitionKey?: CookiePartitionKey | string;
   /**
    * True if cookie partition key is opaque. Supported only in Chrome.
    */


### PR DESCRIPTION
The method allows removing cookies matching a provided filter similar to the deprecated `page.deleteCookie` API.

Closes https://github.com/puppeteer/puppeteer/issues/13456