### PR TITLE
docs: clarify that 'running Puppeteer in the browser' docs does not automate the client-side browser

### DIFF
--- a/docs/guides/running-puppeteer-in-the-browser.md
+++ b/docs/guides/running-puppeteer-in-the-browser.md
@@ -1,17 +1,24 @@
 # Running Puppeteer in the browser
 
-Puppeteer is a powerful tool for automating browsers, but did you know it can also run within a browser itself? This enables you to leverage Puppeteer's capabilities for tasks that don't require Node.js specific features.
+Puppeteer is a powerful tool for automating browsers, but did you know its API can also run within a browser itself? This enables you to leverage Puppeteer's capabilities for tasks that don't require Node.js specific features.
+
+:::note
+
+Note that while the Puppeteer API can run from a client webpage, the automation actions are sent to a separate browser with an open debugging port.
+
+:::
+
 
 ## Supported Features
 
 While running in the browser, Puppeteer offers a variety of functionalities including:
 
 1. WebSocket Connections: Establish connections to existing browser instances using WebSockets. Launching or downloading browsers directly is not supported as it relies on Node.js APIs.
-2. Script Evaluation: Execute JavaScript code within the browser context.
-3. Document Manipulation: Generate PDFs and screenshots of the current web page.
-4. Page Management: Create, close, and navigate between different web pages.
-5. Cookie Handling: Inspect, modify, and manage cookies within the browser.
-6. Network Control: Monitor and intercept network requests made by the browser.
+2. Script Evaluation: Execute JavaScript code within the remote browser context.
+3. Document Manipulation: Generate PDFs and screenshots of the remote browser page.
+4. Page Management: Create, close, and navigate between different web pages in the remote browser.
+5. Cookie Handling: Inspect, modify, and manage cookies within the remote browser.
+6. Network Control: Monitor and intercept network requests made by the remote browser.
 
 ## How to run Puppeteer in the browser
 
@@ -65,7 +72,7 @@ export default {
 
 :::note
 
-Do not forget to include a valid browser WebSocket endpoint when connecting to an instance.
+Do not forget to include a valid browser WebSocket endpoint when connecting to a remote browser instance.
 
 :::
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation clarification.

**Did you add tests for your changes?**

No, it's a documentation change.

**If relevant, did you update the documentation?**

Yes, it's a documentation change.

**Summary**

The current documentation of [Running Puppeteer in the browser](https://pptr.dev/guides/running-puppeteer-in-the-browser) in v24.20.0 is misleading, since it implies you can use Puppeteer to generate a PDF or a screenshot of the client side page running the rollup-bundled Puppeteer. But actually, it's strictly referring to operations you can take on the _remote_ browser that has been pre-launched with a debugging port, using the Playwright API.

As written, the guide reinforces the misconception that Puppeteer can take screenshots of the current client-side page and automate the current browser fully from the client.

This PR clarifies the scope of what "running Puppeteer in the browser" actually entails, which is that it's just the Puppeteer command API, not the actual browser automation.

For evidence of the confusion caused by this particular documentation page (and the motivation for this PR), see [Is it possible to bundle Puppeteer on the frontend (no node.js) to export the current page as a pdf?](https://stackoverflow.com/questions/79757216/is-it-possible-to-bundle-puppeteer-on-the-frontend-no-node-js-to-export-the-cu)

For other threads highlighting the general goals, confusion and misconceptions surrounding running Puppeteer in the browser, see:
- [How to run Puppeteer code in any web browser?](https://stackoverflow.com/questions/54647694/how-to-run-puppeteer-code-in-any-web-browser)
- [How to make Puppeteer work with a ReactJS application on the client-side](https://stackoverflow.com/questions/55031823/how-to-make-puppeteer-work-with-a-reactjs-application-on-the-client-side?noredirect=1&lq=1)
- [is there a way to use require.js for using puppeteer in a web page?](https://stackoverflow.com/questions/61297011/is-there-a-way-to-use-require-js-for-using-puppeteer-in-a-web-page?noredirect=1&lq=1)
- [Why I am getting an error 'Uncaught ReferenceError: require is not defined at app.js:1:19' when using puppeteer](https://stackoverflow.com/questions/75702511/why-i-am-getting-an-error-uncaught-referenceerror-require-is-not-defined-at-ap?noredirect=1&lq=1)
- https://github.com/puppeteer/puppeteer/issues/3343
- https://github.com/puppeteer/puppeteer/issues/1747

**Does this PR introduce a breaking change?**

No.

**Other information**
