### PR TITLE
feat: add locale option to LaunchOptions

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -244,7 +244,16 @@ export class ChromeLauncher extends BrowserLauncher {
       args = [],
       userDataDir,
       enableExtensions = false,
+      locale,
     } = options;
+    if (
+      locale &&
+      !args.some(arg => {
+        return arg.startsWith('--lang');
+      })
+    ) {
+      chromeArguments.push(`--lang=${locale}`);
+    }
     if (userDataDir) {
       // If absolute (for any platform) path is given, we should not resolve it.
       chromeArguments.push(

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.test.ts
@@ -20,5 +20,21 @@ describe('FirefoxLauncher', function () {
       expect(prefs['fission.bfcacheInParent']).toBe(undefined);
       expect(prefs['fission.webContentIsolationStrategy']).toBe(0);
     });
+
+    it('should pass through locale preference', () => {
+      const prefs: Record<string, unknown> = FirefoxLauncher.getPreferences({
+        'intl.locale.requested': 'fr-FR',
+      });
+      expect(prefs['intl.locale.requested']).toBe('fr-FR');
+    });
+
+    it('should allow extraPrefsFirefox to override locale preference', () => {
+      const prefs: Record<string, unknown> = FirefoxLauncher.getPreferences({
+        'intl.locale.requested': 'en-US',
+        'intl.locale.requested2': 'de-DE',
+      });
+      expect(prefs['intl.locale.requested']).toBe('en-US');
+      expect(prefs['intl.locale.requested2']).toBe('de-DE');
+    });
   });
 });

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -107,7 +107,12 @@ export class FirefoxLauncher extends BrowserLauncher {
 
     await createProfile(SupportedBrowsers.FIREFOX, {
       path: userDataDir,
-      preferences: FirefoxLauncher.getPreferences(extraPrefsFirefox),
+      preferences: FirefoxLauncher.getPreferences({
+        ...(options.locale
+          ? {'intl.locale.requested': options.locale}
+          : undefined),
+        ...extraPrefsFirefox,
+      }),
     });
 
     let firefoxExecutable: string;

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -159,4 +159,17 @@ export interface LaunchOptions extends ConnectOptions {
    * If provided, the browser will be closed when the signal is aborted.
    */
   signal?: AbortSignal;
+  /**
+   * Specifies the browser language (locale) to use.
+   *
+   * For Chrome, this sets the `--lang` command-line flag.
+   * For Firefox, this sets the `intl.locale.requested` profile preference.
+   *
+   * @example
+   *
+   * ```ts
+   * const browser = await puppeteer.launch({locale: 'fr-FR'});
+   * ```
+   */
+  locale?: string;
 }

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -439,6 +439,34 @@ describe('Launcher specs', function () {
           );
         }
       });
+      it('should include --lang flag when locale is set (Chrome)', async () => {
+        const {isChrome, puppeteer} = await getTestState({skipLaunch: true});
+        if (!isChrome) {
+          return;
+        }
+        expect(puppeteer.defaultArgs({locale: 'fr-FR'})).toContain(
+          '--lang=fr-FR',
+        );
+        expect(puppeteer.defaultArgs()).not.toContain('--lang=fr-FR');
+      });
+
+      it('should not add --lang flag when user already provided it (Chrome)', async () => {
+        const {isChrome, puppeteer} = await getTestState({skipLaunch: true});
+        if (!isChrome) {
+          return;
+        }
+        const args = puppeteer.defaultArgs({
+          locale: 'fr-FR',
+          args: ['--lang=en-US'],
+        });
+        const langArgs = args.filter(a => {
+          return a.startsWith('--lang');
+        });
+        // User-provided --lang takes precedence; only one --lang should appear.
+        expect(langArgs).toHaveLength(1);
+        expect(langArgs[0]).toBe('--lang=en-US');
+      });
+
       it('should report the correct product', async () => {
         const {isChrome, isFirefox, puppeteer} = await getTestState({
           skipLaunch: true,


### PR DESCRIPTION
Adds a `locale` option to `LaunchOptions` to make it easy to set the browser language at launch, similar to Playwright's API.

- Chrome: passes `--lang=<locale>` as a command-line flag
- Firefox: sets the `intl.locale.requested` profile preference

If `--lang` is already present in `args`, it takes precedence over `locale` for Chrome.

Fixes #11303