### PR TITLE
feat(keyboard): add overwrite flag to type method

### DIFF
--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -1124,7 +1124,7 @@ export abstract class ElementHandle<
    * await elementHandle.press('Enter');
    * ```
    *
-   * @param options - Delay in milliseconds. Defaults to 0.
+   * @param options - An object of options. Accepts `delay` in milliseconds Defaults to 0, and `overwrite` which clears the existing text before typing.
    */
 @throwIfDisposed()
   @bindIsolatedHandle

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -1126,13 +1126,27 @@ export abstract class ElementHandle<
    *
    * @param options - Delay in milliseconds. Defaults to 0.
    */
-  @throwIfDisposed()
+@throwIfDisposed()
   @bindIsolatedHandle
   async type(
     text: string,
     options?: Readonly<KeyboardTypeOptions>,
   ): Promise<void> {
     await this.focus();
+
+    if (options?.overwrite) {
+      // Determine the modifier key based on the operating system
+      // (Meta for macOS, Control for Windows/Linux)
+      // Note: We use globalThis.process to avoid breaking browser-based builds
+      const modifier = (globalThis.process?.platform === 'darwin') ? 'Meta' : 'Control';
+      
+      await this.frame.page().keyboard.down(modifier);
+      await this.frame.page().keyboard.press('KeyA');
+      await this.frame.page().keyboard.up(modifier);
+      
+      await this.frame.page().keyboard.press('Backspace');
+    }
+
     await this.frame.page().keyboard.type(text, options);
   }
 

--- a/packages/puppeteer-core/src/api/Input.ts
+++ b/packages/puppeteer-core/src/api/Input.ts
@@ -31,6 +31,11 @@ export interface KeyDownOptions {
  */
 export interface KeyboardTypeOptions {
   delay?: number;
+  /**
+   * Clears the input before typing.
+   * @defaultValue false
+   */
+  overwrite?: boolean;
 }
 
 /**

--- a/test/src/elementhandle.spec.ts
+++ b/test/src/elementhandle.spec.ts
@@ -1246,4 +1246,18 @@ describe('ElementHandle specs', function () {
       expect(handle.disposed).toBeFalsy();
     });
   });
+
+  describe('ElementHandle.type', () => {
+    it('should clear the input before typing when overwrite is true', async () => {
+      const {page} = await getTestState();
+
+      await page.setContent('<input type="text" value="Old Text">');
+      using input = (await page.$('input'))!;
+
+      await input.type('New Text', { overwrite: true });
+
+      const value = await page.$eval('input', el => el.value);
+      expect(value).toBe('New Text');
+    });
+  });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**Did you add tests for your changes?**
Yes. Added a test in `elementhandle.spec.ts` to verify that the input is cleared before typing when `overwrite: true` is passed.

**If relevant, did you update the documentation?**
Yes, added inline JSDoc for the new `overwrite` property in `KeyboardTypeOptions` and updated the `.type()` method documentation.

**Summary**
Fixes #14114

This PR introduces the `overwrite` flag to the `KeyboardTypeOptions` for the `.type()` method. 
When `overwrite: true` is passed, the method clears the existing input value before typing the new text.

**Does this PR introduce a breaking change?**
No. The new `overwrite` flag is optional.

**Other information**