### PR TITLE
test: increase protocol timeout in waittask test

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1782,13 +1782,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[waittask.spec] waittask specs protocol timeout *",
-    "platforms": ["darwin"],
-    "parameters": ["firefox", "headful", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "session.new before the test consistently times out on mac + headful since 147"
-  },
-  {
     "testIdPattern": "[worker.spec] Workers can be closed",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],

--- a/test/src/waittask.spec.ts
+++ b/test/src/waittask.spec.ts
@@ -931,7 +931,7 @@ describe('waittask specs', function () {
 
   describe('protocol timeout', () => {
     const state = setupSeparateTestBrowserHooks({
-      protocolTimeout: 3000,
+      protocolTimeout: 4000,
     });
 
     it('should error if underyling protocol command times out with raf polling', async () => {


### PR DESCRIPTION
Locally I can see that BiDi in general is slower to connect than CDP. This plus the fact that the mac workers for github actions are known to be quite slow I strongly suspect the frequent intermittent is only due to a minor slowdown of the browser startup session creation, and should rather be addressed in the test.