### PR TITLE
feat(page): expose heap snapshot getter

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1017,6 +1017,15 @@ Device in a request prompt.
 </td></tr>
 <tr><td>
 
+<span id="heapsnapshotoptions">[HeapSnapshotOptions](./puppeteer.heapsnapshotoptions.md)</span>
+
+</td><td>
+
+Options for [Page.captureHeapSnapshot()](./puppeteer.page.captureheapsnapshot.md).
+
+</td></tr>
+<tr><td>
+
 <span id="interceptresolutionstate">[InterceptResolutionState](./puppeteer.interceptresolutionstate.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.heapsnapshotoptions.md
+++ b/docs/api/puppeteer.heapsnapshotoptions.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: HeapSnapshotOptions
+---
+
+# HeapSnapshotOptions interface
+
+Options for [Page.captureHeapSnapshot()](./puppeteer.page.captureheapsnapshot.md).
+
+### Signature
+
+```typescript
+export interface HeapSnapshotOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="path">path</span>
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+The file path to save the heap snapshot to.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.page.captureheapsnapshot.md
+++ b/docs/api/puppeteer.page.captureheapsnapshot.md
@@ -1,0 +1,49 @@
+---
+sidebar_label: Page.captureHeapSnapshot
+---
+
+# Page.captureHeapSnapshot() method
+
+Captures a snapshot of the JavaScript heap and writes it to a file.
+
+### Signature
+
+```typescript
+class Page {
+  abstract captureHeapSnapshot(options?: {path?: string}): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+&#123; path?: string; &#125;
+
+</td><td>
+
+_(Optional)_ Options for capturing the heap snapshot.
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.page.captureheapsnapshot.md
+++ b/docs/api/puppeteer.page.captureheapsnapshot.md
@@ -10,7 +10,7 @@ Captures a snapshot of the JavaScript heap and writes it to a file.
 
 ```typescript
 class Page {
-  abstract captureHeapSnapshot(options?: {path?: string}): Promise<void>;
+  abstract captureHeapSnapshot(options: HeapSnapshotOptions): Promise<void>;
 }
 ```
 
@@ -35,11 +35,9 @@ options
 
 </td><td>
 
-&#123; path?: string; &#125;
+[HeapSnapshotOptions](./puppeteer.heapsnapshotoptions.md)
 
 </td><td>
-
-_(Optional)_ Options for capturing the heap snapshot.
 
 </td></tr>
 </tbody></table>

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -409,6 +409,17 @@ Get the browser context that the page belongs to.
 </td></tr>
 <tr><td>
 
+<span id="captureheapsnapshot">[captureHeapSnapshot(options)](./puppeteer.page.captureheapsnapshot.md)</span>
+
+</td><td>
+
+</td><td>
+
+Captures a snapshot of the JavaScript heap and writes it to a file.
+
+</td></tr>
+<tr><td>
+
 <span id="click">[click(selector, options)](./puppeteer.page.click.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1722,6 +1722,18 @@ export abstract class Page extends EventEmitter<PageEvents> {
   abstract metrics(): Promise<Metrics>;
 
   /**
+   * Captures a snapshot of the JavaScript heap and writes it to a file.
+   *
+   * @param options - Options for capturing the heap snapshot.
+   */
+  abstract captureHeapSnapshot(options?: {
+    /**
+     * The file path to save the heap snapshot to.
+     */
+    path?: string;
+  }): Promise<void>;
+
+  /**
    * The page's URL.
    *
    * @remarks

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -648,6 +648,18 @@ export interface ReloadOptions extends WaitForOptions {
 }
 
 /**
+ * Options for {@link Page.captureHeapSnapshot}.
+ *
+ * @public
+ */
+export interface HeapSnapshotOptions {
+  /**
+   * The file path to save the heap snapshot to.
+   */
+  path: string;
+}
+
+/**
  * Page provides methods to interact with a single tab or
  * {@link https://developer.chrome.com/extensions/background_pages | extension background page}
  * in the browser.
@@ -1723,15 +1735,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
 
   /**
    * Captures a snapshot of the JavaScript heap and writes it to a file.
-   *
-   * @param options - Options for capturing the heap snapshot.
    */
-  abstract captureHeapSnapshot(options?: {
-    /**
-     * The file path to save the heap snapshot to.
-     */
-    path?: string;
-  }): Promise<void>;
+  abstract captureHeapSnapshot(options: HeapSnapshotOptions): Promise<void>;
 
   /**
    * The page's URL.

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -18,6 +18,7 @@ import type {HTTPResponse} from '../api/HTTPResponse.js';
 import type {
   Credentials,
   GeolocationOptions,
+  HeapSnapshotOptions,
   MediaFeature,
   PageEvents,
   ReloadOptions,
@@ -953,9 +954,7 @@ export class BidiPage extends Page {
   }
 
   override async captureHeapSnapshot(
-    _options: {
-      path?: string;
-    } = {},
+    _options: HeapSnapshotOptions,
   ): Promise<void> {
     throw new UnsupportedOperation();
   }

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -952,6 +952,14 @@ export class BidiPage extends Page {
     throw new UnsupportedOperation();
   }
 
+  override async captureHeapSnapshot(
+    _options: {
+      path?: string;
+    } = {},
+  ): Promise<void> {
+    throw new UnsupportedOperation();
+  }
+
   override async goBack(
     options: WaitForOptions = {},
   ): Promise<HTTPResponse | null> {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -446,6 +446,13 @@
     "comment": "https://github.com/w3c/webdriver-bidi/issues/794"
   },
   {
+    "testIdPattern": "[heap_snapshot.spec] Heap Snapshot should capture heap snapshot",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported in WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[idle_override.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -98,6 +98,13 @@
     "comment": "Spawns headful browser, needs display or `xvfb` like which is not required for other headless tests"
   },
   {
+    "testIdPattern": "[heapSnapshot.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported in WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[interventionHeaders.spec] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
@@ -444,13 +451,6 @@
     "parameters": ["webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "https://github.com/w3c/webdriver-bidi/issues/794"
-  },
-  {
-    "testIdPattern": "[heap_snapshot.spec] Heap Snapshot should capture heap snapshot",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Not supported in WebDriver BiDi"
   },
   {
     "testIdPattern": "[idle_override.spec] *",

--- a/test/src/cdp/heapSnapshot.spec.ts
+++ b/test/src/cdp/heapSnapshot.spec.ts
@@ -3,22 +3,32 @@
  * Copyright 2026 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import fs from 'node:fs';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
 import path from 'node:path';
 
 import expect from 'expect';
 
-import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+import {getTestState, setupTestBrowserHooks} from '../mocha-utils.js';
 
 describe('Heap Snapshot', function () {
   setupTestBrowserHooks();
 
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'heap-snapshot-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, {recursive: true, force: true});
+  });
+
   it('should capture heap snapshot', async () => {
     const {page} = await getTestState();
-    const filePath = path.join(
-      import.meta.dirname,
-      '../assets/heap.heapsnapshot',
-    );
+    const filePath = path.join(tempDir, 'heap.heapsnapshot');
 
     await page.captureHeapSnapshot({path: filePath});
 
@@ -28,7 +38,5 @@ describe('Heap Snapshot', function () {
     expect(snapshot.snapshot).toBeDefined();
     expect(snapshot.nodes).toBeDefined();
     expect(snapshot.edges).toBeDefined();
-
-    fs.unlinkSync(filePath);
   });
 });

--- a/test/src/heap_snapshot.spec.ts
+++ b/test/src/heap_snapshot.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import expect from 'expect';
+
+import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+
+describe('Heap Snapshot', function () {
+  setupTestBrowserHooks();
+
+  it('should capture heap snapshot', async () => {
+    const {page} = await getTestState();
+    const filePath = path.join(
+      import.meta.dirname,
+      '../assets/heap.heapsnapshot',
+    );
+
+    await page.captureHeapSnapshot({path: filePath});
+
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf8');
+    const snapshot = JSON.parse(content);
+    expect(snapshot.snapshot).toBeDefined();
+    expect(snapshot.nodes).toBeDefined();
+    expect(snapshot.edges).toBeDefined();
+
+    fs.unlinkSync(filePath);
+  });
+});

--- a/test/src/heap_snapshot.spec.ts
+++ b/test/src/heap_snapshot.spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 Google Inc.
+ * Copyright 2026 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 import fs from 'node:fs';


### PR DESCRIPTION
This PR implements `page.captureHeapSnapshot` as requested in issue #14609.

Changes:
- Added `captureHeapSnapshot` to the abstract `Page` class.
- Implemented `captureHeapSnapshot` in `CdpPage` using the `HeapProfiler` domain.
- Implemented `captureHeapSnapshot` in `BidiPage` (throwing `UnsupportedOperation` as it's not supported yet).
- Added a unit test `test/src/heap_snapshot.spec.ts` to verify the functionality.
- Added an entry to `test/TestExpectations.json` to mark the test as an expected failure for WebDriver BiDi.

The implementation streams the heap snapshot chunks directly to a file stream, ensuring memory efficiency for large snapshots. Error handling is included to manage stream errors during the process.

Closes https://github.com/puppeteer/puppeteer/issues/14609

---
*PR created automatically by Jules for task [1733071219125486670](https://jules.google.com/task/1733071219125486670) started by @OrKoN*