### PR TITLE
fix: always pipe stdio and report process launch errors

### DIFF
--- a/docs/browsers-api/browsers.process.getrecentlogs.md
+++ b/docs/browsers-api/browsers.process.getrecentlogs.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: Process.getRecentLogs
+---
+
+# Process.getRecentLogs() method
+
+Get recent logs (stderr + stdout) emitted by the browser.
+
+### Signature
+
+```typescript
+class Process {
+  getRecentLogs(): string[];
+}
+```
+
+**Returns:**
+
+string\[\]

--- a/docs/browsers-api/browsers.process.md
+++ b/docs/browsers-api/browsers.process.md
@@ -100,6 +100,17 @@ Description
 </td></tr>
 <tr><td>
 
+<span id="getrecentlogs">[getRecentLogs()](./browsers.process.getrecentlogs.md)</span>
+
+</td><td>
+
+</td><td>
+
+Get recent logs (stderr + stdout) emitted by the browser.
+
+</td></tr>
+<tr><td>
+
 <span id="hasclosed">[hasClosed()](./browsers.process.hasclosed.md)</span>
 
 </td><td>

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -5,9 +5,11 @@
  */
 
 import childProcess from 'node:child_process';
+import {EventEmitter} from 'node:events';
 import {accessSync} from 'node:fs';
 import os from 'node:os';
 import readline from 'node:readline';
+import type Stream from 'node:stream';
 
 import {
   type Browser,
@@ -274,6 +276,9 @@ export class Process {
   #hooksRan = false;
   #onExitHook = async () => {};
   #browserProcessExiting: Promise<void>;
+  #logs: string[] = [];
+  #maxLogLinesSize = 100;
+  #lineEmitter = new EventEmitter();
 
   constructor(opts: LaunchOptions) {
     this.#executablePath = opts.executablePath;
@@ -289,10 +294,8 @@ export class Process {
     // process tree with `.kill(-pid)` command. @see
     // https://nodejs.org/api/child_process.html#child_process_options_detached
     opts.detached ??= process.platform !== 'win32';
-
     const stdio = this.#configureStdio({
       pipe: opts.pipe,
-      dumpio: opts.dumpio,
     });
 
     const env = opts.env || {};
@@ -320,6 +323,8 @@ export class Process {
         stdio,
       },
     );
+    this.#recordStream(this.#browserProcess.stderr!);
+    this.#recordStream(this.#browserProcess.stdout!);
 
     debugLaunch(`Launched ${this.#browserProcess.pid}`);
     if (opts.dumpio) {
@@ -367,22 +372,11 @@ export class Process {
     return this.#browserProcess;
   }
 
-  #configureStdio(opts: {
-    pipe: boolean;
-    dumpio: boolean;
-  }): Array<'ignore' | 'pipe'> {
+  #configureStdio(opts: {pipe: boolean}): Array<'ignore' | 'pipe'> {
     if (opts.pipe) {
-      if (opts.dumpio) {
-        return ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'];
-      } else {
-        return ['ignore', 'ignore', 'ignore', 'pipe', 'pipe'];
-      }
+      return ['pipe', 'pipe', 'pipe', 'pipe', 'pipe'];
     } else {
-      if (opts.dumpio) {
-        return ['pipe', 'pipe', 'pipe'];
-      } else {
-        return ['pipe', 'ignore', 'pipe'];
-      }
+      return ['pipe', 'pipe', 'pipe'];
     }
   }
 
@@ -477,46 +471,77 @@ export class Process {
     this.#clearListeners();
   }
 
-  waitForLineOutput(regex: RegExp, timeout = 0): Promise<string> {
-    if (!this.#browserProcess.stderr) {
-      throw new Error('`browserProcess` does not have stderr.');
-    }
-    const rl = readline.createInterface(this.#browserProcess.stderr);
-    let stderr = '';
-
-    return new Promise((resolve, reject) => {
-      rl.on('line', onLine);
-      rl.on('close', onClose);
-      this.#browserProcess.on('exit', onClose);
-      this.#browserProcess.on('error', onClose);
-      const timeoutId =
-        timeout > 0 ? setTimeout(onTimeout, timeout) : undefined;
-
-      const cleanup = (): void => {
-        clearTimeout(timeoutId);
-        rl.off('line', onLine);
-        rl.off('close', onClose);
+  #recordStream(stream: Stream.Readable): void {
+    const rl = readline.createInterface(stream);
+    const cleanup = (): void => {
+      rl.off('line', onLine);
+      rl.off('close', onClose);
+      try {
         rl.close();
-        this.#browserProcess.off('exit', onClose);
-        this.#browserProcess.off('error', onClose);
-      };
+      } catch {}
+    };
+    const onLine = (line: string) => {
+      if (line.trim() === '') {
+        return;
+      }
+      this.#logs.push(line);
+      const delta = this.#logs.length - this.#maxLogLinesSize;
+      if (delta) {
+        this.#logs.splice(0, delta);
+      }
+      this.#lineEmitter.emit('line', line);
+    };
+    const onClose = (): void => {
+      cleanup();
+    };
+    rl.on('line', onLine);
+    rl.on('close', onClose);
+  }
 
-      function onClose(error?: Error): void {
+  /**
+   * Get recent logs (stderr + stdout) emitted by the browser.
+   *
+   * @public
+   */
+  getRecentLogs(): string[] {
+    return [...this.#logs];
+  }
+
+  waitForLineOutput(regex: RegExp, timeout = 0): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const onClose = (errorOrCode?: Error | number): void => {
         cleanup();
         reject(
           new Error(
             [
-              `Failed to launch the browser process!${
-                error ? ' ' + error.message : ''
+              `Failed to launch the browser process: ${
+                errorOrCode instanceof Error
+                  ? ` ${errorOrCode.message}`
+                  : ` Code: ${errorOrCode}`
               }`,
-              stderr,
+              '',
+              `stderr:`,
+              this.getRecentLogs().join('\n'),
               '',
               'TROUBLESHOOTING: https://pptr.dev/troubleshooting',
               '',
             ].join('\n'),
           ),
         );
-      }
+      };
+
+      this.#browserProcess.on('exit', onClose);
+      this.#browserProcess.on('error', onClose);
+      const timeoutId =
+        timeout > 0 ? setTimeout(onTimeout, timeout) : undefined;
+
+      this.#lineEmitter.on('line', onLine);
+      const cleanup = (): void => {
+        clearTimeout(timeoutId);
+        this.#lineEmitter.off('line', onLine);
+        this.#browserProcess.off('exit', onClose);
+        this.#browserProcess.off('error', onClose);
+      };
 
       function onTimeout(): void {
         cleanup();
@@ -528,7 +553,6 @@ export class Process {
       }
 
       function onLine(line: string): void {
-        stderr += line + '\n';
         const match = line.match(regex);
         if (!match) {
           return;

--- a/packages/browsers/test/src/chrome/launch.spec.ts
+++ b/packages/browsers/test/src/chrome/launch.spec.ts
@@ -117,5 +117,26 @@ describe('Chrome', () => {
       await process.close();
       assert.ok(url.startsWith('ws://127.0.0.1:9222/devtools/browser'));
     });
+
+    it('should return recent browser logs', async () => {
+      const executablePath = computeExecutablePath({
+        cacheDir: tmpDir,
+        browser: Browser.CHROME,
+        buildId: testChromeBuildId,
+      });
+      const process = launch({
+        executablePath,
+        args: getArgs(),
+      });
+      const url = await process.waitForLineOutput(CDP_WEBSOCKET_ENDPOINT_REGEX);
+      await process.close();
+      assert.ok(url.startsWith('ws://127.0.0.1:9222/devtools/browser'));
+      assert.ok(process.getRecentLogs().length >= 1);
+      assert.ok(
+        process.getRecentLogs().some(line => {
+          return line.includes(url);
+        }),
+      );
+    });
   });
 });

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -181,6 +181,7 @@ export abstract class BrowserLauncher {
             slowMo,
           });
         }
+
         if (protocol === 'webDriverBiDi') {
           browser = await this.createBiDiOverCdpBrowser(
             browserProcess,
@@ -210,6 +211,17 @@ export abstract class BrowserLauncher {
       }
     } catch (error) {
       void browserCloseCallback();
+      if (
+        browserProcess.getRecentLogs().some(line => {
+          return line.includes(
+            'Failed to create a ProcessSingleton for your profile directory',
+          );
+        })
+      ) {
+        throw new Error(
+          `The browser is already running for ${launchArgs.userDataDir}. Use a different \`userDataDir\` or stop the running browser first.`,
+        );
+      }
       if (error instanceof BrowsersTimeoutError) {
         throw new TimeoutError(error.message);
       }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -192,7 +192,7 @@
     "testIdPattern": "[userDataDir.spec] userDataDir should not launch the browser twice with the same userDataDir *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
-    "expectations": ["FAIL"],
+    "expectations": ["SKIP"],
     "comment": "we currently do not detect this siutation for Firefox"
   },
   {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -175,6 +175,27 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[userDataDir.spec] userDataDir should not launch the browser twice with the same userDataDir *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["FAIL"],
+    "comment": "headless-shell can launch multiple instances from the same user data dir"
+  },
+  {
+    "testIdPattern": "[userDataDir.spec] userDataDir should not launch the browser twice with the same userDataDir *",
+    "platforms": ["win32"],
+    "parameters": ["chrome"],
+    "expectations": ["FAIL"],
+    "comment": "on Windows Chrome seems to have no issues starting on the user data dir"
+  },
+  {
+    "testIdPattern": "[userDataDir.spec] userDataDir should not launch the browser twice with the same userDataDir *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "we currently do not detect this siutation for Firefox"
+  },
+  {
     "testIdPattern": "[waittask.spec] waittask specs Frame.waitForSelector should work when node is added in a shadow root",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": [],

--- a/test/src/cdp/userDataDir.spec.ts
+++ b/test/src/cdp/userDataDir.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import assert from 'node:assert';
+import fs from 'node:fs';
+import {mkdtemp} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import expect from 'expect';
+
+import {launch} from '../mocha-utils.js';
+
+const TMP_FOLDER = path.join(os.tmpdir(), 'pptr_tmp_folder-');
+
+describe('userDataDir', function () {
+  for (const pipe of [true, false]) {
+    it(`should not launch the browser twice with the same userDataDir with pipe=${pipe}`, async () => {
+      const userDataDir = await mkdtemp(TMP_FOLDER);
+      const {browser, close} = await launch({userDataDir, pipe});
+      // Open a page to make sure its functional.
+      try {
+        await browser.newPage();
+        expect(fs.readdirSync(userDataDir).length).toBeGreaterThan(0);
+
+        try {
+          const {close: close2} = await launch({
+            userDataDir,
+            pipe,
+          });
+          await close2();
+          assert.fail('Not reached');
+        } catch (err) {
+          assert.strictEqual(
+            (err as Error).message.startsWith(
+              'The browser is already running for',
+            ),
+            true,
+          );
+        }
+      } finally {
+        await close();
+      }
+    });
+  }
+});


### PR DESCRIPTION
This PR introduces tracking for the recent browser logs and makes sure that `@puppeteer/browsers` subscribes to the logs early. It then uses the logs to detect launch issues related to the same profile having a running browser instance already. It also fixes https://github.com/puppeteer/puppeteer/issues/14062 to implement this.