### PR TITLE
feat: expose Page.hasDevTools

### DIFF
--- a/docs/api/puppeteer.page.hasdevtools.md
+++ b/docs/api/puppeteer.page.hasdevtools.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: Page.hasDevTools
+---
+
+# Page.hasDevTools() method
+
+Returns true if DevTools is attached to the current page. Use [Page.openDevTools()](./puppeteer.page.opendevtools.md) to get the DevTools page.
+
+### Signature
+
+```typescript
+class Page {
+  abstract hasDevTools(): Promise<boolean>;
+}
+```
+
+**Returns:**
+
+Promise&lt;boolean&gt;

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -786,6 +786,17 @@ In headless shell, this method will not throw an error when any valid HTTP statu
 </td></tr>
 <tr><td>
 
+<span id="hasdevtools">[hasDevTools()](./puppeteer.page.hasdevtools.md)</span>
+
+</td><td>
+
+</td><td>
+
+**_(Experimental)_** Returns true if DevTools is attached to the current page. Use [Page.openDevTools()](./puppeteer.page.opendevtools.md) to get the DevTools page.
+
+</td></tr>
+<tr><td>
+
 <span id="hover">[hover(selector)](./puppeteer.page.hover.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -3220,6 +3220,14 @@ export abstract class Page extends EventEmitter<PageEvents> {
   abstract openDevTools(): Promise<Page>;
 
   /**
+   * Returns true if DevTools is attached to the current page.
+   * Use {@link Page.openDevTools} to get the DevTools page.
+   *
+   * @experimental
+   */
+  abstract hasDevTools(): Promise<boolean>;
+
+  /**
    * {@inheritDoc BluetoothEmulation}
    */
   abstract get bluetooth(): BluetoothEmulation;

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -236,6 +236,10 @@ export class BidiPage extends Page {
     throw new UnsupportedOperation();
   }
 
+  override hasDevTools(): Promise<boolean> {
+    throw new UnsupportedOperation();
+  }
+
   async focusedFrame(): Promise<BidiFrame> {
     using handle = (await this.mainFrame()
       .isolatedRealm()

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -433,6 +433,13 @@ export class CdpBrowser extends BrowserBase {
     return page;
   }
 
+  async _hasDevToolsTarget(pageTargetId: string): Promise<string | undefined> {
+    const response = await this.#connection.send('Target.getDevToolsTarget', {
+      targetId: pageTargetId,
+    });
+    return response.targetId;
+  }
+
   override async installExtension(path: string): Promise<string> {
     const {id} = await this.#connection.send('Extensions.loadUnpacked', {path});
     return id;

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -463,10 +463,8 @@ export class CdpPage extends Page {
   }
 
   override async hasDevTools(): Promise<boolean> {
-    const targetId = await this.browser()._hasDevToolsTarget(
-      this.target()._targetId,
-    );
-
+    const browser = this.browser() as CdpBrowser;
+    const targetId = await browser._hasDevToolsTarget(this.target()._targetId);
     return Boolean(targetId);
   }
 

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -462,6 +462,14 @@ export class CdpPage extends Page {
     return devtoolsPage;
   }
 
+  override async hasDevTools(): Promise<boolean> {
+    const targetId = await this.browser()._hasDevToolsTarget(
+      this.target()._targetId,
+    );
+
+    return Boolean(targetId);
+  }
+
   override async waitForFileChooser(
     options: WaitTimeoutOptions = {},
   ): Promise<FileChooser> {

--- a/test/src/cdp/devtools.spec.ts
+++ b/test/src/cdp/devtools.spec.ts
@@ -169,6 +169,19 @@ describe('DevTools', function () {
     await browser.close();
   });
 
+  it('should retrun same object when calling openDevTools twice', async () => {
+    const browser = await launchBrowser({
+      ...launchOptions,
+      devtools: false,
+    });
+    const page = await browser.newPage();
+    await page.goto('about:blank');
+    const devtoolsPage = await page.openDevTools();
+    const devtoolsPage2 = await page.openDevTools();
+    expect(devtoolsPage).toBe(devtoolsPage2);
+    await browser.close();
+  });
+
   describe('hasDevTools', () => {
     it('should report correctly after DevTools is opened', async () => {
       const browser = await launchBrowser({

--- a/test/src/cdp/devtools.spec.ts
+++ b/test/src/cdp/devtools.spec.ts
@@ -155,7 +155,10 @@ describe('DevTools', function () {
   });
 
   it('should support opening DevTools on a page', async () => {
-    const browser = await launchBrowser(launchOptions);
+    const browser = await launchBrowser({
+      ...launchOptions,
+      devtools: false,
+    });
     const page = await browser.newPage();
     await page.goto('about:blank');
     const devtoolsPage = await page.openDevTools();
@@ -164,5 +167,40 @@ describe('DevTools', function () {
       return Boolean(window.DevToolsAPI);
     });
     await browser.close();
+  });
+
+  describe('hasDevTools', () => {
+    it('should report correctly after DevTools is opened', async () => {
+      const browser = await launchBrowser({
+        ...launchOptions,
+        devtools: false,
+      });
+      const page = await browser.newPage();
+      await page.goto('about:blank');
+      expect(await page.hasDevTools()).toBe(false);
+      await page.openDevTools();
+      expect(await page.hasDevTools()).toBe(true);
+      await browser.close();
+    });
+
+    it('should report when DevTools is attached by default', async () => {
+      const browser = await launchBrowser(launchOptions);
+      const page = await browser.newPage();
+      await page.goto('about:blank');
+      expect(await page.hasDevTools()).toBe(true);
+      await browser.close();
+    });
+
+    it('should report when DevTools has been attached to a page with devtools:false', async () => {
+      const browser = await launchBrowser({
+        ...launchOptions,
+        devtools: false,
+      });
+      const page = await browser.newPage();
+      await page.goto('about:blank');
+      await page.openDevTools();
+      expect(await page.hasDevTools()).toBe(true);
+      await browser.close();
+    });
   });
 });


### PR DESCRIPTION
This is a simple method that check if DevTools is open or not.
Currently only supported in Chrome CDP. 
This method is cheap compared to openDevTools as it only check for presence.

If you need the DevTools page only when available:
```ts
if(await page.hasDevTools()) {
  const devToolsPage = await page.openDevTools();
}
```