### PR TITLE
chore: Temporarily change Firefox expectations for navigation.spec test case

### DIFF
--- a/test/CanaryTestExpectations.json
+++ b/test/CanaryTestExpectations.json
@@ -60,5 +60,12 @@
     "parameters": ["chrome"],
     "expectations": ["FAIL"],
     "comment": "Fix for M143 in https://github.com/puppeteer/puppeteer/pull/14351"
+  },
+  {
+    "testIdPattern": "[navigation.spec] navigation Page.goto should fail when server returns 204",
+    "platforms": [ "darwin", "linux", "win32" ],
+    "parameters": [ "firefox", "webDriverBiDi" ],
+    "expectations": [ "TIMEOUT" ],
+    "comment": "See https://bugzilla.mozilla.org/show_bug.cgi?id=2001934"
   }
 ]


### PR DESCRIPTION
**Summary**

Canary expectation change for Firefox  due to a regression from [bug 543435](http://bugzilla.mozilla.org/543435) that will likely be fixed soon in [bug 2001934](http://bugzilla.mozilla.org/2001934).
