### PR TITLE
fix: do not write metadata when uninstalling

### DIFF
--- a/packages/browsers/src/Cache.ts
+++ b/packages/browsers/src/Cache.ts
@@ -225,8 +225,8 @@ export class Cache {
     const key = `${platform}-${buildId}`;
     if (metadata.executablePaths?.[key]) {
       delete metadata.executablePaths[key];
+      this.writeMetadata(browser, metadata);
     }
-    this.writeMetadata(browser, metadata);
     fs.rmSync(this.installationDir(browser, platform, buildId), {
       force: true,
       recursive: true,


### PR DESCRIPTION
Regressed in https://github.com/puppeteer/puppeteer/pull/14552 which would write the metadata file on uninstall even if it did not exist.

Drive-by: fixes the custom providers tests to use the test server and the test build ids.