### PR TITLE
fix: TS fix for path in ScreenshotOptions

### DIFF
--- a/docs/api/puppeteer.screenshotoptions.md
+++ b/docs/api/puppeteer.screenshotoptions.md
@@ -186,7 +186,7 @@ boolean
 
 </td><td>
 
-\`$&#123;string&#125;.$&#123;[ImageFormat](./puppeteer.imageformat.md)&#125;\`
+string
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -306,7 +306,7 @@ export interface ScreenshotOptions {
    * relative to current working directory. If no path is provided, the image
    * won't be saved to the disk.
    */
-  path?: `${string}.${ImageFormat}`;
+  path?: string;
   /**
    * Specifies the region of the page/element to clip.
    */


### PR DESCRIPTION
The TS type for path was changed to ${string}.${ImageFormat} in this [commit](https://github.com/puppeteer/puppeteer/commit/e3586e81521e0d91d4d69990cc44a73504dea3c4), which prevents using a jpg extension, even though jpg is already supported internally by the [screenshot function](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/api/Page.ts#L2627). This update restores the type to a plain string, since it's valid to provide a path without an extension; Puppeteer infers the image type from the path only when the [type option is undefined](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/api/Page.ts#L2616).