### PR TITLE
docs: error by default

### DIFF
--- a/packages/browsers/api-extractor.json
+++ b/packages/browsers/api-extractor.json
@@ -18,7 +18,7 @@
   "messages": {
     "compilerMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
 
@@ -27,13 +27,13 @@
         "logLevel": "none"
       },
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
 
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     }
   }

--- a/packages/puppeteer-core/api-extractor.json
+++ b/packages/puppeteer-core/api-extractor.json
@@ -25,7 +25,7 @@
   "messages": {
     "compilerMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
 
@@ -34,13 +34,13 @@
         "logLevel": "none"
       },
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
 
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     }
   }

--- a/packages/puppeteer/api-extractor.json
+++ b/packages/puppeteer/api-extractor.json
@@ -24,7 +24,7 @@
   "messages": {
     "compilerMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
 
@@ -36,13 +36,13 @@
         "logLevel": "none"
       },
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
 
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     }
   }

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -21,7 +21,27 @@ const puppeteer = new PuppeteerNode({
   configuration,
 });
 
-export const {connect, defaultArgs, executablePath, launch, trimCache} =
-  puppeteer;
+export const {
+  /**
+   * @public
+   */
+  connect,
+  /**
+   * @public
+   */
+  defaultArgs,
+  /**
+   * @public
+   */
+  executablePath,
+  /**
+   * @public
+   */
+  launch,
+  /**
+   * @public
+   */
+  trimCache,
+} = puppeteer;
 
 export default puppeteer;


### PR DESCRIPTION
This will make errors like - https://github.com/puppeteer/puppeteer/pull/14190#discussion_r2339331151
Fail CI and building.
Currently WireIt does not propagate the warnings correctly.