### PR TITLE
fix: request.headers() should not allow mutating data

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -181,6 +181,7 @@ export class BidiHTTPRequest extends HTTPRequest {
   }
 
   override headers(): Record<string, string> {
+    // Callers should not be allowed to mutate internal structure.
     const headers: Record<string, string> = {};
     for (const header of this.#request.headers) {
       headers[header.name.toLowerCase()] = header.value.value;

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -138,7 +138,8 @@ export class CdpHTTPRequest extends HTTPRequest {
   }
 
   override headers(): Record<string, string> {
-    return this.#headers;
+    // Callers should not be allowed to mutate internal structure.
+    return structuredClone(this.#headers);
   }
 
   override response(): CdpHTTPResponse | null {

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -133,6 +133,22 @@ describe('request interception', function () {
       expect(requests[1]!.url()).toContain('/one-style.css');
       expect(requests[1]!.headers()['referer']).toContain('/one-style.html');
     });
+    it('should not allow mutating request headers', async () => {
+      const {page, server} = await getTestState();
+
+      await page.setRequestInterception(true);
+      const requests: HTTPRequest[] = [];
+      page.on('request', request => {
+        if (!isFavicon(request)) {
+          requests.push(request);
+        }
+        const headers = request.headers();
+        headers['test'] = 'test';
+        void request.continue({headers});
+      });
+      await page.goto(server.EMPTY_PAGE);
+      expect(Object.keys(requests[0]!.headers())).not.toContain('test');
+    });
     it('should work with requests without networkId', async () => {
       const {page, server} = await getTestState();
       await page.goto(server.EMPTY_PAGE);


### PR DESCRIPTION
Since we have cooperative interception, mutating the headers like this could lead to bugs that fairly difficult to debug. Changed the CDP method to behave like WebDriver BiDi's and stop allowing accidental mutations of the underlying headers map.

Refs https://github.com/puppeteer/puppeteer/issues/14333