### PR TITLE
fix: remove PartitionAllocSchedulerLoopQuarantineTaskControlledPurge from disabled features

### DIFF
--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -177,7 +177,6 @@ export class ChromeLauncher extends BrowserLauncher {
       'AcceptCHFrame',
       'MediaRouter',
       'OptimizationHints',
-      'PartitionAllocSchedulerLoopQuarantineTaskControlledPurge', // https://crbug.com/489314676
       ...(turnOnExperimentalFeaturesForTesting
         ? []
         : [


### PR DESCRIPTION
Should be fixed with https://chromiumdash.appspot.com/commit/77f144bdad221a81a6078f75a5975008408d9817

Closes http://crbug.com/489314676