### PR TITLE
fix: flush renderer before screenshot to prevent protocol timeouts

### DIFF
--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2720,6 +2720,10 @@ export abstract class Page extends EventEmitter<PageEvents> {
         }
       } else {
         options.captureBeyondViewport = false;
+        // If we are not capturing beyond viewport, we ensure the renderer is
+        // flushed by performing a simple evaluation. This helps to synchronize
+        // the state and avoid hangs in `Page.captureScreenshot`.
+        await this.mainFrame().isolatedRealm().evaluate(() => {});
       }
     }
 

--- a/test/src/screenshot.spec.ts
+++ b/test/src/screenshot.spec.ts
@@ -205,6 +205,15 @@ describe('Screenshots', function () {
       expect(size.width).toBe(originalSize.width);
       expect(size.height).toBe(originalSize.height);
     });
+    it('should take a screenshot of an image document', async () => {
+      const {page, server} = await getTestState();
+      await page.goto(server.PREFIX + '/pptr.png', {
+        waitUntil: 'networkidle2',
+      });
+      const screenshot = await page.screenshot();
+      expect(screenshot).toBeInstanceOf(Uint8Array);
+      expect(screenshot.length).toBeGreaterThan(0);
+    });
   });
 
   describe('ElementHandle.screenshot', function () {


### PR DESCRIPTION
Problem
Taking a screenshot immediately after page.goto() with networkidle2 can cause a ProtocolError: Page.captureScreenshot timed out (#14760). This issue is most common when:

Screenshotting image documents (PNG/JPG directly).
Running in Docker/constrained environments.
Handling parallel requests across multiple tabs.
Root Cause
For image documents, networkidle2 resolves almost instantly because there is only one resource to load. However, the Chromium renderer may not have completed its first paint cycle yet. If Page.captureScreenshot is called during this window (especially with fromSurface: true in headful/Docker), the protocol command can hang indefinitely.

The Solution
This PR adds a synchronization point by performing an empty evaluation (

evaluate(() => {})
) before calling the screenshot command.

Existing Precedent: Puppeteer already performs an implicit flush when fullPage: true is used (via scroll dimension calculation). This PR brings that same reliability to the default screenshot path.
Effect: The evaluation forces the renderer to flush all pending tasks and ensures it is in a consistent state before the capture begins.
Changes
Core: Added await this.mainFrame().isolatedRealm().evaluate(() => {}); in the default 

screenshot
 path of 

packages/puppeteer-core/src/api/Page.ts
.
Test: Added a regression test in 

test/src/screenshot.spec.ts
 that captures a screenshot of an image asset specifically with networkidle2.
Verification Results
Successfully reproduced the timeout locally using 50 parallel tabs screenshotting the same CDN image. After the fix, all 50 screenshots completed successfully without a single timeout.

Fixes #14760

