### PR TITLE
chore(docker): update base image to Node.js 24

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:22@sha256:8739e532180cfe09e03bbb4545fc725b044c921280532d7c9c1480ba2396837e
-
+FROM node:24-bookworm@sha256:b2b2184ba9b78c022e1d6a7924ec6fba577adf28f15c9d9c457730cc4ad3807a
 # Configure default locale (important for chrome-headless-shell).
 ENV LANG=en_US.UTF-8 
 # UID of the non-root user 'pptruser'


### PR DESCRIPTION
### Summary

Updates the Docker base image to Node.js 24 (Debian bookworm), pinned by digest.

This aligns the Docker environment with the latest Node.js release and follows existing Puppeteer Docker image conventions.

### Details

- Switched base image to `node:24-bookworm`
- Image is pinned by SHA256 digest for reproducibility
- No application code or dependency changes included
- No lockfile changes

### Related
- puppeteer/puppeteer#14539
