### PR TITLE
fix: consider browsingContext.navigationCommitted to dispose an existing navigation

### DIFF
--- a/packages/puppeteer-core/src/bidi/core/Navigation.ts
+++ b/packages/puppeteer-core/src/bidi/core/Navigation.ts
@@ -99,6 +99,7 @@ export class Navigation extends EventEmitter<{
     for (const eventName of [
       'browsingContext.domContentLoaded',
       'browsingContext.load',
+      'browsingContext.navigationCommitted',
     ] as const) {
       sessionEmitter.on(eventName, info => {
         if (

--- a/test/src/navigation.spec.ts
+++ b/test/src/navigation.spec.ts
@@ -112,6 +112,23 @@ describe('navigation', function () {
       });
       expect(response!.status()).toBe(200);
     });
+    it('should navigate successfully after encountering network error', async () => {
+      const {page, server} = await getTestState();
+
+      // Destroy the connection to simulate a network error. This will open
+      // about:neterror on Firefox.
+      server.setRoute('/network-error', req => {
+        req.socket.destroy();
+      });
+
+      let error!: Error;
+      await page.goto(server.PREFIX + '/network-error').catch(error_ => {
+        return (error = error_);
+      });
+      expect(error).not.toBe(null);
+      const response = await page.goto(server.PREFIX + '/grid.html');
+      expect(response!.status()).toBe(200);
+    });
     it('should work when page calls history API in beforeunload', async () => {
       const {page, server} = await getTestState();
 


### PR DESCRIPTION
Fixes #14722 

(waiting for CI results to work on a test, let's see if this regresses other scenarios)
