### PR TITLE
fix(webdriver): avoid json serialization

### DIFF
--- a/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
@@ -28,22 +28,22 @@ export async function connectBidiOverCdp(
   const transportBiDi = new NoOpTransport();
   const cdpConnectionAdapter = new CdpConnectionAdapter(cdp);
   const pptrTransport = {
-    send(message: string): void {
+    send(message: string|object): void {
       // Forwards a BiDi command sent by Puppeteer to the input of the BidiServer.
-      transportBiDi.emitMessage(JSON.parse(message));
+      transportBiDi.emitMessage(message);
     },
     close(): void {
       bidiServer.close();
       cdpConnectionAdapter.close();
       cdp.dispose();
     },
-    onmessage(_message: string): void {
+    onmessage(_message: string|object): void {
       // The method is overridden by the Connection.
     },
   };
   transportBiDi.on('bidiResponse', (message: object) => {
     // Forwards a BiDi event sent by BidiServer to Puppeteer.
-    pptrTransport.onmessage(JSON.stringify(message));
+    pptrTransport.onmessage(message);
   });
   const pptrBiDiConnection = new BidiConnection(
     cdp.url(),

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -126,11 +126,11 @@ export class BidiConnection
       return Promise.reject(new ConnectionClosedError('Connection closed.'));
     }
     return this.#callbacks.create(method, timeout ?? this.#timeout, id => {
-      const stringifiedMessage = JSON.stringify({
+      const stringifiedMessage = {
         id,
         method,
         params,
-      } as Bidi.Command);
+      };
       debugProtocolSend(stringifiedMessage);
       this.#transport.send(stringifiedMessage);
     }) as Promise<{result: Commands[T]['returnType']}>;
@@ -139,14 +139,14 @@ export class BidiConnection
   /**
    * @internal
    */
-  protected async onMessage(message: string): Promise<void> {
+  protected async onMessage(message: object|string): Promise<void> {
     if (this.#delay) {
       await new Promise(f => {
         return setTimeout(f, this.#delay);
       });
     }
     debugProtocolReceive(message);
-    const object: Bidi.Message | CdpEvent = JSON.parse(message);
+    const object: Bidi.Message | CdpEvent = message as Bidi.Message | CdpEvent;
     if ('type' in object) {
       switch (object.type) {
         case 'success':

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -169,14 +169,14 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
   /**
    * @internal
    */
-  protected async onMessage(message: string): Promise<void> {
+  protected async onMessage(message: string|object): Promise<void> {
     if (this.#delay) {
       await new Promise(r => {
         return setTimeout(r, this.#delay);
       });
     }
     debugProtocolReceive(message);
-    const object = JSON.parse(message);
+    const object = JSON.parse(message as string);
     if (object.method === 'Target.attachedToTarget') {
       const sessionId = object.params.sessionId;
       const session = new CdpCDPSession(

--- a/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
+++ b/packages/puppeteer-core/src/cdp/ExtensionTransport.ts
@@ -38,7 +38,7 @@ export class ExtensionTransport implements ConnectionTransport {
     return new ExtensionTransport(tabId);
   }
 
-  onmessage?: (message: string) => void;
+  onmessage?: (message: string|object) => void;
   onclose?: () => void;
 
   #tabId: number;

--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
@@ -21,7 +21,7 @@ export class BrowserWebSocketTransport implements ConnectionTransport {
   }
 
   #ws: WebSocket;
-  onmessage?: (message: string) => void;
+  onmessage?: (message: string|object) => void;
   onclose?: () => void;
 
   constructor(ws: WebSocket) {
@@ -40,8 +40,8 @@ export class BrowserWebSocketTransport implements ConnectionTransport {
     this.#ws.addEventListener('error', () => {});
   }
 
-  send(message: string): void {
-    this.#ws.send(message);
+  send(message: string|object): void {
+    this.#ws.send(message as string);
   }
 
   close(): void {

--- a/packages/puppeteer-core/src/common/ConnectionTransport.ts
+++ b/packages/puppeteer-core/src/common/ConnectionTransport.ts
@@ -8,8 +8,8 @@
  * @public
  */
 export interface ConnectionTransport {
-  send(message: string): void;
+  send(message: string|object): void;
   close(): void;
-  onmessage?: (message: string) => void;
+  onmessage?: (message: string|object) => void;
   onclose?: () => void;
 }

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
@@ -36,7 +36,7 @@ export class NodeWebSocketTransport implements ConnectionTransport {
   }
 
   #ws: NodeWebSocket;
-  onmessage?: (message: NodeWebSocket.Data) => void;
+  onmessage?: (message: NodeWebSocket.Data|object) => void;
   onclose?: () => void;
 
   constructor(ws: NodeWebSocket) {
@@ -55,8 +55,8 @@ export class NodeWebSocketTransport implements ConnectionTransport {
     this.#ws.addEventListener('error', () => {});
   }
 
-  send(message: string): void {
-    this.#ws.send(message);
+  send(message: string|object): void {
+    this.#ws.send(message as string);
   }
 
   close(): void {

--- a/packages/puppeteer-core/src/node/PipeTransport.test.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.test.ts
@@ -15,7 +15,7 @@ describe('PipeTransport', () => {
   let myReadable: Readable;
 
   async function waitForNextMessage() {
-    return await new Promise<string>(res => {
+    return await new Promise<string|object>(res => {
       transport.onmessage = message => {
         res(message);
       };
@@ -25,8 +25,8 @@ describe('PipeTransport', () => {
   function waitForNumberOfMessages(count: number): Promise<string[]> {
     const messages: string[] = [];
     return new Promise<string[]>(resolve => {
-      transport.onmessage = (message: string) => {
-        messages.push(message);
+      transport.onmessage = (message: string|object) => {
+        messages.push(message as string);
         if (messages.length === count) {
           resolve(messages);
         }

--- a/packages/puppeteer-core/src/node/PipeTransport.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.ts
@@ -20,7 +20,7 @@ export class PipeTransport implements ConnectionTransport {
   #pendingMessage: Buffer[] = [];
 
   onclose?: () => void;
-  onmessage?: (value: string) => void;
+  onmessage?: (value: string|object) => void;
 
   constructor(
     pipeWrite: NodeJS.WritableStream,
@@ -53,10 +53,10 @@ export class PipeTransport implements ConnectionTransport {
     pipeWriteEmitter.on('error', debugError);
   }
 
-  send(message: string): void {
+  send(message: string|object): void {
     assert(!this.#isClosed, '`PipeTransport` is closed.');
 
-    this.#pipeWrite.write(message);
+    this.#pipeWrite.write(message as string);
     this.#pipeWrite.write('\0');
   }
 

--- a/test/src/console.spec.ts
+++ b/test/src/console.spec.ts
@@ -12,6 +12,53 @@ import {html, waitEvent} from './utils.js';
 
 describe('console', function () {
   setupTestBrowserHooks();
+  it.only('measure performance', async () => {
+    const {page} = await getTestState();
+    await page.setContent(html`<div id="some-counter"></div>`);
+
+    // Measurement
+    const ITERATIONS_PER_RUN = 1000;
+    const latencies: number[] = [];
+    for (let i = 0; i < ITERATIONS_PER_RUN; i++) {
+      const start = performance.now();
+      await page.evaluate(
+        (index, id) => {
+          // Change DOM.
+          document.getElementById(id)!.innerText = `Iter: ${index + 1}`;
+          // Return an object.
+          return {
+            iteration: index + 1,
+            timestamp: Date.now(),
+            someArray: [1, 2, 3],
+            someObject: {a: 1, b: 2, c: 3},
+            someString: 'hello',
+            someNumber: 123,
+            someBoolean: true,
+            someNull: null,
+            someUndefined: undefined,
+          };
+        },
+        i,
+        'some-counter',
+      );
+      const end = performance.now();
+      latencies.push(end - start);
+    }
+
+    latencies.sort((a, b) => {
+      return a - b;
+    });
+    const mean =
+      latencies.reduce((a, b) => {
+        return a + b;
+      }, 0) / latencies.length;
+    const median = latencies[Math.floor(latencies.length / 2)];
+    const p10 = latencies[Math.floor(latencies.length * 0.1)];
+
+    console.log(`Mean: ${mean}ms`);
+    console.log(`Median: ${median}ms`);
+    console.log(`p10: ${p10}ms`);
+  });
   it('should work', async () => {
     const {page} = await getTestState();
 


### PR DESCRIPTION
Proper solution is to make Puppeteer's Transport generic (with string being the default) using object only for BiDi transports.