### PR TITLE
feat: allow configuring the output of @puppeteer/browsers install

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -320,7 +320,7 @@ export class CLI {
             })
             .option('format', {
               type: 'string',
-              desc: 'Format to use for the output',
+              desc: 'Format to use for the output. Supported placeholders: ${browser}, ${buildId}, ${path}, ${platform}',
             });
         },
         async args => {

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -34,6 +34,7 @@ interface InstallArgs {
   platform?: BrowserPlatform;
   baseUrl?: string;
   installDeps?: boolean;
+  format?: string;
 }
 
 function isValidBrowser(browser: unknown): browser is Browser {
@@ -316,6 +317,10 @@ export class CLI {
               type: 'boolean',
               desc: 'Whether to attempt installing system dependencies (only supported on Linux, requires root privileges).',
               default: false,
+            })
+            .option('format', {
+              type: 'string',
+              desc: 'Format to use for the output',
             });
         },
         async args => {
@@ -546,13 +551,22 @@ export class CLI {
         originalBuildId !== args.browser.buildId ? originalBuildId : undefined,
       installDeps: args.installDeps,
     });
-    console.log(
-      `${args.browser.name}@${args.browser.buildId} ${computeExecutablePath({
-        browser: args.browser.name,
-        buildId: args.browser.buildId,
-        cacheDir: args.path ?? this.#cachePath,
-        platform: args.platform,
-      })}`,
-    );
+    const executablePath = computeExecutablePath({
+      browser: args.browser.name,
+      buildId: args.browser.buildId,
+      cacheDir: args.path ?? this.#cachePath,
+      platform: args.platform,
+    });
+    if (args.format) {
+      console.log(
+        args.format
+          .replace(/\${browser}/g, args.browser.name)
+          .replace(/\${buildId}/g, args.browser.buildId)
+          .replace(/\${path}/g, executablePath)
+          .replace(/\${platform}/g, args.platform!),
+      );
+    } else {
+      console.log(`${args.browser.name}@${args.browser.buildId} ${executablePath}`);
+    }
   }
 }

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -566,7 +566,9 @@ export class CLI {
           .replace(/\${platform}/g, args.platform!),
       );
     } else {
-      console.log(`${args.browser.name}@${args.browser.buildId} ${executablePath}`);
+      console.log(
+        `${args.browser.name}@${args.browser.buildId} ${executablePath}`,
+      );
     }
   }
 }

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -34,7 +34,7 @@ interface InstallArgs {
   platform?: BrowserPlatform;
   baseUrl?: string;
   installDeps?: boolean;
-  format?: string;
+  format: string;
 }
 
 function isValidBrowser(browser: unknown): browser is Browser {
@@ -200,7 +200,7 @@ export class CLI {
     return yargs
       .command(
         `install ${browserArgType}`,
-        'Download and install the specified browser. If successful, the command outputs the actual browser buildId that was installed and the absolute path to the browser executable (format: <browser>@<buildID> <path>).',
+        'Download and install the specified browser. If successful, the command outputs the actual browser buildId that was installed and the absolute path to the browser executable (format: <browser>@<buildId> <path>).',
         yargs => {
           if (this.#pinnedBrowsers) {
             yargs.example('$0 install', 'Install all pinned browsers');
@@ -321,6 +321,7 @@ export class CLI {
             .option('format', {
               type: 'string',
               desc: 'Format to use for the output. Supported placeholders: ${browser}, ${buildId}, ${path}, ${platform}',
+              default: '{{browser}}@{{buildId}} {{path}}',
             });
         },
         async args => {
@@ -557,18 +558,13 @@ export class CLI {
       cacheDir: args.path ?? this.#cachePath,
       platform: args.platform,
     });
-    if (args.format) {
-      console.log(
-        args.format
-          .replace(/\${browser}/g, args.browser.name)
-          .replace(/\${buildId}/g, args.browser.buildId)
-          .replace(/\${path}/g, executablePath)
-          .replace(/\${platform}/g, args.platform!),
-      );
-    } else {
-      console.log(
-        `${args.browser.name}@${args.browser.buildId} ${executablePath}`,
-      );
-    }
+
+    console.log(
+      args.format
+        .replace(/{{browser}}/g, args.browser.name)
+        .replace(/{{buildId}}/g, args.browser.buildId)
+        .replace(/{{path}}/g, executablePath)
+        .replace(/{{platform}}/g, args.platform),
+    );
   }
 }

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -561,7 +561,7 @@ export class CLI {
 
     console.log(
       args.format
-        .replace(/{{browser}/g, args.browser.name)
+        .replace(/{{browser}}/g, args.browser.name)
         .replace(/{{buildId}}/g, args.browser.buildId)
         .replace(/{{path}}/g, executablePath)
         .replace(/{{platform}}/g, args.platform),

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -200,7 +200,7 @@ export class CLI {
     return yargs
       .command(
         `install ${browserArgType}`,
-        'Download and install the specified browser. If successful, the command outputs the actual browser buildId that was installed and the absolute path to the browser executable (format: <browser>@<buildId> <path>).',
+        'Download and install the specified browser. If successful, the command outputs the actual browser buildId that was installed and the absolute path to the browser executable (see --format).',
         yargs => {
           if (this.#pinnedBrowsers) {
             yargs.example('$0 install', 'Install all pinned browsers');
@@ -320,7 +320,7 @@ export class CLI {
             })
             .option('format', {
               type: 'string',
-              desc: 'Format to use for the output. Supported placeholders: ${browser}, ${buildId}, ${path}, ${platform}',
+              desc: 'Format to use for the output. Supported placeholders: {{browser}}, {{buildId}}, {{path}}, {{platform}}',
               default: '{{browser}}@{{buildId}} {{path}}',
             });
         },
@@ -561,7 +561,7 @@ export class CLI {
 
     console.log(
       args.format
-        .replace(/{{browser}}/g, args.browser.name)
+        .replace(/{{browser}/g, args.browser.name)
         .replace(/{{buildId}}/g, args.browser.buildId)
         .replace(/{{path}}/g, executablePath)
         .replace(/{{platform}}/g, args.platform),

--- a/packages/browsers/test/src/CLI.spec.ts
+++ b/packages/browsers/test/src/CLI.spec.ts
@@ -114,20 +114,21 @@ describe('CLI', function () {
       console.log = originalLog;
     }
 
-    const found = logs.some(
-      log =>
+    const found = logs.some(log => {
+      return (
         log ===
         `chrome ${testChromeBuildId} ${path.join(
           tmpDir,
           'chrome',
           os.platform() === 'linux' ? `linux-${testChromeBuildId}` : '',
           'chrome-linux64',
-          'chrome'
+          'chrome',
         )}`
-    );
+      );
+    });
     if (!found) {
       throw new Error(
-        `Expected output not found in logs: ${JSON.stringify(logs)}`
+        `Expected output not found in logs: ${JSON.stringify(logs)}`,
       );
     }
   });

--- a/packages/browsers/test/src/CLI.spec.ts
+++ b/packages/browsers/test/src/CLI.spec.ts
@@ -114,13 +114,20 @@ describe('CLI', function () {
       console.log = originalLog;
     }
 
-    const expectedOutputRegex = new RegExp(
-      `chrome ${testChromeBuildId} .*${path.sep}chrome`
+    const found = logs.some(
+      log =>
+        log ===
+        `chrome ${testChromeBuildId} ${path.join(
+          tmpDir,
+          'chrome',
+          os.platform() === 'linux' ? `linux-${testChromeBuildId}` : '',
+          'chrome-linux64',
+          'chrome'
+        )}`
     );
-    const found = logs.some(log => expectedOutputRegex.test(log));
     if (!found) {
       throw new Error(
-        `Expected output matching ${expectedOutputRegex} not found in logs: ${JSON.stringify(logs)}`
+        `Expected output not found in logs: ${JSON.stringify(logs)}`
       );
     }
   });

--- a/packages/browsers/test/src/CLI.spec.ts
+++ b/packages/browsers/test/src/CLI.spec.ts
@@ -108,8 +108,7 @@ describe('CLI', function () {
         `chrome@${testChromeBuildId}`,
         `--path=${tmpDir}`,
         `--base-url=${getServerUrl()}`,
-        '--format',
-        '${browser} ${buildId} ${path}',
+        '--format=${browser} ${buildId} ${path}',
       ]);
     } finally {
       console.log = originalLog;

--- a/packages/browsers/test/src/CLI.spec.ts
+++ b/packages/browsers/test/src/CLI.spec.ts
@@ -92,4 +92,37 @@ describe('CLI', function () {
       process.stdout.write = originalStdoutWrite;
     }
   });
+
+  it('should format output', async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (message: string) => {
+      logs.push(message);
+    };
+
+    try {
+      await new CLI(tmpDir).run([
+        'npx',
+        '@puppeteer/browsers',
+        'install',
+        `chrome@${testChromeBuildId}`,
+        `--path=${tmpDir}`,
+        `--base-url=${getServerUrl()}`,
+        '--format',
+        '${browser} ${buildId} ${path}',
+      ]);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const expectedOutputRegex = new RegExp(
+      `chrome ${testChromeBuildId} .*${path.sep}chrome`
+    );
+    const found = logs.some(log => expectedOutputRegex.test(log));
+    if (!found) {
+      throw new Error(
+        `Expected output matching ${expectedOutputRegex} not found in logs: ${JSON.stringify(logs)}`
+      );
+    }
+  });
 });

--- a/packages/browsers/test/src/CLI.spec.ts
+++ b/packages/browsers/test/src/CLI.spec.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import assert from 'node:assert';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -108,7 +108,7 @@ describe('CLI', function () {
         `chrome@${testChromeBuildId}`,
         `--path=${tmpDir}`,
         `--base-url=${getServerUrl()}`,
-        '--format=${browser} ${buildId} ${path}',
+        '--format={{browser}} {{buildId}} {{path}}',
       ]);
     } finally {
       console.log = originalLog;
@@ -126,10 +126,7 @@ describe('CLI', function () {
         )}`
       );
     });
-    if (!found) {
-      throw new Error(
-        `Expected output not found in logs: ${JSON.stringify(logs)}`,
-      );
-    }
+
+    assert(found, `Expected output not found in logs: ${JSON.stringify(logs)}`);
   });
 });


### PR DESCRIPTION
Added a new `--format` flag to the `@puppeteer/browsers install` command.
This allows users to customize the output format, for example, to print only the executable path.
Supported placeholders: `{{browser}}`, `{{buildId}}`, `{{path}}`, `{{platform}}`.

Fixes #10160

---
*PR created automatically by Jules for task [17751261393760744999](https://jules.google.com/task/17751261393760744999) started by @Lightning00Blade*