### PR TITLE
chore: remove workaround for disabling Firefox Backup

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -225,12 +225,6 @@ function defaultProfilePreferences(
     // Increase the APZ content response timeout to 1 minute
     'apz.content_response_timeout': 60000,
 
-    // Disables backup service to improve startup performance and stability. See
-    // https://github.com/puppeteer/puppeteer/issues/14194. TODO: can be removed
-    // once the service is disabled on the Firefox side for WebDriver (see
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1988250).
-    'browser.backup.enabled': false,
-
     // Prevent various error message on the console
     // jest-puppeteer asserts that no error message is emitted by the console
     'browser.contentblocking.features.standard':


### PR DESCRIPTION
The backup service is now directly disabled in Firefox, so there is no need to have it set on profile creation.