### PR TITLE
fix: HTTPResponse.text() method expected to throw when content is malformed

### DIFF
--- a/docs/api/puppeteer.httpresponse.md
+++ b/docs/api/puppeteer.httpresponse.md
@@ -196,6 +196,10 @@ The status text of the response (e.g. usually an "OK" for a success).
 
 Promise which resolves to a text (utf8) representation of response body.
 
+**Remarks:**
+
+This method will throw if the content is not utf-8 string
+
 </td></tr>
 <tr><td>
 

--- a/docs/api/puppeteer.httpresponse.text.md
+++ b/docs/api/puppeteer.httpresponse.text.md
@@ -17,3 +17,7 @@ class HTTPResponse {
 **Returns:**
 
 Promise&lt;string&gt;
+
+## Remarks
+
+This method will throw if the content is not utf-8 string

--- a/packages/puppeteer-core/src/api/HTTPResponse.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import expect from 'expect';
+import {describe, it} from 'node:test';
+
+import {HTTPResponse} from './HTTPResponse.js';
+
+//@ts-ignore
+class TestResponse extends HTTPResponse {
+  constructor(private readonly contentToReturn: Uint8Array) { super(); }
+
+  override content(): Promise<Uint8Array> {
+    return Promise.resolve(this.contentToReturn);
+  }
+}
+
+describe('HTTPResponse', () => {
+  describe('text', () => {
+    it('should return the content as text', async () => {
+      const content = new TextEncoder().encode('hello');
+      const testResponse = new TestResponse(content);
+
+      const text = await testResponse.text();
+      expect(text).toBe('hello');
+    });
+
+    it('should throw if content is not valid UTF-8', async () => {
+      const content = new Uint8Array([ 0xff ]);
+      const testResponse = new TestResponse(content);
+
+      await expect(testResponse.text()).rejects.toThrow();
+    });
+  });
+});

--- a/packages/puppeteer-core/src/api/HTTPResponse.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google Inc.
+ * Copyright 2026 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 import {describe, it} from 'node:test';

--- a/packages/puppeteer-core/src/api/HTTPResponse.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.test.ts
@@ -3,12 +3,13 @@
  * Copyright 2025 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import expect from 'expect';
 import {describe, it} from 'node:test';
+
+import expect from 'expect';
 
 import {HTTPResponse} from './HTTPResponse.js';
 
-//@ts-expect-error we don't need to implement all the methods for the tests on
+// @ts-expect-error we don't need to implement all the methods for the tests on
 // text method
 class TestResponse extends HTTPResponse {
   private _contentToReturn: Uint8Array = new Uint8Array();
@@ -34,7 +35,7 @@ describe('HTTPResponse', () => {
 
     it('should throw if content is not valid UTF-8', async () => {
       const testResponse = new TestResponse();
-      testResponse.contentToReturn = new Uint8Array([ 0xff ]);
+      testResponse.contentToReturn = new Uint8Array([0xff]);
 
       await expect(testResponse.text()).rejects.toThrow();
     });

--- a/packages/puppeteer-core/src/api/HTTPResponse.test.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.test.ts
@@ -8,28 +8,33 @@ import {describe, it} from 'node:test';
 
 import {HTTPResponse} from './HTTPResponse.js';
 
-//@ts-ignore
+//@ts-expect-error we don't need to implement all the methods for the tests on
+// text method
 class TestResponse extends HTTPResponse {
-  constructor(private readonly contentToReturn: Uint8Array) { super(); }
+  private _contentToReturn: Uint8Array = new Uint8Array();
+
+  set contentToReturn(contentToReturn: Uint8Array) {
+    this._contentToReturn = contentToReturn;
+  }
 
   override content(): Promise<Uint8Array> {
-    return Promise.resolve(this.contentToReturn);
+    return Promise.resolve(this._contentToReturn);
   }
 }
 
 describe('HTTPResponse', () => {
   describe('text', () => {
     it('should return the content as text', async () => {
-      const content = new TextEncoder().encode('hello');
-      const testResponse = new TestResponse(content);
+      const testResponse = new TestResponse();
+      testResponse.contentToReturn = new TextEncoder().encode('hello');
 
       const text = await testResponse.text();
       expect(text).toBe('hello');
     });
 
     it('should throw if content is not valid UTF-8', async () => {
-      const content = new Uint8Array([ 0xff ]);
-      const testResponse = new TestResponse(content);
+      const testResponse = new TestResponse();
+      testResponse.contentToReturn = new Uint8Array([ 0xff ]);
 
       await expect(testResponse.text()).rejects.toThrow();
     });

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -72,12 +72,12 @@ export abstract class HTTPResponse {
    * {@link SecurityDetails} if the response was received over the
    * secure connection, or `null` otherwise.
    */
-  abstract securityDetails(): SecurityDetails | null;
+  abstract securityDetails(): SecurityDetails|null;
 
   /**
    * Timing information related to the response.
    */
-  abstract timing(): Protocol.Network.ResourceTiming | null;
+  abstract timing(): Protocol.Network.ResourceTiming|null;
 
   /**
    * Promise which resolves to a buffer with response body.
@@ -87,7 +87,8 @@ export abstract class HTTPResponse {
    * The buffer might be re-encoded by the browser
    * based on HTTP-headers or other heuristics. If the browser
    * failed to detect the correct encoding, the buffer might
-   * be encoded incorrectly. See https://github.com/puppeteer/puppeteer/issues/6478.
+   * be encoded incorrectly. See
+   * https://github.com/puppeteer/puppeteer/issues/6478.
    */
   abstract content(): Promise<Uint8Array>;
 
@@ -100,10 +101,14 @@ export abstract class HTTPResponse {
   }
   /**
    * Promise which resolves to a text (utf8) representation of response body.
+   *
+   * @remarks
+   *
+   * This method will throw if the content is not utf-8 string
    */
   async text(): Promise<string> {
     const content = await this.content();
-    return new TextDecoder().decode(content);
+    return new TextDecoder('utf-8', {fatal : true}).decode(content);
   }
 
   /**
@@ -139,5 +144,5 @@ export abstract class HTTPResponse {
    * A {@link Frame} that initiated this response, or `null` if
    * navigating to error pages.
    */
-  abstract frame(): Frame | null;
+  abstract frame(): Frame|null;
 }

--- a/packages/puppeteer-core/src/api/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/api/HTTPResponse.ts
@@ -72,12 +72,12 @@ export abstract class HTTPResponse {
    * {@link SecurityDetails} if the response was received over the
    * secure connection, or `null` otherwise.
    */
-  abstract securityDetails(): SecurityDetails|null;
+  abstract securityDetails(): SecurityDetails | null;
 
   /**
    * Timing information related to the response.
    */
-  abstract timing(): Protocol.Network.ResourceTiming|null;
+  abstract timing(): Protocol.Network.ResourceTiming | null;
 
   /**
    * Promise which resolves to a buffer with response body.
@@ -108,7 +108,7 @@ export abstract class HTTPResponse {
    */
   async text(): Promise<string> {
     const content = await this.content();
-    return new TextDecoder('utf-8', {fatal : true}).decode(content);
+    return new TextDecoder('utf-8', {fatal: true}).decode(content);
   }
 
   /**
@@ -144,5 +144,5 @@ export abstract class HTTPResponse {
    * A {@link Frame} that initiated this response, or `null` if
    * navigating to error pages.
    */
-  abstract frame(): Frame|null;
+  abstract frame(): Frame | null;
 }


### PR DESCRIPTION
This patch fixes HTTPResponse.text() method to throw when the content parsed is binary and not an utf-8 string.

Now the text() method will throw instead of returning arbitrary text data when the content is not an utf-8 string but instead a binary data.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
**If relevant, did you update the documentation?**
yes
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Reason for the change:
https://github.com/puppeteer/puppeteer/issues/14449

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
**Other information**
