### PR TITLE
fix(cdp): update request with ExtraInfo if available

### DIFF
--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -100,7 +100,11 @@ export class CdpHTTPRequest extends HTTPRequest {
 
     this.interception.enabled = allowInterception;
 
-    for (const [key, value] of Object.entries(data.request.headers)) {
+    this.updateHeaders(data.request.headers);
+  }
+
+  updateHeaders(headers: Protocol.Network.Headers): void {
+    for (const [key, value] of Object.entries(headers)) {
       this.#headers[key.toLowerCase()] = value;
     }
   }

--- a/packages/puppeteer-core/src/cdp/NetworkEventManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkEventManager.ts
@@ -83,7 +83,10 @@ export class NetworkEventManager {
     Protocol.Fetch.RequestPausedEvent
   >();
   #httpRequestsMap = new Map<NetworkRequestId, CdpHTTPRequest>();
-
+  #requestWillBeSentExtraInfoMap = new Map<
+    NetworkRequestId,
+    Protocol.Network.RequestWillBeSentExtraInfoEvent[]
+  >();
   /*
    * The below maps are used to reconcile Network.responseReceivedExtraInfo
    * events with their corresponding request. Each response and redirect
@@ -103,9 +106,21 @@ export class NetworkEventManager {
   forget(networkRequestId: NetworkRequestId): void {
     this.#requestWillBeSentMap.delete(networkRequestId);
     this.#requestPausedMap.delete(networkRequestId);
+    this.#requestWillBeSentExtraInfoMap.delete(networkRequestId);
     this.#queuedEventGroupMap.delete(networkRequestId);
     this.#queuedRedirectInfoMap.delete(networkRequestId);
     this.#responseReceivedExtraInfoMap.delete(networkRequestId);
+  }
+
+  requestExtraInfo(
+    networkRequestId: NetworkRequestId,
+  ): Protocol.Network.RequestWillBeSentExtraInfoEvent[] {
+    if (!this.#requestWillBeSentExtraInfoMap.has(networkRequestId)) {
+      this.#requestWillBeSentExtraInfoMap.set(networkRequestId, []);
+    }
+    return this.#requestWillBeSentExtraInfoMap.get(
+      networkRequestId,
+    ) as Protocol.Network.RequestWillBeSentExtraInfoEvent[];
   }
 
   responseExtraInfo(

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -133,7 +133,7 @@ describe('request interception', function () {
       expect(requests[1]!.url()).toContain('/one-style.css');
       expect(requests[1]!.headers()['referer']).toContain('/one-style.html');
     });
-    it.only('should not allow mutating request headers', async () => {
+    it('should not allow mutating request headers', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -133,7 +133,7 @@ describe('request interception', function () {
       expect(requests[1]!.url()).toContain('/one-style.css');
       expect(requests[1]!.headers()['referer']).toContain('/one-style.html');
     });
-    it('should not allow mutating request headers', async () => {
+    it.only('should not allow mutating request headers', async () => {
       const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
@@ -144,7 +144,7 @@ describe('request interception', function () {
         }
         const headers = request.headers();
         headers['test'] = 'test';
-        void request.continue({headers});
+        void request.continue({headers: request.headers()});
       });
       await page.goto(server.EMPTY_PAGE);
       expect(Object.keys(requests[0]!.headers())).not.toContain('test');


### PR DESCRIPTION
CDP has an event call `Network.requestWillBeSentExtraInfo` it is send separately and may not even be sent at all.
Given this we can only safely test it once the request was fully completed.

Closes https://github.com/puppeteer/puppeteer/issues/4165