### PR TITLE
Update package.json to fix security hole

### DIFF
--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -142,7 +142,7 @@
   "dependencies": {
     "@puppeteer/browsers": "2.10.8",
     "chromium-bidi": "8.0.0",
-    "debug": "^4.4.1",
+    "debug": "4.4.1",
     "devtools-protocol": "0.0.1495869",
     "typed-query-selector": "^2.12.0",
     "ws": "^8.18.3"


### PR DESCRIPTION
Pinned `debug` to `v4.4.1` to prevent downloading the malicious `v4.4.2` package.

What happens is consumers get Puppeteer and end up downloading the bad version because of the carrot `^`. In general, it's best-practice to pin versions in `package.json` even if using Yarn or `package.lock` because consumers only get `package.json`.

While the package is removed from `npm`, many companies use some form of NPM caching like Artifactory, and if they haven't yet removed the malicious package from their cache, they'll be vulnerable.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Fixes a security flaw in `debug` found in `v4.4.2` and many other packages:
https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

**Did you add tests for your changes?**
No, but `v4.4.2` is malicious.

**If relevant, did you update the documentation?**
No.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
N/A