### PR TITLE
test(bidi): fix bidi test "should throw when evaluation triggers reload"

### DIFF
--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -36,7 +36,7 @@ import {ExposableFunction} from './ExposedFunction.js';
 import type {BidiFrame} from './Frame.js';
 import {BidiJSHandle} from './JSHandle.js';
 import {BidiSerializer} from './Serializer.js';
-import {createEvaluationError} from './util.js';
+import {createEvaluationError, rewriteEvaluationError} from './util.js';
 import type {BidiWebWorker} from './WebWorker.js';
 
 /**
@@ -181,7 +181,7 @@ export abstract class BidiRealm extends Realm {
       );
     }
 
-    const result = await responsePromise;
+    const result = await responsePromise.catch(rewriteEvaluationError);
 
     if ('type' in result && result.type === 'exception') {
       throw createEvaluationError(result.exceptionDetails);

--- a/packages/puppeteer-core/src/bidi/util.ts
+++ b/packages/puppeteer-core/src/bidi/util.ts
@@ -82,3 +82,20 @@ export function rewriteNavigationError(
     throw error;
   };
 }
+
+/**
+ * @internal
+ */
+export function rewriteEvaluationError(error: unknown): never {
+  if (error instanceof Error) {
+    if (
+      error.message.includes('ExecutionContext was destroyed') ||
+      error.message.includes('Inspected target navigated or closed')
+    ) {
+      throw new Error(
+        'Execution context was destroyed, most likely because of a navigation.',
+      );
+    }
+  }
+  throw error;
+}


### PR DESCRIPTION
Fix a test that prevents us from enabling RenderDocument in Chrome once properly fixed version is live.

See also #14745 