### PR TITLE
test: increase protocol timeout in waittask test

### DIFF
--- a/test/src/waittask.spec.ts
+++ b/test/src/waittask.spec.ts
@@ -931,7 +931,7 @@ describe('waittask specs', function () {
 
   describe('protocol timeout', () => {
     const state = setupSeparateTestBrowserHooks({
-      protocolTimeout: 3000,
+      protocolTimeout: 5000,
     });
 
     it('should error if underyling protocol command times out with raf polling', async () => {


### PR DESCRIPTION
With the fix from https://bugzilla.mozilla.org/show_bug.cgi?id=2010507 and the expectations update in https://github.com/puppeteer/puppeteer/commit/cf2b14430cf6f32707bf56b0ad93735a30c7eca6, the waittask test is currently flaky.

I tested on a fork that bumping the timeout to 4s seems to make the test pass consistently: https://github.com/juliandescottes/puppeteer/actions/runs/21681621273?pr=5 (note: the PR where I test this only runs the waittask tests on firefox nightly macos headful)

With the default 3s I had ~50% of failures. With 4s, 4 runs / 4 have succeeded so far. 
We might want to bump it to 5s for safety.

Considering I have seen start time around 3 seconds for the WebDriver BiDi session, it is not too surprising that the current test fails. It would be interesting to know if it was significantly more stable in the past because from what I could tell, the performance on Nightly is on par with Firefox 144.

cc @OrKoN 