### PR TITLE
fix(firefox): set preference dismiss_file_pickers to true

### DIFF
--- a/packages/browsers/src/browser-data/firefox.ts
+++ b/packages/browsers/src/browser-data/firefox.ts
@@ -383,6 +383,10 @@ function defaultProfilePreferences(
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1710839
     'remote.enabled': true,
 
+    // Until Bug 1999693 is resolved, this preference needs to be set to allow
+    // Webdriver BiDi to automatically dismiss file pickers.
+    'remote.bidi.dismiss_file_pickers.enabled': true,
+
     // Disabled screenshots component
     'screenshots.browser.component.enabled': false,
 


### PR DESCRIPTION
After https://bugzilla.mozilla.org/show_bug.cgi?id=2005673 we changed the behavior of WebDriver BiDi to only dismiss file dialogs if the preference remote.bidi.dismiss_file_pickers.enabled is set to true, because in some cases (manual tests), users still want to interact with file dialogs.

Ultimately this preference should become irrelevant when https://bugzilla.mozilla.org/show_bug.cgi?id=1999693 is resolved and we support the "ignore" value for the file dialogs via the unhandledPromptBehavior capability. Until then, this preference should be set in order to avoid showing file dialogs during automated tests.