### PR TITLE
feat: add Browser.get|setWindowBounds and Page.windowId methods

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1842,6 +1842,13 @@ Whether to wait for the element to be [visible](./puppeteer.elementhandle.isvisi
 </td></tr>
 <tr><td>
 
+<span id="windowid">[WindowId](./puppeteer.windowid.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="windowstate">[WindowState](./puppeteer.windowstate.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.browser.getwindowbounds.md
+++ b/docs/api/puppeteer.browser.getwindowbounds.md
@@ -1,0 +1,47 @@
+---
+sidebar_label: Browser.getWindowBounds
+---
+
+# Browser.getWindowBounds() method
+
+Gets the specified window [bounds](./puppeteer.windowbounds.md).
+
+### Signature
+
+```typescript
+class Browser {
+  abstract getWindowBounds(windowId: WindowId): Promise<WindowBounds>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+windowId
+
+</td><td>
+
+[WindowId](./puppeteer.windowid.md)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;[WindowBounds](./puppeteer.windowbounds.md)&gt;

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -253,6 +253,17 @@ Disconnects Puppeteer from this [browser](./puppeteer.browser.md), but leaves th
 </td></tr>
 <tr><td>
 
+<span id="getwindowbounds">[getWindowBounds(windowId)](./puppeteer.browser.getwindowbounds.md)</span>
+
+</td><td>
+
+</td><td>
+
+Gets the specified window [bounds](./puppeteer.windowbounds.md).
+
+</td></tr>
+<tr><td>
+
 <span id="installextension">[installExtension(path)](./puppeteer.browser.installextension.md)</span>
 
 </td><td>
@@ -357,6 +368,17 @@ Sets cookies in the default [BrowserContext](./puppeteer.browsercontext.md).
 **Remarks:**
 
 Shortcut for [browser.defaultBrowserContext().setCookie()](./puppeteer.browsercontext.setcookie.md).
+
+</td></tr>
+<tr><td>
+
+<span id="setwindowbounds">[setWindowBounds(windowId, windowBounds)](./puppeteer.browser.setwindowbounds.md)</span>
+
+</td><td>
+
+</td><td>
+
+Sets the specified window [bounds](./puppeteer.windowbounds.md).
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.setwindowbounds.md
+++ b/docs/api/puppeteer.browser.setwindowbounds.md
@@ -1,0 +1,61 @@
+---
+sidebar_label: Browser.setWindowBounds
+---
+
+# Browser.setWindowBounds() method
+
+Sets the specified window [bounds](./puppeteer.windowbounds.md).
+
+### Signature
+
+```typescript
+class Browser {
+  abstract setWindowBounds(
+    windowId: WindowId,
+    windowBounds: WindowBounds,
+  ): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+windowId
+
+</td><td>
+
+[WindowId](./puppeteer.windowid.md)
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+windowBounds
+
+</td><td>
+
+[WindowBounds](./puppeteer.windowbounds.md)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -1472,6 +1472,17 @@ The optional Parameter in Arguments `options` are:
 </td></tr>
 <tr><td>
 
+<span id="windowid">[windowId()](./puppeteer.page.windowid.md)</span>
+
+</td><td>
+
+</td><td>
+
+**_(Experimental)_** Returns the page's window id.
+
+</td></tr>
+<tr><td>
+
 <span id="workers">[workers()](./puppeteer.page.workers.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.page.windowid.md
+++ b/docs/api/puppeteer.page.windowid.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: Page.windowId
+---
+
+# Page.windowId() method
+
+Returns the page's window id.
+
+### Signature
+
+```typescript
+class Page {
+  abstract windowId(): Promise<WindowId>;
+}
+```
+
+**Returns:**
+
+Promise&lt;[WindowId](./puppeteer.windowid.md)&gt;

--- a/docs/api/puppeteer.windowid.md
+++ b/docs/api/puppeteer.windowid.md
@@ -1,0 +1,11 @@
+---
+sidebar_label: WindowId
+---
+
+# WindowId type
+
+### Signature
+
+```typescript
+export type WindowId = string;
+```

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -229,6 +229,11 @@ export interface WindowBounds {
 /**
  * @public
  */
+export type WindowId = string;
+
+/**
+ * @public
+ */
 export type CreatePageOptions =
   | {
       type: 'tab';
@@ -409,6 +414,19 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * {@link Browser.defaultBrowserContext | default browser context}.
    */
   abstract newPage(options?: CreatePageOptions): Promise<Page>;
+
+  /**
+   * Gets the specified window {@link WindowBounds | bounds}.
+   */
+  abstract getWindowBounds(windowId: WindowId): Promise<WindowBounds>;
+
+  /**
+   * Sets the specified window {@link WindowBounds | bounds}.
+   */
+  abstract setWindowBounds(
+    windowId: WindowId,
+    windowBounds: WindowBounds,
+  ): Promise<void>;
 
   /**
    * Gets all active {@link Target | targets}.

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -82,7 +82,7 @@ import {
 import {stringToTypedArray} from '../util/encoding.js';
 
 import type {BluetoothEmulation} from './BluetoothEmulation.js';
-import type {Browser} from './Browser.js';
+import type {Browser, WindowId} from './Browser.js';
 import type {BrowserContext} from './BrowserContext.js';
 import type {CDPSession} from './CDPSession.js';
 import type {DeviceRequestPrompt} from './DeviceRequestPrompt.js';
@@ -3148,7 +3148,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
   /**
    * Resizes the browser window the page is in so that the content area
-   * (excluding browser UI) is according to the specified widht and height.
+   * (excluding browser UI) is according to the specified width and height.
    *
    * @experimental
    * @internal
@@ -3157,6 +3157,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
     contentWidth: number;
     contentHeight: number;
   }): Promise<void>;
+
+  /**
+   * Returns the page's window id.
+   *
+   * @experimental
+   */
+  abstract windowId(): Promise<WindowId>;
 
   /** @internal */
   override [disposeSymbol](): void {

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -16,6 +16,8 @@ import {
   type BrowserContextOptions,
   type ScreenInfo,
   type AddScreenParams,
+  type WindowBounds,
+  type WindowId,
   type DebugInfo,
 } from '../api/Browser.js';
 import {BrowserContextEvent} from '../api/BrowserContext.js';
@@ -301,6 +303,17 @@ export class BidiBrowser extends Browser {
   }
 
   override removeScreen(_screenId: string): Promise<void> {
+    throw new UnsupportedOperation();
+  }
+
+  override getWindowBounds(_windowId: WindowId): Promise<WindowBounds> {
+    throw new UnsupportedOperation();
+  }
+
+  override setWindowBounds(
+    _windowId: WindowId,
+    _windowBounds: WindowBounds,
+  ): Promise<void> {
     throw new UnsupportedOperation();
   }
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -260,15 +260,15 @@ export class BidiPage extends Page {
     contentWidth: number;
     contentHeight: number;
   }): Promise<void> {
-    throw new Error('Method not implemented for WebDriver BiDi yet.');
+    throw new UnsupportedOperation();
   }
 
   override windowId(): Promise<WindowId> {
-    throw new Error('Method not implemented for WebDriver BiDi yet.');
+    throw new UnsupportedOperation();
   }
 
   override openDevTools(): Promise<Page> {
-    throw new Error('Method not implemented for WebDriver BiDi yet.');
+    throw new UnsupportedOperation();
   }
 
   async focusedFrame(): Promise<BidiFrame> {

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -9,6 +9,7 @@ import * as Bidi from 'webdriver-bidi-protocol';
 
 import {firstValueFrom, from, raceWith} from '../../third_party/rxjs/rxjs.js';
 import type {BluetoothEmulation} from '../api/BluetoothEmulation.js';
+import type {WindowId} from '../api/Browser.js';
 import type {CDPSession} from '../api/CDPSession.js';
 import type {DeviceRequestPrompt} from '../api/DeviceRequestPrompt.js';
 import type {BoundingBox} from '../api/ElementHandle.js';
@@ -259,6 +260,10 @@ export class BidiPage extends Page {
     contentWidth: number;
     contentHeight: number;
   }): Promise<void> {
+    throw new Error('Method not implemented for WebDriver BiDi yet.');
+  }
+
+  override windowId(): Promise<WindowId> {
     throw new Error('Method not implemented for WebDriver BiDi yet.');
   }
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -18,6 +18,8 @@ import {
   type TargetFilterCallback,
   type ScreenInfo,
   type AddScreenParams,
+  type WindowBounds,
+  type WindowId,
 } from '../api/Browser.js';
 import {BrowserContextEvent} from '../api/BrowserContext.js';
 import {CDPSessionEvent} from '../api/CDPSession.js';
@@ -451,6 +453,23 @@ export class CdpBrowser extends BrowserBase {
 
   override async removeScreen(screenId: string): Promise<void> {
     return await this.#connection.send('Emulation.removeScreen', {screenId});
+  }
+
+  override async getWindowBounds(windowId: WindowId): Promise<WindowBounds> {
+    const {bounds} = await this.#connection.send('Browser.getWindowBounds', {
+      windowId: Number(windowId),
+    });
+    return bounds;
+  }
+
+  override async setWindowBounds(
+    windowId: WindowId,
+    windowBounds: WindowBounds,
+  ): Promise<void> {
+    await this.#connection.send('Browser.setWindowBounds', {
+      windowId: Number(windowId),
+      bounds: windowBounds,
+    });
   }
 
   override targets(): CdpTarget[] {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -8,7 +8,7 @@ import type {Protocol} from 'devtools-protocol';
 
 import {firstValueFrom, from, raceWith} from '../../third_party/rxjs/rxjs.js';
 import type {BluetoothEmulation} from '../api/BluetoothEmulation.js';
-import type {Browser} from '../api/Browser.js';
+import type {Browser, WindowId} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
 import type {DeviceRequestPrompt} from '../api/DeviceRequestPrompt.js';
@@ -375,15 +375,20 @@ export class CdpPage extends Page {
     contentWidth: number;
     contentHeight: number;
   }): Promise<void> {
+    const windowId = await this.windowId();
+    await this.#primaryTargetClient.send('Browser.setContentsSize', {
+      windowId: Number(windowId),
+      width: params.contentWidth,
+      height: params.contentHeight,
+    });
+  }
+
+  override async windowId(): Promise<WindowId> {
     const {windowId} = await this.#primaryTargetClient.send(
       'Browser.getWindowForTarget',
     );
 
-    await this.#primaryTargetClient.send('Browser.setContentsSize', {
-      windowId,
-      width: params.contentWidth,
-      height: params.contentHeight,
-    });
+    return windowId.toString();
   }
 
   async #onFileChooser(

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -265,6 +265,20 @@
     "comment": "Not testable in headful"
   },
   {
+    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should get and set browser window bounds",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported by WebDriver BiDi"
+  },
+  {
+    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should set and get browser window maximized state",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported by WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[browser.spec] Browser specs Browser.screens should return default screen info",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -633,6 +647,13 @@
     "parameters": ["firefox"],
     "expectations": ["FAIL"],
     "comment": "Not yet supported https://bugzilla.mozilla.org/show_bug.cgi?id=1851561"
+  },
+  {
+    "testIdPattern": "[page.spec] Page Page.resize should resize the browser window to fit page content",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported by WebDriver BiDi"
   },
   {
     "testIdPattern": "[page.spec] Page Page.setBypassCSP *",
@@ -1495,6 +1516,13 @@
     "parameters": ["chrome", "headless"],
     "expectations": ["FAIL"],
     "comment": "Returns a different window size in Chrome Headless on Mac"
+  },
+  {
+    "testIdPattern": "[page.spec] Page Page.resize should resize the browser window to fit page content",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "firefox"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "Flaky on all platforms"
   },
   {
     "testIdPattern": "[page.spec] Page Page.setJavaScriptEnabled should work",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -273,10 +273,24 @@
   },
   {
     "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should set and get browser window maximized state",
+    "platforms": ["darwin", "win32"],
+    "parameters": ["headless"],
+    "expectations": ["FAIL"],
+    "comment": "Exact window bounds are different on Windows and Mac."
+  },
+  {
+    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should set and get browser window maximized state",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "Not supported by WebDriver BiDi"
+  },
+  {
+    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should set and get browser window maximized state",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["headful"],
+    "expectations": ["FAIL"],
+    "comment": "Screen methods are only supported in headless mode"
   },
   {
     "testIdPattern": "[browser.spec] Browser specs Browser.screens should return default screen info",
@@ -1518,13 +1532,6 @@
     "comment": "Returns a different window size in Chrome Headless on Mac"
   },
   {
-    "testIdPattern": "[page.spec] Page Page.resize should resize the browser window to fit page content",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["chrome", "firefox"],
-    "expectations": ["FAIL", "PASS"],
-    "comment": "Flaky on all platforms"
-  },
-  {
     "testIdPattern": "[page.spec] Page Page.setJavaScriptEnabled should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -1800,6 +1807,13 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["PASS"]
+  },
+  {
+    "testIdPattern": "[browser.spec] Browser specs Browser.get|setWindowBounds should get and set browser window bounds",
+    "platforms": ["win32"],
+    "parameters": ["cdp", "chrome", "headful"],
+    "expectations": ["FAIL"],
+    "comment": "Different dimensions on Windows for headful"
   },
   {
     "testIdPattern": "[CDPSession.spec] Target.createCDPSession should send events",

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -2753,4 +2753,25 @@ describe('Page', function () {
       await page2.close();
     });
   });
+
+  describe('Page.resize', function () {
+    it('should resize the browser window to fit page content', async () => {
+      const {context} = await getTestState();
+
+      const page = await context.newPage();
+
+      // Default view port restricts window to 800x600, so remove it.
+      await page.setViewport(null);
+
+      const contentWidth = 500;
+      const contentHeight = 400;
+      await page.resize({contentWidth, contentHeight});
+
+      const innerSize = await page.evaluate(() => {
+        return {width: window.innerWidth, height: window.innerHeight};
+      });
+      expect(innerSize.width).toBe(contentWidth);
+      expect(innerSize.height).toBe(contentHeight);
+    });
+  });
 });

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -2765,7 +2765,13 @@ describe('Page', function () {
 
       const contentWidth = 500;
       const contentHeight = 400;
+      const resized = page.evaluate(() => {
+        return new Promise(resolve => {
+          window.onresize = resolve;
+        });
+      });
       await page.resize({contentWidth, contentHeight});
+      await resized;
 
       const innerSize = await page.evaluate(() => {
         return {width: window.innerWidth, height: window.innerHeight};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This change introduces Browser.get|setWindowBounds and Page,windowId methods. The latter one returns a WindowID that is used by the former two  to identify a browser window.

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
Yes

**Summary**
These new browser methods allow users to manage browser window position and state. This allows windows to be placed on a particular screen in a required state.

**Does this PR introduce a breaking change?**
No

**Other information**
None