### PR TITLE
fix: replace function eval with parsing in page.evaluate()

### DIFF
--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -40,7 +40,8 @@
     "check": "wireit",
     "clean": "../../tools/clean.mjs",
     "prepack": "wireit",
-    "unit": "wireit"
+    "unit": "wireit",
+    "unit:only": "wireit"
   },
   "wireit": {
     "check": {
@@ -122,6 +123,12 @@
     },
     "unit": {
       "command": "node --test --test-reporter=spec \"lib/cjs/**/*.test.js\"",
+      "dependencies": [
+        "build"
+      ]
+    },
+    "unit:only": {
+      "command": "node --test --test-only --test-reporter=spec \"lib/cjs/**/*.test.js\"",
       "dependencies": [
         "build"
       ]

--- a/packages/puppeteer-core/src/util/Function.test.ts
+++ b/packages/puppeteer-core/src/util/Function.test.ts
@@ -8,7 +8,7 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {interpolateFunction} from './Function.js';
+import {interpolateFunction, stringifyFunction} from './Function.js';
 
 describe('Function', function () {
   describe('interpolateFunction', function () {
@@ -31,6 +31,62 @@ describe('Function', function () {
         {test: `() => 5`},
       );
       expect(test()).toBe(5);
+    });
+  });
+
+  describe('stringifyFunction', () => {
+    // prettier-ignore
+    it('should work', () => { /* eslint-disable @typescript-eslint/no-unused-expressions */
+      class K1 { m() {} }
+      class K2 { m () {} }
+      class K3 { async m() {} }
+      class K4 { async m () {} }
+
+      const variations = [
+        // Non-arrow functions.
+        function() {},
+        function () {},
+        function x() {},
+        function x () {},
+        async function() {},
+        async function () {},
+        async function x() {},
+        async function x () {},
+        // Concise methods.
+        new K1().m,
+        new K2().m,
+        new K3().m,
+        new K4().m,
+        // Arrow functions.
+        () => {},
+        // @ts-expect-error irrelevant
+        (a) => {a;},
+        // @ts-expect-error irrelevant
+        a => {a;},
+        async () => {},
+        // @ts-expect-error irrelevant
+        async (a) => {a;},
+        // @ts-expect-error irrelevant
+        async a => {a;},
+        // Generator functions
+        function*a() {},
+        function *a() {},
+        function* a() {},
+        // Async generator functions
+        async function*a() {},
+        async function *a() {},
+        async function* a() {},
+      ];
+
+      for (const v of variations) {
+        const fnStr = stringifyFunction(v);
+        try {
+          new Function(`(${fnStr})`);
+        } catch {
+          throw new Error(`Could not stringify:
+${v.toString()}`);
+        }
+      }
     });
   });
 });

--- a/packages/puppeteer-core/src/util/Function.ts
+++ b/packages/puppeteer-core/src/util/Function.ts
@@ -29,37 +29,29 @@ export const createFunction = (
  */
 export function stringifyFunction(fn: (...args: never) => unknown): string {
   let value = fn.toString();
-  try {
-    new Function(`(${value})`);
-  } catch (err) {
-    if (
-      (err as Error).message.includes(
-        `Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive`,
-      ) ||
-      (err as Error).message.includes(
-        'Evaluating a string as JavaScript violates the following Content Security Policy',
-      )
-    ) {
-      // The content security policy does not allow Function eval. Let's
-      // assume the value might be valid as is.
-      return value;
-    }
-    // This means we might have a function shorthand (e.g. `test(){}`). Let's
-    // try prefixing.
-    let prefix = 'function ';
-    if (value.startsWith('async ')) {
-      prefix = `async ${prefix}`;
-      value = value.substring('async '.length);
-    }
-    value = `${prefix}${value}`;
-    try {
-      new Function(`(${value})`);
-    } catch {
-      // We tried hard to serialize, but there's a weird beast here.
-      throw new Error('Passed function cannot be serialized!');
-    }
+  if (
+    value.match(/^(async )*function /) ||
+    value.match(/^(async )*function\s*\*\s*/)
+  ) {
+    return value;
   }
-  return value;
+  const isArrow =
+    value.startsWith('(') ||
+    value.match(/^async\s*\(/) ||
+    value.match(
+      /^(async)*\s*(?:[$_\p{ID_Start}])(?:[$\u200C\u200D\p{ID_Continue}])*\s*=>/u,
+    );
+  if (isArrow) {
+    return value;
+  }
+  // This means we might have a function shorthand (e.g. `test(){}`). Let's
+  // try prefixing.
+  let prefix = 'function ';
+  if (value.startsWith('async ')) {
+    prefix = `async ${prefix}`;
+    value = value.substring('async '.length);
+  }
+  return `${prefix}${value}`;
 }
 
 /**

--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -121,6 +121,17 @@ describe('Evaluation specs', function () {
       expect(await page.evaluate(a.sum, 1, 2)).toBe(3);
       expect(await page.evaluate(a.mult, 2, 4)).toBe(8);
     });
+    it('should work with function shorthands and nested arrow functions', async () => {
+      const {page} = await getTestState();
+      const a = {
+        sum(a: number, b: number) {
+          const _arrow = () => {};
+          _arrow();
+          return a + b;
+        },
+      };
+      expect(await page.evaluate(a.sum, 1, 2)).toBe(3);
+    });
     it('should work with unicode chars', async () => {
       const {page} = await getTestState();
 


### PR DESCRIPTION
`new Function(str)`  evals were used to validate and stringify JS functions. This causes issues when running in environments with CSP. This PR replaces this with rules to stringify functions correctly.