### PR TITLE
test: update eval test for RenderDocument

### DIFF
--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -146,7 +146,10 @@ describe('Evaluation specs', function () {
         .catch(error_ => {
           return (error = error_);
         });
-      expect(error.message).toContain('Protocol error');
+      expect(error.message).atLeastOneToContain([
+        'Execution context was destroyed', // Chrome
+        'no such frame', // Firefox
+      ]);
     });
     it('should await promise', async () => {
       const {page} = await getTestState();


### PR DESCRIPTION
With the RenderDocument feature, the error will be different. This change captures the expectations better.