### PR TITLE
feat: support offline parameter in emulateNetworkConditions

### DIFF
--- a/docs/api/puppeteer.networkconditions.md
+++ b/docs/api/puppeteer.networkconditions.md
@@ -69,6 +69,29 @@ Latency (ms)
 </td></tr>
 <tr><td>
 
+<span id="offline">offline</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Emulates the offline mode.
+
+**Remarks:**
+
+Shortcut for [Page.setOfflineMode()](./puppeteer.page.setofflinemode.md).
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="upload">upload</span>
 
 </td><td>

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -1144,9 +1144,9 @@ NOTE: changing this value won't affect scripts that have already been run. It wi
 
 </td><td>
 
-Sets the network connection to offline.
+Emulates the offline mode.
 
-It does not change the parameters used in [Page.emulateNetworkConditions()](./puppeteer.page.emulatenetworkconditions.md)
+It does not change the download/upload/latency parameters set by [Page.emulateNetworkConditions()](./puppeteer.page.emulatenetworkconditions.md)
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.setofflinemode.md
+++ b/docs/api/puppeteer.page.setofflinemode.md
@@ -4,9 +4,9 @@ sidebar_label: Page.setOfflineMode
 
 # Page.setOfflineMode() method
 
-Sets the network connection to offline.
+Emulates the offline mode.
 
-It does not change the parameters used in [Page.emulateNetworkConditions()](./puppeteer.page.emulatenetworkconditions.md)
+It does not change the download/upload/latency parameters set by [Page.emulateNetworkConditions()](./puppeteer.page.emulatenetworkconditions.md)
 
 ### Signature
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -987,9 +987,10 @@ export abstract class Page extends EventEmitter<PageEvents> {
   abstract setDragInterception(enabled: boolean): Promise<void>;
 
   /**
-   * Sets the network connection to offline.
+   * Emulates the offline mode.
    *
-   * It does not change the parameters used in {@link Page.emulateNetworkConditions}
+   * It does not change the download/upload/latency parameters set by
+   * {@link Page.emulateNetworkConditions}
    *
    * @param enabled - When `true`, enables offline mode for the page.
    */

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -769,7 +769,7 @@ export class BidiPage extends Page {
     }
     if (!this.#emulatedNetworkConditions) {
       this.#emulatedNetworkConditions = {
-        offline: false,
+        offline: networkConditions?.offline ?? false,
         upload: -1,
         download: -1,
         latency: 0,
@@ -784,6 +784,8 @@ export class BidiPage extends Page {
     this.#emulatedNetworkConditions.latency = networkConditions
       ? networkConditions.latency
       : 0;
+    this.#emulatedNetworkConditions.offline =
+      networkConditions?.offline ?? false;
     return await this.#applyNetworkConditions();
   }
 

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -32,6 +32,14 @@ import {
  */
 export interface NetworkConditions {
   /**
+   * Emulates the offline mode.
+   *
+   * @remarks
+   *
+   * Shortcut for {@link Page.setOfflineMode}.
+   */
+  offline?: boolean;
+  /**
    * Download speed (bytes/s)
    */
   download: number;
@@ -207,7 +215,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   ): Promise<void> {
     if (!this.#emulatedNetworkConditions) {
       this.#emulatedNetworkConditions = {
-        offline: false,
+        offline: networkConditions?.offline ?? false,
         upload: -1,
         download: -1,
         latency: 0,
@@ -222,7 +230,8 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     this.#emulatedNetworkConditions.latency = networkConditions
       ? networkConditions.latency
       : 0;
-
+    this.#emulatedNetworkConditions.offline =
+      networkConditions?.offline ?? false;
     await this.#applyToAllClients(this.#applyNetworkConditions.bind(this));
   }
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -279,6 +279,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[emulation.spec] Emulation Page.emulateNetworkConditions should support offline",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported by WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[emulation.spec] Emulation Page.emulateTimezone should support timezone offset",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/src/emulation.spec.ts
+++ b/test/src/emulation.spec.ts
@@ -567,6 +567,24 @@ describe('Emulation', () => {
   });
 
   describe('Page.emulateNetworkConditions', function () {
+    it('should support offline', async () => {
+      const {page, server} = await getTestState();
+
+      await page.emulateNetworkConditions({
+        offline: true,
+        download: 0,
+        upload: 0,
+        latency: 0,
+      });
+
+      try {
+        await page.goto(server.EMPTY_PAGE);
+        throw new Error('not reached');
+      } catch (err) {
+        expect((err as Error).message).toMatch(/ERR_INTERNET_DISCONNECTED/);
+      }
+    });
+
     it('should change navigator.connection.effectiveType', async () => {
       const {page} = await getTestState();
 


### PR DESCRIPTION
This aligns Puppeteer with the CDP's interface and offers a shortcut for setting the offline mode together with throttling settings.