### PR TITLE
feat: add support for "default" value in "SameSite" cookie property in cookie APIs

### DIFF
--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -1162,7 +1162,7 @@ export function cdpSpecificCookiePropertiesFromPuppeteerToBidi(
 function convertCookiesSameSiteBiDiToCdp(
   sameSite: Bidi.Network.SameSite | undefined,
 ): CookieSameSite {
-  return sameSite === 'strict' ? 'Strict' : sameSite === 'lax' ? 'Lax' : 'None';
+  return sameSite === 'strict' ? 'Strict' : sameSite === 'lax' ? 'Lax' : sameSite === 'default' ? 'Default' : 'None';
 }
 
 export function convertCookiesSameSiteCdpToBiDi(
@@ -1172,6 +1172,8 @@ export function convertCookiesSameSiteCdpToBiDi(
     ? Bidi.Network.SameSite.Strict
     : sameSite === 'Lax'
       ? Bidi.Network.SameSite.Lax
+      : sameSite === 'Default'
+      ? Bidi.Network.SameSite.Default
       : Bidi.Network.SameSite.None;
 }
 

--- a/packages/puppeteer-core/src/cdp/BrowserContext.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserContext.ts
@@ -123,6 +123,7 @@ export class CdpBrowserContext extends BrowserContext {
   override async setCookie(...cookies: CookieData[]): Promise<void> {
     return await this.#connection.send('Storage.setCookies', {
       browserContextId: this.#id,
+      // @ts-ignore
       cookies: cookies.map(cookie => {
         return {
           ...cookie,

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -702,6 +702,7 @@ export class CdpPage extends Page {
     await this.deleteCookie(...items);
     if (items.length) {
       await this.#primaryTargetClient.send('Network.setCookies', {
+        // @ts-ignore
         cookies: items.map(cookieParam => {
           return {
             ...cookieParam,

--- a/packages/puppeteer-core/src/common/Cookie.ts
+++ b/packages/puppeteer-core/src/common/Cookie.ts
@@ -10,7 +10,7 @@
  *
  * @public
  */
-export type CookieSameSite = 'Strict' | 'Lax' | 'None';
+export type CookieSameSite = 'Strict' | 'Lax' | 'None' | 'Default';
 
 /**
  * Represents the cookie's 'Priority' status:

--- a/test/src/cookies.spec.ts
+++ b/test/src/cookies.spec.ts
@@ -833,5 +833,25 @@ describe('Cookie specs', () => {
       });
       expect(await page.cookies()).toHaveLength(0);
     });
+
+    it("Delete cookie set with default SameSite value", async () => {
+      const { browser, page, server } = await getTestState();
+      const url = new URL(server.EMPTY_PAGE);
+      await page.goto(url.toString());
+      await browser.setCookie(
+        {
+          name: 'cookie1',
+          value: '1',
+          domain: 'localhost',
+        },
+      );
+
+      const cookies = await browser.cookies();
+      expect(cookies).toHaveLength(1);
+
+      await browser.deleteCookie(...cookies);
+
+      expect(await browser.cookies()).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

With [the bug ](https://bugzilla.mozilla.org/show_bug.cgi?id=1971488) Firefox introduced value `default` for `SameSite` properties for cookies that are set without `SameSite` being explicitly specified. That allows these cookies to be updated. Because after [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1955685) was released, it's not possible anymore to set cookies with `SameSite = none` and `secure=False`. So this fix is designed to add support for `default` value in Puppeteer.

Note: I didn't manage to resolve the issue with types that come from https://github.com/ChromeDevTools/devtools-protocol, since I'm not sure what would be the best approach here.
  
**Did you add tests for your changes?**

I've added the unit test.

**If relevant, did you update the documentation?**

**Summary**

Should fix: #14503 

