### PR TITLE
fix: regression in function stringification

### DIFF
--- a/packages/puppeteer-core/function-fixture.mjs
+++ b/packages/puppeteer-core/function-fixture.mjs
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// prettier-ignore
+class K1 { m() {} }
+// prettier-ignore
+class K2 { m () {} }
+// prettier-ignore
+class K3 { async m() {} }
+// prettier-ignore
+class K4 { async m () {} }
+
+// prettier-ignore
+export const variations = [
+  // Non-arrow functions.
+  function() {},
+  function () {},
+  function x() {},
+  function x () {},
+  async function() {},
+  async function () {},
+  async function x() {},
+  async function x () {},
+  // Concise methods.
+  new K1().m,
+  new K2().m,
+  new K3().m,
+  new K4().m,
+  // Arrow functions.
+  () => {},
+  // @ts-expect-error irrelevant
+  (a) => {a;},
+  // @ts-expect-error irrelevant
+  a => {a;},
+  async () => {},
+  // @ts-expect-error irrelevant
+  async (a) => {a;},
+  // @ts-expect-error irrelevant
+  async a => {a;},
+  // Generator functions
+  function*a() {},
+  function *a() {},
+  function* a() {},
+  // Async generator functions
+  async function*a() {},
+  async function *a() {},
+  async function* a() {},
+];

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -137,6 +137,7 @@
   "files": [
     "lib",
     "src",
+    "!function-fixture.mjs",
     "!*.test.ts",
     "!*.test.js",
     "!*.test.d.ts",

--- a/packages/puppeteer-core/src/util/Function.test.ts
+++ b/packages/puppeteer-core/src/util/Function.test.ts
@@ -35,49 +35,9 @@ describe('Function', function () {
   });
 
   describe('stringifyFunction', () => {
-    // prettier-ignore
-    it('should work', () => { /* eslint-disable @typescript-eslint/no-unused-expressions */
-      class K1 { m() {} }
-      class K2 { m () {} }
-      class K3 { async m() {} }
-      class K4 { async m () {} }
-
-      const variations = [
-        // Non-arrow functions.
-        function() {},
-        function () {},
-        function x() {},
-        function x () {},
-        async function() {},
-        async function () {},
-        async function x() {},
-        async function x () {},
-        // Concise methods.
-        new K1().m,
-        new K2().m,
-        new K3().m,
-        new K4().m,
-        // Arrow functions.
-        () => {},
-        // @ts-expect-error irrelevant
-        (a) => {a;},
-        // @ts-expect-error irrelevant
-        a => {a;},
-        async () => {},
-        // @ts-expect-error irrelevant
-        async (a) => {a;},
-        // @ts-expect-error irrelevant
-        async a => {a;},
-        // Generator functions
-        function*a() {},
-        function *a() {},
-        function* a() {},
-        // Async generator functions
-        async function*a() {},
-        async function *a() {},
-        async function* a() {},
-      ];
-
+    it('should work', async () => {
+      // @ts-expect-error no types
+      const {variations} = await import('../../../../function-fixture.mjs');
       for (const v of variations) {
         const fnStr = stringifyFunction(v);
         try {

--- a/packages/puppeteer-core/src/util/Function.ts
+++ b/packages/puppeteer-core/src/util/Function.ts
@@ -30,7 +30,7 @@ export const createFunction = (
 export function stringifyFunction(fn: (...args: never) => unknown): string {
   let value = fn.toString();
   if (
-    value.match(/^(async )*function /) ||
+    value.match(/^(async )*function(\(|\s)/) ||
     value.match(/^(async )*function\s*\*\s*/)
   ) {
     return value;


### PR DESCRIPTION
tsc was changing the whitespaces in test functions so tests were passing while the new approach would not work in non-tsc projects. This PR moves the fixture to be a plain js file and fixes the regex.

fixes https://github.com/puppeteer/puppeteer/issues/14244