### PR TITLE
chore: experimental includeAll flag for browser.pages()

### DIFF
--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -277,7 +277,7 @@ Creates a new [page](./puppeteer.page.md) in the [default browser context](./pup
 </td></tr>
 <tr><td>
 
-<span id="pages">[pages()](./puppeteer.browser.pages.md)</span>
+<span id="pages">[pages(includeAll)](./puppeteer.browser.pages.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.browser.pages.md
+++ b/docs/api/puppeteer.browser.pages.md
@@ -12,9 +12,39 @@ If there are multiple [browser contexts](./puppeteer.browsercontext.md), this re
 
 ```typescript
 class Browser {
-  pages(): Promise<Page[]>;
+  pages(includeAll?: boolean): Promise<Page[]>;
 }
 ```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+includeAll
+
+</td><td>
+
+boolean
+
+</td><td>
+
+_(Optional)_ experimental, setting to true includes all kinds of pages.
+
+</td></tr>
+</tbody></table>
 
 **Returns:**
 

--- a/docs/api/puppeteer.browsercontext.md
+++ b/docs/api/puppeteer.browsercontext.md
@@ -205,7 +205,7 @@ Grants this [browser context](./puppeteer.browsercontext.md) the given `permissi
 </td></tr>
 <tr><td>
 
-<span id="pages">[pages()](./puppeteer.browsercontext.pages.md)</span>
+<span id="pages">[pages(includeAll)](./puppeteer.browsercontext.pages.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.browsercontext.pages.md
+++ b/docs/api/puppeteer.browsercontext.pages.md
@@ -10,9 +10,39 @@ Gets a list of all open [pages](./puppeteer.page.md) inside this [browser contex
 
 ```typescript
 class BrowserContext {
-  abstract pages(): Promise<Page[]>;
+  abstract pages(includeAll?: boolean): Promise<Page[]>;
 }
 ```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+includeAll
+
+</td><td>
+
+boolean
+
+</td><td>
+
+_(Optional)_ experimental, setting to true includes all kinds of pages.
+
+</td></tr>
+</tbody></table>
 
 **Returns:**
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -392,13 +392,15 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * returns all {@link Page | pages} in all
    * {@link BrowserContext | browser contexts}.
    *
+   * @param includeAll - experimental, setting to true includes all kinds of pages.
+   *
    * @remarks Non-visible {@link Page | pages}, such as `"background_page"`,
    * will not be listed here. You can find them using {@link Target.page}.
    */
-  async pages(): Promise<Page[]> {
+  async pages(includeAll = false): Promise<Page[]> {
     const contextPages = await Promise.all(
       this.browserContexts().map(context => {
-        return context.pages();
+        return context.pages(includeAll);
       }),
     );
     // Flatten array.

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -186,10 +186,12 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
    * Gets a list of all open {@link Page | pages} inside this
    * {@link BrowserContext | browser context}.
    *
+   * @param includeAll - experimental, setting to true includes all kinds of pages.
+   *
    * @remarks Non-visible {@link Page | pages}, such as `"background_page"`,
    * will not be listed here. You can find them using {@link Target.page}.
    */
-  abstract pages(): Promise<Page[]>;
+  abstract pages(includeAll?: boolean): Promise<Page[]>;
 
   /**
    * Grants this {@link BrowserContext | browser context} the given

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -224,7 +224,7 @@ export class BidiBrowserContext extends BrowserContext {
     return this.#browser;
   }
 
-  override async pages(): Promise<BidiPage[]> {
+  override async pages(_includeAll = false): Promise<BidiPage[]> {
     return [...this.userContext.browsingContexts].map(context => {
       return this.#pages.get(context)!;
     });

--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -45,13 +45,13 @@ export class CdpBrowserContext extends BrowserContext {
     });
   }
 
-  override async pages(): Promise<Page[]> {
+  override async pages(includeAll = false): Promise<Page[]> {
     const pages = await Promise.all(
       this.targets()
         .filter(target => {
           return (
             target.type() === 'page' ||
-            (target.type() === 'other' &&
+            ((target.type() === 'other' || includeAll) &&
               this.#browser._getIsPageTargetCallback()?.(target))
           );
         })


### PR DESCRIPTION
This would allow easier get targets like webviews that are available in Electron. We still do not support Electron officially but this is a feature that might be useful for other use cases. 