### PR TITLE
chore: fix sameParty attribute that is removed fron Chrome Canary

### DIFF
--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -1166,6 +1166,10 @@ function cdpSpecificCookiePropertiesFromBidiToPuppeteer(
       result[property] = bidiCookie[CDP_SPECIFIC_PREFIX + property];
     }
   }
+  // TODO: remove once deprecated sameParty attribute is dropped.
+  if (!result.sameParty) {
+    result.sameParty = false;
+  }
   return result;
 }
 

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -650,6 +650,8 @@ export class CdpPage extends Page {
         partitionKey: cookie.partitionKey
           ? cookie.partitionKey.topLevelSite
           : undefined,
+        // TODO: remove sameParty as it is removed from Chrome.
+        sameParty: cookie.sameParty ?? false,
       };
     });
   }


### PR DESCRIPTION
To unblock Canary jobs.