### PR TITLE
test: fix TargetManager tests failing in Canary

### DIFF
--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -27,18 +27,25 @@ describe('TargetManager', () => {
     const {server, context, browser} = state;
 
     const targetManager = (browser as CdpBrowser)._targetManager();
-    expect(targetManager.getAvailableTargets().size).toBe(3);
+
+    const initialTargetCount = targetManager.getAvailableTargets().size;
+    // There could be an conditional extra prerender targets.
+    expect(initialTargetCount === 3 || initialTargetCount === 4).toBeTruthy();
 
     expect(await context.pages()).toHaveLength(0);
-    expect(targetManager.getAvailableTargets().size).toBe(3);
+    expect(targetManager.getAvailableTargets().size).toBe(initialTargetCount);
 
     const page = await context.newPage();
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(5);
+    expect(targetManager.getAvailableTargets().size).toBe(
+      initialTargetCount + 2,
+    );
 
     await page.goto(server.EMPTY_PAGE);
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(5);
+    expect(targetManager.getAvailableTargets().size).toBe(
+      initialTargetCount + 2,
+    );
 
     // attach a local iframe.
     let framePromise = page.waitForFrame(frame => {
@@ -47,7 +54,9 @@ describe('TargetManager', () => {
     await attachFrame(page, 'frame1', server.EMPTY_PAGE);
     await framePromise;
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(5);
+    expect(targetManager.getAvailableTargets().size).toBe(
+      initialTargetCount + 2,
+    );
     expect(page.frames()).toHaveLength(2);
 
     // // attach a remote frame iframe.
@@ -61,7 +70,9 @@ describe('TargetManager', () => {
     );
     await framePromise;
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(6);
+    expect(targetManager.getAvailableTargets().size).toBe(
+      initialTargetCount + 3,
+    );
     expect(page.frames()).toHaveLength(3);
 
     framePromise = page.waitForFrame(frame => {
@@ -74,7 +85,9 @@ describe('TargetManager', () => {
     );
     await framePromise;
     expect(await context.pages()).toHaveLength(1);
-    expect(targetManager.getAvailableTargets().size).toBe(7);
+    expect(targetManager.getAvailableTargets().size).toBe(
+      initialTargetCount + 4,
+    );
     expect(page.frames()).toHaveLength(4);
   });
 });

--- a/test/src/cdp/TargetManager.spec.ts
+++ b/test/src/cdp/TargetManager.spec.ts
@@ -29,7 +29,7 @@ describe('TargetManager', () => {
     const targetManager = (browser as CdpBrowser)._targetManager();
 
     const initialTargetCount = targetManager.getAvailableTargets().size;
-    // There could be an conditional extra prerender targets.
+    // There could be an conditional extra prerender target.
     expect(initialTargetCount === 3 || initialTargetCount === 4).toBeTruthy();
 
     expect(await context.pages()).toHaveLength(0);


### PR DESCRIPTION
This PR adapts the test to account for possible pre-render targets that seems to be created in Canary Chrome (headful builds).