### PR TITLE
test: refactor keyboard modifier tests for clarity

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1180,7 +1180,7 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
-    "testIdPattern": "[keyboard.spec] Keyboard should report shiftKey",
+    "testIdPattern": "[keyboard.spec] Keyboard should report modifiers",
     "platforms": ["darwin"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],


### PR DESCRIPTION
Improved the clarity of keyboard modifier tests by renaming 'should report shiftKey' to 'should report modifiers' and unrolling the loop into explicit cases for Shift, Alt, and Control. Added comments to document the desired behavior where Puppeteer suppresses input events for Alt and Control modifiers to ensure consistent results across different operating systems. Resolved an unused import and fixed ESLint line length issues.

Closes https://github.com/puppeteer/puppeteer/issues/11599

---
*PR created automatically by Jules for task [7853427696639347935](https://jules.google.com/task/7853427696639347935) started by @OrKoN*