### PR TITLE
chore: fix latest release commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "last-release-sha": "0b006175eea0c58957715b2c1cd7e56aec5170f1",
+  "last-release-sha": "7d3f88132698d4c7374ca059662d2d750001e521",
   "separate-pull-requests": false,
   "packages": {
     "packages/puppeteer": {


### PR DESCRIPTION
We had to re-create tags due to issues with the provenance. 