### PR TITLE
fix: do not resolve user data dir if it is absolute

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -245,7 +245,10 @@ export class ChromeLauncher extends BrowserLauncher {
       enableExtensions = false,
     } = options;
     if (userDataDir) {
-      chromeArguments.push(`--user-data-dir=${path.resolve(userDataDir)}`);
+      // If absolute (for any platform) path is given, we should not resolve it.
+      chromeArguments.push(
+        `--user-data-dir=${path.posix.isAbsolute(userDataDir) || path.win32.isAbsolute(userDataDir) ? userDataDir : path.resolve(userDataDir)}`,
+      );
     }
     if (devtools) {
       chromeArguments.push('--auto-open-devtools-for-tabs');


### PR DESCRIPTION
Currently, if running in WSL on Windows, an absolute path for Windows host is provided it is corrupted by path.resolve and transformed into an incorrect WSL path.