### PR TITLE
feat(webdriver): get detailed initiator data from CDP if available

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/Request.ts
+++ b/packages/puppeteer-core/src/bidi/core/Request.ts
@@ -154,7 +154,15 @@ export class Request extends EventEmitter<{
     return this.#event.request.request;
   }
   get initiator(): Bidi.Network.Initiator | undefined {
-    return this.#event.initiator;
+    return {
+      ...this.#event.initiator,
+      type: this.#event.initiator?.type ?? 'other',
+      // Initiator URL is not specified in BiDi.
+      // @ts-expect-error non-standard property.
+      url: this.#event.request['goog:resourceInitiator']?.url,
+      // @ts-expect-error non-standard property.
+      stack: this.#event.request['goog:resourceInitiator']?.stack,
+    };
   }
   get method(): string {
     return this.#event.request.method;

--- a/packages/puppeteer-core/src/bidi/core/Request.ts
+++ b/packages/puppeteer-core/src/bidi/core/Request.ts
@@ -156,7 +156,6 @@ export class Request extends EventEmitter<{
   get initiator(): Bidi.Network.Initiator | undefined {
     return {
       ...this.#event.initiator,
-      type: this.#event.initiator?.type ?? 'other',
       // Initiator URL is not specified in BiDi.
       // @ts-expect-error non-standard property.
       url: this.#event.request['goog:resourceInitiator']?.url,

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -447,13 +447,6 @@
     "comment": "Flaky with both CDP and WebDriver BiDi. Needs investigation."
   },
   {
-    "testIdPattern": "[network.spec] network Request.initiator should return the initiator",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
     "testIdPattern": "[network.spec] network Request.resourceType *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -1291,6 +1284,13 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "network.getData(request) is not yet supported"
+  },
+  {
+    "testIdPattern": "[network.spec] network Request.initiator should return the initiator",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Initiator url and stack is not specified in WebDriver BiDi"
   },
   {
     "testIdPattern": "[network.spec] network Request.postData should be |undefined| when there is no post data",


### PR DESCRIPTION
And filter out `goog:` data from events in `PUPPETEER_WEBDRIVER_BIDI_ONLY` mode.