### PR TITLE
test: fix extension test flakiness

### DIFF
--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -461,23 +461,23 @@ export class CdpBrowser extends BrowserBase {
     // the Target.targetDestroyed event for service workers. This causes
     // flakiness in the extension tests.
     // TODO(nroscino): Remove this once the event is correctly emitted.
-    const targets = this.targets().filter(target => {
-      return target.url().includes(id) && target.type() === 'service_worker';
-    });
-
     const targetDestroyedPromises = [];
-    for (const target of targets) {
-      this._targetManager().addToIgnoreTarget(target._targetId);
-      targetDestroyedPromises.push(
-        new Promise(resolve => {
-          return setTimeout(() => {
-            this.#connection.emit('Target.targetDestroyed', {
-              targetId: target._targetId,
-            });
-            resolve(null);
-          }, 0);
-        }),
-      );
+    for (const [targetId, targetInfo] of this._targetManager()
+      .getDiscoveredTargetInfos()
+      .entries()) {
+      if (targetInfo.url.includes(id) && targetInfo.type === 'service_worker') {
+        this._targetManager().addToIgnoreTarget(targetId);
+        targetDestroyedPromises.push(
+          new Promise(resolve => {
+            return setTimeout(() => {
+              this.#connection.emit('Target.targetDestroyed', {
+                targetId: targetId,
+              });
+              resolve(null);
+            }, 0);
+          }),
+        );
+      }
     }
     await Promise.all(targetDestroyedPromises);
 

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -265,14 +265,14 @@ export class TargetManager
     this.#discoveredTargetsByTargetId.delete(event.targetId);
     this.#finishInitializationIfReady(event.targetId);
 
-    const target = this.#attachedTargetsByTargetId.get(event.targetId);
-    if (
-      target &&
-      (target.type() === 'service_worker' ||
-        targetInfo?.type === 'service_worker')
-    ) {
-      this.#attachedTargetsByTargetId.delete(event.targetId);
-      this.emit(TargetManagerEvent.TargetGone, target);
+    if (targetInfo?.type === 'service_worker') {
+      // Special case for service workers: report TargetGone event when
+      // the worker is destroyed.
+      const target = this.#attachedTargetsByTargetId.get(event.targetId);
+      if (target) {
+        this.emit(TargetManagerEvent.TargetGone, target);
+        this.#attachedTargetsByTargetId.delete(event.targetId);
+      }
     }
   };
 

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -176,6 +176,10 @@ export class TargetManager
     return this.#attachedTargetsByTargetId;
   }
 
+  getDiscoveredTargetInfos(): ReadonlyMap<string, Protocol.Target.TargetInfo> {
+    return this.#discoveredTargetsByTargetId;
+  }
+
   #setupAttachmentListeners(session: CDPSession | Connection): void {
     const listener = (event: Protocol.Target.AttachedToTargetEvent) => {
       void this.#onAttachedToTarget(session, event);
@@ -260,14 +264,15 @@ export class TargetManager
     const targetInfo = this.#discoveredTargetsByTargetId.get(event.targetId);
     this.#discoveredTargetsByTargetId.delete(event.targetId);
     this.#finishInitializationIfReady(event.targetId);
-    if (targetInfo?.type === 'service_worker') {
-      // Special case for service workers: report TargetGone event when
-      // the worker is destroyed.
-      const target = this.#attachedTargetsByTargetId.get(event.targetId);
-      if (target) {
-        this.emit(TargetManagerEvent.TargetGone, target);
-        this.#attachedTargetsByTargetId.delete(event.targetId);
-      }
+
+    const target = this.#attachedTargetsByTargetId.get(event.targetId);
+    if (
+      target &&
+      (target.type() === 'service_worker' ||
+        targetInfo?.type === 'service_worker')
+    ) {
+      this.#attachedTargetsByTargetId.delete(event.targetId);
+      this.emit(TargetManagerEvent.TargetGone, target);
     }
   };
 
@@ -339,7 +344,8 @@ export class TargetManager
       await this.#silentDetach(session, parentSession);
       if (
         this.#attachedTargetsByTargetId.has(targetInfo.targetId) ||
-        this.#ignoredTargets.has(targetInfo.targetId)
+        this.#ignoredTargets.has(targetInfo.targetId) ||
+        !this.#discoveredTargetsByTargetId.has(targetInfo.targetId)
       ) {
         return;
       }


### PR DESCRIPTION
- service worker might not be fully available yet when the extension is uninstalled.
- service worker target can be made available after it has been destroyed.