### PR TITLE
chore: Increase timeout values for Windows and other platforms

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-let timeout = process.platform === 'win32' ? 20_000 : 10_000;
+let timeout = process.platform === 'win32' ? 30_000 : 15_000;
 if (!!process.env.DEBUGGER_ATTACHED) {
   timeout = 0;
 }


### PR DESCRIPTION
It seems GitHub actions are generally slower/more flaky recently. Cannot repro flakiness locally.