### PR TITLE
test: add a keep alive fetch interception test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -789,6 +789,20 @@
     "comment": "https://github.com/w3c/webdriver-bidi/issues/508"
   },
   {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with keep alive redirects",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome"],
+    "expectations": ["FAIL"],
+    "comment": "crbug.com/469591372"
+  },
+  {
+    "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with keep alive redirects",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "Missing events for keep alive requests?"
+  },
+  {
     "testIdPattern": "[requestinterception.spec] request interception Page.setRequestInterception should work with worker",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],


### PR DESCRIPTION
Adds a test for keep alive requests.

Refs: https://github.com/puppeteer/puppeteer/issues/14515