### PR TITLE
docs: fix 'getting started' code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ await page.goto('https://developer.chrome.com/');
 // Set screen size.
 await page.setViewport({width: 1080, height: 1024});
 
+// Open the search menu using the keyboard.
+await page.keyboard.press('/');
+
 // Type into search box using accessible input name.
-await page.locator('aria/Search').fill('automate beyond recorder');
+await page.locator('::-p-aria(Search)').fill('automate beyond recorder');
 
 // Wait and click on first result.
 await page.locator('.devsite-result-item-link').click();
 
 // Locate the full title with a unique string.
 const textSelector = await page
-  .locator('text/Customize and automate')
+  .locator('::-p-text(Customize and automate)')
   .waitHandle();
 const fullTitle = await textSelector?.evaluate(el => el.textContent);
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i puppeteer-core # Alternatively, install as a library, without downloading 
 import puppeteer from 'puppeteer';
 // Or import puppeteer from 'puppeteer-core';
 
-// Launch the browser and open a new blank page
+// Launch the browser and open a new blank page.
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -13,7 +13,7 @@ The following example searches [developer.chrome.com](https://developer.chrome.c
 import puppeteer from 'puppeteer';
 // Or import puppeteer from 'puppeteer-core';
 
-// Launch the browser and open a new blank page
+// Launch the browser and open a new blank page.
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -11,37 +11,37 @@ The following example searches [developer.chrome.com](https://developer.chrome.c
 
 ```ts
 import puppeteer from 'puppeteer';
+// Or import puppeteer from 'puppeteer-core';
 
-(async () => {
-  // Launch the browser and open a new blank page
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+// Launch the browser and open a new blank page
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
 
-  // Navigate the page to a URL
-  await page.goto('https://developer.chrome.com/');
+// Navigate the page to a URL.
+await page.goto('https://developer.chrome.com/');
 
-  // Set screen size
-  await page.setViewport({width: 1080, height: 1024});
+// Set screen size.
+await page.setViewport({width: 1080, height: 1024});
 
-  // Type into search box
-  await page.type('.devsite-search-field', 'automate beyond recorder');
+// Open the search menu using the keyboard.
+await page.keyboard.press('/');
 
-  // Wait and click on first result
-  const searchResultSelector = '.devsite-result-item-link';
-  await page.waitForSelector(searchResultSelector);
-  await page.click(searchResultSelector);
+// Type into search box using accessible input name.
+await page.locator('::-p-aria(Search)').fill('automate beyond recorder');
 
-  // Locate the full title with a unique string
-  const textSelector = await page.waitForSelector(
-    'text/Customize and automate',
-  );
-  const fullTitle = await textSelector?.evaluate(el => el.textContent);
+// Wait and click on first result.
+await page.locator('.devsite-result-item-link').click();
 
-  // Print the full title
-  console.log('The title of this blog post is "%s".', fullTitle);
+// Locate the full title with a unique string.
+const textSelector = await page
+  .locator('::-p-text(Customize and automate)')
+  .waitHandle();
+const fullTitle = await textSelector?.evaluate(el => el.textContent);
 
-  await browser.close();
-})();
+// Print the full title.
+console.log('The title of this blog post is "%s".', fullTitle);
+
+await browser.close();
 ```
 
 For more in-depth usage, check our [documentation](https://pptr.dev/docs)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ npm i puppeteer-core # Alternatively, install as a library, without downloading 
 import puppeteer from 'puppeteer';
 // Or import puppeteer from 'puppeteer-core';
 
-// Launch the browser and open a new blank page
+// Launch the browser and open a new blank page.
 const browser = await puppeteer.launch();
 const page = await browser.newPage();
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,15 +39,18 @@ await page.goto('https://developer.chrome.com/');
 // Set screen size.
 await page.setViewport({width: 1080, height: 1024});
 
+// Open the search menu using the keyboard.
+await page.keyboard.press('/');
+
 // Type into search box using accessible input name.
-await page.locator('aria/Search').fill('automate beyond recorder');
+await page.locator('::-p-aria(Search)').fill('automate beyond recorder');
 
 // Wait and click on first result.
 await page.locator('.devsite-result-item-link').click();
 
 // Locate the full title with a unique string.
 const textSelector = await page
-  .locator('text/Customize and automate')
+  .locator('::-p-text(Customize and automate)')
   .waitHandle();
 const fullTitle = await textSelector?.evaluate(el => el.textContent);
 

--- a/examples/search.js
+++ b/examples/search.js
@@ -19,6 +19,9 @@ const puppeteer = require('puppeteer');
 
   await page.goto('https://developers.google.com/web/');
 
+  // Open the search menu using the keyboard.
+  await page.keyboard.press('/');
+
   // Type into search box.
   await page.type('.devsite-search-field', 'Headless Chrome');
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This fixes the 'getting started' code, ensuring the search term input is in the viewport and available by pressing the `/` key before typing:

<img width="248" height="84" alt="image" src="https://github.com/user-attachments/assets/b386bd3c-c87e-4f5d-9c0e-ca41ebd506df" />

This PR also uses p-selector syntax, since the docs [discourage prefix syntax](https://pptr.dev/guides/page-interactions#prefixed-selector-syntax). I'm fine dropping this change though, it's an aside.

Finally, the PR makes all versions of this getting started script consistent. One has an IIFE and doesn't use a locator.

**Did you add tests for your changes?**

No automated tests, but I did manually run all code changes to ensure the title was printed:

```none
% node test-doc-change.mjs
The title of this blog post is "Customize and automate user flows beyond Chrome DevTools Recorder








      Stay organized with collections



      Save and categorize content based on your preferences.".
```

**If relevant, did you update the documentation?**

Yes, since this is a pure documentation change.

**Summary**

Fixes https://github.com/puppeteer/puppeteer/issues/13500--please see rationale in that thread and above.

**Does this PR introduce a breaking change?**

No.

**Other information**

I'm not sure if I'm supposed to update the versioned docs or if those should be kept as-is.
