### PR TITLE
fix: support multiple paths for system executables on Windows and WSL

### DIFF
--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -221,7 +221,7 @@ export async function createProfile(
 /**
  * @public
  *
- * Get's the most first resolved system path
+ * Get's the first resolved system path
  */
 export function resolveSystemExecutablePath(
   browser: Browser,
@@ -244,8 +244,8 @@ export function resolveSystemExecutablePath(
 /**
  * @internal
  *
- * Tries to find multiple paths that the executable may be.
- * Return them priority based on heuristics.
+ * Returns multiple paths where the executable may be located at on the current system
+ * ordered by likelihood (based on heuristics).
  */
 export function resolveSystemExecutablePaths(
   browser: Browser,

--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -220,6 +220,8 @@ export async function createProfile(
 
 /**
  * @public
+ *
+ * Get's the most first resolved system path
  */
 export function resolveSystemExecutablePath(
   browser: Browser,
@@ -235,7 +237,31 @@ export function resolveSystemExecutablePath(
         `System browser detection is not supported for ${browser} yet.`,
       );
     case Browser.CHROME:
-      return chrome.resolveSystemExecutablePath(platform, channel);
+      return chrome.resolveSystemExecutablePaths(platform, channel)[0];
+  }
+}
+
+/**
+ * @internal
+ *
+ * Tries to find multiple paths that the executable may be.
+ * Return them priority based on heuristics.
+ */
+export function resolveSystemExecutablePaths(
+  browser: Browser,
+  platform: BrowserPlatform,
+  channel: ChromeReleaseChannel,
+): [string, ...string[]] {
+  switch (browser) {
+    case Browser.CHROMEDRIVER:
+    case Browser.CHROMEHEADLESSSHELL:
+    case Browser.FIREFOX:
+    case Browser.CHROMIUM:
+      throw new Error(
+        `System browser detection is not supported for ${browser} yet.`,
+      );
+    case Browser.CHROME:
+      return chrome.resolveSystemExecutablePaths(platform, channel);
   }
 }
 

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -78,18 +78,26 @@ describe('Chrome', () => {
     );
   });
 
-  it('should resolve system executable path', () => {
+  it.only('should resolve system executable path', () => {
     process.env['PROGRAMFILES'] = 'C:\\ProgramFiles';
+    process.env['ProgramW6432'] = 'C:\\ProgramFiles';
+    process.env['ProgramFiles(x86)'] = 'C:\\ProgramFiles (x86)';
+
     try {
       assert.deepStrictEqual(
         resolveSystemExecutablePaths(
           BrowserPlatform.WIN32,
           ChromeReleaseChannel.DEV,
         ),
-        ['C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe'],
+        [
+          'C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe',
+          'C:\\ProgramFiles (x86)\\Google\\Chrome Dev\\Application\\chrome.exe',
+        ],
       );
     } finally {
       delete process.env['PROGRAMFILES'];
+      delete process.env['ProgramW6432'];
+      delete process.env['ProgramFiles(x86)'];
     }
 
     assert.deepStrictEqual(

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -78,7 +78,7 @@ describe('Chrome', () => {
     );
   });
 
-  it.only('should resolve system executable path', () => {
+  it('should resolve system executable path', () => {
     process.env['PROGRAMFILES'] = 'C:\\ProgramFiles';
     process.env['ProgramW6432'] = 'C:\\ProgramFiles';
     process.env['ProgramFiles(x86)'] = 'C:\\ProgramFiles (x86)';

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -14,7 +14,7 @@ import {
 import {
   resolveDownloadUrl,
   relativeExecutablePath,
-  resolveSystemExecutablePath,
+  resolveSystemExecutablePaths,
   resolveBuildId,
   compareVersions,
 } from '../../../lib/cjs/browser-data/chrome.js';
@@ -81,30 +81,32 @@ describe('Chrome', () => {
   it('should resolve system executable path', () => {
     process.env['PROGRAMFILES'] = 'C:\\ProgramFiles';
     try {
-      assert.strictEqual(
-        resolveSystemExecutablePath(
+      assert.deepStrictEqual(
+        resolveSystemExecutablePaths(
           BrowserPlatform.WIN32,
           ChromeReleaseChannel.DEV,
         ),
-        'C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe',
+        ['C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe'],
       );
     } finally {
       delete process.env['PROGRAMFILES'];
     }
 
-    assert.strictEqual(
-      resolveSystemExecutablePath(
+    assert.deepStrictEqual(
+      resolveSystemExecutablePaths(
         BrowserPlatform.MAC,
         ChromeReleaseChannel.BETA,
       ),
-      '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+      [
+        '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+      ],
     );
-    assert.strictEqual(
-      resolveSystemExecutablePath(
+    assert.deepStrictEqual(
+      resolveSystemExecutablePaths(
         BrowserPlatform.LINUX,
         ChromeReleaseChannel.CANARY,
       ),
-      '/opt/google/chrome-canary/chrome',
+      ['/opt/google/chrome-canary/chrome'],
     );
   });
 


### PR DESCRIPTION
Implement more robust logic when working with Windows and WSL,
so that we try to launch the browser installed in Windows and not WSL.