### PR TITLE
fix(webdriver): align deserialization with CDP

### DIFF
--- a/packages/puppeteer-core/src/bidi/Deserializer.ts
+++ b/packages/puppeteer-core/src/bidi/Deserializer.ts
@@ -31,13 +31,13 @@ export class BidiDeserializer {
           return acc.add(this.deserialize(value));
         }, new Set());
       case 'object':
-        if (!result?.value) {
+        if (!result?.value && !result.internalId) {
           // Heuristic detecting platform objects. WebDriver BiDi serializes platform
           // objects without value. Return an empty object, as there is no way to restore
           // the original value's constructor.
           return {};
         }
-        return result.value.reduce((acc: Record<any, unknown>, tuple) => {
+        return result.value?.reduce((acc: Record<any, unknown>, tuple) => {
           const {key, value} = this.#deserializeTuple(tuple);
           acc[key as any] = value;
           return acc;

--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -275,6 +275,20 @@ describe('Evaluation specs', function () {
       expect(result).not.toBe(object);
       expect(result).toEqual(object);
     });
+    it('should serialize platform object as an empty object', async () => {
+      const {page} = await getTestState();
+
+      const result = await page.evaluate(()=>new URLSearchParams('foo=1&bar=2'));
+      // Platform objects are serialized as an empty object.
+      expect(result).toEqual({});
+    });
+    it('should serialize error as an empty object', async () => {
+      const {page} = await getTestState();
+
+      const result = await page.evaluate(()=>new Error("some error"));
+      // Platform objects are serialized as an empty object.
+      expect(result).toEqual({});
+    });
     it('should return BigInt', async () => {
       const {page} = await getTestState();
 

--- a/test/src/evaluation.spec.ts
+++ b/test/src/evaluation.spec.ts
@@ -278,15 +278,18 @@ describe('Evaluation specs', function () {
     it('should serialize platform object as an empty object', async () => {
       const {page} = await getTestState();
 
-      const result = await page.evaluate(()=>new URLSearchParams('foo=1&bar=2'));
+      const result = await page.evaluate(() => {
+        return new URLSearchParams('foo=1&bar=2');
+      });
       // Platform objects are serialized as an empty object.
       expect(result).toEqual({});
     });
     it('should serialize error as an empty object', async () => {
       const {page} = await getTestState();
 
-      const result = await page.evaluate(()=>new Error("some error"));
-      // Platform objects are serialized as an empty object.
+      const result = await page.evaluate(() => {
+        return new Error('some error');
+      });
       expect(result).toEqual({});
     });
     it('should return BigInt', async () => {


### PR DESCRIPTION
Serialize errors and platform objects as empty objects.