### PR TITLE
docs: document signal option in Page waitFor methods

### DIFF
--- a/docs/api/puppeteer.frame.waitforfunction.md
+++ b/docs/api/puppeteer.frame.waitforfunction.md
@@ -57,7 +57,7 @@ options
 
 </td><td>
 
-_(Optional)_ options to configure the polling method and timeout.
+_(Optional)_ options to configure the polling method, timeout and signal.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -1466,6 +1466,8 @@ Optional Waiting Parameters have:
 
 - `timeout`: Maximum wait time in milliseconds, defaults to `30` seconds, pass `0` to disable the timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.
 
+- `signal`: A signal object that allows you to cancel a waitForRequest call.
+
 </td></tr>
 <tr><td>
 
@@ -1480,6 +1482,8 @@ Optional Waiting Parameters have:
 Optional Parameter have:
 
 - `timeout`: Maximum wait time in milliseconds, defaults to `30` seconds, pass `0` to disable the timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.
+
+- `signal`: A signal object that allows you to cancel a waitForResponse call.
 
 </td></tr>
 <tr><td>
@@ -1501,6 +1505,8 @@ The optional Parameter in Arguments `options` are:
 - `hidden`: Wait for element to not be found in the DOM or to be hidden, i.e. have `display: none` or `visibility: hidden` CSS properties. Defaults to `false`.
 
 - `timeout`: maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.
+
+- `signal`: A signal object that allows you to cancel a waitForSelector call.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.waitforrequest.md
+++ b/docs/api/puppeteer.page.waitforrequest.md
@@ -70,6 +70,8 @@ Optional Waiting Parameters have:
 
 - `timeout`: Maximum wait time in milliseconds, defaults to `30` seconds, pass `0` to disable the timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.
 
+- `signal`: A signal object that allows you to cancel a waitForRequest call.
+
 ## Example
 
 ```ts

--- a/docs/api/puppeteer.page.waitforresponse.md
+++ b/docs/api/puppeteer.page.waitforresponse.md
@@ -70,6 +70,8 @@ Optional Parameter have:
 
 - `timeout`: Maximum wait time in milliseconds, defaults to `30` seconds, pass `0` to disable the timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.
 
+- `signal`: A signal object that allows you to cancel a waitForResponse call.
+
 ## Example
 
 ```ts

--- a/docs/api/puppeteer.page.waitforselector.md
+++ b/docs/api/puppeteer.page.waitforselector.md
@@ -76,6 +76,8 @@ The optional Parameter in Arguments `options` are:
 
 - `timeout`: maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [Page.setDefaultTimeout()](./puppeteer.page.setdefaulttimeout.md) method.
 
+- `signal`: A signal object that allows you to cancel a waitForSelector call.
+
 ## Example
 
 This method works across navigations:

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -773,7 +773,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
    * ```
    *
    * @param pageFunction - the function to evaluate in the frame context.
-   * @param options - options to configure the polling method and timeout.
+   * @param options - options to configure the polling method, timeout and signal.
    * @param args - arguments to pass to the `pageFunction`.
    * @returns the promise which resolve when the `pageFunction` returns a truthy value.
    */

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -1839,6 +1839,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * - `timeout`: Maximum wait time in milliseconds, defaults to `30` seconds, pass
    *   `0` to disable the timeout. The default value can be changed by using the
    *   {@link Page.setDefaultTimeout} method.
+   *
+   * - `signal`: A signal object that allows you to cancel a waitForRequest call.
    */
   waitForRequest(
     urlOrPredicate: string | AwaitablePredicate<HTTPRequest>,
@@ -1892,6 +1894,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * - `timeout`: Maximum wait time in milliseconds, defaults to `30` seconds,
    *   pass `0` to disable the timeout. The default value can be changed by using
    *   the {@link Page.setDefaultTimeout} method.
+   *
+   * - `signal`: A signal object that allows you to cancel a waitForResponse call.
    */
   waitForResponse(
     urlOrPredicate: string | AwaitablePredicate<HTTPResponse>,
@@ -3076,6 +3080,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * - `timeout`: maximum time to wait for in milliseconds. Defaults to `30000`
    *   (30 seconds). Pass `0` to disable timeout. The default value can be changed
    *   by using the {@link Page.setDefaultTimeout} method.
+   *
+   * - `signal`: A signal object that allows you to cancel a waitForSelector call.
    */
   async waitForSelector<Selector extends string>(
     selector: Selector,


### PR DESCRIPTION
Updated JSDoc for `Page.waitForRequest`, `Page.waitForResponse`, and `Page.waitForSelector` to include `signal` in the list of options. Verified by running `npm run docs` and checking the generated markdown files.

---
*PR created automatically by Jules for task [18232130634320851068](https://jules.google.com/task/18232130634320851068) started by @Lightning00Blade*