### PR TITLE
test: fix test "Page.waitForNetworkIdle should work with delayed response" to wait for 400ms or greater

### DIFF
--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -1121,7 +1121,7 @@ describe('Page', function () {
       ]);
       expect(t1).toBeGreaterThan(t2);
       // request finished + idle time.
-      expect(t1 - t0).toBeGreaterThan(400);
+      expect(t1 - t0).toBeGreaterThanOrEqual(400);
       // request finished + idle time - request finished.
       expect(t1 - t2).toBeGreaterThanOrEqual(100);
     });


### PR DESCRIPTION
Seen in our own CI when running Puppeteer tests which seem to have faster machines as on GitHub: https://bugzilla.mozilla.org/show_bug.cgi?id=2011113#c5

@OrKoN as we discussed here is the PR. Thanks