### PR TITLE
fix(webdriver): properly pipe network interception flag

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -136,7 +136,11 @@ export class BidiFrame extends Frame {
     });
 
     this.browsingContext.on('request', ({request}) => {
-      const httpRequest = BidiHTTPRequest.from(request, this);
+      const httpRequest = BidiHTTPRequest.from(
+        request,
+        this,
+        this.page().isNetworkInterceptionEnabled,
+      );
       request.once('success', () => {
         this.page().trustedEmitter.emit(PageEvent.RequestFinished, httpRequest);
       });

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -711,11 +711,15 @@ export class BidiPage extends Page {
     return [...this.#workers];
   }
 
-  #userInterception?: string;
+  get isNetworkInterceptionEnabled(): boolean {
+    return Boolean(this.#requestInterception);
+  }
+
+  #requestInterception?: string;
   override async setRequestInterception(enable: boolean): Promise<void> {
-    this.#userInterception = await this.#toggleInterception(
+    this.#requestInterception = await this.#toggleInterception(
       [Bidi.Network.InterceptPhase.BeforeRequestSent],
-      this.#userInterception,
+      this.#requestInterception,
       enable,
     );
   }

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -715,7 +715,8 @@ export class BidiPage extends Page {
     return (
       Boolean(this.#requestInterception) ||
       Boolean(this.#extraHeadersInterception) ||
-      Boolean(this.#authInterception)
+      Boolean(this.#authInterception) ||
+      Boolean(this.#userAgentInterception)
     );
   }
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -712,7 +712,11 @@ export class BidiPage extends Page {
   }
 
   get isNetworkInterceptionEnabled(): boolean {
-    return Boolean(this.#requestInterception);
+    return (
+      Boolean(this.#requestInterception) ||
+      Boolean(this.#extraHeadersInterception) ||
+      Boolean(this.#authInterception)
+    );
   }
 
   #requestInterception?: string;


### PR DESCRIPTION
Closes https://github.com/puppeteer/puppeteer/issues/14234

We relied on the `isBlocked` flag but that represent whether the current request is and can be blocked.
We need to get this information from the page to properly handle the assertions down the line.  