### PR TITLE
fix: disable ReadAnythingOmniboxChip by default

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -178,6 +178,8 @@ export class ChromeLauncher extends BrowserLauncher {
       'MediaRouter',
       'OptimizationHints',
       'RenderDocument', // https://crbug.com/444150315
+      'IPH_ReadingModePageActionLabel', // b/479237585
+      'ReadAnythingOmniboxChip', // b/479237585
       ...(turnOnExperimentalFeaturesForTesting
         ? []
         : [


### PR DESCRIPTION
It affects JS coverage due to Chrome executing scripts on the page to determine readability.