### PR TITLE
chore: introduce webDriverBiDiOnly protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test-types": "wireit",
     "test:chrome": "wireit",
     "test:chrome:bidi": "wireit",
+    "test:chrome:bidi-only": "wireit",
     "test:chrome:headful": "wireit",
     "test:chrome:headless": "wireit",
     "test:chrome:shell": "wireit",
@@ -116,6 +117,12 @@
     },
     "test:chrome:bidi": {
       "command": "npm test -- --test-suite chrome-bidi"
+    },
+    "test:chrome:bidi-only": {
+      "command": "npm test -- --test-suite chrome-bidi",
+      "env": {
+        "PUPPETEER_WEBDRIVER_BIDI_ONLY": "true"
+      }
     },
     "test:chrome:headful": {
       "command": "npm test -- --test-suite chrome-headful"

--- a/package.json
+++ b/package.json
@@ -119,10 +119,7 @@
       "command": "npm test -- --test-suite chrome-bidi"
     },
     "test:chrome:bidi-only": {
-      "command": "npm test -- --test-suite chrome-bidi",
-      "env": {
-        "PUPPETEER_WEBDRIVER_BIDI_ONLY": "true"
-      }
+      "command": "npm test -- --test-suite chrome-bidi-only"
     },
     "test:chrome:headful": {
       "command": "npm test -- --test-suite chrome-headful"

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -92,10 +92,12 @@ export class BidiBrowser extends Browser {
       },
     });
 
+    // Subscribe to all WebDriver BiDi events. Also subscribe to CDP events if CDP
+    // connection is available.
     await session.subscribe(
-      (session.capabilities.browserName.toLocaleLowerCase().includes('firefox')
-        ? BidiBrowser.subscribeModules
-        : [...BidiBrowser.subscribeModules, ...BidiBrowser.subscribeCdpEvents]
+      (opts.cdpConnection
+        ? [...BidiBrowser.subscribeModules, ...BidiBrowser.subscribeCdpEvents]
+        : BidiBrowser.subscribeModules
       ).filter(module => {
         if (!opts.networkEnabled) {
           return (

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -372,7 +372,7 @@ export abstract class BrowserLauncher {
    */
   protected async createBiDiOverCdpBrowser(
     browserProcess: ReturnType<typeof launch>,
-    connection: Connection,
+    cdpConnection: Connection,
     closeCallback: BrowserCloseCallback,
     opts: {
       defaultViewport: Viewport | null;
@@ -380,11 +380,14 @@ export abstract class BrowserLauncher {
       networkEnabled: boolean;
     },
   ): Promise<Browser> {
+    const bidiOnly = process.env['PUPPETEER_WEBDRIVER_BIDI_ONLY'] === 'true';
     const BiDi = await import(/* webpackIgnore: true */ '../bidi/bidi.js');
-    const bidiConnection = await BiDi.connectBidiOverCdp(connection);
+    const bidiConnection = await BiDi.connectBidiOverCdp(cdpConnection);
     return await BiDi.BidiBrowser.create({
       connection: bidiConnection,
-      cdpConnection: connection,
+      // Do not provide CDP connection to Browser, if BiDi-only mode is enabled. This
+      // would restrict Browser to use only BiDi endpoint.
+      cdpConnection: bidiOnly ? undefined : cdpConnection,
       closeCallback,
       process: browserProcess.nodeProcess,
       defaultViewport: opts.defaultViewport,

--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -25,6 +25,10 @@
       "parameters": ["chrome", "headless", "webDriverBiDi"]
     },
     {
+      "id": "chrome-bidi-only",
+      "parameters": ["chrome", "headless", "webDriverBiDiOnly"]
+    },
+    {
       "id": "chrome-pipe",
       "parameters": ["chrome", "headless", "cdp", "pipe"]
     }
@@ -47,6 +51,10 @@
     },
     "webDriverBiDi": {
       "PUPPETEER_PROTOCOL": "webDriverBiDi"
+    },
+    "webDriverBiDiOnly": {
+      "PUPPETEER_PROTOCOL": "webDriverBiDi",
+      "PUPPETEER_WEBDRIVER_BIDI_ONLY": "true"
     },
     "cdp": {},
     "pipe": {


### PR DESCRIPTION
Alternative to https://github.com/puppeteer/puppeteer/pull/14263 approach.

Rely on `PUPPETEER_WEBDRIVER_BIDI_ONLY` environment variable, and do not provide CDP connection to BiDi browser for BiDi-only. Details: http://goto.google.com/webdriver-bidi:pure-bidi-puppeteer.

Also introduced a new test suit `webDriverBiDiOnly`.