### PR TITLE
feat(browsers): show extraction progress after browser download

### DIFF
--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -448,13 +448,18 @@ async function installUrl(
     }
 
     debugInstall(`Installing ${archivePath} to ${outputPath}`);
+    process.stdout.write(
+      `Extracting ${options.browser} ${options.buildId}...\n`,
+    );
     try {
       debugTime('extract');
       await unpackArchive(archivePath, outputPath);
     } finally {
       debugTimeEnd('extract');
     }
-
+    process.stdout.write(
+      `Finished extracting ${options.browser} ${options.buildId}\n`,
+    );
     if (options.buildIdAlias) {
       const metadata = installedBrowser.readMetadata();
       metadata.aliases[options.buildIdAlias] = options.buildId;


### PR DESCRIPTION
Currently Puppeteer shows a download progress indicator in the terminal, but after the download finishes the unpacking process runs silently, which may make it appear as if the installation is stuck.

This change adds a CLI message indicating when extraction begins and when it completes so users can understand that installation is still progressing.

Fixes #13083