### PR TITLE
fix: check previously received log lines in waitForLineOutput

### DIFF
--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -552,6 +552,10 @@ export class Process {
         );
       }
 
+      for (const line of this.#logs) {
+        onLine(line);
+      }
+
       function onLine(line: string): void {
         const match = line.match(regex);
         if (!match) {


### PR DESCRIPTION
It's possible that by the time waitForLineOutput the expected line was already emitted.