### PR TITLE
docs: clarify how to pass data into filter

### DIFF
--- a/docs/guides/page-interactions.md
+++ b/docs/guides/page-interactions.md
@@ -145,12 +145,22 @@ await page
 
 The following example shows how to add extra conditions to the locator expressed
 as a JavaScript function. The button element will only be clicked if its
-`innerText` is 'My button'.
+`textContent` is 'My button'.
 
 ```ts
 await page
   .locator('button')
-  .filter(button => button.innerText === 'My button')
+  .filter(button => button.textContent === 'My button')
+  .click();
+```
+
+Since `.filter()`'s callback is executed in browser context, it doesn't have access to variables from the Node scope. You can build a string function to inject a variable:
+
+```ts
+const buttonName = 'My button';
+await page
+  .locator('button')
+  .filter(`button => button.textContent === '${buttonName}'`)
   .click();
 ```
 

--- a/docs/guides/page-interactions.md
+++ b/docs/guides/page-interactions.md
@@ -160,7 +160,7 @@ Since `.filter()`'s callback is executed in browser context, it doesn't have acc
 const buttonName = 'My button';
 await page
   .locator('button')
-  .filter(`button => button.textContent === '${buttonName}'`)
+  .filter(`button => button.textContent === ${JSON.stringify(buttonName)}`)
   .click();
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Docs clarification. See discussion in https://github.com/puppeteer/puppeteer/issues/11893.

**Did you add tests for your changes?**

I tested the syntax to make sure it works:

```js
const puppeteer = require("puppeteer"); // ^24.36.1

const html = `<button onclick="f()">My button</button>
<script>function f() {
  const b = document.querySelector("button");
  b.textContent = "clicked!";
}</script>`;

let browser;
(async () => {
  browser = await puppeteer.launch();
  const [page] = await browser.pages();
  await page.setContent(html);
  const buttonName = 'My button';
  await page
    .locator('button')
    .filter(`button => button.textContent === ${JSON.stringify(buttonName)}`)
    .click();
  console.log(await page.$eval("button", el => el.textContent)); // => clicked!
})()
  .catch(err => console.error(err))
  .finally(() => browser?.close());
```

**If relevant, did you update the documentation?**

Yes.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

See [this comment](https://github.com/puppeteer/puppeteer/issues/11893#issuecomment-3866937217) for motivation.

In short, it's currently not readily possible to pass dynamic variables into the locator `.filter()` function via variable args, so this provides an option via string concatenation.

Granted, passing strings in like this is perhaps not the _best_ approach, so long-term, it might be worth considering adding variable args to pass data into the function.

If we don't want to encourage the string concatenation, this PR can be modified to at least mention that values from the outer scope aren't accessible to [save folks time](https://stackoverflow.com/questions/79882866/locator-filter-works-with-hardcoded-value-but-not-variable#comment140973672_79882931).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**Other information**

This also makes a minor tweak to [prefer using `textContent` over `innerText`](https://stackoverflow.com/questions/35213147/difference-between-textcontent-vs-innertext). I'm fine skipping that part too if it's unwanted!