### PR TITLE
test: fix flaky extension test

### DIFF
--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -462,24 +462,22 @@ export class CdpBrowser extends BrowserBase {
     // flakiness in the extension tests.
     // TODO(nroscino): Remove this once the event is correctly emitted.
     const targets = this.targets().filter(target => {
-      return target.url().includes(id);
+      return target.url().includes(id) && target.type() === 'service_worker';
     });
 
     const targetDestroyedPromises = [];
     for (const target of targets) {
-      if (target.type() === 'service_worker') {
-        this._targetManager().addToIgnoreTarget(target._targetId);
-        targetDestroyedPromises.push(
-          new Promise(resolve => {
-            return setTimeout(() => {
-              this.#connection.emit('Target.targetDestroyed', {
-                targetId: target._targetId,
-              });
-              resolve(null);
-            }, 0);
-          }),
-        );
-      }
+      this._targetManager().addToIgnoreTarget(target._targetId);
+      targetDestroyedPromises.push(
+        new Promise(resolve => {
+          return setTimeout(() => {
+            this.#connection.emit('Target.targetDestroyed', {
+              targetId: target._targetId,
+            });
+            resolve(null);
+          }, 0);
+        }),
+      );
     }
     await Promise.all(targetDestroyedPromises);
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -461,20 +461,28 @@ export class CdpBrowser extends BrowserBase {
       return curr.url().includes(id);
     });
 
+    const promises = [];
+
+    console.log(`TARGETS at uninstall of ${id}: ${targets.length} targets`);
     for (const target of targets) {
       const targetType = target.type();
+      console.log('target', target._targetId, targetType);
       if (targetType === 'service_worker' || targetType === 'shared_worker') {
         this._targetManager().addToIgnoreTarget(target._targetId);
-        await new Promise(resolve => {
-          return setTimeout(() => {
-            this.#connection.emit('Target.targetDestroyed', {
-              targetId: target._targetId,
-            });
-            resolve(null);
-          }, 0);
-        });
+        promises.push(
+          new Promise(resolve => {
+            return setTimeout(() => {
+              this.#connection.emit('Target.targetDestroyed', {
+                targetId: target._targetId,
+              });
+              resolve(null);
+            }, 0);
+          }),
+        );
       }
     }
+
+    await Promise.all(promises);
 
     this.#extensions.delete(id);
   }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -456,6 +456,18 @@ export class CdpBrowser extends BrowserBase {
 
   override async uninstallExtension(id: string): Promise<void> {
     await this.#connection.send('Extensions.uninstall', {id});
+
+    const targets = this.targets().filter(curr => curr.url().includes(id));
+
+    for (const target of targets) {
+      const targetType = target.type();
+      if (targetType === 'service_worker' || targetType === 'shared_worker') {
+        this.#connection.emit('Target.targetDestroyed', {
+          targetId: target._targetId,
+        });
+      }
+    }
+
     this.#extensions.delete(id);
   }
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -457,16 +457,19 @@ export class CdpBrowser extends BrowserBase {
   override async uninstallExtension(id: string): Promise<void> {
     await this.#connection.send('Extensions.uninstall', {id});
 
-    const targets = this.targets().filter(curr => {
-      return curr.url().includes(id);
+    // Currently sending the Extensions.uninstall command does not trigger
+    // the Target.targetDestroyed event for service workers. This causes
+    // flakiness in the extension tests.
+    // TODO(nroscino): Remove this once the event is correctly emitted.
+    const targets = this.targets().filter(target => {
+      return target.url().includes(id);
     });
 
-    const promises = [];
+    const targetDestroyedPromises = [];
     for (const target of targets) {
-      const targetType = target.type();
-      if (targetType === 'service_worker' || targetType === 'shared_worker') {
+      if (target.type() === 'service_worker') {
         this._targetManager().addToIgnoreTarget(target._targetId);
-        promises.push(
+        targetDestroyedPromises.push(
           new Promise(resolve => {
             return setTimeout(() => {
               this.#connection.emit('Target.targetDestroyed', {
@@ -478,8 +481,7 @@ export class CdpBrowser extends BrowserBase {
         );
       }
     }
-
-    await Promise.all(promises);
+    await Promise.all(targetDestroyedPromises);
 
     this.#extensions.delete(id);
   }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -464,9 +464,14 @@ export class CdpBrowser extends BrowserBase {
     for (const target of targets) {
       const targetType = target.type();
       if (targetType === 'service_worker' || targetType === 'shared_worker') {
-        this.#connection.emit('Target.targetDestroyed', {
-          targetId: target._targetId,
-        });
+        await new Promise(resolve =>
+          setTimeout(() => {
+            this.#connection.emit('Target.targetDestroyed', {
+              targetId: target._targetId,
+            });
+            resolve(null);
+          }, 0),
+        );
       }
     }
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -462,11 +462,8 @@ export class CdpBrowser extends BrowserBase {
     });
 
     const promises = [];
-
-    console.log(`TARGETS at uninstall of ${id}: ${targets.length} targets`);
     for (const target of targets) {
       const targetType = target.type();
-      console.log('target', target._targetId, targetType);
       if (targetType === 'service_worker' || targetType === 'shared_worker') {
         this._targetManager().addToIgnoreTarget(target._targetId);
         promises.push(

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -465,14 +465,14 @@ export class CdpBrowser extends BrowserBase {
       const targetType = target.type();
       if (targetType === 'service_worker' || targetType === 'shared_worker') {
         this._targetManager().addToIgnoreTarget(target._targetId);
-        await new Promise(resolve =>
-          setTimeout(() => {
+        await new Promise(resolve => {
+          return setTimeout(() => {
             this.#connection.emit('Target.targetDestroyed', {
               targetId: target._targetId,
             });
             resolve(null);
-          }, 0),
-        );
+          }, 0);
+        });
       }
     }
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -457,7 +457,9 @@ export class CdpBrowser extends BrowserBase {
   override async uninstallExtension(id: string): Promise<void> {
     await this.#connection.send('Extensions.uninstall', {id});
 
-    const targets = this.targets().filter(curr => curr.url().includes(id));
+    const targets = this.targets().filter(curr => {
+      return curr.url().includes(id);
+    });
 
     for (const target of targets) {
       const targetType = target.type();

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -464,6 +464,7 @@ export class CdpBrowser extends BrowserBase {
     for (const target of targets) {
       const targetType = target.type();
       if (targetType === 'service_worker' || targetType === 'shared_worker') {
+        this._targetManager().addToIgnoreTarget(target._targetId);
         await new Promise(resolve =>
           setTimeout(() => {
             this.#connection.emit('Target.targetDestroyed', {

--- a/packages/puppeteer-core/src/cdp/Extension.ts
+++ b/packages/puppeteer-core/src/cdp/Extension.ts
@@ -5,8 +5,11 @@
  */
 import type {Page, Target, WebWorker} from '../api/api.js';
 import {Extension} from '../api/api.js';
+import {debugError} from '../common/util.js';
+import {isErrorLike} from '../util/ErrorLike.js';
 
 import type {CdpBrowser} from './Browser.js';
+import {isTargetClosedError} from './Connection.js';
 
 export class CdpExtension extends Extension {
   // needed to access the CDPSession to trigger an extension action.
@@ -34,10 +37,18 @@ export class CdpExtension extends Extension {
 
     const workers: WebWorker[] = [];
     for (const target of extensionWorkers) {
-      const worker = await target.worker();
+      try {
+        const worker = await target.worker();
 
-      if (worker) {
-        workers.push(worker);
+        if (worker) {
+          workers.push(worker);
+        }
+      } catch (err) {
+        if (this.#canIgnoreError(err)) {
+          debugError(err);
+          continue;
+        }
+        throw err;
       }
     }
 
@@ -57,18 +68,26 @@ export class CdpExtension extends Extension {
 
     const pages: Page[] = [];
     for (const target of extensionPages) {
-      let page = this.#pages.get(target);
-      if (!page) {
-        // TODO: asPage should return always the same instance
-        // issue: https://github.com/puppeteer/puppeteer/issues/14843
-        page = await target.asPage();
-        if (page) {
-          this.#pages.set(target, page);
+      try {
+        let page = this.#pages.get(target);
+        if (!page) {
+          // TODO: asPage should return always the same instance
+          // issue: https://github.com/puppeteer/puppeteer/issues/14843
+          page = await target.asPage();
+          if (page) {
+            this.#pages.set(target, page);
+          }
         }
-      }
 
-      if (page) {
-        pages.push(page);
+        if (page) {
+          pages.push(page);
+        }
+      } catch (err) {
+        if (this.#canIgnoreError(err)) {
+          debugError(err);
+          continue;
+        }
+        throw err;
       }
     }
 
@@ -80,5 +99,13 @@ export class CdpExtension extends Extension {
       id: this.id,
       targetId: page._tabId,
     });
+  }
+
+  #canIgnoreError(error: unknown): boolean {
+    return (
+      isErrorLike(error) &&
+      (isTargetClosedError(error) ||
+        error.message.includes('No target with given id found'))
+    );
   }
 }

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -152,6 +152,10 @@ export class TargetManager
     await this.#initializeDeferred.valueOrThrow();
   }
 
+  addToIgnoreTarget(targetId: string) {
+    this.#ignoredTargets.add(targetId);
+  }
+
   getChildTargets(target: CdpTarget): ReadonlySet<CdpTarget> {
     return target._childTargets();
   }
@@ -333,7 +337,10 @@ export class TargetManager
     // CDP.
     if (targetInfo.type === 'service_worker') {
       await this.#silentDetach(session, parentSession);
-      if (this.#attachedTargetsByTargetId.has(targetInfo.targetId)) {
+      if (
+        this.#attachedTargetsByTargetId.has(targetInfo.targetId) ||
+        this.#ignoredTargets.has(targetInfo.targetId)
+      ) {
         return;
       }
       const target = this.#targetFactory(targetInfo);

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -152,7 +152,7 @@ export class TargetManager
     await this.#initializeDeferred.valueOrThrow();
   }
 
-  addToIgnoreTarget(targetId: string) {
+  addToIgnoreTarget(targetId: string): void {
     this.#ignoredTargets.add(targetId);
   }
 

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -10,6 +10,8 @@ import expect from 'expect';
 import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
+import assert from 'node:assert';
+import {Target} from 'puppeteer-core/internal/api/Target.js';
 
 const extensionWithPagePath = path.join(
   import.meta.dirname,
@@ -44,6 +46,8 @@ describe('extensions', function () {
     });
     expect(serviceWorkerTarget).toBeTruthy();
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('can evaluate in the service worker', async function () {
@@ -73,6 +77,8 @@ describe('extensions', function () {
     }
     expect(result).toBe(42);
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should list extensions and their properties', async () => {
@@ -88,6 +94,8 @@ describe('extensions', function () {
     expect(extension?.version).toBe('0.1');
     expect(extension?.id).toBe(extensionId);
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should list extension workers', async () => {
@@ -108,6 +116,8 @@ describe('extensions', function () {
     const workers = await extension!.workers();
     expect(workers.length).toBeGreaterThan(0);
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should trigger extension action', async () => {
@@ -120,6 +130,8 @@ describe('extensions', function () {
     await page.triggerExtensionAction(extension!);
     // If it doesn't throw, we consider it successful for this level of testing.
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should list extension pages', async () => {
@@ -148,6 +160,8 @@ describe('extensions', function () {
       }),
     ).toBe(true);
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should capture console logs from extension pages', async () => {
@@ -183,10 +197,9 @@ describe('extensions', function () {
 
     expect(message).toBe('hello from extension page');
 
-    const beforeTargets = browser.targets();
     await browser.uninstallExtension(extensionId);
-    const afterTargets = browser.targets();
-    expect(beforeTargets.length).toBeGreaterThan(afterTargets.length);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should capture console logs from extension workers', async () => {
@@ -224,6 +237,8 @@ describe('extensions', function () {
 
     expect(message).toBe(messageToLog);
     await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, extensionId);
   });
 
   it('should remove extension from list after uninstall', async () => {
@@ -233,8 +248,17 @@ describe('extensions', function () {
     expect(extensions.has(id)).toBe(true);
 
     await browser.uninstallExtension(id);
+    const targets = browser.targets();
+    ensureNoWorkerWithIdFound(targets, id);
 
     extensions = await browser.extensions();
     expect(extensions.has(id)).toBe(false);
   });
 });
+
+function ensureNoWorkerWithIdFound(targets: Target[], id: string) {
+  const target = targets.find(
+    curr => curr.url().includes(id) && curr.type() === 'service_worker',
+  );
+  assert(target === undefined);
+}

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import assert from 'node:assert';
 import path from 'node:path';
 
 import expect from 'expect';
+import type {Target} from 'puppeteer-core/internal/api/Target.js';
 import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
 
 import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
-import assert from 'node:assert';
-import {Target} from 'puppeteer-core/internal/api/Target.js';
 
 const extensionWithPagePath = path.join(
   import.meta.dirname,
@@ -85,6 +85,14 @@ describe('extensions', function () {
     const {browser} = state;
 
     const extensionId = await browser.installExtension(extensionPath);
+
+    const target = await browser.waitForTarget(target => {
+      return (
+        target.url().includes(extensionId) && target.type() === 'service_worker'
+      );
+    });
+    expect(target).toBeTruthy();
+
     const extensions = await browser.extensions();
 
     const extension = extensions.get(extensionId);
@@ -129,6 +137,13 @@ describe('extensions', function () {
 
     await page.triggerExtensionAction(extension!);
     // If it doesn't throw, we consider it successful for this level of testing.
+    const target = await browser.waitForTarget(target => {
+      return (
+        target.url().includes(extensionId) && target.type() === 'service_worker'
+      );
+    });
+    expect(target).toBeTruthy();
+
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
     ensureNoWorkerWithIdFound(targets, extensionId);
@@ -144,7 +159,12 @@ describe('extensions', function () {
     await page.goto(server.EMPTY_PAGE);
 
     await extension?.triggerAction(page);
-
+    const target = await browser.waitForTarget(target => {
+      return (
+        target.url().includes(extensionId) && target.type() === 'service_worker'
+      );
+    });
+    expect(target).toBeTruthy();
     await browser.waitForTarget(target => {
       return (
         target.url().includes('popup.html') &&
@@ -175,6 +195,12 @@ describe('extensions', function () {
 
     await page.triggerExtensionAction(extension!);
 
+    const target = await browser.waitForTarget(target => {
+      return (
+        target.url().includes(extensionId) && target.type() === 'service_worker'
+      );
+    });
+    expect(target).toBeTruthy();
     const optionsPageTarget = await browser.waitForTarget(target => {
       return (
         target.url().includes('popup.html') &&
@@ -244,6 +270,12 @@ describe('extensions', function () {
   it('should remove extension from list after uninstall', async () => {
     const {browser} = state;
     const id = await browser.installExtension(extensionPath);
+
+    const target = await browser.waitForTarget(target => {
+      return target.url().includes(id) && target.type() === 'service_worker';
+    });
+    expect(target).toBeTruthy();
+
     let extensions = await browser.extensions();
     expect(extensions.has(id)).toBe(true);
 
@@ -257,8 +289,8 @@ describe('extensions', function () {
 });
 
 function ensureNoWorkerWithIdFound(targets: Target[], id: string) {
-  const target = targets.find(
-    curr => curr.url().includes(id) && curr.type() === 'service_worker',
-  );
+  const target = targets.find(curr => {
+    return curr.url().includes(id) && curr.type() === 'service_worker';
+  });
   assert(target === undefined);
 }

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -47,7 +47,7 @@ describe('extensions', function () {
     expect(serviceWorkerTarget).toBeTruthy();
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('can evaluate in the service worker', async function () {
@@ -78,7 +78,7 @@ describe('extensions', function () {
     expect(result).toBe(42);
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should list extensions and their properties', async () => {
@@ -103,7 +103,7 @@ describe('extensions', function () {
     expect(extension?.id).toBe(extensionId);
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should list extension workers', async () => {
@@ -125,7 +125,7 @@ describe('extensions', function () {
     expect(workers.length).toBeGreaterThan(0);
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should trigger extension action', async () => {
@@ -146,7 +146,7 @@ describe('extensions', function () {
 
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should list extension pages', async () => {
@@ -181,7 +181,7 @@ describe('extensions', function () {
     ).toBe(true);
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should capture console logs from extension pages', async () => {
@@ -225,7 +225,7 @@ describe('extensions', function () {
 
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should capture console logs from extension workers', async () => {
@@ -264,7 +264,7 @@ describe('extensions', function () {
     expect(message).toBe(messageToLog);
     await browser.uninstallExtension(extensionId);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, extensionId);
+    assertNoServiceWorkerReported(targets, extensionId);
   });
 
   it('should remove extension from list after uninstall', async () => {
@@ -281,16 +281,16 @@ describe('extensions', function () {
 
     await browser.uninstallExtension(id);
     const targets = browser.targets();
-    ensureNoWorkerWithIdFound(targets, id);
+    assertNoServiceWorkerReported(targets, id);
 
     extensions = await browser.extensions();
     expect(extensions.has(id)).toBe(false);
   });
 });
 
-function ensureNoWorkerWithIdFound(targets: Target[], id: string) {
-  const target = targets.find(curr => {
-    return curr.url().includes(id) && curr.type() === 'service_worker';
+function assertNoServiceWorkerReported(targets: Target[], id: string) {
+  const target = targets.find(target => {
+    return target.url().includes(id) && target.type() === 'service_worker';
   });
   assert(target === undefined);
 }

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -182,7 +182,11 @@ describe('extensions', function () {
     ]);
 
     expect(message).toBe('hello from extension page');
+
+    const beforeTargets = browser.targets();
     await browser.uninstallExtension(extensionId);
+    const afterTargets = browser.targets();
+    expect(beforeTargets.length).toBeGreaterThan(afterTargets.length);
   });
 
   it('should capture console logs from extension workers', async () => {

--- a/test/src/cdp/extensions.spec.ts
+++ b/test/src/cdp/extensions.spec.ts
@@ -31,7 +31,6 @@ describe('extensions', function () {
   const state = setupSeparateTestBrowserHooks(
     {
       enableExtensions: true,
-      args: [`--load-extension=${extensionPath}`],
       pipe: true,
     },
     {createContext: false},
@@ -39,14 +38,17 @@ describe('extensions', function () {
 
   it('service_worker target type should be available', async function () {
     const {browser} = state;
+    const extensionId = await browser.installExtension(extensionPath);
     const serviceWorkerTarget = await browser.waitForTarget(target => {
       return target.type() === 'service_worker';
     });
     expect(serviceWorkerTarget).toBeTruthy();
+    await browser.uninstallExtension(extensionId);
   });
 
   it('can evaluate in the service worker', async function () {
     const {browser} = state;
+    const extensionId = await browser.installExtension(extensionPath);
     const serviceWorkerTarget = await browser.waitForTarget(target => {
       return target.type() === 'service_worker';
     });
@@ -70,6 +72,7 @@ describe('extensions', function () {
       });
     }
     expect(result).toBe(42);
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should list extensions and their properties', async () => {
@@ -84,6 +87,7 @@ describe('extensions', function () {
     expect(extension?.name).toBe('Simple extension');
     expect(extension?.version).toBe('0.1');
     expect(extension?.id).toBe(extensionId);
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should list extension workers', async () => {
@@ -103,6 +107,7 @@ describe('extensions', function () {
 
     const workers = await extension!.workers();
     expect(workers.length).toBeGreaterThan(0);
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should trigger extension action', async () => {
@@ -114,6 +119,7 @@ describe('extensions', function () {
 
     await page.triggerExtensionAction(extension!);
     // If it doesn't throw, we consider it successful for this level of testing.
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should list extension pages', async () => {
@@ -141,6 +147,7 @@ describe('extensions', function () {
         return p.url().includes('popup.html');
       }),
     ).toBe(true);
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should capture console logs from extension pages', async () => {
@@ -175,6 +182,7 @@ describe('extensions', function () {
     ]);
 
     expect(message).toBe('hello from extension page');
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should capture console logs from extension workers', async () => {
@@ -211,6 +219,7 @@ describe('extensions', function () {
     ]);
 
     expect(message).toBe(messageToLog);
+    await browser.uninstallExtension(extensionId);
   });
 
   it('should remove extension from list after uninstall', async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Fixes flaky extension tests failing. 

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
The chromium backend doesn't correctly send events to remove service workers when an extension is uninstalled. This lead to the extension service worker targets not being removed correctly. This PR emulates the event to enable clearing of those targets.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
