### PR TITLE
Merge duplicate response headers with comma-space

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -100,8 +100,23 @@ export class BidiHTTPResponse extends HTTPResponse {
       // TODO: How to handle Binary Headers
       // https://w3c.github.io/webdriver-bidi/#type-network-Header
       if (header.value.type === 'string') {
-        headers[header.name.toLowerCase()] = header.value.value;
+        const name = header.name.toLowerCase();
+        if (name in headers) {
+          if (name === 'set-cookie') {
+            headers[name] += '\n' + header.value.value;
+          } else {
+            headers[name] += ', ' + header.value.value;
+          }
+        } else {
+          headers[name] = header.value.value;
+        }
       }
+    }
+    for (const [name, value] of Object.entries(headers)) {
+      if (name === 'set-cookie') {
+        continue;
+      }
+      headers[name] = value.replaceAll('\n', ', ');
     }
     return headers;
   }

--- a/packages/puppeteer-core/src/cdp/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPResponse.ts
@@ -51,7 +51,12 @@ export class CdpHTTPResponse extends HTTPResponse {
     this.#status = extraInfo ? extraInfo.statusCode : responsePayload.status;
     const headers = extraInfo ? extraInfo.headers : responsePayload.headers;
     for (const [key, value] of Object.entries(headers)) {
-      this.#headers[key.toLowerCase()] = value;
+      const lowerName = key.toLowerCase();
+      if (lowerName === 'set-cookie') {
+        this.#headers[lowerName] = value;
+      } else {
+        this.#headers[lowerName] = value.replaceAll('\n', ', ');
+      }
     }
 
     this.#securityDetails = responsePayload.securityDetails

--- a/test/src/network.spec.ts
+++ b/test/src/network.spec.ts
@@ -177,6 +177,28 @@ describe('network', function () {
       const response = (await page.goto(server.EMPTY_PAGE))!;
       expect(response.headers()['foo']).toBe('bar');
     });
+
+    it('should merge duplicate headers with comma-space', async () => {
+      const {page, server} = await getTestState();
+
+      server.setRoute('/empty.html', (_req, res) => {
+        res.setHeader('X-Duplicate', ['value1', 'value2']);
+        res.end();
+      });
+      const response = (await page.goto(server.EMPTY_PAGE))!;
+      expect(response.headers()['x-duplicate']).toBe('value1, value2');
+    });
+
+    it('should merge set-cookie headers with newline', async () => {
+      const {page, server} = await getTestState();
+
+      server.setRoute('/empty.html', (_req, res) => {
+        res.setHeader('Set-Cookie', ['a=b', 'c=d']);
+        res.end();
+      });
+      const response = (await page.goto(server.EMPTY_PAGE))!;
+      expect(response.headers()['set-cookie']).toBe('a=b\nc=d');
+    });
   });
 
   describe('Request.initiator', () => {


### PR DESCRIPTION
Merged duplicate response headers with comma-space instead of newlines, except for 'Set-Cookie' which continues to use newlines. This applies to both CDP and BiDi implementations of HTTPResponse. Added unit tests to verify the behavior.

---
*PR created automatically by Jules for task [3663487473595240133](https://jules.google.com/task/3663487473595240133) started by @OrKoN*