### PR TITLE
refactor: Migrate from postData to postDataEntries in CDP HTTPRequest

### DIFF
--- a/packages/puppeteer-core/src/cdp/HTTPRequest.test.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import type {CDPSession} from '../api/CDPSession.js';
+import type {Frame} from '../api/Frame.js';
+
+import {CdpHTTPRequest} from './HTTPRequest.js';
+
+describe('CdpHTTPRequest', () => {
+  it('should reconstruct postData from postDataEntries', () => {
+    const client = {} as CDPSession;
+    const frame = {} as Frame;
+    const request = new CdpHTTPRequest(
+      client,
+      frame,
+      'interceptionId',
+      true,
+      {
+        requestId: 'requestId',
+        request: {
+          url: 'http://example.com',
+          method: 'POST',
+          headers: {},
+          postDataEntries: [
+            {bytes: btoa('part1')},
+            {bytes: btoa('part2')},
+          ],
+        } as any,
+      } as any,
+      [],
+    );
+    expect(request.postData()).toBe('part1part2');
+  });
+
+  it('should fallback to postData if postDataEntries is missing', () => {
+    const client = {} as CDPSession;
+    const frame = {} as Frame;
+    const request = new CdpHTTPRequest(
+      client,
+      frame,
+      'interceptionId',
+      true,
+      {
+        requestId: 'requestId',
+        request: {
+          url: 'http://example.com',
+          method: 'POST',
+          headers: {},
+          postData: 'originalData',
+        } as any,
+      } as any,
+      [],
+    );
+    expect(request.postData()).toBe('originalData');
+  });
+});

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.test.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.test.ts
@@ -27,10 +27,7 @@ describe('CdpHTTPRequest', () => {
           url: 'http://example.com',
           method: 'POST',
           headers: {},
-          postDataEntries: [
-            {bytes: btoa('part1')},
-            {bytes: btoa('part2')},
-          ],
+          postDataEntries: [{bytes: btoa('part1')}, {bytes: btoa('part2')}],
         } as any,
       } as any,
       [],

--- a/packages/puppeteer-core/src/cdp/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/cdp/HTTPRequest.ts
@@ -92,7 +92,10 @@ export class CdpHTTPRequest extends HTTPRequest {
     this.#url = data.request.url + (data.request.urlFragment ?? '');
     this.#resourceType = (data.type || 'other').toLowerCase() as ResourceType;
     this.#method = data.request.method;
-    if (data.request.postDataEntries && data.request.postDataEntries.length > 0) {
+    if (
+      data.request.postDataEntries &&
+      data.request.postDataEntries.length > 0
+    ) {
       this.#postData = '';
       for (const entry of data.request.postDataEntries) {
         if (entry.bytes) {


### PR DESCRIPTION
Migrated from postData to postDataEntries in CdpHTTPRequest to handle deprecated protocol field. Reconstructs postData from entries and maintains fallback. Added unit tests to verify the logic.

Closes https://github.com/puppeteer/puppeteer/issues/12137

---
*PR created automatically by Jules for task [11951163744226476627](https://jules.google.com/task/11951163744226476627) started by @OrKoN*