### PR TITLE
fix: do not change CDP state if interception was not toggled

### DIFF
--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -77,7 +77,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #credentials: Credentials | null = null;
   #attemptedAuthentications = new Set<string>();
   #userRequestInterceptionEnabled = false;
-  #protocolRequestInterceptionEnabled = false;
+  #protocolRequestInterceptionEnabled?: boolean;
   #userCacheDisabled?: boolean;
   #emulatedNetworkConditions?: InternalNetworkConditions;
   #userAgent?: string;
@@ -310,6 +310,9 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   async #applyProtocolRequestInterception(client: CDPSession): Promise<void> {
+    if (this.#protocolRequestInterceptionEnabled === undefined) {
+      return;
+    }
     if (this.#userCacheDisabled === undefined) {
       this.#userCacheDisabled = false;
     }


### PR DESCRIPTION
Currently, the CDP configuration commands (with false values) would be send even if interception was not enabled forcing the cache state change.

Closes https://github.com/puppeteer/puppeteer/issues/14202