### PR TITLE
feat(webdriver): use `network.setExtraHeaders` instead of network interception

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPRequest.ts
@@ -109,17 +109,6 @@ export class BidiHTTPRequest extends HTTPRequest {
     this.#request.on('authenticate', this.#handleAuthentication);
 
     this.#frame.page().trustedEmitter.emit(PageEvent.Request, this);
-
-    if (this.#hasInternalHeaderOverwrite) {
-      this.interception.handlers.push(async () => {
-        await this.continue(
-          {
-            headers: this.headers(),
-          },
-          0,
-        );
-      });
-    }
   }
 
   protected canBeIntercepted(): boolean {
@@ -165,14 +154,6 @@ export class BidiHTTPRequest extends HTTPRequest {
     return await this.#request.fetchPostData();
   }
 
-  get #hasInternalHeaderOverwrite(): boolean {
-    return Boolean(Object.keys(this.#extraHTTPHeaders).length);
-  }
-
-  get #extraHTTPHeaders(): Record<string, string> {
-    return this.#frame?.page()._extraHTTPHeaders ?? {};
-  }
-
   override headers(): Record<string, string> {
     // Callers should not be allowed to mutate internal structure.
     const headers: Record<string, string> = {};
@@ -181,7 +162,6 @@ export class BidiHTTPRequest extends HTTPRequest {
     }
     return {
       ...headers,
-      ...this.#extraHTTPHeaders,
     };
   }
 
@@ -213,19 +193,6 @@ export class BidiHTTPRequest extends HTTPRequest {
 
   override frame(): BidiFrame {
     return this.#frame;
-  }
-
-  override async continue(
-    overrides?: ContinueRequestOverrides,
-    priority?: number | undefined,
-  ): Promise<void> {
-    return await super.continue(
-      {
-        headers: this.#hasInternalHeaderOverwrite ? this.headers() : undefined,
-        ...overrides,
-      },
-      priority,
-    );
   }
 
   override async _continue(

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -49,7 +49,6 @@ import type {PDFOptions} from '../common/PDFOptions.js';
 import type {Awaitable} from '../common/types.js';
 import {
   evaluationString,
-  isString,
   parsePDFOptions,
   timeout,
 } from '../common/util.js';
@@ -726,7 +725,6 @@ export class BidiPage extends Page {
   get isNetworkInterceptionEnabled(): boolean {
     return (
       Boolean(this.#requestInterception) ||
-      Boolean(this.#extraHeadersInterception) ||
       Boolean(this.#authInterception)
     );
   }
@@ -743,26 +741,10 @@ export class BidiPage extends Page {
   /**
    * @internal
    */
-  _extraHTTPHeaders: Record<string, string> = {};
-  #extraHeadersInterception?: string;
   override async setExtraHTTPHeaders(
     headers: Record<string, string>,
   ): Promise<void> {
-    const extraHTTPHeaders: Record<string, string> = {};
-    for (const [key, value] of Object.entries(headers)) {
-      assert(
-        isString(value),
-        `Expected value of header "${key}" to be String, but "${typeof value}" is found.`,
-      );
-      extraHTTPHeaders[key.toLowerCase()] = value;
-    }
-    this._extraHTTPHeaders = extraHTTPHeaders;
-
-    this.#extraHeadersInterception = await this.#toggleInterception(
-      [Bidi.Network.InterceptPhase.BeforeRequestSent],
-      this.#extraHeadersInterception,
-      Boolean(Object.keys(this._extraHTTPHeaders).length),
-    );
+    await this.#frame.browsingContext.setExtraHTTPHeaders(headers);
   }
 
   /**

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -47,11 +47,7 @@ import {EventEmitter} from '../common/EventEmitter.js';
 import {FileChooser} from '../common/FileChooser.js';
 import type {PDFOptions} from '../common/PDFOptions.js';
 import type {Awaitable} from '../common/types.js';
-import {
-  evaluationString,
-  parsePDFOptions,
-  timeout,
-} from '../common/util.js';
+import {evaluationString, parsePDFOptions, timeout} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
 import {assert} from '../util/assert.js';
 import {bubble} from '../util/decorators.js';
@@ -724,8 +720,7 @@ export class BidiPage extends Page {
 
   get isNetworkInterceptionEnabled(): boolean {
     return (
-      Boolean(this.#requestInterception) ||
-      Boolean(this.#authInterception)
+      Boolean(this.#requestInterception) || Boolean(this.#authInterception)
     );
   }
 

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -797,7 +797,7 @@ export class BrowsingContext extends EventEmitter<{
         );
 
         return {
-          name: key,
+          name: key.toLowerCase(),
           value: {type: 'string', value: value},
         };
       }),

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -21,6 +21,8 @@ import {WindowRealm} from './Realm.js';
 import {Request} from './Request.js';
 import type {UserContext} from './UserContext.js';
 import {UserPrompt} from './UserPrompt.js';
+import {assert} from '../../util/assert.js';
+import {isString} from '../../common/util.js';
 
 /**
  * @internal
@@ -784,5 +786,21 @@ export class BrowsingContext extends EventEmitter<{
       timeout,
       signal,
     );
+  }
+
+  async setExtraHTTPHeaders(headers: Record<string, string>): Promise<void> {
+    await this.#session.send('network.setExtraHeaders', {
+      headers: Object.entries(headers).map(([key, value])=>{
+        assert(
+          isString(value),
+          `Expected value of header "${key}" to be String, but "${typeof value}" is found.`,
+        );
+
+        return {
+          name: key,
+          value: {type: 'string', value: value}
+        }}),
+      contexts: [this.id],
+    });
   }
 }

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -9,6 +9,8 @@ import type * as Bidi from 'webdriver-bidi-protocol';
 import type {BluetoothEmulation} from '../../api/BluetoothEmulation.js';
 import type {DeviceRequestPrompt} from '../../api/DeviceRequestPrompt.js';
 import {EventEmitter} from '../../common/EventEmitter.js';
+import {isString} from '../../common/util.js';
+import {assert} from '../../util/assert.js';
 import {inertIfDisposed, throwIfDisposed} from '../../util/decorators.js';
 import {DisposableStack, disposeSymbol} from '../../util/disposable.js';
 import {BidiBluetoothEmulation} from '../BluetoothEmulation.js';
@@ -21,8 +23,6 @@ import {WindowRealm} from './Realm.js';
 import {Request} from './Request.js';
 import type {UserContext} from './UserContext.js';
 import {UserPrompt} from './UserPrompt.js';
-import {assert} from '../../util/assert.js';
-import {isString} from '../../common/util.js';
 
 /**
  * @internal
@@ -790,7 +790,7 @@ export class BrowsingContext extends EventEmitter<{
 
   async setExtraHTTPHeaders(headers: Record<string, string>): Promise<void> {
     await this.#session.send('network.setExtraHeaders', {
-      headers: Object.entries(headers).map(([key, value])=>{
+      headers: Object.entries(headers).map(([key, value]) => {
         assert(
           isString(value),
           `Expected value of header "${key}" to be String, but "${typeof value}" is found.`,
@@ -798,8 +798,9 @@ export class BrowsingContext extends EventEmitter<{
 
         return {
           name: key,
-          value: {type: 'string', value: value}
-        }}),
+          value: {type: 'string', value: value},
+        };
+      }),
       contexts: [this.id],
     });
   }


### PR DESCRIPTION
WebDriver BiDi spec: https://www.w3.org/TR/webdriver-bidi/#command-network-setExtraHeaders

### ~~Blocked till [December 9, 2025](https://whattrainisitnow.com/release/?version=146)~~
* ~~[Firefox 146](https://whattrainisitnow.com/release/?version=146) with [implementation of `network.setExtraHeaders`](https://bugzilla.mozilla.org/show_bug.cgi?id=1979731) reaches stable.~~