### PR TITLE
fix: ignore non-page DevTools targets when handleDevToolsAsPage=true

### DIFF
--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -198,7 +198,9 @@ export class CdpBrowser extends BrowserBase {
           target.type() === 'webview' ||
           (this.#handleDevToolsAsPage &&
             target.type() === 'other' &&
-            target.url().startsWith('devtools://'))
+            target
+              .url()
+              .startsWith('devtools://devtools/bundled/devtools_app.html'))
         );
       });
   }


### PR DESCRIPTION
Specifically, DevTools can have worker targets. b/465052462