### PR TITLE
feat(webdriver): use `emulation.setUserAgentOverride` instead of network interception

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -166,18 +166,11 @@ export class BidiHTTPRequest extends HTTPRequest {
   }
 
   get #hasInternalHeaderOverwrite(): boolean {
-    return Boolean(
-      Object.keys(this.#extraHTTPHeaders).length ||
-        Object.keys(this.#userAgentHeaders).length,
-    );
+    return Boolean(Object.keys(this.#extraHTTPHeaders).length);
   }
 
   get #extraHTTPHeaders(): Record<string, string> {
     return this.#frame?.page()._extraHTTPHeaders ?? {};
-  }
-
-  get #userAgentHeaders(): Record<string, string> {
-    return this.#frame?.page()._userAgentHeaders ?? {};
   }
 
   override headers(): Record<string, string> {
@@ -189,7 +182,6 @@ export class BidiHTTPRequest extends HTTPRequest {
     return {
       ...headers,
       ...this.#extraHTTPHeaders,
-      ...this.#userAgentHeaders,
     };
   }
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -186,9 +186,7 @@ export class BidiPage extends Page {
 
     await this.#frame.browsingContext.setUserAgent(enable ? userAgent : null);
 
-    const overrideNavigatorProperties = (
-      platform: string | undefined,
-    ) => {
+    const overrideNavigatorProperties = (platform: string | undefined) => {
       if (platform) {
         Object.defineProperty(navigator, 'platform', {
           value: platform,

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -739,4 +739,11 @@ export class BrowsingContext extends EventEmitter<{
   isJavaScriptEnabled(): boolean {
     return this.#emulationState.javaScriptEnabled;
   }
+
+  async setUserAgent(userAgent: string | null) {
+    await this.#session.send('emulation.setUserAgentOverride', {
+      userAgent,
+      contexts: [this.id],
+    });
+  }
 }

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -740,7 +740,7 @@ export class BrowsingContext extends EventEmitter<{
     return this.#emulationState.javaScriptEnabled;
   }
 
-  async setUserAgent(userAgent: string | null) {
+  async setUserAgent(userAgent: string | null): Promise<void> {
     await this.#session.send('emulation.setUserAgentOverride', {
       userAgent,
       contexts: [this.id],


### PR DESCRIPTION
Spec: https://www.w3.org/TR/webdriver-bidi/#commands-emulationsetuseragentoverride

No changes in the test expectations, as the feature used to be implemented via network interception.