### PR TITLE
fix: improve Chrome installation detection on Windows

### DIFF
--- a/packages/browsers/src/browser-data/chrome.ts
+++ b/packages/browsers/src/browser-data/chrome.ts
@@ -158,6 +158,8 @@ const WINDOWS_ENV_PARAM_NAMES = [
   'PROGRAMFILES',
   'ProgramW6432',
   'ProgramFiles(x86)',
+  // https://source.chromium.org/chromium/chromium/src/+/main:chrome/installer/mini_installer/README.md
+  'LOCALAPPDATA',
 ];
 
 function getChromeWindowsLocation(
@@ -171,21 +173,21 @@ function getChromeWindowsLocation(
   let suffix: string;
   switch (channel) {
     case ChromeReleaseChannel.STABLE:
-      suffix = '\\Google\\Chrome\\Application\\chrome.exe';
+      suffix = 'Google\\Chrome\\Application\\chrome.exe';
       break;
     case ChromeReleaseChannel.BETA:
-      suffix = '\\Google\\Chrome Beta\\Application\\chrome.exe';
+      suffix = 'Google\\Chrome Beta\\Application\\chrome.exe';
       break;
     case ChromeReleaseChannel.CANARY:
-      suffix = '\\Google\\Chrome SxS\\Application\\chrome.exe';
+      suffix = 'Google\\Chrome SxS\\Application\\chrome.exe';
       break;
     case ChromeReleaseChannel.DEV:
-      suffix = '\\Google\\Chrome Dev\\Application\\chrome.exe';
+      suffix = 'Google\\Chrome Dev\\Application\\chrome.exe';
       break;
   }
 
   return [...locationsPrefixes.values()].map(l => {
-    return `${l}${suffix}`;
+    return path.win32.join(l, suffix);
   }) as [string, ...string[]];
 }
 
@@ -275,6 +277,11 @@ export function resolveSystemExecutablePaths(
           return !!l;
         }),
       );
+      // Fallbacks in case env vars are misconfigured.
+      prefixLocation.add('C:\\Program Files');
+      prefixLocation.add('C:\\Program Files (x86)');
+      prefixLocation.add('D:\\Program Files');
+      prefixLocation.add('D:\\Program Files (x86)');
       return getChromeWindowsLocation(channel, prefixLocation);
     case BrowserPlatform.MAC_ARM:
     case BrowserPlatform.MAC:

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -82,6 +82,7 @@ describe('Chrome', () => {
     process.env['PROGRAMFILES'] = 'C:\\ProgramFiles';
     process.env['ProgramW6432'] = 'C:\\ProgramFiles';
     process.env['ProgramFiles(x86)'] = 'C:\\ProgramFiles (x86)';
+    process.env['LOCALAPPDATA'] = 'C:\\LocalAppData';
 
     try {
       assert.deepStrictEqual(
@@ -92,6 +93,11 @@ describe('Chrome', () => {
         [
           'C:\\ProgramFiles\\Google\\Chrome Dev\\Application\\chrome.exe',
           'C:\\ProgramFiles (x86)\\Google\\Chrome Dev\\Application\\chrome.exe',
+          'C:\\LocalAppData\\Google\\Chrome Dev\\Application\\chrome.exe',
+          'C:\\Program Files\\Google\\Chrome Dev\\Application\\chrome.exe',
+          'C:\\Program Files (x86)\\Google\\Chrome Dev\\Application\\chrome.exe',
+          'D:\\Program Files\\Google\\Chrome Dev\\Application\\chrome.exe',
+          'D:\\Program Files (x86)\\Google\\Chrome Dev\\Application\\chrome.exe',
         ],
       );
     } finally {


### PR DESCRIPTION
- check LOCALAPPDATA for user profile installations
- check a few default locations if env vars are misconfigured
- use path.win32.join to concatenate paths

Closes https://github.com/puppeteer/puppeteer/issues/14251