### PR TITLE
feat(webdriver): Implement window management

### DIFF
--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -25,8 +25,7 @@ import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
 import type {Connection as CdpConnection} from '../cdp/Connection.js';
 import type {SupportedWebDriverCapabilities} from '../common/ConnectOptions.js';
-import {ProtocolError} from '../common/Errors.js';
-import {UnsupportedOperation} from '../common/Errors.js';
+import {ProtocolError, UnsupportedOperation} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {debugError} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
@@ -306,15 +305,48 @@ export class BidiBrowser extends Browser {
     throw new UnsupportedOperation();
   }
 
-  override getWindowBounds(_windowId: WindowId): Promise<WindowBounds> {
-    throw new UnsupportedOperation();
+  override async getWindowBounds(windowId: WindowId): Promise<WindowBounds> {
+    const clientWindowInfo =
+      await this.#browserCore.getClientWindowInfo(windowId);
+    return {
+      left: clientWindowInfo.x,
+      top: clientWindowInfo.y,
+      width: clientWindowInfo.width,
+      height: clientWindowInfo.height,
+      windowState: clientWindowInfo.state,
+    };
   }
 
-  override setWindowBounds(
-    _windowId: WindowId,
-    _windowBounds: WindowBounds,
+  override async setWindowBounds(
+    windowId: WindowId,
+    windowBounds: WindowBounds,
   ): Promise<void> {
-    throw new UnsupportedOperation();
+    let params: Bidi.Browser.SetClientWindowStateParameters | undefined;
+    const windowState = windowBounds.windowState ?? 'normal';
+    if (windowState === 'normal') {
+      params = {
+        clientWindow: windowId,
+        state: 'normal',
+        ...windowBounds,
+      };
+    } else {
+      if (
+        windowBounds.height !== undefined ||
+        windowBounds.width !== undefined ||
+        windowBounds.left !== undefined ||
+        windowBounds.top !== undefined
+      ) {
+        throw new ProtocolError(
+          'Window size and position are not supported for non-normal window states',
+        );
+      }
+      params = {
+        clientWindow: windowId,
+        state: windowState,
+      };
+    }
+
+    await this.#browserCore.setClientWindowState(params);
   }
 
   override targets(): Target[] {

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -330,16 +330,6 @@ export class BidiBrowser extends Browser {
         ...windowBounds,
       };
     } else {
-      if (
-        windowBounds.height !== undefined ||
-        windowBounds.width !== undefined ||
-        windowBounds.left !== undefined ||
-        windowBounds.top !== undefined
-      ) {
-        throw new ProtocolError(
-          'Window size and position are not supported for non-normal window states',
-        );
-      }
       params = {
         clientWindow: windowId,
         state: windowState,

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -209,6 +209,16 @@ export class BidiBrowserContext extends BrowserContext {
         // No support for setViewport in Firefox.
       }
     }
+    if (options?.type === 'window' && options?.windowBounds !== undefined) {
+      try {
+        await this.browser().setWindowBounds(
+          context.windowId,
+          options.windowBounds,
+        );
+      } catch {
+        // Tolerate not supporting `browser.setClientWindowState`.
+      }
+    }
 
     return page;
   }

--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -205,8 +205,9 @@ export class BidiBrowserContext extends BrowserContext {
     if (this.#defaultViewport) {
       try {
         await page.setViewport(this.#defaultViewport);
-      } catch {
-        // No support for setViewport in Firefox.
+      } catch (error) {
+        // Tolerate not supporting `browsingContext.setViewport`. Only log it.
+        debugError(error);
       }
     }
     if (options?.type === 'window' && options?.windowBounds !== undefined) {
@@ -215,8 +216,9 @@ export class BidiBrowserContext extends BrowserContext {
           context.windowId,
           options.windowBounds,
         );
-      } catch {
-        // Tolerate not supporting `browser.setClientWindowState`.
+      } catch (error) {
+        // Tolerate not supporting `browser.setClientWindowState`. Only log it.
+        debugError(error);
       }
     }
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -228,8 +228,8 @@ export class BidiPage extends Page {
     throw new UnsupportedOperation();
   }
 
-  override windowId(): Promise<WindowId> {
-    throw new UnsupportedOperation();
+  override async windowId(): Promise<WindowId> {
+    return this.#frame.browsingContext.windowId;
   }
 
   override openDevTools(): Promise<Page> {

--- a/packages/puppeteer-core/src/bidi/core/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/core/Browser.ts
@@ -286,6 +286,36 @@ export class Browser extends EventEmitter<{
     await this.session.send('webExtension.uninstall', {extension: id});
   }
 
+  @throwIfDisposed<Browser>(browser => {
+    // SAFETY: By definition of `disposed`, `#reason` is defined.
+    return browser.#reason!;
+  })
+  async setClientWindowState(
+    params: Bidi.Browser.SetClientWindowStateParameters,
+  ): Promise<void> {
+    await this.session.send('browser.setClientWindowState', params);
+  }
+
+  @throwIfDisposed<Browser>(browser => {
+    // SAFETY: By definition of `disposed`, `#reason` is defined.
+    return browser.#reason!;
+  })
+  async getClientWindowInfo(
+    windowId: string,
+  ): Promise<Bidi.Browser.ClientWindowInfo> {
+    const {
+      result: {clientWindows},
+    } = await this.session.send('browser.getClientWindows', {});
+
+    const window = clientWindows.find(window => {
+      return window.clientWindow === windowId;
+    });
+    if (!window) {
+      throw new Error('Window not found');
+    }
+    return window;
+  }
+
   override [disposeSymbol](): void {
     this.#reason ??=
       'Browser was disconnected, probably because the session ended.';

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -140,6 +140,7 @@ export class BrowsingContext extends EventEmitter<{
     id: string,
     url: string,
     originalOpener: string | null,
+    clientWindow: string,
   ): BrowsingContext {
     const browsingContext = new BrowsingContext(
       userContext,
@@ -147,6 +148,7 @@ export class BrowsingContext extends EventEmitter<{
       id,
       url,
       originalOpener,
+      clientWindow,
     );
     browsingContext.#initialize();
     return browsingContext;
@@ -166,6 +168,7 @@ export class BrowsingContext extends EventEmitter<{
   readonly parent: BrowsingContext | undefined;
   readonly userContext: UserContext;
   readonly originalOpener: string | null;
+  readonly windowId: string;
   readonly #emulationState: {
     javaScriptEnabled: boolean;
   } = {javaScriptEnabled: true};
@@ -178,6 +181,7 @@ export class BrowsingContext extends EventEmitter<{
     id: string,
     url: string,
     originalOpener: string | null,
+    clientWindow: string,
   ) {
     super();
 
@@ -186,6 +190,7 @@ export class BrowsingContext extends EventEmitter<{
     this.parent = parent;
     this.userContext = userContext;
     this.originalOpener = originalOpener;
+    this.windowId = clientWindow;
 
     this.defaultRealm = this.#createWindowRealm();
     this.#bluetoothEmulation = new BidiBluetoothEmulation(
@@ -226,6 +231,7 @@ export class BrowsingContext extends EventEmitter<{
         info.context,
         info.url,
         info.originalOpener,
+        info.clientWindow,
       );
       this.#children.set(info.context, browsingContext);
 

--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -96,6 +96,7 @@ export class UserContext extends EventEmitter<{
         info.context,
         info.url,
         info.originalOpener,
+        info.clientWindow,
       );
       this.#browsingContexts.set(browsingContext.id, browsingContext);
 

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -665,7 +665,7 @@
   {
     "testIdPattern": "[page.spec] Page Page.newPage should open pages in a new window at the specified position",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["firefox"],
     "expectations": ["FAIL"],
     "comment": "Not supported by WebDriver BiDi"
   },
@@ -679,7 +679,7 @@
   {
     "testIdPattern": "[page.spec] Page Page.newPage should open pages in a new window in maximized state",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["webDriverBiDi"],
+    "parameters": ["firefox"],
     "expectations": ["FAIL"],
     "comment": "Not supported by WebDriver BiDi"
   },


### PR DESCRIPTION
Use `browser.setClientWindowState`, `browser.getClientWindows` and rely on `clientWindow`.

Out of scope: update page's `windowId` when the page changes window.