### PR TITLE
fix: make `Target.asPage` return the same Page instance

### DIFF
--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -187,6 +187,13 @@ export class BidiBrowserContext extends BrowserContext {
     });
   }
 
+  /**
+   * @internal
+   */
+  getTargetForPage(page: BidiPage): BidiPageTarget | undefined {
+    return this.#targets.get(page)?.[0];
+  }
+
   override async newPage(options?: CreatePageOptions): Promise<Page> {
     using _guard = await this.waitForScreenshotOperations();
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -31,6 +31,7 @@ import {
   type NewDocumentScriptEvaluation,
   type ScreenshotOptions,
 } from '../api/Page.js';
+import type {Target} from '../api/Target.js';
 import {Coverage} from '../cdp/Coverage.js';
 import {EmulationManager} from '../cdp/EmulationManager.js';
 import type {
@@ -671,8 +672,12 @@ export class BidiPage extends Page {
     throw new UnsupportedOperation();
   }
 
-  override target(): never {
-    throw new UnsupportedOperation();
+  override target(): Target {
+    const target = this.browserContext().getTargetForPage(this);
+    if (!target) {
+      throw new Error('Target not found for page');
+    }
+    return target;
   }
 
   override async waitForFileChooser(

--- a/packages/puppeteer-core/src/bidi/Target.ts
+++ b/packages/puppeteer-core/src/bidi/Target.ts
@@ -63,10 +63,7 @@ export class BidiPageTarget extends Target {
     return this.#page;
   }
   override async asPage(): Promise<BidiPage> {
-    return BidiPage.from(
-      this.browserContext(),
-      this.#page.mainFrame().browsingContext,
-    );
+    return await this.page();
   }
   override url(): string {
     return this.#page.url();
@@ -110,7 +107,7 @@ export class BidiFrameTarget extends Target {
     return this.#page;
   }
   override async asPage(): Promise<BidiPage> {
-    return BidiPage.from(this.browserContext(), this.#frame.browsingContext);
+    return await this.page();
   }
   override url(): string {
     return this.#frame.url();

--- a/packages/puppeteer-core/src/cdp/Extension.ts
+++ b/packages/puppeteer-core/src/cdp/Extension.ts
@@ -14,7 +14,6 @@ import {isTargetClosedError} from './Connection.js';
 export class CdpExtension extends Extension {
   // needed to access the CDPSession to trigger an extension action.
   #browser: CdpBrowser;
-  #pages = new WeakMap<Target, Page>();
 
   /*
    * @internal
@@ -66,32 +65,23 @@ export class CdpExtension extends Extension {
       );
     });
 
-    const pages: Page[] = [];
-    for (const target of extensionPages) {
-      try {
-        let page = this.#pages.get(target);
-        if (!page) {
-          // TODO: asPage should return always the same instance
-          // issue: https://github.com/puppeteer/puppeteer/issues/14843
-          page = await target.asPage();
-          if (page) {
-            this.#pages.set(target, page);
+    const pages = await Promise.all(
+      extensionPages.map(async target => {
+        try {
+          return await target.asPage();
+        } catch (err) {
+          if (this.#canIgnoreError(err)) {
+            debugError(err);
+            return null;
           }
+          throw err;
         }
+      }),
+    );
 
-        if (page) {
-          pages.push(page);
-        }
-      } catch (err) {
-        if (this.#canIgnoreError(err)) {
-          debugError(err);
-          continue;
-        }
-        throw err;
-      }
-    }
-
-    return pages;
+    return pages.filter((page): page is Page => {
+      return page !== null;
+    });
   }
 
   async triggerAction(page: Page): Promise<void> {

--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -42,6 +42,9 @@ export class CdpTarget extends Target {
   _initializedDeferred = Deferred.create<InitializationStatus>();
   _isClosedDeferred = Deferred.create<void>();
   _targetId: string;
+  _asPagePromise?: Promise<Page>;
+  /** @internal */
+  pagePromise?: Promise<Page>;
 
   /**
    * To initialize the target for use, call initialize.
@@ -70,13 +73,23 @@ export class CdpTarget extends Target {
   }
 
   override async asPage(): Promise<Page> {
-    const session = this._session();
-    if (!session) {
-      return await this.createCDPSession().then(client => {
+    if (this.pagePromise) {
+      const page = await this.pagePromise;
+      if (page) {
+        return page;
+      }
+    }
+    if (!this._asPagePromise) {
+      const session = this._session();
+      this._asPagePromise = (
+        session
+          ? Promise.resolve(session)
+          : this._sessionFactory()(/* isAutoAttachEmulated=*/ false)
+      ).then(client => {
         return CdpPage._create(client, this, null);
       });
     }
-    return await CdpPage._create(session, this, null);
+    return (await this._asPagePromise) ?? null;
   }
 
   _subtype(): string | undefined {
@@ -206,7 +219,6 @@ export class CdpTarget extends Target {
  */
 export class PageTarget extends CdpTarget {
   #defaultViewport?: Viewport;
-  protected pagePromise?: Promise<Page>;
 
   constructor(
     targetInfo: Protocol.Target.TargetInfo,

--- a/test/src/cdp/devtools.spec.ts
+++ b/test/src/cdp/devtools.spec.ts
@@ -113,6 +113,9 @@ describe('DevTools', function () {
       return target.type() === 'other';
     });
     const page = (await devtoolsPageTarget.asPage())!;
+    const page2 = (await devtoolsPageTarget.asPage())!;
+    expect(page).toBe(page2);
+
     expect(
       await page.evaluate(() => {
         return 2 * 3;

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -16,6 +16,23 @@ import {waitEvent} from './utils.js';
 describe('Target', function () {
   setupTestBrowserHooks();
 
+  it.only('Target.asPage() should return the same instance', async () => {
+    const {browser} = await getTestState();
+    const page = await browser.newPage();
+    const target = page.target();
+
+    // Test that target.page() and target.asPage() return the same instance
+    const page1 = await target.page();
+    const page2 = await target.asPage();
+    const page3 = await target.asPage();
+
+    expect(page1).toBe(page);
+    expect(page2).toBe(page);
+    expect(page3).toBe(page);
+
+    await page.close();
+  });
+
   it('Browser.targets should return all of the targets', async () => {
     const {browser} = await getTestState();
 

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -16,7 +16,7 @@ import {waitEvent} from './utils.js';
 describe('Target', function () {
   setupTestBrowserHooks();
 
-  it.only('Target.asPage() should return the same instance', async () => {
+  it('Target.asPage() should return the same instance', async () => {
     const {browser} = await getTestState();
     const page = await browser.newPage();
     const target = page.target();


### PR DESCRIPTION
Closes https://github.com/puppeteer/puppeteer/pull/14860
Fixes https://github.com/puppeteer/puppeteer/issues/14843