### PR TITLE
chore: make CDP message ID generator configurable

### DIFF
--- a/docs/api/puppeteer.connection._constructor_.md
+++ b/docs/api/puppeteer.connection._constructor_.md
@@ -16,6 +16,7 @@ class Connection {
     delay?: number,
     timeout?: number,
     rawErrors?: boolean,
+    idGenerator?: () => number,
   );
 }
 ```
@@ -90,6 +91,19 @@ rawErrors
 </td><td>
 
 boolean
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+<tr><td>
+
+idGenerator
+
+</td><td>
+
+() =&gt; number
 
 </td><td>
 

--- a/docs/api/puppeteer.connection.md
+++ b/docs/api/puppeteer.connection.md
@@ -29,7 +29,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-<span id="_constructor_">[(constructor)(url, transport, delay, timeout, rawErrors)](./puppeteer.connection._constructor_.md)</span>
+<span id="_constructor_">[(constructor)(url, transport, delay, timeout, rawErrors, idGenerator)](./puppeteer.connection._constructor_.md)</span>
 
 </td><td>
 

--- a/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
@@ -48,6 +48,7 @@ export async function connectBidiOverCdp(
   const pptrBiDiConnection = new BidiConnection(
     cdp.url(),
     pptrTransport,
+    cdp._idGenerator,
     cdp.delay,
     cdp.timeout,
   );

--- a/packages/puppeteer-core/src/bidi/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserConnector.ts
@@ -105,10 +105,10 @@ async function getBiDiConnection(
   const cdpConnection = new Connection(
     url,
     connectionTransport,
-    idGenerator,
     slowMo,
     protocolTimeout,
     /* rawErrors= */ true,
+    idGenerator,
   );
 
   const version = await cdpConnection.send('Browser.getVersion');

--- a/packages/puppeteer-core/src/bidi/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserConnector.ts
@@ -10,6 +10,7 @@ import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import type {ConnectOptions} from '../common/ConnectOptions.js';
 import {ProtocolError, UnsupportedOperation} from '../common/Errors.js';
 import {debugError, DEFAULT_VIEWPORT} from '../common/util.js';
+import {createIncrementalIdGenerator} from '../util/incremental-id-generator.js';
 
 import type {BidiBrowser} from './Browser.js';
 import type {BidiConnection} from './Connection.js';
@@ -66,12 +67,17 @@ async function getBiDiConnection(
   closeCallback: BrowserCloseCallback;
 }> {
   const BiDi = await import(/* webpackIgnore: true */ './bidi.js');
-  const {slowMo = 0, protocolTimeout} = options;
+  const {
+    slowMo = 0,
+    protocolTimeout,
+    idGenerator = createIncrementalIdGenerator(),
+  } = options;
 
   // Try pure BiDi first.
   const pureBidiConnection = new BiDi.BidiConnection(
     url,
     connectionTransport,
+    idGenerator,
     slowMo,
     protocolTimeout,
   );
@@ -99,6 +105,7 @@ async function getBiDiConnection(
   const cdpConnection = new Connection(
     url,
     connectionTransport,
+    idGenerator,
     slowMo,
     protocolTimeout,
     /* rawErrors= */ true,

--- a/packages/puppeteer-core/src/bidi/Connection.test.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.test.ts
@@ -9,6 +9,7 @@ import {describe, it} from 'node:test';
 import expect from 'expect';
 
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
+import {createIncrementalIdGenerator} from '../util/incremental-id-generator.js';
 
 import {BidiConnection} from './Connection.js';
 
@@ -28,7 +29,11 @@ describe('WebDriver BiDi Connection', () => {
 
   it('should work', async () => {
     const transport = new TestConnectionTransport();
-    const connection = new BidiConnection('ws://127.0.0.1', transport);
+    const connection = new BidiConnection(
+      'ws://127.0.0.1',
+      transport,
+      createIncrementalIdGenerator(),
+    );
     const responsePromise = connection.send('session.new', {
       capabilities: {},
     });

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -14,6 +14,7 @@ import {ConnectionClosedError} from '../common/Errors.js';
 import type {EventsWithWildcard} from '../common/EventEmitter.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
+import type {GetIdFn} from '../util/incremental-id-generator.js';
 
 import {BidiCdpSession} from './CDPSession.js';
 import type {
@@ -57,12 +58,13 @@ export class BidiConnection
   #delay: number;
   #timeout = 0;
   #closed = false;
-  #callbacks = new CallbackRegistry();
+  #callbacks: CallbackRegistry;
   #emitters: Array<EventEmitter<any>> = [];
 
   constructor(
     url: string,
     transport: ConnectionTransport,
+    idGenerator: GetIdFn,
     delay = 0,
     timeout?: number,
   ) {
@@ -70,6 +72,7 @@ export class BidiConnection
     this.#url = url;
     this.#delay = delay;
     this.#timeout = timeout ?? 180_000;
+    this.#callbacks = new CallbackRegistry(idGenerator);
 
     this.#transport = transport;
     this.#transport.onmessage = this.onMessage.bind(this);

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -39,9 +39,10 @@ export async function _connectToCdpBrowser(
   const connection = new Connection(
     url,
     connectionTransport,
-    idGenerator,
     slowMo,
     protocolTimeout,
+    /* rawErrors */ false,
+    idGenerator,
   );
 
   const {browserContextIds} = await connection.send(

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -7,6 +7,7 @@
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
 import type {ConnectOptions} from '../common/ConnectOptions.js';
 import {debugError, DEFAULT_VIEWPORT} from '../common/util.js';
+import {createIncrementalIdGenerator} from '../util/incremental-id-generator.js';
 
 import {CdpBrowser} from './Browser.js';
 import {Connection} from './Connection.js';
@@ -32,11 +33,13 @@ export async function _connectToCdpBrowser(
     slowMo = 0,
     protocolTimeout,
     handleDevToolsAsPage,
+    idGenerator = createIncrementalIdGenerator(),
   } = options;
 
   const connection = new Connection(
     url,
     connectionTransport,
+    idGenerator,
     slowMo,
     protocolTimeout,
   );

--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -27,7 +27,7 @@ import type {CdpTarget} from './Target.js';
 export class CdpCDPSession extends CDPSession {
   #sessionId: string;
   #targetType: string;
-  #callbacks = new CallbackRegistry();
+  #callbacks: CallbackRegistry;
   #connection: Connection;
   #parentSessionId?: string;
   #target?: CdpTarget;
@@ -46,6 +46,7 @@ export class CdpCDPSession extends CDPSession {
     super();
     this.#connection = connection;
     this.#targetType = targetType;
+    this.#callbacks = new CallbackRegistry(connection._idGenerator);
     this.#sessionId = sessionId;
     this.#parentSessionId = parentSessionId;
     this.#rawErrors = rawErrors;

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -19,7 +19,7 @@ import {debug} from '../common/Debug.js';
 import {ConnectionClosedError, TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {createProtocolErrorMessage} from '../util/ErrorLike.js';
-import type {GetIdFn} from '../util/incremental-id-generator.js';
+import {createIncrementalIdGenerator, type GetIdFn} from '../util/incremental-id-generator.js';
 
 import {CdpCDPSession} from './CdpSession.js';
 
@@ -44,10 +44,10 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
   constructor(
     url: string,
     transport: ConnectionTransport,
-    idGenerator: GetIdFn,
     delay = 0,
     timeout?: number,
     rawErrors = false,
+    idGenerator: () => number = createIncrementalIdGenerator(),
   ) {
     super();
     this.#rawErrors = rawErrors;

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -19,7 +19,10 @@ import {debug} from '../common/Debug.js';
 import {ConnectionClosedError, TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {createProtocolErrorMessage} from '../util/ErrorLike.js';
-import {createIncrementalIdGenerator, type GetIdFn} from '../util/incremental-id-generator.js';
+import {
+  createIncrementalIdGenerator,
+  type GetIdFn,
+} from '../util/incremental-id-generator.js';
 
 import {CdpCDPSession} from './CdpSession.js';
 

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -19,6 +19,7 @@ import {debug} from '../common/Debug.js';
 import {ConnectionClosedError, TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {createProtocolErrorMessage} from '../util/ErrorLike.js';
+import type {GetIdFn} from '../util/incremental-id-generator.js';
 
 import {CdpCDPSession} from './CdpSession.js';
 
@@ -38,17 +39,20 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
   #manuallyAttached = new Set<string>();
   #callbacks: CallbackRegistry;
   #rawErrors = false;
+  #idGenerator: GetIdFn;
 
   constructor(
     url: string,
     transport: ConnectionTransport,
+    idGenerator: GetIdFn,
     delay = 0,
     timeout?: number,
     rawErrors = false,
   ) {
     super();
     this.#rawErrors = rawErrors;
-    this.#callbacks = new CallbackRegistry();
+    this.#idGenerator = idGenerator;
+    this.#callbacks = new CallbackRegistry(idGenerator);
     this.#url = url;
     this.#delay = delay;
     this.#timeout = timeout ?? 180_000;
@@ -78,6 +82,13 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
    */
   get _closed(): boolean {
     return this.#closed;
+  }
+
+  /**
+   * @internal
+   */
+  get _idGenerator(): GetIdFn {
+    return this.#idGenerator;
   }
 
   /**

--- a/packages/puppeteer-core/src/common/CallbackRegistry.ts
+++ b/packages/puppeteer-core/src/common/CallbackRegistry.ts
@@ -6,12 +6,10 @@
 
 import {Deferred} from '../util/Deferred.js';
 import {rewriteError} from '../util/ErrorLike.js';
-import {createIncrementalIdGenerator} from '../util/incremental-id-generator.js';
+import type {GetIdFn} from '../util/incremental-id-generator.js';
 
 import {ProtocolError, TargetCloseError} from './Errors.js';
 import {debugError} from './util.js';
-
-const idGenerator = createIncrementalIdGenerator();
 
 /**
  * Manages callbacks and their IDs for the protocol request/response communication.
@@ -19,8 +17,12 @@ const idGenerator = createIncrementalIdGenerator();
  * @internal
  */
 export class CallbackRegistry {
-  #callbacks = new Map<number, Callback>();
-  #idGenerator = idGenerator;
+  readonly #callbacks = new Map<number, Callback>();
+  readonly #idGenerator: GetIdFn;
+
+  constructor(idGenerator: GetIdFn) {
+    this.#idGenerator = idGenerator;
+  }
 
   create(
     label: string,

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -113,10 +113,13 @@ export interface ConnectOptions {
   browserURL?: string;
   transport?: ConnectionTransport;
   /**
+   * @internal
+   *
    * Custom ID generator for CDP / BiDi messages. Useful if the same transport
    * is shared for multiple connections.
    */
   idGenerator?: () => number;
+
   /**
    * Headers to use for the web socket connection.
    * @remarks

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -113,6 +113,11 @@ export interface ConnectOptions {
   browserURL?: string;
   transport?: ConnectionTransport;
   /**
+   * Custom ID generator for CDP / BiDi messages. Useful if the same transport
+   * is shared for multiple connections.
+   */
+  idGenerator?: () => number;
+  /**
    * Headers to use for the web socket connection.
    * @remarks
    * Only works in the Node.js environment.

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -30,6 +30,10 @@ import {TimeoutError} from '../common/Errors.js';
 import type {SupportedBrowser} from '../common/SupportedBrowser.js';
 import {debugError, DEFAULT_VIEWPORT} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
+import {
+  createIncrementalIdGenerator,
+  type GetIdFn,
+} from '../util/incremental-id-generator.js';
 
 import type {ChromeReleaseChannel, LaunchOptions} from './LaunchOptions.js';
 import {NodeWebSocketTransport as WebSocketTransport} from './NodeWebSocketTransport.js';
@@ -88,6 +92,7 @@ export abstract class BrowserLauncher {
       waitForInitialPage = true,
       protocolTimeout,
       handleDevToolsAsPage,
+      idGenerator = createIncrementalIdGenerator(),
     } = options;
 
     let {protocol} = options;
@@ -166,6 +171,7 @@ export abstract class BrowserLauncher {
             defaultViewport,
             acceptInsecureCerts,
             networkEnabled,
+            idGenerator,
           },
         );
       } else {
@@ -174,12 +180,14 @@ export abstract class BrowserLauncher {
             timeout,
             protocolTimeout,
             slowMo,
+            idGenerator,
           });
         } else {
           cdpConnection = await this.createCdpSocketConnection(browserProcess, {
             timeout,
             protocolTimeout,
             slowMo,
+            idGenerator,
           });
         }
 
@@ -342,6 +350,7 @@ export abstract class BrowserLauncher {
       timeout: number;
       protocolTimeout: number | undefined;
       slowMo: number;
+      idGenerator: GetIdFn;
     },
   ): Promise<Connection> {
     const browserWSEndpoint = await browserProcess.waitForLineOutput(
@@ -352,6 +361,7 @@ export abstract class BrowserLauncher {
     return new Connection(
       browserWSEndpoint,
       transport,
+      opts.idGenerator,
       opts.slowMo,
       opts.protocolTimeout,
     );
@@ -366,6 +376,7 @@ export abstract class BrowserLauncher {
       timeout: number;
       protocolTimeout: number | undefined;
       slowMo: number;
+      idGenerator: GetIdFn;
     },
   ): Promise<Connection> {
     // stdio was assigned during start(), and the 'pipe' option there adds the
@@ -375,7 +386,13 @@ export abstract class BrowserLauncher {
       pipeWrite as NodeJS.WritableStream,
       pipeRead as NodeJS.ReadableStream,
     );
-    return new Connection('', transport, opts.slowMo, opts.protocolTimeout);
+    return new Connection(
+      '',
+      transport,
+      opts.idGenerator,
+      opts.slowMo,
+      opts.protocolTimeout,
+    );
   }
 
   /**
@@ -417,6 +434,7 @@ export abstract class BrowserLauncher {
       timeout: number;
       protocolTimeout: number | undefined;
       slowMo: number;
+      idGenerator: GetIdFn;
       defaultViewport: Viewport | null;
       acceptInsecureCerts?: boolean;
       networkEnabled?: boolean;
@@ -432,6 +450,7 @@ export abstract class BrowserLauncher {
     const bidiConnection = new BiDi.BidiConnection(
       browserWSEndpoint,
       transport,
+      opts.idGenerator,
       opts.slowMo,
       opts.protocolTimeout,
     );

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -361,9 +361,10 @@ export abstract class BrowserLauncher {
     return new Connection(
       browserWSEndpoint,
       transport,
-      opts.idGenerator,
       opts.slowMo,
       opts.protocolTimeout,
+      /* rawErrors */ false,
+      opts.idGenerator,
     );
   }
 
@@ -389,9 +390,10 @@ export abstract class BrowserLauncher {
     return new Connection(
       '',
       transport,
-      opts.idGenerator,
       opts.slowMo,
       opts.protocolTimeout,
+      /* rawErrors */ false,
+      opts.idGenerator,
     );
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
no

**Summary**
This PR makes the ID generator for CDP messages configurable. This is useful if the same transport is shared across multiple connections and is a pre-requisite that puppeteer can proxy a Chrome DevTools connection and Chrome DevTools proxy a puppeter connection.

**Does this PR introduce a breaking change?**
Changes constructor ordering of CDP connection, this may or may not break users.

**Other information**


BEGIN_COMMIT_OVERRIDE
refactor: make protocol (cdp/bidi) command ID generator configurable
END_COMMIT_OVERRIDE
