### PR TITLE
chore: add internal _tabId to page

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -704,6 +704,15 @@ export abstract class Page extends EventEmitter<PageEvents> {
    */
   _timeoutSettings = new TimeoutSettings();
 
+  /**
+   * Internal API to get an implementation-specific identifier
+   * for the tab. In Chrome, it is a tab target id. If unknown,
+   * returns an empty string.
+   *
+   * @internal
+   */
+  _tabId = '';
+
   #requestHandlers = new WeakMap<Handler<HTTPRequest>, Handler<HTTPRequest>>();
 
   #inflight$ = new ReplaySubject<number>(1);

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -151,6 +151,7 @@ export class CdpPage extends Page {
     assert(this.#tabTargetClient, 'Tab target session is not defined.');
     this.#tabTarget = (this.#tabTargetClient as CdpCDPSession).target();
     assert(this.#tabTarget, 'Tab target is not defined.');
+    this._tabId = this.#tabTarget._getTargetInfo().targetId;
     this.#primaryTarget = target;
     this.#targetManager = target._targetManager();
     this.#keyboard = new CdpKeyboard(client);

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -844,6 +844,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[target.spec] Target page should return tab target id",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not implemented for WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[target.spec] Target should close a service worker",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -40,6 +40,12 @@ describe('Target', function () {
     expect(allPages).toHaveLength(1);
     expect(allPages).toContain(page);
   });
+
+  it('page should return tab target id', async () => {
+    const {page} = await getTestState();
+    expect(page._tabId.length).toBeGreaterThan(0);
+  });
+
   it('should contain browser target', async () => {
     const {browser} = await getTestState();
 


### PR DESCRIPTION
this is useful for locating the tab target via a parallel CDP connection. The API is internal for now to experiment and test.