### PR TITLE
feat(browsers): add unpacking indicator during install

### DIFF
--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -448,6 +448,8 @@ async function installUrl(
     }
 
     debugInstall(`Installing ${archivePath} to ${outputPath}`);
+    // Install step can take time; show an indicator after download completes.
+    process.stderr.write(`Unpacking ${fileName}...\n`);
     try {
       debugTime('extract');
       await unpackArchive(archivePath, outputPath);


### PR DESCRIPTION
Adds a small user-visible indicator after download completes and before archive extraction begins, so it’s clearer that the install command is still doing work (unpacking).

Fixes #13083