### PR TITLE
fix: without azimuthAngle the altitudeAngle should no be specified

### DIFF
--- a/packages/puppeteer-core/src/bidi/Input.ts
+++ b/packages/puppeteer-core/src/bidi/Input.ts
@@ -732,7 +732,6 @@ export class BidiTouchscreen extends Touchscreen {
       width: 0.5 * 2, // 2 times default touch radius.
       height: 0.5 * 2, // 2 times default touch radius.
       pressure: 0.5,
-      altitudeAngle: Math.PI / 2,
     };
     const touch = new BidiTouchHandle(this.#page, this, id, x, y, properties);
     await touch.start(options);


### PR DESCRIPTION
Noticed when implementing the `altitudeAngle` and `azimuthAngle` properties for touch events in Firefox for WebDriver. [Based on the pointer-events spec](https://www.w3.org/TR/pointerevents3/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle):

> Depending on the specific hardware and platform, user agents will likely only receive one set of values for the transducer orientation relative to the screen plane — either tiltX / tiltY or altitudeAngle / azimuthAngle.

But for `touchStart` [only `altitudeAngle` is specified and that even with the default value of pi/2](https://github.com/puppeteer/puppeteer/blame/7a8b8e60e28c07eb68ab91508874dae6ce7d4106/packages/puppeteer-core/src/bidi/Input.ts#L735) the browser should set anyway on the platform side. Given that no `azimuthAngle` is specified we should just remove `altitudeAngle`.

