### PR TITLE
feat: expose connection in CdpBrowserContext

### DIFF
--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -34,6 +34,10 @@ export class CdpBrowserContext extends BrowserContext {
     this.#id = contextId;
   }
 
+  get connection(): Connection {
+    return this.#connection;
+  }
+
   override get id(): string | undefined {
     return this.#id;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

feature

**Did you add tests for your changes?**

No, this change only adds a simple getter method that exposes an existing private property.

**If relevant, did you update the documentation?**

No documentation update needed as this is an internal API addition.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR exposes the internal `Connection` object in `CdpBrowserContext` by adding a public getter method. This allows external code to access the underlying CDP connection when working with browser contexts, which can be useful for advanced use cases that need direct access to the connection for sending custom CDP commands or managing sessions.

The change adds a simple `get connection(): Connection` method that returns the private `#connection` property, maintaining the existing encapsulation while providing controlled access to the connection object.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, this is a purely additive change that doesn't modify any existing APIs or behavior.

**Other information**

This change only modifies `packages/puppeteer-core/src/cdp/BrowserContext.ts` and adds 4 lines of code to expose the connection getter method.
