### PR TITLE
feat: implement console event on web workers

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -637,6 +637,13 @@ All the events that a page instance may emit.
 </td><td>
 
 </td></tr>
+<tr><td>
+
+<span id="webworkerevent">[WebWorkerEvent](./puppeteer.webworkerevent.md)</span>
+
+</td><td>
+
+</td></tr>
 </tbody></table>
 
 ## Functions
@@ -1368,6 +1375,13 @@ The TouchHandle interface exposes methods to manipulate touches that have been s
 <tr><td>
 
 <span id="waittimeoutoptions">[WaitTimeoutOptions](./puppeteer.waittimeoutoptions.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="webworkerevents">[WebWorkerEvents](./puppeteer.webworkerevents.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.webworker.md
+++ b/docs/api/puppeteer.webworker.md
@@ -9,10 +9,10 @@ This class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web
 ### Signature
 
 ```typescript
-export declare abstract class WebWorker extends EventEmitter<Record<EventType, unknown>>
+export declare abstract class WebWorker extends EventEmitter<WebWorkerEvents>
 ```
 
-**Extends:** [EventEmitter](./puppeteer.eventemitter.md)&lt;Record&lt;[EventType](./puppeteer.eventtype.md), unknown&gt;&gt;
+**Extends:** [EventEmitter](./puppeteer.eventemitter.md)&lt;[WebWorkerEvents](./puppeteer.webworkerevents.md)&gt;
 
 ## Remarks
 

--- a/docs/api/puppeteer.webworkerevent.md
+++ b/docs/api/puppeteer.webworkerevent.md
@@ -1,0 +1,54 @@
+---
+sidebar_label: WebWorkerEvent
+---
+
+# WebWorkerEvent enum
+
+### Signature
+
+```typescript
+export declare enum WebWorkerEvent
+```
+
+## Enumeration Members
+
+<table><thead><tr><th>
+
+Member
+
+</th><th>
+
+Value
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+Console
+
+</td><td>
+
+`"console"`
+
+</td><td>
+
+Emitted when the worker calls a console API.
+
+</td></tr>
+<tr><td>
+
+Error
+
+</td><td>
+
+`"error"`
+
+</td><td>
+
+Emitted when the worker throws an exception.
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.webworkerevents.md
+++ b/docs/api/puppeteer.webworkerevents.md
@@ -1,0 +1,68 @@
+---
+sidebar_label: WebWorkerEvents
+---
+
+# WebWorkerEvents interface
+
+### Signature
+
+```typescript
+export interface WebWorkerEvents extends Record<EventType, unknown>
+```
+
+**Extends:** Record&lt;[EventType](./puppeteer.eventtype.md), unknown&gt;
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="console">console</span>
+
+</td><td>
+
+</td><td>
+
+[ConsoleMessage](./puppeteer.consolemessage.md)
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="error">error</span>
+
+</td><td>
+
+</td><td>
+
+Error
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/packages/puppeteer-core/src/api/WebWorker.ts
+++ b/packages/puppeteer-core/src/api/WebWorker.ts
@@ -4,14 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {ConsoleMessage} from '../common/ConsoleMessage.js';
 import {UnsupportedOperation} from '../common/Errors.js';
-import {EventEmitter, type EventType} from '../common/EventEmitter.js';
+import type {EventType} from '../common/EventEmitter.js';
+import {EventEmitter} from '../common/EventEmitter.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {withSourcePuppeteerURLIfNone} from '../common/util.js';
 
 import type {CDPSession} from './CDPSession.js';
 import type {Realm} from './Realm.js';
+
+/**
+ * @public
+ */
+export enum WebWorkerEvent {
+  /**
+   * Emitted when the worker calls a console API.
+   */
+  Console = 'console',
+  /**
+   * Emitted when the worker throws an exception.
+   */
+  Error = 'error',
+}
+
+/**
+ * @public
+ */
+export interface WebWorkerEvents extends Record<EventType, unknown> {
+  [WebWorkerEvent.Console]: ConsoleMessage;
+  [WebWorkerEvent.Error]: Error;
+}
 
 /**
  * This class represents a
@@ -39,9 +63,7 @@ import type {Realm} from './Realm.js';
  *
  * @public
  */
-export abstract class WebWorker extends EventEmitter<
-  Record<EventType, unknown>
-> {
+export abstract class WebWorker extends EventEmitter<WebWorkerEvents> {
   /**
    * @internal
    */

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -30,11 +30,6 @@ import {
 } from '../api/Frame.js';
 import {PageEvent, type WaitTimeoutOptions} from '../api/Page.js';
 import {Accessibility} from '../cdp/Accessibility.js';
-import type {ConsoleMessageType} from '../common/ConsoleMessage.js';
-import {
-  ConsoleMessage,
-  type ConsoleMessageLocation,
-} from '../common/ConsoleMessage.js';
 import {TargetCloseError, UnsupportedOperation} from '../common/Errors.js';
 import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import type {Awaitable, HandleFor} from '../common/types.js';
@@ -50,33 +45,21 @@ import {BidiCdpSession} from './CDPSession.js';
 import type {BrowsingContext} from './core/BrowsingContext.js';
 import type {Navigation} from './core/Navigation.js';
 import type {Request} from './core/Request.js';
-import {BidiDeserializer} from './Deserializer.js';
 import {BidiDialog} from './Dialog.js';
 import {BidiElementHandle} from './ElementHandle.js';
 import {ExposableFunction} from './ExposedFunction.js';
 import {BidiHTTPRequest, requests} from './HTTPRequest.js';
 import type {BidiHTTPResponse} from './HTTPResponse.js';
-import {BidiJSHandle} from './JSHandle.js';
 import type {BidiPage} from './Page.js';
 import type {BidiRealm} from './Realm.js';
 import {BidiFrameRealm} from './Realm.js';
-import {rewriteNavigationError} from './util.js';
+import {
+  getConsoleMessage,
+  isConsoleLogEntry,
+  isJavaScriptLogEntry,
+  rewriteNavigationError,
+} from './util.js';
 import {BidiWebWorker} from './WebWorker.js';
-
-// TODO: Remove this and map CDP the correct method.
-// Requires breaking change.
-function convertConsoleMessageLevel(method: string): ConsoleMessageType {
-  switch (method) {
-    case 'group':
-      return 'startGroup';
-    case 'groupCollapsed':
-      return 'startGroupCollapsed';
-    case 'groupEnd':
-      return 'endGroup';
-    default:
-      return method as ConsoleMessageType;
-  }
-}
 
 export class BidiFrame extends Frame {
   static from(
@@ -178,30 +161,16 @@ export class BidiFrame extends Frame {
         return;
       }
       if (isConsoleLogEntry(entry)) {
+        if (!this.page().listenerCount(PageEvent.Console)) {
+          return;
+        }
         const args = entry.args.map(arg => {
           return this.mainRealm().createHandle(arg);
         });
 
-        const text = args
-          .reduce((value, arg) => {
-            const parsedValue =
-              arg instanceof BidiJSHandle && arg.isPrimitiveValue
-                ? BidiDeserializer.deserialize(arg.remoteValue())
-                : arg.toString();
-            return `${value} ${parsedValue}`;
-          }, '')
-          .slice(1);
-
         this.page().trustedEmitter.emit(
           PageEvent.Console,
-          new ConsoleMessage(
-            convertConsoleMessageLevel(entry.method),
-            text,
-            args,
-            getStackTraceLocations(entry.stackTrace),
-            this,
-            undefined,
-          ),
+          getConsoleMessage(entry, args, this),
         );
       } else if (isJavaScriptLogEntry(entry)) {
         const error = new Error(entry.text ?? '');
@@ -638,32 +607,4 @@ export class BidiFrame extends Frame {
       [element.remoteValue() as Bidi.Script.SharedReference],
     );
   }
-}
-
-function isConsoleLogEntry(
-  event: Bidi.Log.Entry,
-): event is Bidi.Log.ConsoleLogEntry {
-  return event.type === 'console';
-}
-
-function isJavaScriptLogEntry(
-  event: Bidi.Log.Entry,
-): event is Bidi.Log.JavascriptLogEntry {
-  return event.type === 'javascript';
-}
-
-function getStackTraceLocations(
-  stackTrace?: Bidi.Script.StackTrace,
-): ConsoleMessageLocation[] {
-  const stackTraceLocations: ConsoleMessageLocation[] = [];
-  if (stackTrace) {
-    for (const callFrame of stackTrace.callFrames) {
-      stackTraceLocations.push({
-        url: callFrame.url,
-        lineNumber: callFrame.lineNumber,
-        columnNumber: callFrame.columnNumber,
-      });
-    }
-  }
-  return stackTraceLocations;
 }

--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -7,6 +7,7 @@ import * as Bidi from 'webdriver-bidi-protocol';
 
 import type {JSHandle} from '../api/JSHandle.js';
 import {Realm} from '../api/Realm.js';
+import {WebWorkerEvent} from '../api/WebWorker.js';
 import {ARIAQueryHandler} from '../common/AriaQueryHandler.js';
 import {LazyArg} from '../common/LazyArg.js';
 import {scriptInjector} from '../common/ScriptInjector.js';
@@ -36,7 +37,12 @@ import {ExposableFunction} from './ExposedFunction.js';
 import type {BidiFrame} from './Frame.js';
 import {BidiJSHandle} from './JSHandle.js';
 import {BidiSerializer} from './Serializer.js';
-import {createEvaluationError, rewriteEvaluationError} from './util.js';
+import {
+  createEvaluationError,
+  getConsoleMessage,
+  isConsoleLogEntry,
+  rewriteEvaluationError,
+} from './util.js';
 import type {BidiWebWorker} from './WebWorker.js';
 
 /**
@@ -398,6 +404,28 @@ export class BidiWorkerRealm extends BidiRealm {
   ) {
     super(realm, frame.timeoutSettings);
     this.#worker = frame;
+  }
+
+  override initialize(): void {
+    super.initialize();
+    this.realm.on('log', entry => {
+      if (
+        isConsoleLogEntry(entry) &&
+        this.#worker.listenerCount(WebWorkerEvent.Console)
+      ) {
+        const args = entry.args.map(arg => {
+          return this.createHandle(arg);
+        });
+
+        const message = getConsoleMessage(
+          entry,
+          args,
+          undefined,
+          this.realm.id,
+        );
+        this.#worker.emit(WebWorkerEvent.Console, message);
+      }
+    });
   }
 
   override get environment(): BidiWebWorker {

--- a/packages/puppeteer-core/src/bidi/core/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/core/Realm.ts
@@ -43,6 +43,8 @@ export abstract class Realm extends EventEmitter<{
   worker: DedicatedWorkerRealm;
   /** Emitted when a shared worker is created in the realm. */
   sharedworker: SharedWorkerRealm;
+  /** Emitted whenever a log entry is added to the realm. */
+  log: Bidi.Log.Entry;
 }> {
   #reason?: string;
   protected readonly disposables = new DisposableStack();
@@ -207,6 +209,13 @@ export class WindowRealm extends Realm {
 
       this.emit('worker', realm);
     });
+
+    sessionEmitter.on('log.entryAdded', entry => {
+      if (entry.source.realm !== this.id) {
+        return;
+      }
+      this.emit('log', entry);
+    });
   }
 
   override get session(): Session {
@@ -278,6 +287,13 @@ export class DedicatedWorkerRealm extends Realm {
 
       this.emit('worker', realm);
     });
+
+    sessionEmitter.on('log.entryAdded', entry => {
+      if (entry.source.realm !== this.id) {
+        return;
+      }
+      this.emit('log', entry);
+    });
   }
 
   override get session(): Session {
@@ -329,6 +345,13 @@ export class SharedWorkerRealm extends Realm {
       });
 
       this.emit('worker', realm);
+    });
+
+    sessionEmitter.on('log.entryAdded', entry => {
+      if (entry.source.realm !== this.id) {
+        return;
+      }
+      this.emit('log', entry);
     });
   }
 

--- a/packages/puppeteer-core/src/bidi/util.ts
+++ b/packages/puppeteer-core/src/bidi/util.ts
@@ -6,10 +6,104 @@
 
 import type * as Bidi from 'webdriver-bidi-protocol';
 
+import type {Frame} from '../api/Frame.js';
+import {ConsoleMessage} from '../common/ConsoleMessage.js';
+import type {
+  ConsoleMessageLocation,
+  ConsoleMessageType,
+} from '../common/ConsoleMessage.js';
 import {ProtocolError, TimeoutError} from '../common/Errors.js';
 import {PuppeteerURL} from '../common/util.js';
 
+import type {BidiElementHandle} from './bidi.js';
 import {BidiDeserializer} from './Deserializer.js';
+import {BidiJSHandle} from './JSHandle.js';
+
+/**
+ * @internal
+ *
+ * TODO: Remove this and map CDP the correct method.
+ * Requires breaking change.
+ */
+export function convertConsoleMessageLevel(method: string): ConsoleMessageType {
+  switch (method) {
+    case 'group':
+      return 'startGroup';
+    case 'groupCollapsed':
+      return 'startGroupCollapsed';
+    case 'groupEnd':
+      return 'endGroup';
+    default:
+      return method as ConsoleMessageType;
+  }
+}
+
+/**
+ * @internal
+ */
+export function getStackTraceLocations(
+  stackTrace?: Bidi.Script.StackTrace,
+): ConsoleMessageLocation[] {
+  const stackTraceLocations: ConsoleMessageLocation[] = [];
+  if (stackTrace) {
+    for (const callFrame of stackTrace.callFrames) {
+      stackTraceLocations.push({
+        url: callFrame.url,
+        lineNumber: callFrame.lineNumber,
+        columnNumber: callFrame.columnNumber,
+      });
+    }
+  }
+  return stackTraceLocations;
+}
+
+/**
+ * @internal
+ */
+export function getConsoleMessage(
+  entry: Bidi.Log.ConsoleLogEntry,
+  args: Array<BidiJSHandle<unknown> | BidiElementHandle<Node>>,
+  frame?: Frame,
+  targetId?: string,
+): ConsoleMessage {
+  const text = args
+    .reduce((value, arg) => {
+      const parsedValue =
+        arg instanceof BidiJSHandle && arg.isPrimitiveValue
+          ? BidiDeserializer.deserialize(arg.remoteValue())
+          : arg.toString();
+      return `${value} ${parsedValue}`;
+    }, '')
+    .slice(1);
+
+  return new ConsoleMessage(
+    convertConsoleMessageLevel(entry.method),
+    text,
+    args,
+    getStackTraceLocations(entry.stackTrace),
+    frame,
+    undefined,
+    targetId,
+  );
+}
+
+/**
+ * @internal
+ */
+export function isConsoleLogEntry(
+  event: Bidi.Log.Entry,
+): event is Bidi.Log.ConsoleLogEntry {
+  return event.type === 'console';
+}
+
+/**
+ * @internal
+ */
+export function isJavaScriptLogEntry(
+  event: Bidi.Log.Entry,
+): event is Bidi.Log.JavascriptLogEntry {
+  return event.type === 'javascript';
+}
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -32,10 +32,8 @@ import {
   type ScreenshotOptions,
   type WaitTimeoutOptions,
 } from '../api/Page.js';
-import {
-  ConsoleMessage,
-  type ConsoleMessageType,
-} from '../common/ConsoleMessage.js';
+import {WebWorker, WebWorkerEvent} from '../api/WebWorker.js';
+import {ConsoleMessage} from '../common/ConsoleMessage.js';
 import type {
   Cookie,
   DeleteCookiesRequest,
@@ -86,20 +84,12 @@ import {TargetManagerEvent} from './TargetManageEvents.js';
 import type {TargetManager} from './TargetManager.js';
 import {Tracing} from './Tracing.js';
 import {
+  convertConsoleMessageLevel,
   createClientError,
+  createConsoleMessage,
   pageBindingInitString,
-  valueFromJSHandle,
 } from './utils.js';
 import {CdpWebWorker} from './WebWorker.js';
-
-function convertConsoleMessageLevel(method: string): ConsoleMessageType {
-  switch (method) {
-    case 'warning':
-      return 'warn';
-    default:
-      return method as ConsoleMessageType;
-  }
-}
 
 /**
  * @internal
@@ -368,11 +358,29 @@ export class CdpPage extends Page {
         session.target().url(),
         session.target()._targetId,
         session.target().type(),
-        this.#onConsoleAPI.bind(this),
         this.#handleException.bind(this),
         this.#frameManager.networkManager,
       );
       this.#workers.set(session.id(), worker);
+      worker.internalEmitter.on(WebWorkerEvent.Console, message => {
+        const noListenersForConsoleOnPage =
+          this.listenerCount(PageEvent.Console) === 0;
+        const noListenersForConsoleOnWorker =
+          worker.listenerCount(WebWorkerEvent.Console) === 0;
+
+        if (noListenersForConsoleOnPage && noListenersForConsoleOnWorker) {
+          // eslint-disable-next-line max-len -- The comment is long.
+          // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
+          for (const arg of message.args()) {
+            void arg.dispose().catch(debugError);
+          }
+          return;
+        }
+
+        if (!noListenersForConsoleOnPage) {
+          this.emit(PageEvent.Console, message);
+        }
+      });
       this.emit(PageEvent.WorkerCreated, worker);
     }
     session.on(CDPSessionEvent.Ready, this.#onAttachedToTarget);
@@ -905,32 +913,28 @@ export class CdpPage extends Page {
   #onConsoleAPI(
     world: IsolatedWorld,
     event: Protocol.Runtime.ConsoleAPICalledEvent,
+    values?: JSHandle[],
   ): void {
-    const values = event.args.map(arg => {
-      return world.createCdpHandle(arg);
-    });
-
-    if (!this.listenerCount(PageEvent.Console)) {
-      values.forEach(arg => {
-        return arg.dispose();
+    if (!values) {
+      values = event.args.map(arg => {
+        return world.createCdpHandle(arg);
       });
-      return;
     }
-    const textTokens = [];
-    // eslint-disable-next-line max-len -- The comment is long.
-    // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
-    for (const arg of values) {
-      textTokens.push(valueFromJSHandle(arg));
-    }
-    const stackTraceLocations = [];
-    if (event.stackTrace) {
-      for (const callFrame of event.stackTrace.callFrames) {
-        stackTraceLocations.push({
-          url: callFrame.url,
-          lineNumber: callFrame.lineNumber,
-          columnNumber: callFrame.columnNumber,
-        });
+
+    const hasPageConsoleListeners = this.listenerCount(PageEvent.Console) > 0;
+    const hasWorkerConsoleListeners =
+      world.environment instanceof WebWorker &&
+      world.environment.listenerCount(WebWorkerEvent.Console) > 0;
+
+    if (!hasPageConsoleListeners) {
+      if (!hasWorkerConsoleListeners) {
+        // eslint-disable-next-line max-len -- The comment is long.
+        // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
+        for (const value of values) {
+          void value.dispose().catch(debugError);
+        }
       }
+      return;
     }
 
     let targetId;
@@ -938,16 +942,7 @@ export class CdpPage extends Page {
       targetId = world.environment.client.target()._targetId;
     }
 
-    const message = new ConsoleMessage(
-      convertConsoleMessageLevel(event.type),
-      textTokens.join(' '),
-      values,
-      stackTraceLocations,
-      undefined,
-      event.stackTrace,
-      targetId,
-    );
-    this.emit(PageEvent.Console, message);
+    this.emit(PageEvent.Console, createConsoleMessage(event, values, targetId));
   }
 
   async #onBindingCalled(

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -284,7 +284,6 @@ export class WorkerTarget extends CdpTarget {
   override async worker(): Promise<CdpWebWorker | null> {
     if (!this.#workerPromise) {
       const session = this._session();
-      // TODO(einbinder): Make workers send their console logs.
       this.#workerPromise = (
         session
           ? Promise.resolve(session)
@@ -295,7 +294,6 @@ export class WorkerTarget extends CdpTarget {
           this._getTargetInfo().url,
           this._targetId,
           this.type(),
-          () => {} /* consoleAPICalled */,
           () => {} /* exceptionThrown */,
           undefined /* networkManager */,
         );

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -8,21 +8,19 @@ import type {Protocol} from 'devtools-protocol';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
 import type {Realm} from '../api/Realm.js';
 import {TargetType} from '../api/Target.js';
-import {WebWorker} from '../api/WebWorker.js';
+import {
+  WebWorker,
+  WebWorkerEvent,
+  type WebWorkerEvents,
+} from '../api/WebWorker.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError} from '../common/util.js';
 
 import {ExecutionContext} from './ExecutionContext.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import type {NetworkManager} from './NetworkManager.js';
-
-/**
- * @internal
- */
-export type ConsoleAPICalledCallback = (
-  world: IsolatedWorld,
-  event: Protocol.Runtime.ConsoleAPICalledEvent,
-) => void;
+import {createConsoleMessage} from './utils.js';
+import {EventEmitter} from '../common/EventEmitter.js';
 
 /**
  * @internal
@@ -39,13 +37,17 @@ export class CdpWebWorker extends WebWorker {
   #client: CDPSession;
   readonly #id: string;
   readonly #targetType: TargetType;
+  readonly #emitter: EventEmitter<WebWorkerEvents>;
+
+  get internalEmitter() {
+    return this.#emitter;
+  }
 
   constructor(
     client: CDPSession,
     url: string,
     targetId: string,
     targetType: TargetType,
-    consoleAPICalled: ConsoleAPICalledCallback,
     exceptionThrown: ExceptionThrownCallback,
     networkManager?: NetworkManager,
   ) {
@@ -54,6 +56,7 @@ export class CdpWebWorker extends WebWorker {
     this.#client = client;
     this.#targetType = targetType;
     this.#world = new IsolatedWorld(this, new TimeoutSettings());
+    this.#emitter = new EventEmitter<WebWorkerEvents>();
 
     this.#client.once('Runtime.executionContextCreated', async event => {
       this.#world.setContext(
@@ -62,7 +65,29 @@ export class CdpWebWorker extends WebWorker {
     });
     this.#world.emitter.on('consoleapicalled', async event => {
       try {
-        return consoleAPICalled(this.#world, event);
+        const values = event.args.map(arg => {
+          return this.#world.createCdpHandle(arg);
+        });
+
+        const noInternalListeners =
+          this.#emitter.listenerCount(WebWorkerEvent.Console) === 0;
+        const noWorkerListeners =
+          this.listenerCount(WebWorkerEvent.Console) === 0;
+
+        if (noInternalListeners && noWorkerListeners) {
+          // eslint-disable-next-line max-len -- The comment is long.
+          // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
+          for (const value of values) {
+            void value.dispose().catch(debugError);
+          }
+          return;
+        }
+
+        const consoleMessages = createConsoleMessage(event, values, this.#id);
+        this.#emitter.emit(WebWorkerEvent.Console, consoleMessages);
+        if (!noWorkerListeners) {
+          this.emit(WebWorkerEvent.Console, consoleMessages);
+        }
       } catch (err) {
         debugError(err);
       }

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -13,6 +13,7 @@ import {
   WebWorkerEvent,
   type WebWorkerEvents,
 } from '../api/WebWorker.js';
+import {EventEmitter} from '../common/EventEmitter.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError} from '../common/util.js';
 
@@ -20,7 +21,6 @@ import {ExecutionContext} from './ExecutionContext.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
 import type {NetworkManager} from './NetworkManager.js';
 import {createConsoleMessage} from './utils.js';
-import {EventEmitter} from '../common/EventEmitter.js';
 
 /**
  * @internal
@@ -39,7 +39,7 @@ export class CdpWebWorker extends WebWorker {
   readonly #targetType: TargetType;
   readonly #emitter: EventEmitter<WebWorkerEvents>;
 
-  get internalEmitter() {
+  get internalEmitter(): EventEmitter<WebWorkerEvents> {
     return this.#emitter;
   }
 

--- a/packages/puppeteer-core/src/cdp/utils.ts
+++ b/packages/puppeteer-core/src/cdp/utils.ts
@@ -7,8 +7,48 @@
 import type {Protocol} from 'devtools-protocol';
 
 import type {JSHandle} from '../api/JSHandle.js';
+import {
+  ConsoleMessage,
+  type ConsoleMessageType,
+} from '../common/ConsoleMessage.js';
 import {PuppeteerURL, evaluationString} from '../common/util.js';
 import {assert} from '../util/assert.js';
+
+/**
+ * @internal
+ */
+export function createConsoleMessage(
+  event: Protocol.Runtime.ConsoleAPICalledEvent,
+  values: JSHandle[],
+  targetId?: string,
+): ConsoleMessage {
+  const textTokens = [];
+  // eslint-disable-next-line max-len -- The comment is long.
+  // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
+  for (const arg of values) {
+    textTokens.push(valueFromJSHandle(arg));
+  }
+  const stackTraceLocations = [];
+  if (event.stackTrace) {
+    for (const callFrame of event.stackTrace.callFrames) {
+      stackTraceLocations.push({
+        url: callFrame.url,
+        lineNumber: callFrame.lineNumber,
+        columnNumber: callFrame.columnNumber,
+      });
+    }
+  }
+
+  return new ConsoleMessage(
+    convertConsoleMessageLevel(event.type),
+    textTokens.join(' '),
+    values,
+    stackTraceLocations,
+    undefined,
+    event.stackTrace,
+    targetId,
+  );
+}
 
 /**
  * @internal
@@ -268,4 +308,16 @@ export const CDP_BINDING_PREFIX = 'puppeteer_';
  */
 export function pageBindingInitString(type: string, name: string): string {
   return evaluationString(addPageBinding, type, name, CDP_BINDING_PREFIX);
+}
+
+/**
+ * @internal
+ */
+export function convertConsoleMessageLevel(method: string): ConsoleMessageType {
+  switch (method) {
+    case 'warning':
+      return 'warn';
+    default:
+      return method as ConsoleMessageType;
+  }
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -886,6 +886,13 @@
     "comment": "tests chrome-specific flags"
   },
   {
+    "testIdPattern": "[worker.spec] Workers console should return remote objects",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "BiDi does not support getting a Handle for log args"
+  },
+  {
     "testIdPattern": "[acceptInsecureCerts.spec] acceptInsecureCerts Response.securityDetails Network redirects should report SecurityDetails",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/src/console.spec.ts
+++ b/test/src/console.spec.ts
@@ -71,47 +71,72 @@ describe('console', function () {
 
     expect(message.text()).toEqual('SOME_LOG_MESSAGE');
   });
-  it('should work for different console API calls with logging functions', async () => {
+  it('should work for console.trace', async () => {
     const {page} = await getTestState();
 
-    const messages: ConsoleMessage[] = [];
-    page.on('console', msg => {
-      return messages.push(msg);
-    });
-    // All console events will be reported before `page.evaluate` is finished.
-    await page.evaluate(() => {
-      console.trace('calling console.trace');
-      console.dir('calling console.dir');
-      console.warn('calling console.warn');
-      console.error('calling console.error');
-      console.log(Promise.resolve('should not wait until resolved!'));
-    });
-    expect(
-      messages.map(msg => {
-        return msg.type();
+    const [message] = await Promise.all([
+      waitEvent<ConsoleMessage>(page, 'console'),
+      page.evaluate(() => {
+        console.trace('calling console.trace');
       }),
-    ).toEqual(['trace', 'dir', 'warn', 'error', 'log']);
-    const texts = messages.map(msg => {
-      return msg.text();
-    });
-    try {
-      expect(texts).toEqual([
-        'calling console.trace',
-        'calling console.dir',
-        'calling console.warn',
-        'calling console.error',
-        '[promise Promise]',
-      ]);
-    } catch {
-      // WebDriver BiDi expectation.
-      expect(texts).toEqual([
-        'calling console.trace',
-        'calling console.dir',
-        'calling console.warn',
-        'calling console.error',
-        'JSHandle@promise',
-      ]);
-    }
+    ]);
+    expect(message.type()).toBe('trace');
+    expect(message.text()).toBe('calling console.trace');
+  });
+
+  it('should work for console.dir', async () => {
+    const {page} = await getTestState();
+
+    const [message] = await Promise.all([
+      waitEvent<ConsoleMessage>(page, 'console'),
+      page.evaluate(() => {
+        console.dir('calling console.dir');
+      }),
+    ]);
+    expect(message.type()).toBe('dir');
+    expect(message.text()).toBe('calling console.dir');
+  });
+
+  it('should work for console.warn', async () => {
+    const {page} = await getTestState();
+
+    const [message] = await Promise.all([
+      waitEvent<ConsoleMessage>(page, 'console'),
+      page.evaluate(() => {
+        console.warn('calling console.warn');
+      }),
+    ]);
+    expect(message.type()).toBe('warn');
+    expect(message.text()).toBe('calling console.warn');
+  });
+
+  it('should work for console.error', async () => {
+    const {page} = await getTestState();
+
+    const [message] = await Promise.all([
+      waitEvent<ConsoleMessage>(page, 'console'),
+      page.evaluate(() => {
+        console.error('calling console.error');
+      }),
+    ]);
+    expect(message.type()).toBe('error');
+    expect(message.text()).toBe('calling console.error');
+  });
+
+  it('should work for console.log with promise', async () => {
+    const {page} = await getTestState();
+
+    const [message] = await Promise.all([
+      waitEvent<ConsoleMessage>(page, 'console'),
+      page.evaluate(() => {
+        console.log(Promise.resolve('should not wait until resolved!'));
+      }),
+    ]);
+    expect(message.type()).toBe('log');
+    expect(message.text()).atLeastOneToContain([
+      '[promise Promise]',
+      'JSHandle@promise', // WebDriver BiDi expectation.
+    ]);
   });
   it('should work for different console API calls with timing functions', async () => {
     const {page} = await getTestState();
@@ -187,6 +212,21 @@ describe('console', function () {
     expect(log.args()).toHaveLength(4);
     using property = await log.args()[3]!.getProperty('test');
     expect(await property.jsonValue()).toBe(1);
+  });
+  it('should not dispose handles when page has listeners', async () => {
+    const {page} = await getTestState();
+
+    const [message] = await Promise.all([
+      waitEvent<ConsoleMessage>(page, 'console'),
+      page.evaluate(() => {
+        return console.log({foo: 'bar'});
+      }),
+    ]);
+    using handle = message.args()[0]!;
+    expect(handle.disposed).toBe(false);
+    expect(await handle.jsonValue()).toEqual({foo: 'bar'});
+    await handle.dispose();
+    expect(handle.disposed).toBe(true);
   });
   it('should trigger correct Log', async () => {
     const {page, server, isChrome} = await getTestState();

--- a/test/src/worker.spec.ts
+++ b/test/src/worker.spec.ts
@@ -6,6 +6,7 @@
 
 import expect from 'expect';
 import type {WebWorker} from 'puppeteer-core/internal/api/WebWorker.js';
+import {WebWorkerEvent} from 'puppeteer-core/internal/api/WebWorker.js';
 import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
@@ -178,5 +179,247 @@ describe('Workers', function () {
     await expect(testResponse!.text()).resolves.toContain(
       'hello from the worker',
     );
+  });
+
+  describe('console', function () {
+    setupTestBrowserHooks();
+
+    async function createWorker(page: any): Promise<WebWorker> {
+      const workerCreatedPromise = waitEvent<WebWorker>(page, 'workercreated');
+      await page.evaluate(() => {
+        return new Worker(`data:text/javascript,1`);
+      });
+      return await workerCreatedPromise;
+    }
+
+    it('should work', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          return console.log('hello', 5, {foo: 'bar'});
+        }),
+      ]);
+      expect(message.text()).atLeastOneToContain([
+        'hello 5 [object Object]',
+        'hello 5 JSHandle@object', // WebDriver BiDi
+      ]);
+      expect(message.type()).toEqual('log');
+      expect(message.args()).toHaveLength(3);
+
+      expect(await message.args()[0]!.jsonValue()).toEqual('hello');
+      expect(await message.args()[1]!.jsonValue()).toEqual(5);
+      expect(await message.args()[2]!.jsonValue()).toEqual({foo: 'bar'});
+    });
+
+    it('should work for Error instances', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          return console.log(new Error('test error'));
+        }),
+      ]);
+
+      expect(message.text()).atLeastOneToContain([
+        'Error: test error', // CDP expectation
+        'JSHandle@error', // BiDi current behavior
+      ]);
+      expect(message.type()).toEqual('log');
+      expect(message.args()).toHaveLength(1);
+    });
+    it('should return the first line of the error message in text()', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          return console.log(new Error('test error\nsecond line'));
+        }),
+      ]);
+      expect(message.text()).atLeastOneToContain([
+        'Error: test error', // CDP expectation
+        'JSHandle@error', // BiDi current behavior
+      ]);
+      expect(message.type()).toEqual('log');
+      expect(message.args()).toHaveLength(1);
+    });
+    it('should work for console.trace', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          console.trace('calling console.trace');
+        }),
+      ]);
+      expect(message.type()).toBe('trace');
+      expect(message.text()).toBe('calling console.trace');
+    });
+
+    it('should work for console.dir', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          console.dir('calling console.dir');
+        }),
+      ]);
+      expect(message.type()).toBe('dir');
+      expect(message.text()).toBe('calling console.dir');
+    });
+
+    it('should work for console.warn', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          console.warn('calling console.warn');
+        }),
+      ]);
+      expect(message.type()).toBe('warn');
+      expect(message.text()).toBe('calling console.warn');
+    });
+
+    it('should work for console.error', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          console.error('calling console.error');
+        }),
+      ]);
+      expect(message.type()).toBe('error');
+      expect(message.text()).toBe('calling console.error');
+    });
+
+    it('should work for console.log with promise', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          console.log(Promise.resolve('should not wait until resolved!'));
+        }),
+      ]);
+      expect(message.type()).toBe('log');
+      expect(message.text()).atLeastOneToContain([
+        '[promise Promise]',
+        'JSHandle@promise', // WebDriver BiDi expectation.
+      ]);
+    });
+    it('should work for different console API calls with timing functions', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const messages: ConsoleMessage[] = [];
+      worker.on(WebWorkerEvent.Console, msg => {
+        return messages.push(msg);
+      });
+      // All console events will be reported before `worker.evaluate` is finished.
+      await worker.evaluate(() => {
+        // A pair of time/timeEnd generates only one Console API call.
+        console.time('calling console.time');
+        console.timeEnd('calling console.time');
+      });
+      expect(
+        messages.map(msg => {
+          return msg.type();
+        }),
+      ).toEqual(['timeEnd']);
+      expect(messages[0]!.text()).toContain('calling console.time');
+    });
+    it('should work for different console API calls with group functions', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const messages: ConsoleMessage[] = [];
+      worker.on(WebWorkerEvent.Console, msg => {
+        return messages.push(msg);
+      });
+      // All console events will be reported before `worker.evaluate` is finished.
+      await worker.evaluate(() => {
+        console.group('calling console.group');
+        console.groupEnd();
+      });
+      expect(
+        messages.map(msg => {
+          return msg.type();
+        }),
+      ).toEqual(['startGroup', 'endGroup']);
+
+      // We should be able to check both messages, but Chrome report text
+      expect(messages[0]!.text()).toContain('calling console.group');
+    });
+    it('should return remote objects', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const logPromise = waitEvent<ConsoleMessage>(
+        worker,
+        WebWorkerEvent.Console,
+      );
+      await worker.evaluate(() => {
+        (globalThis as any).test = 1;
+        console.log(1, 2, 3, globalThis);
+      });
+      const log = await logPromise;
+
+      expect(log.text()).atLeastOneToContain([
+        '1 2 3 [object DedicatedWorkerGlobalScope]',
+        '1 2 3 JSHandle@object', // WebDriver BiDi
+      ]);
+      expect(log.args()).toHaveLength(4);
+      using property = await log.args()[3]!.getProperty('test');
+      expect(await property.jsonValue()).toBe(1);
+    });
+    it('should have location and stack trace for console API calls', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          function consoleTrace() {
+            console.trace('yellow');
+          }
+          consoleTrace();
+        }),
+      ]);
+      expect(message.text()).toBe('yellow');
+      expect(message.type()).toBe('trace');
+      expect(message.location().url).toBeDefined();
+      expect(message.stackTrace().length).toBeGreaterThan(0);
+    });
+
+    it('should not dispose handles when worker has listeners', async () => {
+      const {page} = await getTestState();
+      const worker = await createWorker(page);
+
+      const [message] = await Promise.all([
+        waitEvent<ConsoleMessage>(worker, WebWorkerEvent.Console),
+        worker.evaluate(() => {
+          return console.log({foo: 'bar'});
+        }),
+      ]);
+      using handle = message.args()[0]!;
+      expect(handle.disposed).toBe(false);
+      expect(await handle.jsonValue()).toEqual({foo: 'bar'});
+      await handle.dispose();
+      expect(handle.disposed).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR introduces the possibility to listen for console events on a WebWorker via `on("console", listener);`. 
Right now WebWorker are sending console logs directly to the `page.on("console",...)` event.
This change allows to specifically listen to WebWorkers logs only.  

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Extension service workers are treated as WebWorkers but are not connected to any page, this makes listening for console from service worker impossible without relying on the raw events on the CDP. this PR introduces a way to retrieve those logs in a simpler way.

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
