### PR TITLE
fix: typo in the config path in getConfigHomeLinux

### DIFF
--- a/packages/browsers/src/browser-data/chrome.ts
+++ b/packages/browsers/src/browser-data/chrome.ts
@@ -397,7 +397,7 @@ function getConfigHomeLinux() {
   return (
     process.env['CHROME_CONFIG_HOME'] ||
     process.env['XDG_CONFIG_HOME'] ||
-    path.join(os.homedir(), 'config')
+    path.join(os.homedir(), '.config')
   );
 }
 

--- a/packages/browsers/test/src/chrome/chrome-data.spec.ts
+++ b/packages/browsers/test/src/chrome/chrome-data.spec.ts
@@ -348,7 +348,7 @@ describe('Chrome', () => {
             BrowserPlatform.LINUX,
             ChromeReleaseChannel.CANARY,
           ),
-          path.join(os.homedir(), 'config', 'google-chrome-canary'),
+          path.join(os.homedir(), '.config', 'google-chrome-canary'),
         );
       });
 
@@ -358,7 +358,7 @@ describe('Chrome', () => {
             BrowserPlatform.LINUX_ARM,
             ChromeReleaseChannel.DEV,
           ),
-          path.join(os.homedir(), 'config', 'google-chrome-unstable'),
+          path.join(os.homedir(), '.config', 'google-chrome-unstable'),
         );
       });
 
@@ -368,7 +368,7 @@ describe('Chrome', () => {
             BrowserPlatform.LINUX,
             ChromeReleaseChannel.STABLE,
           ),
-          path.join(os.homedir(), 'config', 'google-chrome'),
+          path.join(os.homedir(), '.config', 'google-chrome'),
         );
       });
     });


### PR DESCRIPTION
Closes https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/818