### PR TITLE
chore: expose originating targetId on ConsoleMessage

### DIFF
--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -200,6 +200,7 @@ export class BidiFrame extends Frame {
             args,
             getStackTraceLocations(entry.stackTrace),
             this,
+            undefined,
           ),
         );
       } else if (isJavaScriptLogEntry(entry)) {

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -14,16 +14,14 @@ import {debugError} from '../common/util.js';
 
 import {ExecutionContext} from './ExecutionContext.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
-import {CdpJSHandle} from './JSHandle.js';
 import type {NetworkManager} from './NetworkManager.js';
 
 /**
  * @internal
  */
 export type ConsoleAPICalledCallback = (
-  eventType: string,
-  handles: CdpJSHandle[],
-  trace?: Protocol.Runtime.StackTrace,
+  world: IsolatedWorld,
+  event: Protocol.Runtime.ConsoleAPICalledEvent,
 ) => void;
 
 /**
@@ -64,13 +62,7 @@ export class CdpWebWorker extends WebWorker {
     });
     this.#world.emitter.on('consoleapicalled', async event => {
       try {
-        return consoleAPICalled(
-          event.type,
-          event.args.map((object: Protocol.Runtime.RemoteObject) => {
-            return new CdpJSHandle(this.#world, object);
-          }),
-          event.stackTrace,
-        );
+        return consoleAPICalled(this.#world, event);
       } catch (err) {
         debugError(err);
       }

--- a/packages/puppeteer-core/src/common/ConsoleMessage.ts
+++ b/packages/puppeteer-core/src/common/ConsoleMessage.ts
@@ -65,6 +65,7 @@ export class ConsoleMessage {
   #stackTraceLocations: ConsoleMessageLocation[];
   #frame?: Frame;
   #rawStackTrace?: Protocol.Runtime.StackTrace;
+  #targetId?: string;
 
   /**
    * @internal
@@ -76,6 +77,7 @@ export class ConsoleMessage {
     stackTraceLocations: ConsoleMessageLocation[],
     frame?: Frame,
     rawStackTrace?: Protocol.Runtime.StackTrace,
+    targetId?: string,
   ) {
     this.#type = type;
     this.#text = text;
@@ -83,6 +85,7 @@ export class ConsoleMessage {
     this.#stackTraceLocations = stackTraceLocations;
     this.#frame = frame;
     this.#rawStackTrace = rawStackTrace;
+    this.#targetId = targetId;
   }
 
   /**
@@ -130,5 +133,14 @@ export class ConsoleMessage {
    */
   _rawStackTrace(): Protocol.Runtime.StackTrace | undefined {
     return this.#rawStackTrace;
+  }
+
+  /**
+   * The targetId from which this console message originated.
+   *
+   * @internal
+   */
+  _targetId(): string | undefined {
+    return this.#targetId;
   }
 }


### PR DESCRIPTION
Drive-by refactoring: We combine `#onConsoleAPI` and `#addConsoleMessage` in the `Page` into a single message. This makes the `WebWorker` a bit easier.