### PR TITLE
chore: mark "console should work for different console API calls with group functions" as failing in Firefox.

### DIFF
--- a/test/CanaryTestExpectations.json
+++ b/test/CanaryTestExpectations.json
@@ -26,5 +26,12 @@
     "parameters": ["firefox", "headful", "webDriverBiDi"],
     "expectations": ["PASS"],
     "comment": "Fixed by https://bugzilla.mozilla.org/show_bug.cgi?id=2010507"
+  },
+  {
+    "testIdPattern": "[console.spec] console should work for different console API calls with group functions",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "See https://github.com/w3c/webdriver-bidi/issues/1097"
   }
 ]


### PR DESCRIPTION
The consequences of the work on https://bugzilla.mozilla.org/show_bug.cgi?id=1866749.