### PR TITLE
feat: enhance accessibility tree snapshot with more properties

### DIFF
--- a/docs/api/puppeteer.serializedaxnode.md
+++ b/docs/api/puppeteer.serializedaxnode.md
@@ -37,6 +37,25 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="atomic">atomic</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether the live region is [atomic](https://www.w3.org/TR/wai-aria/#aria-atomic).
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="autocomplete">autocomplete</span>
 
 </td><td>
@@ -48,6 +67,25 @@ Default
 string
 
 </td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="busy">busy</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether the node is [busy](https://www.w3.org/TR/wai-aria/#aria-busy).
 
 </td><td>
 
@@ -111,6 +149,25 @@ An additional human readable description of the node.
 </td></tr>
 <tr><td>
 
+<span id="details">details</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+The [details](https://www.w3.org/TR/wai-aria/#aria-details) for the node.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="disabled">disabled</span>
 
 </td><td>
@@ -122,6 +179,25 @@ An additional human readable description of the node.
 boolean
 
 </td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="errormessage">errormessage</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+The [error message](https://www.w3.org/TR/wai-aria/#aria-errormessage) for the node.
 
 </td><td>
 
@@ -230,6 +306,25 @@ number
 </td><td>
 
 The level of a heading.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="live">live</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+The [live](https://www.w3.org/TR/wai-aria/#aria-live) status of the node.
 
 </td><td>
 
@@ -355,6 +450,25 @@ Whether the node is checked or in a mixed state.
 boolean
 
 </td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="relevant">relevant</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+The [relevant](https://www.w3.org/TR/wai-aria/#aria-relevant) changes for the live region.
 
 </td><td>
 

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -936,4 +936,75 @@ describe('Accessibility', function () {
     }
     return null;
   }
+
+  it('should capture new accessibility properties and not prune them', async () => {
+    const {page} = await getTestState();
+
+    await page.setContent(
+      htmlRaw`
+        <div role="alert" aria-busy="true">This is an alert</div>
+        <div aria-live="polite" aria-atomic="true" aria-relevant="additions text">
+          This is polite live region
+        </div>
+        <div aria-modal="true" role="dialog" aria-roledescription="My Modal">
+          Modal content
+        </div>
+        <div id="error">Error message</div>
+        <input aria-invalid="true" aria-errormessage="error" value="invalid input">
+        <div id="details">Additional details</div>
+        <div aria-details="details">Element with details</div>
+        <div aria-description="This is a description"></div>
+      `,
+    );
+
+    const snapshot = await page.accessibility.snapshot();
+    expect(snapshot).toMatchObject({
+      role: 'RootWebArea',
+      children: [
+        {
+          role: 'alert',
+          name: 'This is an alert',
+          busy: true,
+          live: 'assertive',
+          atomic: true,
+        },
+        {
+          role: 'generic',
+          live: 'polite',
+          atomic: true,
+          relevant: 'additions text',
+          children: [{role: 'StaticText', name: 'This is polite live region'}],
+        },
+        {
+          role: 'dialog',
+          name: 'Modal content',
+          modal: true,
+          roledescription: 'My Modal',
+        },
+        {
+          role: 'StaticText',
+          name: 'Error message',
+        },
+        {
+          role: 'textbox',
+          value: 'invalid input',
+          invalid: 'true',
+          errormessage: 'error',
+        },
+        {
+          role: 'StaticText',
+          name: 'Additional details',
+        },
+        {
+          role: 'generic',
+          details: 'details',
+          children: [{role: 'StaticText', name: 'Element with details'}],
+        },
+        {
+          role: 'generic',
+          description: 'This is a description',
+        },
+      ],
+    });
+  });
 });

--- a/test/src/accessibility.spec.ts
+++ b/test/src/accessibility.spec.ts
@@ -963,13 +963,15 @@ describe('Accessibility', function () {
       children: [
         {
           role: 'alert',
-          name: 'This is an alert',
+          name: '',
           busy: true,
           live: 'assertive',
           atomic: true,
+          children: [{role: 'StaticText', name: 'This is an alert'}],
         },
         {
           role: 'generic',
+          name: '',
           live: 'polite',
           atomic: true,
           relevant: 'additions text',
@@ -977,9 +979,10 @@ describe('Accessibility', function () {
         },
         {
           role: 'dialog',
-          name: 'Modal content',
+          name: '',
           modal: true,
           roledescription: 'My Modal',
+          children: [{role: 'StaticText', name: 'Modal content'}],
         },
         {
           role: 'StaticText',


### PR DESCRIPTION
Enhanced the accessibility snapshot by adding more relevant properties and improving the pruning logic to keep critical accessibility information. Added tests to verify the new behavior.

Closes https://github.com/puppeteer/puppeteer/issues/14319

---
*PR created automatically by Jules for task [12226184733840195943](https://jules.google.com/task/12226184733840195943) started by @OrKoN*