### PR TITLE
fix: ignore wasn't found errors in NetworkManager

### DIFF
--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -108,7 +108,9 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #canIgnoreError(error: unknown) {
     return (
       isErrorLike(error) &&
-      (isTargetClosedError(error) || error.message.includes('Not supported'))
+      (isTargetClosedError(error) ||
+        error.message.includes('Not supported') ||
+        error.message.includes("wasn't found"))
     );
   }
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -661,7 +661,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "Workers do not work in Firefox yet"
   },
   {
     "testIdPattern": "[screencast.spec] Screencasts Page.screencast should validate options",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -657,6 +657,13 @@
     "comment": "https://github.com/w3c/webdriver-bidi/issues/508"
   },
   {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with worker",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
     "testIdPattern": "[screencast.spec] Screencasts Page.screencast should validate options",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -1777,13 +1784,6 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with worker",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   }
 ]

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1778,5 +1778,12 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with worker",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   }
 ]

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -705,6 +705,16 @@ describe('request interception', function () {
       await page.goto(server.PREFIX + '/cached/one-style-font.html');
       await responsePromise;
     });
+    it('should work with worker', async () => {
+      const {page, server} = await getTestState();
+
+      await Promise.all([
+        waitEvent(page, 'workercreated'),
+        page.goto(server.PREFIX + '/worker/worker.html'),
+      ]);
+
+      await page.setRequestInterception(true);
+    });
   });
 
   describe('Request.continue', function () {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

no

**If relevant, did you update the documentation?**

n/a

**Summary**

if you send `Fetch.enable` for a worker, you receive the following error `ProtocolError: Protocol error (Fetch.enable): 'Fetch.enable' wasn't found`

**Does this PR introduce a breaking change?**

no

**Other information**

this issue was introduced here https://github.com/puppeteer/puppeteer/issues/13752