### PR TITLE
fix(a11y): expose the url property for links

### DIFF
--- a/docs/api/puppeteer.serializedaxnode.md
+++ b/docs/api/puppeteer.serializedaxnode.md
@@ -431,6 +431,25 @@ boolean
 </td></tr>
 <tr><td>
 
+<span id="url">url</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+Url for link elements.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="value">value</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/cdp/Accessibility.ts
+++ b/packages/puppeteer-core/src/cdp/Accessibility.ts
@@ -76,6 +76,11 @@ export interface SerializedAXNode {
    */
   invalid?: string;
   orientation?: string;
+
+  /**
+   * Url for link elements.
+   */
+  url?: string;
   /**
    * Children of this node, if there are any.
    */
@@ -542,7 +547,8 @@ class AXNode {
       | 'description'
       | 'keyshortcuts'
       | 'roledescription'
-      | 'valuetext';
+      | 'valuetext'
+      | 'url';
 
     const userStringProperties: UserStringProperty[] = [
       'name',
@@ -551,6 +557,7 @@ class AXNode {
       'keyshortcuts',
       'roledescription',
       'valuetext',
+      'url',
     ];
     const getUserStringPropertyValue = (key: UserStringProperty): string => {
       return properties.get(key) as string;


### PR DESCRIPTION
Drive-by: removed isFirefox expectations since the feature is not supported by Firefox currently. 

Closes https://github.com/puppeteer/puppeteer/issues/6311