### PR TITLE
feat: support PUPPETEER_DANGEROUS_NO_SANDBOX environment variable

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -245,6 +245,14 @@ export class ChromeLauncher extends BrowserLauncher {
       userDataDir,
       enableExtensions = false,
     } = options;
+
+    if (
+      process.env['PUPPETEER_DANGEROUS_NO_SANDBOX'] &&
+      !args.includes('--no-sandbox')
+    ) {
+      chromeArguments.push('--no-sandbox');
+    }
+
     if (userDataDir) {
       // If absolute (for any platform) path is given, we should not resolve it.
       chromeArguments.push(

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -247,7 +247,7 @@ export class ChromeLauncher extends BrowserLauncher {
     } = options;
 
     if (
-      process.env['PUPPETEER_DANGEROUS_NO_SANDBOX'] &&
+      process.env['PUPPETEER_DANGEROUS_NO_SANDBOX'] === 'true' &&
       !args.includes('--no-sandbox')
     ) {
       chromeArguments.push('--no-sandbox');


### PR DESCRIPTION
### Description
This PR introduces the `PUPPETEER_DANGEROUS_NO_SANDBOX` environment variable. When set, it automatically appends the `--no-sandbox` flag to the browser's launch default arguments, provided it hasn't already been passed manually by the user in the `args` array.

This is particularly useful for Docker and CI environments where modifying the application code to pass `--no-sandbox` to every `puppeteer.launch()` invocation is not feasible or desirable.

Fixes #5505