### PR TITLE
chore: keep more lines in case the browser is verbose

### DIFF
--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -277,7 +277,7 @@ export class Process {
   #onExitHook = async () => {};
   #browserProcessExiting: Promise<void>;
   #logs: string[] = [];
-  #maxLogLinesSize = 100;
+  #maxLogLinesSize = 1000;
   #lineEmitter = new EventEmitter();
 
   constructor(opts: LaunchOptions) {


### PR DESCRIPTION
Increase to 1000 lines in case the browser outputs a lot of logs.