### PR TITLE
feat: emulate focused page

### DIFF
--- a/docs/api/puppeteer.page.emulatefocusedpage.md
+++ b/docs/api/puppeteer.page.emulatefocusedpage.md
@@ -1,0 +1,49 @@
+---
+sidebar_label: Page.emulateFocusedPage
+---
+
+# Page.emulateFocusedPage() method
+
+Emulates focus state of the page.
+
+### Signature
+
+```typescript
+class Page {
+  abstract emulateFocusedPage(enabled: boolean): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+enabled
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether to emulate focus.
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -543,6 +543,17 @@ Enables CPU throttling to emulate slow CPUs.
 </td></tr>
 <tr><td>
 
+<span id="emulatefocusedpage">[emulateFocusedPage(enabled)](./puppeteer.page.emulatefocusedpage.md)</span>
+
+</td><td>
+
+</td><td>
+
+Emulates focus state of the page.
+
+</td></tr>
+<tr><td>
+
 <span id="emulateidlestate">[emulateIdleState(overrides)](./puppeteer.page.emulateidlestate.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2704,6 +2704,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
   }
 
   /**
+   * Emulates focus state of the page.
+   *
+   * @param enabled - Whether to emulate focus.
+   */
+  abstract emulateFocusedPage(enabled: boolean): Promise<void>;
+
+  /**
    * @internal
    */
   abstract _screenshot(options: Readonly<ScreenshotOptions>): Promise<string>;

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -256,6 +256,10 @@ export class BidiPage extends Page {
     return this.#frame;
   }
 
+  override async emulateFocusedPage(enabled: boolean): Promise<void> {
+    return await this.#cdpEmulationManager.emulateFocus(enabled);
+  }
+
   override resize(_params: {
     contentWidth: number;
     contentHeight: number;

--- a/packages/puppeteer-core/src/cdp/EmulationManager.ts
+++ b/packages/puppeteer-core/src/cdp/EmulationManager.ts
@@ -66,6 +66,11 @@ interface JavascriptEnabledState {
   active: boolean;
 }
 
+interface FocusState {
+  enabled: boolean;
+  active: boolean;
+}
+
 /**
  * @internal
  */
@@ -192,6 +197,14 @@ export class EmulationManager implements ClientProvider {
     },
     this,
     this.#setJavaScriptEnabled,
+  );
+  #focusState = new EmulatedState<FocusState>(
+    {
+      enabled: true,
+      active: false,
+    },
+    this,
+    this.#emulateFocus,
   );
 
   #secondaryClients = new Set<CDPSession>();
@@ -576,6 +589,23 @@ export class EmulationManager implements ClientProvider {
     await this.#javascriptEnabledState.setState({
       active: true,
       javaScriptEnabled: enabled,
+    });
+  }
+
+  @invokeAtMostOnceForArguments
+  async #emulateFocus(client: CDPSession, state: FocusState): Promise<void> {
+    if (!state.active) {
+      return;
+    }
+    await client.send('Emulation.setFocusEmulationEnabled', {
+      enabled: state.enabled,
+    });
+  }
+
+  async emulateFocus(enabled: boolean): Promise<void> {
+    await this.#focusState.setState({
+      active: true,
+      enabled,
     });
   }
 }

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -585,6 +585,10 @@ export class CdpPage extends Page {
     );
   }
 
+  override async emulateFocusedPage(enabled: boolean): Promise<void> {
+    return await this.#emulationManager.emulateFocus(enabled);
+  }
+
   override setDefaultNavigationTimeout(timeout: number): void {
     this._timeoutSettings.setDefaultNavigationTimeout(timeout);
   }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -70,6 +70,13 @@
     "comment": "TODO: Not yet supported in Puppeteer for WebDriver BiDi"
   },
   {
+    "testIdPattern": "[emulation.spec] Emulation Page.emulateFocusedPage *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported in Firefox"
+  },
+  {
     "testIdPattern": "[extensions.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -381,6 +388,13 @@
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[emulation.spec] Emulation Page.emulateFocusedPage should reset focus",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["FAIL"],
+    "comment": "shell always emulates a focused page"
   },
   {
     "testIdPattern": "[emulation.spec] Emulation Page.emulateNetworkConditions should support offline",

--- a/test/src/emulation.spec.ts
+++ b/test/src/emulation.spec.ts
@@ -614,4 +614,50 @@ describe('Emulation', () => {
       await page.emulateCPUThrottling(null);
     });
   });
+
+  describe('Page.emulateFocusedPage', function () {
+    it('should emulate focus', async () => {
+      const {page, context} = await getTestState();
+
+      await page.emulateFocusedPage(true);
+      expect(
+        await page.evaluate(() => {
+          return document.hasFocus();
+        }),
+      ).toBe(true);
+
+      const page2 = await context.newPage();
+      // Move page into background by focusing page2.
+      await page2.bringToFront();
+
+      expect(
+        await page.evaluate(() => {
+          return document.hasFocus();
+        }),
+      ).toBe(true);
+    });
+
+    it('should reset focus', async () => {
+      const {page, context} = await getTestState();
+
+      await page.emulateFocusedPage(true);
+
+      const page2 = await context.newPage();
+      // Move page into background by focusing page2.
+      await page2.bringToFront();
+
+      expect(
+        await page.evaluate(() => {
+          return document.hasFocus();
+        }),
+      ).toBe(true);
+
+      await page.emulateFocusedPage(false);
+      expect(
+        await page.evaluate(() => {
+          return document.hasFocus();
+        }),
+      ).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
This allows emulating a focused page similar to the DevTools feature.