### PR TITLE
fix(cdp): add missing .catch(debugError) to void initialize() in onAttachedToTarget

### DIFF
--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -341,7 +341,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
       frame.updateClient(target._session()!);
     }
     this.setupEventListeners(target._session()!);
-    void this.initialize(target._session()!, frame);
+    void this.initialize(target._session()!, frame).catch(debugError);
   }
 
   _deviceRequestPromptManager(


### PR DESCRIPTION
Fixes #14700

## Summary

One-line fix: adds `.catch(debugError)` to the fire-and-forget `void this.initialize()` call in `FrameManager.onAttachedToTarget()`.

## Problem

When an OOP iframe target attaches and Chrome is unresponsive (e.g., renderer hang), the CDP commands inside `initialize()` (`Page.enable`, `Runtime.enable`, etc.) timeout with `ProtocolError`. The `catch` block inside `initialize()` only handles `TargetCloseError`, so the `ProtocolError` is re-thrown — and since `onAttachedToTarget` uses `void` without `.catch()`, this becomes an unhandled promise rejection.

## Fix

```diff
- void this.initialize(target._session()!, frame);
+ void this.initialize(target._session()!, frame).catch(debugError);
```

This is consistent with the existing pattern used throughout the same file:
- Line 63: `this.#onClientDisconnect().catch(debugError)`
- Line 116: `this.#onClientDisconnect().catch(debugError)`  
- Line 255: `client.send(...).catch(debugError)`
- Line 385: `page.close().catch(debugError)`

`debugError` is already imported in `FrameManager.ts`.