### PR TITLE
feat(browsers): add unpacking indicator to install command

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -547,6 +547,7 @@ export class CLI {
       platform: args.platform,
       cacheDir: args.path ?? this.#cachePath,
       downloadProgressCallback: 'default',
+      unpackProgressCallback: 'default',
       baseUrl: args.baseUrl,
       buildIdAlias:
         originalBuildId !== args.browser.buildId ? originalBuildId : undefined,

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -84,6 +84,16 @@ export interface InstallOptions {
     | 'default'
     | ((downloadedBytes: number, totalBytes: number) => void);
   /**
+   * Provides information about the progress of the archive-unpacking step,
+   * which can run for many seconds after the download completes. Called
+   * with `'started'` before extraction begins and `'finished'` after it
+   * succeeds. If set to `'default'`, a short status line is written to
+   * stderr.
+   */
+  unpackProgressCallback?:
+    | 'default'
+    | ((event: 'started' | 'finished') => void);
+  /**
    * Determines the host that will be used for downloading.
    *
    * @defaultValue Either
@@ -367,6 +377,10 @@ async function installUrl(
       options.buildIdAlias ?? options.buildId,
     );
   }
+  const unpackProgressCallback =
+    options.unpackProgressCallback === 'default'
+      ? makeUnpackProgressCallback()
+      : options.unpackProgressCallback;
   const fileName = decodeURIComponent(url.toString()).split('/').pop();
   assert(fileName, `A malformed download URL was found: ${url}.`);
   const cache = new Cache(options.cacheDir);
@@ -450,7 +464,9 @@ async function installUrl(
     debugInstall(`Installing ${archivePath} to ${outputPath}`);
     try {
       debugTime('extract');
+      unpackProgressCallback?.('started');
       await unpackArchive(archivePath, outputPath);
+      unpackProgressCallback?.('finished');
     } finally {
       debugTimeEnd('extract');
     }
@@ -651,4 +667,26 @@ export function makeProgressCallback(
 function toMegabytes(bytes: number) {
   const mb = bytes / 1000 / 1000;
   return `${Math.round(mb * 10) / 10} MB`;
+}
+
+/**
+ * @public
+ */
+export function makeUnpackProgressCallback(): (
+  event: 'started' | 'finished',
+) => void {
+  const isTTY = Boolean(process.stderr.isTTY);
+  return (event: 'started' | 'finished') => {
+    if (event === 'started') {
+      process.stderr.write('Unpacking archive...');
+    } else if (event === 'finished') {
+      // Overwrite the "Unpacking archive..." line on TTYs so output stays
+      // compact; append a newline on non-TTYs so piped logs stay tidy.
+      if (isTTY) {
+        process.stderr.write('\rUnpacking archive... done.\n');
+      } else {
+        process.stderr.write(' done.\n');
+      }
+    }
+  };
 }

--- a/packages/browsers/src/main.ts
+++ b/packages/browsers/src/main.ts
@@ -26,6 +26,7 @@ export type {
 export {
   install,
   makeProgressCallback,
+  makeUnpackProgressCallback,
   getInstalledBrowsers,
   canDownload,
   uninstall,

--- a/packages/browsers/test/src/unpackProgressCallback.spec.ts
+++ b/packages/browsers/test/src/unpackProgressCallback.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+
+import {makeUnpackProgressCallback} from '../../lib/esm/main.js';
+
+describe('makeUnpackProgressCallback', () => {
+  let originalStderrWrite: typeof process.stderr.write;
+  let captured: string;
+
+  beforeEach(() => {
+    captured = '';
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured += typeof chunk === 'string' ? chunk : chunk.toString();
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+  });
+
+  it('writes a status line on "started"', () => {
+    const cb = makeUnpackProgressCallback();
+    cb('started');
+    assert.ok(
+      captured.includes('Unpacking archive'),
+      `expected "Unpacking archive" in output, got ${JSON.stringify(captured)}`,
+    );
+  });
+
+  it('writes a completion marker on "finished"', () => {
+    const cb = makeUnpackProgressCallback();
+    cb('started');
+    cb('finished');
+    assert.ok(
+      captured.includes('done'),
+      `expected "done" in output, got ${JSON.stringify(captured)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

After a successful browser download the CLI sits silently through the archive-extract step, which can take many seconds on large Chrome builds and made the process look hung. This PR mirrors the existing download-progress pattern for unpacking.

## API

New optional field on `InstallOptions`:

```ts
unpackProgressCallback?:
  | 'default'
  | ((event: 'started' | 'finished') => void);
```

Fires `'started'` immediately before `unpackArchive` and `'finished'` immediately after it succeeds.

- `'default'` (used by the bundled CLI) writes a short status line to **stderr**:
  `Unpacking archive... done.` — overwritten in place on TTYs so output stays compact, terminated with a newline on pipes.
- Custom callback functions are supported for programmatic use.
- `makeUnpackProgressCallback` is exported from `@puppeteer/browsers` so library consumers can reuse the default formatter.

## Backwards compatibility

The CLI opts in with `unpackProgressCallback: 'default'`. Consumers calling `install()` directly see no behavior change until they opt in.

## Test plan

- [x] `tsc --noEmit` on both the library and test projects — clean (pre-existing errors in `cli.spec.ts` and `utils.ts` are unrelated)
- [x] Added `packages/browsers/test/src/unpackProgressCallback.spec.ts` — stubs `process.stderr.write` and asserts the status line + completion marker
- [ ] I didn't get mocha to run locally against the built tests (the package mixes ESM-built tests with a CJS runtime and it tripped a "Cannot use import" error on my box). CI is the authoritative signal here.

Closes #13083