### PR TITLE
fix: tasks and session management in ExtensionTransport

### DIFF
--- a/packages/puppeteer-core/src/cdp/ExtensionTransport.test.ts
+++ b/packages/puppeteer-core/src/cdp/ExtensionTransport.test.ts
@@ -99,6 +99,10 @@ describe('ExtensionTransport', function () {
       const onmessageFake = sinon.fake();
       transport.onmessage = onmessageFake;
       transport.send(JSON.stringify(command));
+      // Drain microtasks scheduled by send.
+      await new Promise(resolve => {
+        return setTimeout(resolve, 0);
+      });
       expect(fakeSendCommand.notCalled).toBeTruthy();
       return onmessageFake.getCalls().map(call => {
         return call.args[0];
@@ -160,7 +164,7 @@ describe('ExtensionTransport', function () {
           sessionId: 'tabTargetSessionId',
         }),
       ).toStrictEqual([
-        '{"method":"Target.attachedToTarget","params":{"targetInfo":{"targetId":"pageTargetId","type":"page","title":"page","url":"about:blank","attached":false,"canAccessOpener":false},"sessionId":"pageTargetSessionId"}}',
+        '{"method":"Target.attachedToTarget","sessionId":"tabTargetSessionId","params":{"targetInfo":{"targetId":"pageTargetId","type":"page","title":"page","url":"about:blank","attached":false,"canAccessOpener":false},"sessionId":"pageTargetSessionId"}}',
         '{"id":1,"sessionId":"tabTargetSessionId","method":"Target.setAutoAttach","result":{}}',
       ]);
     });
@@ -208,7 +212,11 @@ describe('ExtensionTransport', function () {
           sessionId: 'testSessionId',
         }),
       );
-      // Drain task queue.
+      // Drain microtasks scheduled by send.
+      await new Promise(resolve => {
+        return setTimeout(resolve, 0);
+      });
+      // Drain response message tasks by dispatchResponse.
       await new Promise(resolve => {
         return setTimeout(resolve, 0);
       });

--- a/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
+++ b/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
@@ -68,7 +68,10 @@ export class ExtensionTransport implements ConnectionTransport {
   };
 
   #dispatchResponse(message: object): void {
-    this.onmessage?.(JSON.stringify(message));
+    // Dispatch in a new task like other transports.
+    setTimeout(() => {
+      this.onmessage?.(JSON.stringify(message));
+    }, 0);
   }
 
   send(message: string): void {
@@ -125,6 +128,7 @@ export class ExtensionTransport implements ConnectionTransport {
         if (parsed.sessionId === 'tabTargetSessionId') {
           this.#dispatchResponse({
             method: 'Target.attachedToTarget',
+            sessionId: 'tabTargetSessionId',
             params: {
               targetInfo: pageTargetInfo,
               sessionId: 'pageTargetSessionId',


### PR DESCRIPTION
Puppeteer expects each CDP message to be dispatched in a separate JS task. This PR uses setTimeout to implement it as the only available method in browsers right now.  It also fixes the page attach event to happen on the tab target session.