### PR TITLE
fix: prevent accessibility nodes attributes with false from being ignored

### DIFF
--- a/packages/puppeteer-core/src/cdp/Accessibility.ts
+++ b/packages/puppeteer-core/src/cdp/Accessibility.ts
@@ -618,7 +618,7 @@ class AXNode {
         continue;
       }
       const value = getBooleanPropertyValue(booleanProperty);
-      if (!value) {
+      if (value === undefined) {
         continue;
       }
       node[booleanProperty] = getBooleanPropertyValue(booleanProperty);

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -72,6 +72,7 @@ describe('Accessibility', function () {
           name: '',
           value: 'First Option',
           haspopup: 'menu',
+          expanded: false,
           children: [
             {role: 'option', name: 'First Option', selected: true},
             {role: 'option', name: 'Second Option'},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR prevents attributes with a correct value of `false` from being ignored during serialization.

**Did you add tests for your changes?**

Yes.

**If relevant, did you update the documentation?**

N/A

**Summary**

When serializing accessibility nodes, boolean properties can be `false`, but the current serialization function ignores all falsey values, which is wrong. For example, when a `select` (a ComboBox) is not open (not expanded), it should have the property `expanded` set to `false`.

**Does this PR introduce a breaking change?**

No.

**Other information**
