### PR TITLE
feat(browsers): report unpacking progress

### DIFF
--- a/docs/browsers-api/browsers.installoptions.md
+++ b/docs/browsers-api/browsers.installoptions.md
@@ -140,7 +140,7 @@ Determines the path to download browsers to.
 
 </td><td>
 
-Provides information about the progress of the download. If set to 'default', the default callback implementing a progress bar will be used.
+Provides information about the progress of the download. If set to 'default', the default callback implementing a progress bar and install status updates will be used.
 
 </td><td>
 

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -29,6 +29,14 @@ import type {BrowserProvider} from './provider.js';
 
 const debugInstall = debug('puppeteer:browsers:install');
 
+interface InstallProgressCallbackSet {
+  downloadProgressCallback?: (
+    downloadedBytes: number,
+    totalBytes: number,
+  ) => void;
+  onExtract?: () => void;
+}
+
 const times = new Map<string, [number, number]>();
 function debugTime(label: string) {
   times.set(label, process.hrtime());
@@ -77,8 +85,8 @@ export interface InstallOptions {
   buildIdAlias?: string;
   /**
    * Provides information about the progress of the download. If set to
-   * 'default', the default callback implementing a progress bar will be
-   * used.
+   * 'default', the default callback implementing a progress bar and install
+   * status updates will be used.
    */
   downloadProgressCallback?:
     | 'default'
@@ -361,11 +369,14 @@ async function installUrl(
     );
   }
   let downloadProgressCallback = options.downloadProgressCallback;
+  let onExtract: (() => void) | undefined;
   if (downloadProgressCallback === 'default') {
-    downloadProgressCallback = await makeProgressCallback(
+    const progressCallbackSet = makeProgressCallbackSet(
       options.browser,
       options.buildIdAlias ?? options.buildId,
     );
+    downloadProgressCallback = progressCallbackSet.downloadProgressCallback;
+    onExtract = progressCallbackSet.onExtract;
   }
   const fileName = decodeURIComponent(url.toString()).split('/').pop();
   assert(fileName, `A malformed download URL was found: ${url}.`);
@@ -448,6 +459,7 @@ async function installUrl(
     }
 
     debugInstall(`Installing ${archivePath} to ${outputPath}`);
+    onExtract?.();
     try {
       debugTime('extract');
       await unpackArchive(archivePath, outputPath);
@@ -627,24 +639,36 @@ export function makeProgressCallback(
   browser: Browser,
   buildId: string,
 ): (downloadedBytes: number, totalBytes: number) => void {
+  return makeProgressCallbackSet(browser, buildId).downloadProgressCallback!;
+}
+
+function makeProgressCallbackSet(
+  browser: Browser,
+  buildId: string,
+): InstallProgressCallbackSet {
   let progressBar: ProgressBar;
 
   let lastDownloadedBytes = 0;
-  return (downloadedBytes: number, totalBytes: number) => {
-    if (!progressBar) {
-      progressBar = new ProgressBarClass(
-        `Downloading ${browser} ${buildId} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `,
-        {
-          complete: '=',
-          incomplete: ' ',
-          width: 20,
-          total: totalBytes,
-        },
-      );
-    }
-    const delta = downloadedBytes - lastDownloadedBytes;
-    lastDownloadedBytes = downloadedBytes;
-    progressBar.tick(delta);
+  return {
+    downloadProgressCallback: (downloadedBytes: number, totalBytes: number) => {
+      if (!progressBar) {
+        progressBar = new ProgressBarClass(
+          `Downloading ${browser} ${buildId} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `,
+          {
+            complete: '=',
+            incomplete: ' ',
+            width: 20,
+            total: totalBytes,
+          },
+        );
+      }
+      const delta = downloadedBytes - lastDownloadedBytes;
+      lastDownloadedBytes = downloadedBytes;
+      progressBar.tick(delta);
+    },
+    onExtract: () => {
+      process.stderr.write(`Unpacking ${browser} ${buildId}\n`);
+    },
   };
 }
 

--- a/packages/browsers/test/src/CLI.spec.ts
+++ b/packages/browsers/test/src/CLI.spec.ts
@@ -130,4 +130,32 @@ describe('CLI', function () {
     );
     assert.strictEqual(found[2], 'chrome', 'Expected browser to match');
   });
+
+  it('should report when unpacking starts', async () => {
+    const logs: string[] = [];
+    const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+    process.stderr.write = chunk => {
+      logs.push(chunk.toString());
+      return true;
+    };
+
+    try {
+      await new CLI(tmpDir).run([
+        'npx',
+        '@puppeteer/browsers',
+        'install',
+        `chrome@${testChromeBuildId}`,
+        `--path=${tmpDir}`,
+        `--base-url=${getServerUrl()}`,
+      ]);
+    } finally {
+      process.stderr.write = originalStderrWrite;
+    }
+
+    assert(
+      logs.join('').includes(`Unpacking chrome ${testChromeBuildId}`),
+      `Expected unpacking status in ${JSON.stringify(logs)}`,
+    );
+  });
 });


### PR DESCRIPTION
 ## Summary
  - report when archive extraction starts during the default `@puppeteer/browsers
  install` flow
  - keep the existing download progress bar behavior while adding a clear unpacking
  status line
  - add a CLI regression test that asserts the unpacking message is emitted

  ## Why
  After the download finishes, the install command can spend noticeable time extracting
  the archive without printing any terminal feedback. That makes the command appear
  stuck even though installation is still progressing.

  ## User Impact
  Users now get an explicit `Unpacking <browser> <buildId>` status update after the
  download completes, so the install flow remains transparent during archive
  extraction.

  ## Validation
  - ran `npm run build:test --workspace @puppeteer/browsers`
  - ran `npx mocha --config .mocharc.cjs test/build/CLI.spec.js --grep "should report
  when unpacking starts"` in `packages/browsers`

  Closes #13083