### PR TITLE
chore: bump chromium-bidi to 10.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30991,7 +30991,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "10.3.1",
+        "chromium-bidi": "10.4.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1508733",
         "puppeteer-core": "24.25.0",
@@ -31012,7 +31012,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "10.3.1",
+        "chromium-bidi": "10.4.0",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1508733",
         "typed-query-selector": "^2.12.0",
@@ -31050,9 +31050,9 @@
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.1.tgz",
-      "integrity": "sha512-sIssPgzgjBnISfy97iWY0rHJT2c6rdIMRpsUH3D/E+McNEoowzZ2nKRqh3NyZ2WUjwIdfGQI5cZK9uCaAntz2w==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.4.0.tgz",
+      "integrity": "sha512-P8VnNnmIO6XZUwP5xydbLETD7RsgB3/bemWfkSQiTGdZ9E2R/Xh8IvZ6QgIjUxVZuP05sIBJPdTLyaCnM5duWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -31092,9 +31092,9 @@
       "license": "MIT"
     },
     "packages/puppeteer/node_modules/chromium-bidi": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.1.tgz",
-      "integrity": "sha512-sIssPgzgjBnISfy97iWY0rHJT2c6rdIMRpsUH3D/E+McNEoowzZ2nKRqh3NyZ2WUjwIdfGQI5cZK9uCaAntz2w==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.4.0.tgz",
+      "integrity": "sha512-P8VnNnmIO6XZUwP5xydbLETD7RsgB3/bemWfkSQiTGdZ9E2R/Xh8IvZ6QgIjUxVZuP05sIBJPdTLyaCnM5duWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30991,7 +30991,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "9.1.0",
+        "chromium-bidi": "10.3.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1508733",
         "puppeteer-core": "24.25.0",
@@ -31012,7 +31012,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "9.1.0",
+        "chromium-bidi": "10.3.0",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1508733",
         "typed-query-selector": "^2.12.0",
@@ -31050,9 +31050,9 @@
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.1.0.tgz",
-      "integrity": "sha512-rlUzQ4WzIAWdIbY/viPShhZU2n21CxDUgazXVbw4Hu1MwaeUSEksSeM6DqPgpRjCLXRk702AVRxJxoOz0dw4OA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.0.tgz",
+      "integrity": "sha512-uWUaPlAcCd633ph+q8Vxezaasv+C227R/mwaXXs2jWYqqwT8sh0X/d51wJhJP3GHlKxTTMS/R+2+havgycPiog==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -31092,9 +31092,9 @@
       "license": "MIT"
     },
     "packages/puppeteer/node_modules/chromium-bidi": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.1.0.tgz",
-      "integrity": "sha512-rlUzQ4WzIAWdIbY/viPShhZU2n21CxDUgazXVbw4Hu1MwaeUSEksSeM6DqPgpRjCLXRk702AVRxJxoOz0dw4OA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.0.tgz",
+      "integrity": "sha512-uWUaPlAcCd633ph+q8Vxezaasv+C227R/mwaXXs2jWYqqwT8sh0X/d51wJhJP3GHlKxTTMS/R+2+havgycPiog==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30991,7 +30991,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "10.3.0",
+        "chromium-bidi": "10.3.1",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1508733",
         "puppeteer-core": "24.25.0",
@@ -31012,7 +31012,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
-        "chromium-bidi": "10.3.0",
+        "chromium-bidi": "10.3.1",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1508733",
         "typed-query-selector": "^2.12.0",
@@ -31050,9 +31050,9 @@
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.0.tgz",
-      "integrity": "sha512-uWUaPlAcCd633ph+q8Vxezaasv+C227R/mwaXXs2jWYqqwT8sh0X/d51wJhJP3GHlKxTTMS/R+2+havgycPiog==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.1.tgz",
+      "integrity": "sha512-sIssPgzgjBnISfy97iWY0rHJT2c6rdIMRpsUH3D/E+McNEoowzZ2nKRqh3NyZ2WUjwIdfGQI5cZK9uCaAntz2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -31092,9 +31092,9 @@
       "license": "MIT"
     },
     "packages/puppeteer/node_modules/chromium-bidi": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.0.tgz",
-      "integrity": "sha512-uWUaPlAcCd633ph+q8Vxezaasv+C227R/mwaXXs2jWYqqwT8sh0X/d51wJhJP3GHlKxTTMS/R+2+havgycPiog==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.3.1.tgz",
+      "integrity": "sha512-sIssPgzgjBnISfy97iWY0rHJT2c6rdIMRpsUH3D/E+McNEoowzZ2nKRqh3NyZ2WUjwIdfGQI5cZK9uCaAntz2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -149,7 +149,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.10.12",
-    "chromium-bidi": "9.1.0",
+    "chromium-bidi": "10.3.0",
     "debug": "^4.4.3",
     "devtools-protocol": "0.0.1508733",
     "typed-query-selector": "^2.12.0",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -149,7 +149,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.10.12",
-    "chromium-bidi": "10.3.1",
+    "chromium-bidi": "10.4.0",
     "debug": "^4.4.3",
     "devtools-protocol": "0.0.1508733",
     "typed-query-selector": "^2.12.0",

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -149,7 +149,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.10.12",
-    "chromium-bidi": "10.3.0",
+    "chromium-bidi": "10.3.1",
     "debug": "^4.4.3",
     "devtools-protocol": "0.0.1508733",
     "typed-query-selector": "^2.12.0",

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -89,6 +89,8 @@ export class BidiBrowser extends Browser {
         // yet because WebDriver BiDi behavior is not specified. See
         // https://github.com/w3c/webdriver-bidi/issues/321.
         'goog:prerenderingDisabled': true,
+        // TODO: remove after Puppeteer rolled Chrome to 142 after Oct 28, 2025.
+        'goog:disableNetworkDurableMessages': true,
       },
     });
 

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -132,7 +132,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.10.12",
-    "chromium-bidi": "10.3.1",
+    "chromium-bidi": "10.4.0",
     "cosmiconfig": "^9.0.0",
     "devtools-protocol": "0.0.1508733",
     "puppeteer-core": "24.25.0",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -132,7 +132,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.10.12",
-    "chromium-bidi": "9.1.0",
+    "chromium-bidi": "10.3.0",
     "cosmiconfig": "^9.0.0",
     "devtools-protocol": "0.0.1508733",
     "puppeteer-core": "24.25.0",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -132,7 +132,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@puppeteer/browsers": "2.10.12",
-    "chromium-bidi": "10.3.0",
+    "chromium-bidi": "10.3.1",
     "cosmiconfig": "^9.0.0",
     "devtools-protocol": "0.0.1508733",
     "puppeteer-core": "24.25.0",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1689,6 +1689,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[network.spec] network Response.buffer should work with compression",
+    "platforms": ["linux"],
+    "parameters": ["chrome", "headless", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "https://crbug.com/452295916 `Network.getResponseBody` returns compressed durable data"
+  },
+  {
+    "testIdPattern": "[network.spec] network Response.text should return uncompressed text",
+    "platforms": ["linux"],
+    "parameters": ["chrome", "headless", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "https://crbug.com/452295916 `Network.getResponseBody` returns compressed durable data"
+  },
+  {
     "testIdPattern": "[oopif.spec] OOPIF should support lazy OOP frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "headless", "webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1689,20 +1689,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[network.spec] network Response.buffer should work with compression",
-    "platforms": ["linux"],
-    "parameters": ["chrome", "headless", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "https://crbug.com/452295916 `Network.getResponseBody` returns compressed durable data"
-  },
-  {
-    "testIdPattern": "[network.spec] network Response.text should return uncompressed text",
-    "platforms": ["linux"],
-    "parameters": ["chrome", "headless", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "https://crbug.com/452295916 `Network.getResponseBody` returns compressed durable data"
-  },
-  {
     "testIdPattern": "[oopif.spec] OOPIF should support lazy OOP frames",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "headless", "webDriverBiDi"],


### PR DESCRIPTION
This includes the following Chromium BiDi releases:

## [9.2.0](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v9.1.0...chromium-bidi-v9.2.0) (2025-09-29)


### Features

* respect `network.addDataCollector: maxEncodedDataSize` param ([#3782](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3782)) ([7471cee](https://github.com/GoogleChromeLabs/chromium-bidi/commit/7471cee0a91330ff4d8799ca833f4d565a5626dd))

## [9.2.1](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v9.2.0...chromium-bidi-v9.2.1) (2025-10-02)


### Bug Fixes

* don't report interception for DataUrl and servedFromCache ([#3797](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3797)) ([de963da](https://github.com/GoogleChromeLabs/chromium-bidi/commit/de963da9ffc5cf30362b152f992d1aedb953e3aa))


## [10.0.0](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v9.2.1...chromium-bidi-v10.0.0) (2025-10-07)


### ⚠ BREAKING CHANGES

* **chrome:** update the pinned browser version to 143.0.7447.0 ([#3802](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3802))

### Features

* **chrome:** update the pinned browser version to 143.0.7447.0 ([#3802](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3802)) ([d40b75f](https://github.com/GoogleChromeLabs/chromium-bidi/commit/d40b75f0ae7e0b9ce7e58a72ac849f898b88d2f0))
* speculation module implementation  ([#3731](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3731)) ([66d3585](https://github.com/GoogleChromeLabs/chromium-bidi/commit/66d3585e0062f21adcabcc85ceb686ee515f687f))
* support request data collection ([#3809](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3809)) ([ac9792f](https://github.com/GoogleChromeLabs/chromium-bidi/commit/ac9792f643e601ee749b6ef35b4e03302b5d1b3c))
* support request post data collection ([#3815](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3815)) ([6123a55](https://github.com/GoogleChromeLabs/chromium-bidi/commit/6123a55bb766967420e1dbfd08ad54735a64ffc0))


## [10.1.0](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v10.0.0...chromium-bidi-v10.1.0) (2025-10-09)


### Features

* implement `emulation.setNetworkConditions:offline` ([#3819](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3819)) ([cc702ca](https://github.com/GoogleChromeLabs/chromium-bidi/commit/cc702caf1e249e4e6141fc9fa75d374027529569))


## [10.2.0](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v10.1.0...chromium-bidi-v10.2.0) (2025-10-10)


### Features

* add `embeddedOrigin` in `permissions.setPermission` ([#3799](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3799)) ([fa1ea6f](https://github.com/GoogleChromeLabs/chromium-bidi/commit/fa1ea6f4a3a0df4f86be81c68081ae6e13396d59))


## [10.3.0](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v10.2.0...chromium-bidi-v10.3.0) (2025-10-14)


### Features

* `network.getData` survives navigations ([#3826](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3826)) ([047ca85](https://github.com/GoogleChromeLabs/chromium-bidi/commit/047ca85a6b20c8c5b34656ce52a50a1b842aa917))
* validate headers set in `network.setExtraHeaders` ([#3832](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3832)) ([2f2238c](https://github.com/GoogleChromeLabs/chromium-bidi/commit/2f2238ce54fb3dbb51da36b6a2da1b2ab803c3b5))


### Bug Fixes

* merge `network.setExtraHeaders` for browsing context, user context and global ([#3840](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3840)) ([fbe7018](https://github.com/GoogleChromeLabs/chromium-bidi/commit/fbe7018e32ed84174cd93c96390a9fb5701a7d72))


## [10.3.1](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v10.3.0...chromium-bidi-v10.3.1) (2025-10-15)


### Bug Fixes

* don't crash on worker's requests ([#3845](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3845)) ([c0edf96](https://github.com/GoogleChromeLabs/chromium-bidi/commit/c0edf9685d001d52e7e70d2fe063528d8f5e1c22))


## [10.4.0](https://github.com/GoogleChromeLabs/chromium-bidi/compare/chromium-bidi-v10.3.1...chromium-bidi-v10.4.0) (2025-10-15)


### Features

* allow for disabling durable messages ([#3848](https://github.com/GoogleChromeLabs/chromium-bidi/issues/3848)) ([e6b28ac](https://github.com/GoogleChromeLabs/chromium-bidi/commit/e6b28ac25990bb997074d4505415d1a8fc9e281a))