### PR TITLE
chore: use Uint8Array.fromBase64 if available

### DIFF
--- a/packages/puppeteer-core/src/util/encoding.ts
+++ b/packages/puppeteer-core/src/util/encoding.ts
@@ -12,9 +12,11 @@ export function stringToTypedArray(
   base64Encoded = false,
 ): Uint8Array {
   if (base64Encoded) {
-    // TODO: use
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64
-    // once available.
+    if ('fromBase64' in Uint8Array) {
+      // @ts-expect-error fromBase64 is newer than the types we use.
+      return Uint8Array.fromBase64(string);
+    }
+    // TODO: remove Buffer in v26 when it becomes LTS.
     if (typeof Buffer === 'function') {
       return Buffer.from(string, 'base64');
     }


### PR DESCRIPTION
This PR updates `packages/puppeteer-core/src/util/encoding.ts` to use the native `Uint8Array.fromBase64` method for decoding base64 strings when supported by the environment. This provides a potential performance improvement and aligns with modern JS standards.

The implementation retains the existing `Buffer` and `atob` fallbacks for compatibility with older environments. A comment has been added to remove the `Buffer` fallback once Node.js v26 becomes LTS.

Tests were run to ensure no regressions, and a temporary mock test verified the new code path works as expected.

---
*PR created automatically by Jules for task [2616647560280026893](https://jules.google.com/task/2616647560280026893) started by @Lightning00Blade*