### PR TITLE
feat: support ignoreCache in page.reload()

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1176,6 +1176,13 @@ Valid options to configure PDF generation via [Page.pdf()](./puppeteer.page.pdf.
 </td></tr>
 <tr><td>
 
+<span id="reloadoptions">[ReloadOptions](./puppeteer.reloadoptions.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="remoteaddress">[RemoteAddress](./puppeteer.remoteaddress.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.page.reload.md
+++ b/docs/api/puppeteer.page.reload.md
@@ -10,7 +10,7 @@ Reloads the page.
 
 ```typescript
 class Page {
-  abstract reload(options?: WaitForOptions): Promise<HTTPResponse | null>;
+  abstract reload(options?: ReloadOptions): Promise<HTTPResponse | null>;
 }
 ```
 
@@ -35,7 +35,7 @@ options
 
 </td><td>
 
-[WaitForOptions](./puppeteer.waitforoptions.md)
+[ReloadOptions](./puppeteer.reloadoptions.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.reloadoptions.md
+++ b/docs/api/puppeteer.reloadoptions.md
@@ -1,0 +1,59 @@
+---
+sidebar_label: ReloadOptions
+---
+
+# ReloadOptions interface
+
+### Signature
+
+```typescript
+export interface ReloadOptions extends WaitForOptions
+```
+
+**Extends:** [WaitForOptions](./puppeteer.waitforoptions.md)
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="ignorecache">ignoreCache</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+If set to true, the browser caches are ignored for the page reload.
+
+</td><td>
+
+true
+
+</td></tr>
+</tbody></table>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -634,6 +634,19 @@ export function setDefaultScreenshotOptions(options: ScreenshotOptions): void {
 }
 
 /**
+ * @public
+ */
+export interface ReloadOptions extends WaitForOptions {
+  /**
+   * If set to true, the browser caches are ignored for the page reload.
+   *
+   * @defaultValue true
+   * @public
+   */
+  ignoreCache?: boolean;
+}
+
+/**
  * Page provides methods to interact with a single tab or
  * {@link https://developer.chrome.com/extensions/background_pages | extension background page}
  * in the browser.
@@ -1743,7 +1756,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * multiple redirects, the navigation will resolve with the response of the
    * last redirect.
    */
-  abstract reload(options?: WaitForOptions): Promise<HTTPResponse | null>;
+  abstract reload(options?: ReloadOptions): Promise<HTTPResponse | null>;
 
   /**
    * Waits for the page to navigate to a new URL or to reload. It is useful when

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -17,6 +17,7 @@ import type {
   GeolocationOptions,
   MediaFeature,
   PageEvents,
+  ReloadOptions,
   WaitTimeoutOptions,
 } from '../api/Page.js';
 import {
@@ -332,11 +333,13 @@ export class BidiPage extends Page {
   }
 
   override async reload(
-    options: WaitForOptions = {},
+    options: ReloadOptions = {},
   ): Promise<BidiHTTPResponse | null> {
     const [response] = await Promise.all([
       this.#frame.waitForNavigation(options),
-      this.#frame.browsingContext.reload(),
+      this.#frame.browsingContext.reload({
+        ignoreCache: options.ignoreCache ? true : undefined,
+      }),
     ]).catch(
       rewriteNavigationError(
         this.url(),

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -14,7 +14,7 @@ import type {ElementHandle} from '../api/ElementHandle.js';
 import type {Frame, WaitForOptions} from '../api/Frame.js';
 import type {HTTPResponse} from '../api/HTTPResponse.js';
 import type {JSHandle} from '../api/JSHandle.js';
-import type {Credentials} from '../api/Page.js';
+import type {Credentials, ReloadOptions} from '../api/Page.js';
 import {
   Page,
   PageEvent,
@@ -898,15 +898,15 @@ export class CdpPage extends Page {
     this.emit(PageEvent.Dialog, dialog);
   }
 
-  override async reload(
-    options?: WaitForOptions,
-  ): Promise<HTTPResponse | null> {
+  override async reload(options?: ReloadOptions): Promise<HTTPResponse | null> {
     const [result] = await Promise.all([
       this.waitForNavigation({
         ...options,
         ignoreSameDocumentNavigation: true,
       }),
-      this.#primaryTargetClient.send('Page.reload'),
+      this.#primaryTargetClient.send('Page.reload', {
+        ignoreCache: options?.ignoreCache ?? false,
+      }),
     ]);
 
     return result;

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -552,6 +552,13 @@
     "comment": "With BiDi we get only text and not a serializable value for console messages"
   },
   {
+    "testIdPattern": "[page.spec] Page Page.reload should enable or disable the cache based on reload params",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Not yet supported https://bugzilla.mozilla.org/show_bug.cgi?id=1851561"
+  },
+  {
     "testIdPattern": "[page.spec] Page Page.setBypassCSP *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -2301,6 +2301,28 @@ describe('Page', function () {
     });
   });
 
+  describe('Page.reload', function () {
+    it('should enable or disable the cache based on reload params', async () => {
+      const {page, server} = await getTestState();
+
+      await page.goto(server.PREFIX + '/cached/one-style.html');
+      const [cachedRequest] = await Promise.all([
+        server.waitForRequest('/cached/one-style.html'),
+        page.reload(),
+      ]);
+      // Rely on "if-modified-since" caching in our test server.
+      expect(cachedRequest.headers['if-modified-since']).not.toBe(undefined);
+
+      const [nonCachedRequest] = await Promise.all([
+        server.waitForRequest('/cached/one-style.html'),
+        page.reload({
+          ignoreCache: true,
+        }),
+      ]);
+      expect(nonCachedRequest.headers['if-modified-since']).toBe(undefined);
+    });
+  });
+
   describe('Page.setCacheEnabled', function () {
     it('should enable or disable the cache based on the state passed', async () => {
       const {page, server} = await getTestState();


### PR DESCRIPTION
The feature is available in both CDP and WebDriver BiDi (except Firefox).