### PR TITLE
Test previously skipped tests (mouse, geolocation) for Firefox

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -537,13 +537,6 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[mouse.spec] Mouse should select the text with mouse",
-    "platforms": ["win32"],
-    "parameters": ["firefox"],
-    "expectations": ["SKIP"],
-    "comment": "Suddenly started being flaky on Windows"
-  },
-  {
     "testIdPattern": "[navigation.spec] navigation Page.goto should send referer",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -710,13 +703,6 @@
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[page.spec] Page Page.setGeolocation should work",
-    "platforms": ["win32"],
-    "parameters": ["firefox"],
-    "expectations": ["SKIP"],
-    "comment": "Suddenly started being flaky on Windows"
   },
   {
     "testIdPattern": "[page.spec] Page Page.setJavaScriptEnabled setInterval should pause",

--- a/test/src/mouse.spec.ts
+++ b/test/src/mouse.spec.ts
@@ -84,7 +84,7 @@ describe('Mouse', function () {
     expect(newDimensions.width).toBe(Math.round(width + 104));
     expect(newDimensions.height).toBe(Math.round(height + 104));
   });
-  it('should select the text with mouse', async () => {
+  it.only('should select the text with mouse', async () => {
     const {page, server} = await getTestState();
 
     const text =

--- a/test/src/page.spec.ts
+++ b/test/src/page.spec.ts
@@ -424,7 +424,7 @@ describe('Page', function () {
   });
 
   describe('Page.setGeolocation', function () {
-    it('should work', async () => {
+    it.only('should work', async () => {
       const {page, server, context} = await getTestState();
 
       await context.overridePermissions(server.PREFIX, ['geolocation']);


### PR DESCRIPTION
Follow-up from https://github.com/puppeteer/puppeteer/pull/14186. Lets see if those tests are still failing and if yes why it happens.