### PR TITLE
fix!: normalize newline-separated headers to comma-separated format

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -12,6 +12,7 @@ import {PageEvent} from '../api/Page.js';
 import {UnsupportedOperation} from '../common/Errors.js';
 import {SecurityDetails} from '../common/SecurityDetails.js';
 import {invokeAtMostOnceForArguments} from '../util/decorators.js';
+import {normalizeHeaderValue} from '../util/httpUtils.js';
 
 import type {BidiHTTPRequest} from './HTTPRequest.js';
 
@@ -90,7 +91,9 @@ export class BidiHTTPResponse extends HTTPResponse {
       // TODO: How to handle Binary Headers
       // https://w3c.github.io/webdriver-bidi/#type-network-Header
       if (header.value.type === 'string') {
-        headers[header.name.toLowerCase()] = header.value.value;
+        headers[header.name.toLowerCase()] = normalizeHeaderValue(
+          header.value.value,
+        );
       }
     }
     return headers;

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -51,7 +51,7 @@ export class CdpHTTPResponse extends HTTPResponse {
     this.#status = extraInfo ? extraInfo.statusCode : responsePayload.status;
     const headers = extraInfo ? extraInfo.headers : responsePayload.headers;
     for (const [key, value] of Object.entries(headers)) {
-      this.#headers[key.toLowerCase()] = value;
+      this.#headers[key.toLowerCase()] = this.#normalizeHeaderValue(value);
     }
 
     this.#securityDetails = responsePayload.securityDetails
@@ -79,6 +79,20 @@ export class CdpHTTPResponse extends HTTPResponse {
       return;
     }
     return statusText;
+  }
+
+  #normalizeHeaderValue(header: string): string {
+    if (!header.includes('\n')) {
+      return header;
+    }
+
+    return header
+      .split('\n')
+      .map(v => {
+        return v.trim();
+      })
+      .filter(Boolean)
+      .join(', ');
   }
 
   _resolveBody(err?: Error): void {

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -11,6 +11,7 @@ import {ProtocolError} from '../common/Errors.js';
 import {SecurityDetails} from '../common/SecurityDetails.js';
 import {Deferred} from '../util/Deferred.js';
 import {stringToTypedArray} from '../util/encoding.js';
+import {normalizeHeaderValue} from '../util/httpUtils.js';
 
 import type {CdpHTTPRequest} from './HTTPRequest.js';
 
@@ -51,7 +52,7 @@ export class CdpHTTPResponse extends HTTPResponse {
     this.#status = extraInfo ? extraInfo.statusCode : responsePayload.status;
     const headers = extraInfo ? extraInfo.headers : responsePayload.headers;
     for (const [key, value] of Object.entries(headers)) {
-      this.#headers[key.toLowerCase()] = this.#normalizeHeaderValue(value);
+      this.#headers[key.toLowerCase()] = normalizeHeaderValue(value);
     }
 
     this.#securityDetails = responsePayload.securityDetails
@@ -79,20 +80,6 @@ export class CdpHTTPResponse extends HTTPResponse {
       return;
     }
     return statusText;
-  }
-
-  #normalizeHeaderValue(header: string): string {
-    if (!header.includes('\n')) {
-      return header;
-    }
-
-    return header
-      .split('\n')
-      .map(v => {
-        return v.trim();
-      })
-      .filter(Boolean)
-      .join(', ');
   }
 
   _resolveBody(err?: Error): void {

--- a/packages/puppeteer-core/src/util/httpUtils.test.ts
+++ b/packages/puppeteer-core/src/util/httpUtils.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {normalizeHeaderValue} from './httpUtils.js';
+
+describe('HTTP Utilities', function () {
+  describe('normalizeHeaderValue', function () {
+    it('should give single-line header value unchanged', () => {
+      const header = 'application/json; charset=utf-8';
+      const result = normalizeHeaderValue(header);
+
+      expect(result).toBe(header);
+    });
+
+    it('should normalize multiline header with newlines', () => {
+      const header = 'text/html;\n charset=utf-8;\n boundary=something';
+      const result = normalizeHeaderValue(header);
+
+      expect(result).toBe('text/html;, charset=utf-8;, boundary=something');
+    });
+
+    it('should trim whitespace from each line', () => {
+      const header = 'text/html; \n  charset=utf-8  \n   boundary=something   ';
+      const result = normalizeHeaderValue(header);
+
+      expect(result).toBe('text/html;, charset=utf-8, boundary=something');
+    });
+
+    it('should filter out empty lines', () => {
+      const header = 'text/html;\n\n charset=utf-8;\n\n\n boundary=something';
+      const result = normalizeHeaderValue(header);
+
+      expect(result).toBe('text/html;, charset=utf-8;, boundary=something');
+    });
+  });
+});

--- a/packages/puppeteer-core/src/util/httpUtils.ts
+++ b/packages/puppeteer-core/src/util/httpUtils.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Normalizes HTTP header values by handling multiline values.
+ * Multiline header values are joined with commas according to HTTP/1.1 spec.
+ *
+ * @internal
+ */
+export function normalizeHeaderValue(header: string): string {
+  if (!header.includes('\n')) {
+    return header;
+  }
+
+  return header
+    .split('\n')
+    .map(v => {
+      return v.trim();
+    })
+    .filter(Boolean)
+    .join(', ');
+}

--- a/packages/puppeteer-core/src/util/util.ts
+++ b/packages/puppeteer-core/src/util/util.ts
@@ -10,4 +10,5 @@ export * from './Mutex.js';
 export * from './ErrorLike.js';
 export * from './AsyncIterableUtil.js';
 export * from './disposable.js';
+export * from './httpUtils.js';
 export * from './incremental-id-generator.js';

--- a/test/src/requestinterception.spec.ts
+++ b/test/src/requestinterception.spec.ts
@@ -900,7 +900,7 @@ describe('request interception', function () {
       expect(response.url()).toBe(server.EMPTY_PAGE);
     });
     it('should allow mocking multiple headers with same key', async () => {
-      const {isFirefox, page, server} = await getTestState();
+      const {page, server} = await getTestState();
 
       await page.setRequestInterception(true);
       page.on('request', request => {
@@ -924,20 +924,7 @@ describe('request interception', function () {
       });
       expect(response.status()).toBe(200);
       expect(response.headers()['foo']).toBe('bar');
-
-      // The separator used to handle headers with multiple values is browser
-      // specific.
-      // Per https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2 the default
-      // should be a list of comma separated values with optional whitespace.
-      // Per note in https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3,
-      // clients are also allowed to use other separators for special cases.
-      // However Chrome DevTools do return comma separated values for headers
-      // with multiple values, so this might be a bug.
-      if (isFirefox) {
-        expect(response.headers()['arr']).toBe('1, 2');
-      } else {
-        expect(response.headers()['arr']).toBe('1\n2');
-      }
+      expect(response.headers()['arr']).toBe('1, 2');
       // request.respond() will not trigger Network.responseReceivedExtraInfo
       // fail to get 'set-cookie' header from response
       expect(firstCookie?.value).toBe('1');


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes, updated existing header tests to verify comma-separated format.

**If relevant, did you update the documentation?**

No documentation changes needed.

**Summary**

Fixes #14325

Chrome DevTools Protocol (CDP) returns duplicate HTTP response headers merged with newline characters (`\n`). When Puppeteer exposed these headers directly, it caused errors when creating `Response` objects since newlines are invalid in HTTP header values:
```
TypeError: Headers.append: "sis; desc=0
geo; desc=IN
ak_p; desc="...";dur=1" is an invalid header value.
```

This PR adds a `normalizeHeaderValue()` method that converts newline-separated header values to comma-separated format, which complies with [RFC 9110 Section 5.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2).

Before:
```javascript
{
  'server-timing': 'sis; desc=0\ngeo; desc=IN\nak_p; desc="...";dur=1'
}
```

After:
```javascript
{
  'server-timing': 'sis; desc=0, geo; desc=IN, ak_p; desc="...";dur=1'
}
```

**Does this PR introduce a breaking change?**

No. Header values are now returned in a valid format per HTTP spec. Any code that was previously handling newline-separated values may need to be updated, but this is unlikely as such values were invalid and would cause errors in most HTTP clients.

**Other information**

Tested locally by navigating to sites that return duplicate headers (e.g., adobe.com) and verifying that `Response` objects can be created without errors.