### PR TITLE
test: remove coverage test

### DIFF
--- a/test/src/coverage.spec.ts
+++ b/test/src/coverage.spec.ts
@@ -148,18 +148,6 @@ describe('Coverage specs', function () {
       await page.coverage.stopJSCoverage();
     });
     describe('resetOnNavigation', function () {
-      it('should report scripts across navigations when disabled', async () => {
-        const {page, server} = await getTestState();
-
-        await page.coverage.startJSCoverage({resetOnNavigation: false});
-        await page.goto(server.PREFIX + '/jscoverage/multiple.html');
-        // TODO: navigating too fast might loose JS coverage data in the browser.
-        await page.waitForNetworkIdle();
-        await page.goto(server.EMPTY_PAGE);
-        const coverage = await page.coverage.stopJSCoverage();
-        expect(coverage).toHaveLength(2);
-      });
-
       it('should NOT report scripts across navigations when enabled', async () => {
         const {page, server} = await getTestState();
 


### PR DESCRIPTION
With RenderDocument navigations coverage is not retained anyway so it is not possible to implement resetOnNavigation: false as the data is always reset (the default value). This PR deletes the test to unblock rollout of RenderDocument.

Closes crbug.com/444371566