### PR TITLE
feat: support ignore tab target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           - chrome-headless-shell
           - chrome-bidi
           - chrome-pipe
+          - chrome-headless-page
         os:
           - ubuntu-latest
           - windows-latest
@@ -186,6 +187,10 @@ jobs:
             suite: chrome-bidi
           - os: macos-15
             suite: chrome-headful
+          - os: windows-latest
+            suite: chrome-headless-page
+          - os: macos-15
+            suite: chrome-headless-page
     steps:
       - name: Check out repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:chrome:bidi-only": "wireit",
     "test:chrome:headful": "wireit",
     "test:chrome:headless": "wireit",
+    "test:chrome:headless-page": "wireit",
     "test:chrome:shell": "wireit",
     "test:chrome:pipe": "wireit",
     "test:firefox": "wireit",
@@ -127,6 +128,9 @@
     },
     "test:chrome:headless": {
       "command": "npm test -- --test-suite chrome-headless"
+    },
+    "test:chrome:headless-page": {
+      "command": "npm test -- --test-suite chrome-headless-page"
     },
     "test:chrome:shell": {
       "command": "npm test -- --test-suite chrome-headless-shell"

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -19,6 +19,7 @@ import type {CdpTarget} from './Target.js';
 import {InitializationStatus} from './Target.js';
 import type {TargetManagerEvents} from './TargetManageEvents.js';
 import {TargetManagerEvent} from './TargetManageEvents.js';
+import {IGNORE_TAB_TARGET} from '../environment.js';
 
 /**
  * @internal
@@ -93,7 +94,15 @@ export class TargetManager
   #initializeDeferred = Deferred.create<void>();
   #waitForInitiallyDiscoveredTargets = true;
 
-  #discoveryFilter: Protocol.Target.FilterEntry[] = [{}];
+  #discoveryFilter: Protocol.Target.FilterEntry[] = IGNORE_TAB_TARGET
+    ? [
+        {
+          type: 'tab',
+          exclude: true,
+        },
+        {},
+      ]
+    : [{}];
   // IDs of tab targets detected while running the initial Target.setAutoAttach
   // request. These are the targets whose initialization we want to await for
   // before resolving puppeteer.connect() or launch() to avoid flakiness.
@@ -139,10 +148,14 @@ export class TargetManager
       flatten: true,
       autoAttach: true,
       filter: [
-        {
-          type: 'page',
-          exclude: true,
-        },
+        ...(IGNORE_TAB_TARGET
+          ? []
+          : [
+              {
+                type: 'page',
+                exclude: true,
+              },
+            ]),
         ...this.#discoveryFilter,
       ],
     });

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -36,3 +36,14 @@ export const environment: {
     },
   },
 };
+
+/**
+ * Whether to ignore tab targets.
+ * Some chrome versions do not support tab targets. eg: chrome 114 and above.
+ *
+ * @defaultValue false
+ */
+export const IGNORE_TAB_TARGET =
+  typeof process !== 'undefined'
+    ? process.env['PUPPETEER_IGNORE_TAB_TARGET'] === 'true'
+    : false;

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -25,6 +25,7 @@ import {
 } from './LaunchOptions.js';
 import type {PuppeteerNode} from './PuppeteerNode.js';
 import {rm} from './util/fs.js';
+import { IGNORE_TAB_TARGET } from '../environment.js';
 
 /**
  * @internal
@@ -190,6 +191,10 @@ export class ChromeLauncher extends BrowserLauncher {
     ].filter(feature => {
       return feature !== '';
     });
+
+    if (IGNORE_TAB_TARGET) {
+      disabledFeatures.push('Prerender2');
+    }
 
     const userEnabledFeatures = getFeatures('--enable-features', options.args);
     if (options.args && userEnabledFeatures.length > 0) {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -712,6 +712,34 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[prerender.spec] Prerender can navigate to a prerendered page via input",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp", "ignoreTabTarget"],
+    "expectations": ["TIMEOUT"],
+    "comment": "page target do not support prerender"
+  },
+  {
+    "testIdPattern": "[prerender.spec] Prerender via frame can navigate to a prerendered page via input",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp", "ignoreTabTarget"],
+    "expectations": ["TIMEOUT"],
+    "comment": "page target do not support prerender"
+  },
+  {
+    "testIdPattern": "[prerender.spec] Prerender with network requests can receive requests from the prerendered page",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp", "ignoreTabTarget"],
+    "expectations": ["TIMEOUT"],
+    "comment": "page target do not support prerender"
+  },
+  {
+    "testIdPattern": "[prerender.spec] Prerender with emulation can configure viewport for prerendered pages",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp", "ignoreTabTarget"],
+    "expectations": ["TIMEOUT"],
+    "comment": "page target do not support prerender"
+  },
+  {
     "testIdPattern": "[queryObjects.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -1710,6 +1738,13 @@
     "parameters": ["chrome", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[TargetManager.spec] TargetManager should handle targets",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "headless", "cdp", "ignoreTabTarget"],
+    "expectations": ["FAIL"],
+    "comment": "ignore tab target, targets will not include tab target"
   },
   {
     "testIdPattern": "[touchscreen.spec] Touchscreen Touchscreen.prototype.tap should work",

--- a/test/TestSuites.json
+++ b/test/TestSuites.json
@@ -31,6 +31,10 @@
     {
       "id": "chrome-pipe",
       "parameters": ["chrome", "headless", "cdp", "pipe"]
+    },
+    {
+      "id": "chrome-headless-page",
+      "parameters": ["chrome", "headless", "cdp", "ignoreTabTarget"]
     }
   ],
   "parameterDefinitions": {
@@ -59,6 +63,9 @@
     "cdp": {},
     "pipe": {
       "PUPPETEER_PIPE": "true"
+    },
+    "ignoreTabTarget": {
+      "PUPPETEER_IGNORE_TAB_TARGET": "true"
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Feature: Adds a global IGNORE_TAB_TARGET variable to support ignoring tab targets, ensuring compatibility with older Chrome versions (Chrome 114 and below).

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Add chrome-headless-page test-suite

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Older Chrome versions (114 and below) exhibit inconsistent tab target behavior that can cause Puppeteer to misidentify or process redundant tab targets, leading to unexpected errors in page initialization and target management workflows.

This PR introduces the global IGNORE_TAB_TARGET variable as a toggle to skip the handling of tab targets. When enabled, it suppresses the problematic target detection logic that conflicts with legacy Chrome versions, while maintaining full functionality for newer Chrome releases when the flag is disabled.

This change addresses the compatibility gap without altering the core target handling logic for modern browsers, ensuring a seamless experience for users working with older Chrome deployments.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. This PR is fully backward-compatible:

- The IGNORE_TAB_TARGET flag defaults to false, preserving the existing behavior for all users who do not explicitly enable it.
- No modifications are made to existing APIs or target processing logic for modern Chrome versions.
- No migration steps are required for existing applications.

**Other information**
