### PR TITLE
ci: enforce Node.js 24 for GitHub Actions to resolve deprecation warnings

### DIFF
--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -2,6 +2,10 @@ name: Check which packages changed
 
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_call:
     inputs:
@@ -30,7 +34,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -40,7 +44,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
@@ -95,7 +100,8 @@ jobs:
         run: npm ci
       - name: Build website
         working-directory: ./website
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           NODE_OPTIONS: --max-old-space-size=6144
         run: npm run build
       - name: Deploy to GitHub Pages
@@ -110,7 +116,8 @@ jobs:
       - name: Test Algolia if Crawler is blocked
         # Only change on push to main
         if: ${{ github.event_name != 'pull_request'}}
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
           CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
           CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
@@ -121,7 +128,8 @@ jobs:
       - name: Trigger Algolia reindexing
         # Only change on push to main
         if: ${{ github.event_name != 'pull_request'}}
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
           CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
           CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
@@ -146,7 +154,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Run tests
         run: npm run doctest
@@ -199,7 +208,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
@@ -281,7 +291,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
@@ -353,13 +364,15 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
 
       - name: Build install test
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PKG_MANAGER: ${{ matrix.pkg_manager }}
         run: ${{ matrix.pkg_manager }} run build -w @puppeteer-test/installation
 
@@ -369,7 +382,8 @@ jobs:
           cache: npm
           node-version: '20.19'
       - name: Test install
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PKG_MANAGER: ${{ matrix.pkg_manager }}
         run: ${{ matrix.pkg_manager }} run test-ci -w @puppeteer-test/installation
 
@@ -400,7 +414,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build --workspace puppeteer
@@ -430,7 +445,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Run unit tests
         run: |
@@ -451,7 +467,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Run tests
         run: npm run unit --workspace @puppeteer/ng-schematics
@@ -493,7 +510,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build all and schematics
         run: npm run build
@@ -545,7 +563,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Setup cache for browsers
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/.github/workflows/convetional-commit.yml
+++ b/.github/workflows/convetional-commit.yml
@@ -3,6 +3,10 @@ name: 'Conventional Commit'
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request_target:
     types:
@@ -23,5 +27,6 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,6 +3,10 @@ name: Puppeteer Canary CI
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   schedule:
     # Run everyday at: https://crontab.guru/#0_7_*_*_1-5 UTC
@@ -49,7 +53,8 @@ jobs:
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
@@ -57,7 +62,8 @@ jobs:
         run: npm run build -w @puppeteer-test/test
       - name: Install browsers
         run: npm run postinstall
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_CHROME_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_VERSION: canary
           PUPPETEER_FIREFOX_SKIP_DOWNLOAD: true
@@ -66,7 +72,8 @@ jobs:
       - name: Run all tests (MacOS)
         if: ${{ matrix.os == 'macos-15' }}
         run: npm run test -- --ignore-unexpectedly-passing --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_CHROME_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
@@ -74,7 +81,8 @@ jobs:
       - name: Run all tests (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: npm run test -- --ignore-unexpectedly-passing --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_CHROME_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
@@ -82,7 +90,8 @@ jobs:
       - name: Run all tests (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: xvfb-run --auto-servernum npm run test -- --ignore-unexpectedly-passing --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_CHROME_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_VERSION: canary
           PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
@@ -122,7 +131,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Disable AppArmor
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -133,7 +143,8 @@ jobs:
         run: npm run build -w @puppeteer-test/test
       - name: Install browsers
         run: npm run postinstall
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_CHROME_SKIP_DOWNLOAD: true
           PUPPETEER_CHROME_HEADLESS_SHELL_SKIP_DOWNLOAD: true
           PUPPETEER_FIREFOX_VERSION: nightly
@@ -142,17 +153,20 @@ jobs:
       - name: Run all tests (MacOS)
         if: ${{ matrix.os == 'macos-15' }}
         run: npm run test -- --ignore-unexpectedly-passing --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_FIREFOX_VERSION: nightly
       - name: Run all tests (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: npm run test -- --ignore-unexpectedly-passing --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_FIREFOX_VERSION: nightly
       - name: Run all tests (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: xvfb-run --auto-servernum npm run test -- --ignore-unexpectedly-passing --shard '${{ matrix.shard }}' --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_FIREFOX_VERSION: nightly
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}
@@ -177,14 +191,16 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build -w @puppeteer/browsers
       - name: Generate comment
         id: genearate-comment-body
         run: node tools/build_daily_comment.mjs
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0

--- a/.github/workflows/deflake.yml
+++ b/.github/workflows/deflake.yml
@@ -3,6 +3,10 @@ name: Deflake Puppeteer test
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: deflake-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -56,7 +60,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
@@ -72,19 +77,22 @@ jobs:
       - name: Run all tests (MacOS)
         if: ${{ matrix.os == 'macos-15' }}
         run: npm run test -- --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_DEFLAKE_TESTS: '${{ inputs.tests }}'
           PUPPETEER_DEFLAKE_RETRIES: ${{ inputs.retries }}
       - name: Run all tests (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: npm run test -- --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_DEFLAKE_TESTS: '${{ inputs.tests }}'
           PUPPETEER_DEFLAKE_RETRIES: ${{ inputs.retries }}
       - name: Run all tests (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: xvfb-run --auto-servernum npm run test -- --test-suite ${{ matrix.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_DEFLAKE_TESTS: '${{ inputs.tests }}'
           PUPPETEER_DEFLAKE_RETRIES: ${{ inputs.retries }}
 
@@ -104,7 +112,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       # Set up GitHub Actions caching for Wireit.
       - uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2.0.4
@@ -120,12 +129,14 @@ jobs:
       - name: Run all tests (for non-Linux)
         if: ${{ inputs.os != 'ubuntu-latest' }}
         run: npm run test -- --test-suite ${{ inputs.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_DEFLAKE_TESTS: '${{ inputs.tests }}'
           PUPPETEER_DEFLAKE_RETRIES: ${{ inputs.retries }}
       - name: Run all tests (for Linux)
         if: ${{ inputs.os == 'ubuntu-latest' }}
         run: xvfb-run --auto-servernum npm run test -- --test-suite ${{ inputs.suite }} --save-stats-to /tmp/artifacts/${{ github.event_name }}_INSERTID.json
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_DEFLAKE_TESTS: '${{ inputs.tests }}'
           PUPPETEER_DEFLAKE_RETRIES: ${{ inputs.retries }}

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -3,6 +3,10 @@ name: DevTools CI
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   pull_request:
     types: [labeled]
@@ -26,7 +30,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build Puppeteer
         run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -2,6 +2,10 @@ name: Pre-release
 
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -32,12 +36,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build all packages
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUBLISH: 1
         run: |
           npm run build
       - name: Build docs
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUBLISH: 1
         run: |
           npm run changelog
@@ -49,7 +55,8 @@ jobs:
           npm run docusaurus docs:version $(jq -r .version ../packages/puppeteer/package.json)
           npm run archive
       - name: Re-build docs after versioning
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUBLISH: 1
         run: |
           npm run docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish
 
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
   push:
@@ -31,7 +35,8 @@ jobs:
         run: npm install -g npm@latest
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build
@@ -40,7 +45,8 @@ jobs:
           npm publish --provenance --access public --workspace packages/${GITHUB_REF_NAME%-v*}
       - name: Deprecate old Puppeteer versions
         if: ${{ startsWith(github.ref_name, 'puppeteer-v') }}
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_PUPPETEER}}
         run: |
           npm config set '//wombat-dressing-room.appspot.com/:_authToken' $NODE_AUTH_TOKEN
@@ -53,7 +59,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-    env:
+    # TODO: Remove this once all third-party actions natively support Node 24+
+env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
@@ -68,7 +75,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           PUPPETEER_SKIP_DOWNLOAD: true
       - name: Build packages
         run: npm run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,10 @@ name: release-please
 
 # Declare default permissions as read only.
 permissions: read-all
+
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 on:
   push:
     branches:

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -11,6 +11,10 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analysis:
     name: Scorecards analysis

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-browser-pins.yml
+++ b/.github/workflows/update-browser-pins.yml
@@ -4,6 +4,10 @@ name: 'Update the pinned browsers'
 
 permissions: read-all
 
+# TODO: Remove this once all third-party actions natively support Node 24+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   schedule:
     # Run everyday at: https://crontab.guru/#0_6_*_*_*.
@@ -30,7 +34,8 @@ jobs:
         id: update
         run: |
           node tools/update_browser_revision.mjs
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           BROWSER_TO_UPDATE: 'chrome'
       - name: Create Pull Request
         if: ${{ steps.update.outputs.commit }}
@@ -66,7 +71,8 @@ jobs:
         id: update
         run: |
           node tools/update_browser_revision.mjs
-        env:
+        # TODO: Remove this once all third-party actions natively support Node 24+
+env:
           BROWSER_TO_UPDATE: 'firefox'
       - name: Create Pull Request
         if: ${{ steps.update.outputs.commit }}


### PR DESCRIPTION
### Description
This PR resolves the widespread `Node.js 20 actions are deprecated` warnings appearing across CI runs.

Instead of waiting for all third-party action authors (e.g., `google/wireit`, `dorny/paths-filter`) to release new major versions, this PR applies the official GitHub-recommended environment variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` globally across all workflow files.

### Changes
- Added `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the root of all 12 `.github/workflows/*.yml` files.

This ensures all JavaScript actions run on the supported Node.js 24 runtime, immediately silencing the deprecation warnings without requiring potentially breaking updates to the action versions themselves.

Fixes #14782