### PR TITLE
feat: implement URL blocklist to restrict access to unauthorized sites

### DIFF
--- a/docs/api/puppeteer.connectoptions.md
+++ b/docs/api/puppeteer.connectoptions.md
@@ -70,7 +70,17 @@ string\[\]
 
 </td><td>
 
-**_(Experimental)_**
+**_(Experimental)_** A list of URL patterns to block.
+
+This option allows you to restrict the browser from accessing specific URLs or origins. It uses the standard \[URLPattern\](https://urlpattern.spec.whatwg.org/) API to match URLs.
+
+When connecting to an existing browser, Puppeteer will silently detach from any already open targets that violate the patterns.
+
+For any network requests made by the browser (including navigations and subresources like images or scripts), the request will fail with an error if the URL matches a blocked pattern.
+
+**Remarks:**
+
+Currently only supported for CDP connections.
 
 </td><td>
 

--- a/docs/api/puppeteer.connectoptions.md
+++ b/docs/api/puppeteer.connectoptions.md
@@ -58,6 +58,25 @@ Whether to ignore HTTPS errors during navigation.
 </td></tr>
 <tr><td>
 
+<span id="blocklist">blockList</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string\[\]
+
+</td><td>
+
+**_(Experimental)_**
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="browserurl">browserURL</span>
 
 </td><td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -41864,7 +41864,8 @@
         "@types/ws": "8.18.1",
         "mitt": "3.0.1",
         "parsel-js": "1.2.2",
-        "rxjs": "7.8.2"
+        "rxjs": "7.8.2",
+        "urlpattern-polyfill": "10.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -42044,6 +42045,13 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
       "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "license": "MIT"
+    },
+    "packages/puppeteer-core/node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
       "license": "MIT"
     },
     "packages/puppeteer-core/node_modules/webdriver-bidi-protocol": {

--- a/packages/puppeteer-core/Herebyfile.mjs
+++ b/packages/puppeteer-core/Herebyfile.mjs
@@ -146,6 +146,15 @@ export const buildTask = task({
               'utf-8',
             );
             break;
+          case 'urlpattern-polyfill':
+            license = await readFile(
+              path.join(
+                path.dirname(require.resolve('urlpattern-polyfill')),
+                'LICENSE',
+              ),
+              'utf-8',
+            );
+            break;
           default:
             throw new Error(`Add license handling for ${path}`);
         }

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -163,6 +163,7 @@
     "@types/ws": "8.18.1",
     "mitt": "3.0.1",
     "parsel-js": "1.2.2",
-    "rxjs": "7.8.2"
+    "rxjs": "7.8.2",
+    "urlpattern-polyfill": "10.1.0"
   }
 }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -71,6 +71,7 @@ export class CdpBrowser extends BrowserBase {
     networkEnabled = true,
     issuesEnabled = true,
     handleDevToolsAsPage = false,
+    blockList?: string[],
   ): Promise<CdpBrowser> {
     const browser = new CdpBrowser(
       connection,
@@ -84,6 +85,7 @@ export class CdpBrowser extends BrowserBase {
       networkEnabled,
       issuesEnabled,
       handleDevToolsAsPage,
+      getNetworkConditions(blockList),
     );
     if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {
@@ -119,6 +121,7 @@ export class CdpBrowser extends BrowserBase {
     networkEnabled = true,
     issuesEnabled = true,
     handleDevToolsAsPage = false,
+    networkConditions?: Protocol.Network.EmulateNetworkConditionsByRuleRequest,
   ) {
     super();
     this.#networkEnabled = networkEnabled;
@@ -139,6 +142,7 @@ export class CdpBrowser extends BrowserBase {
       this.#createTarget,
       this.#targetFilterCallback,
       waitForInitiallyDiscoveredTargets,
+      networkConditions,
     );
     this.#defaultContext = new CdpBrowserContext(this.#connection, this);
     for (const contextId of contextIds) {
@@ -618,4 +622,22 @@ export class CdpBrowser extends BrowserBase {
   override isIssuesEnabled(): boolean {
     return this.#issuesEnabled;
   }
+}
+
+function getNetworkConditions(
+  blockList?: string[],
+): Protocol.Network.EmulateNetworkConditionsByRuleRequest | undefined {
+  if (!blockList?.length) {
+    return undefined;
+  }
+  const matchedNetworkConditions = blockList.map(pattern => {
+    return {
+      offline: true,
+      urlPattern: pattern,
+      latency: 0,
+      downloadThroughput: -1,
+      uploadThroughput: -1,
+    };
+  });
+  return {matchedNetworkConditions};
 }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -632,12 +632,11 @@ function getNetworkConditions(
   }
   const matchedNetworkConditions = blockList.map(pattern => {
     return {
-      offline: true,
       urlPattern: pattern,
       latency: 0,
       downloadThroughput: -1,
       uploadThroughput: -1,
     };
   });
-  return {matchedNetworkConditions};
+  return {matchedNetworkConditions, offline: true};
 }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -85,7 +85,7 @@ export class CdpBrowser extends BrowserBase {
       networkEnabled,
       issuesEnabled,
       handleDevToolsAsPage,
-      getNetworkConditions(blockList),
+      blockList,
     );
     if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {
@@ -121,7 +121,7 @@ export class CdpBrowser extends BrowserBase {
     networkEnabled = true,
     issuesEnabled = true,
     handleDevToolsAsPage = false,
-    networkConditions?: Protocol.Network.EmulateNetworkConditionsByRuleRequest,
+    networkConditions?: string[],
   ) {
     super();
     this.#networkEnabled = networkEnabled;
@@ -622,21 +622,4 @@ export class CdpBrowser extends BrowserBase {
   override isIssuesEnabled(): boolean {
     return this.#issuesEnabled;
   }
-}
-
-function getNetworkConditions(
-  blockList?: string[],
-): Protocol.Network.EmulateNetworkConditionsByRuleRequest | undefined {
-  if (!blockList?.length) {
-    return undefined;
-  }
-  const matchedNetworkConditions = blockList.map(pattern => {
-    return {
-      urlPattern: pattern,
-      latency: 0,
-      downloadThroughput: -1,
-      uploadThroughput: -1,
-    };
-  });
-  return {matchedNetworkConditions, offline: true};
 }

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -35,6 +35,7 @@ export async function _connectToCdpBrowser(
     protocolTimeout,
     handleDevToolsAsPage,
     idGenerator = createIncrementalIdGenerator(),
+    blockList,
   } = options;
 
   const connection = new Connection(
@@ -65,6 +66,7 @@ export async function _connectToCdpBrowser(
     networkEnabled,
     issuesEnabled,
     handleDevToolsAsPage,
+    blockList,
   );
   return browser;
 }

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -484,8 +484,7 @@ export class TargetManager
       try {
         const pattern = new URLPattern(rule.urlPattern);
         if (pattern.test(url)) {
-          // Returns false if rule.offline is true (blocked)
-          return !rule.offline;
+          return false; // return false as url matches pattern from blockList
         }
       } catch {
         debugError(`Invalid URL pattern: ${rule.urlPattern}`);

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -107,21 +107,21 @@ export class TargetManager
   // done. It indicates whethere we are running the initial auto-attach step or
   // if we are handling targets after that.
   #initialAttachDone = false;
-  #networkConditions?: Protocol.Network.EmulateNetworkConditionsByRuleRequest;
+  #blockList?: string[];
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
     targetFilterCallback?: TargetFilterCallback,
     waitForInitiallyDiscoveredTargets = true,
-    networkConditions?: Protocol.Network.EmulateNetworkConditionsByRuleRequest,
+    networkConditions?: string[],
   ) {
     super();
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;
     this.#waitForInitiallyDiscoveredTargets = waitForInitiallyDiscoveredTargets;
-    this.#networkConditions = networkConditions;
+    this.#blockList = networkConditions;
 
     this.#connection.on('Target.targetCreated', this.#onTargetCreated);
     this.#connection.on('Target.targetDestroyed', this.#onTargetDestroyed);
@@ -337,6 +337,13 @@ export class TargetManager
       return;
     }
 
+    // If we connect to a browser that is already open,
+    // immediately detach from any tab that is on the blocklist.
+    if (!this.#initialAttachDone && !this.#isUrlAllowed(targetInfo.url)) {
+      await this.#silentDetach(session, parentSession);
+      return;
+    }
+
     // Special case for service workers: being attached to service workers will
     // prevent them from ever being destroyed. Therefore, we silently detach
     // from service workers unless the connection was manually created via
@@ -357,13 +364,6 @@ export class TargetManager
       target._initialize();
       this.#attachedTargetsByTargetId.set(targetInfo.targetId, target);
       this.emit(TargetManagerEvent.TargetAvailable, target);
-      return;
-    }
-
-    // If we connect to a browser that is already open,
-    // immediately detach from any tab that is on the blocklist.
-    if (!this.#initialAttachDone && !this.#isUrlAllowed(targetInfo.url)) {
-      await this.#silentDetach(session, parentSession);
       return;
     }
 
@@ -469,7 +469,7 @@ export class TargetManager
    * Helper to validate URL against blocklist patterns
    */
   #isUrlAllowed = (url: string): boolean => {
-    if (!this.#networkConditions) {
+    if (!this.#blockList) {
       return true;
     }
 
@@ -478,16 +478,14 @@ export class TargetManager
       return true;
     }
 
-    const rules = this.#networkConditions.matchedNetworkConditions;
-
-    for (const rule of rules) {
+    for (const rule of this.#blockList) {
       try {
-        const pattern = new URLPattern(rule.urlPattern);
+        const pattern = new URLPattern(rule);
         if (pattern.test(url)) {
           return false; // return false as url matches pattern from blockList
         }
       } catch {
-        debugError(`Invalid URL pattern: ${rule.urlPattern}`);
+        debugError(`Invalid URL pattern: ${rule}`);
       }
     }
 
@@ -495,14 +493,22 @@ export class TargetManager
   };
 
   #maybeSetupNetworkConditions = async (session: CDPSession): Promise<void> => {
-    if (!this.#networkConditions) {
+    if (!this.#blockList?.length) {
       return;
     }
 
-    await session.send('Network.enable');
-    await session.send(
-      'Network.emulateNetworkConditionsByRule',
-      this.#networkConditions,
-    );
+    const matchedNetworkConditions = this.#blockList.map(pattern => {
+      return {
+        urlPattern: pattern,
+        latency: 0,
+        downloadThroughput: -1,
+        uploadThroughput: -1,
+      };
+    });
+
+    await session.send('Network.emulateNetworkConditionsByRule', {
+      matchedNetworkConditions,
+      offline: true,
+    });
   };
 }

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -6,6 +6,7 @@
 
 import type {Protocol} from 'devtools-protocol';
 
+import {URLPattern} from '../../third_party/urlpattern-polyfill/urlpattern-polyfill.js';
 import type {TargetFilterCallback} from '../api/Browser.js';
 import type {CDPSession} from '../api/CDPSession.js';
 import {CDPSessionEvent} from '../api/CDPSession.js';
@@ -106,18 +107,21 @@ export class TargetManager
   // done. It indicates whethere we are running the initial auto-attach step or
   // if we are handling targets after that.
   #initialAttachDone = false;
+  #networkConditions?: Protocol.Network.EmulateNetworkConditionsByRuleRequest;
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
     targetFilterCallback?: TargetFilterCallback,
     waitForInitiallyDiscoveredTargets = true,
+    networkConditions?: Protocol.Network.EmulateNetworkConditionsByRuleRequest,
   ) {
     super();
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;
     this.#waitForInitiallyDiscoveredTargets = waitForInitiallyDiscoveredTargets;
+    this.#networkConditions = networkConditions;
 
     this.#connection.on('Target.targetCreated', this.#onTargetCreated);
     this.#connection.on('Target.targetDestroyed', this.#onTargetDestroyed);
@@ -356,6 +360,13 @@ export class TargetManager
       return;
     }
 
+    // If we connect to a browser that is already open,
+    // immediately detach from any tab that is on the blocklist.
+    if (!this.#initialAttachDone && !this.#isUrlAllowed(targetInfo.url)) {
+      await this.#silentDetach(session, parentSession);
+      return;
+    }
+
     let target = this.#attachedTargetsByTargetId.get(targetInfo.targetId);
     const isExistingTarget = target !== undefined;
 
@@ -417,6 +428,7 @@ export class TargetManager
         autoAttach: true,
         filter: this.#discoveryFilter,
       }),
+      this.#maybeSetupNetworkConditions(session),
       session.send('Runtime.runIfWaitingForDebugger'),
     ]).catch(debugError);
   };
@@ -451,5 +463,47 @@ export class TargetManager
     }
     this.#attachedTargetsByTargetId.delete(target._targetId);
     this.emit(TargetManagerEvent.TargetGone, target);
+  };
+
+  /**
+   * Helper to validate URL against blocklist patterns
+   */
+  #isUrlAllowed = (url: string): boolean => {
+    if (!this.#networkConditions) {
+      return true;
+    }
+
+    // Always allow internal or setup pages
+    if (!url || url === 'about:blank') {
+      return true;
+    }
+
+    const rules = this.#networkConditions.matchedNetworkConditions;
+
+    for (const rule of rules) {
+      try {
+        const pattern = new URLPattern(rule.urlPattern);
+        if (pattern.test(url)) {
+          // Returns false if rule.offline is true (blocked)
+          return !rule.offline;
+        }
+      } catch {
+        debugError(`Invalid URL pattern: ${rule.urlPattern}`);
+      }
+    }
+
+    return true;
+  };
+
+  #maybeSetupNetworkConditions = async (session: CDPSession): Promise<void> => {
+    if (!this.#networkConditions) {
+      return;
+    }
+
+    await session.send('Network.enable');
+    await session.send(
+      'Network.emulateNetworkConditionsByRule',
+      this.#networkConditions,
+    );
   };
 }

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -168,12 +168,12 @@ export interface ConnectOptions {
    * This option allows you to restrict the browser from accessing specific
    * URLs or origins. It uses the standard [URLPattern](https://urlpattern.spec.whatwg.org/) API to match URLs.
    *
-   * If a pattern matches:
+   * When connecting to an existing browser, Puppeteer will silently detach from any
+   * already open targets that violate the patterns.
    *
-   * - **During initial connection**: Puppeteer will silently detach from any
-   *   pre-existing targets (tabs) that violate the patterns.
-   * - **During navigation or resource fetching**: The request will be blocked
-   *   (resulting in `net::ERR_INTERNET_DISCONNECTED`).
+   * For any network requests made by the browser (including navigations and
+   * subresources like images or scripts), the request will fail with an error
+   * if the URL matches a blocked pattern.
    *
    * @example Pattern to block a specific domain:
    * `*://example.com/*`

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -163,6 +163,27 @@ export interface ConnectOptions {
   capabilities?: SupportedWebDriverCapabilities;
 
   /**
+   * A list of URL patterns to block.
+   *
+   * This option allows you to restrict the browser from accessing specific
+   * URLs or origins. It uses the standard [URLPattern](https://urlpattern.spec.whatwg.org/) API to match URLs.
+   *
+   * If a pattern matches:
+   *
+   * - **During initial connection**: Puppeteer will silently detach from any
+   *   pre-existing targets (tabs) that violate the patterns.
+   * - **During navigation or resource fetching**: The request will be blocked
+   *   (resulting in `net::ERR_INTERNET_DISCONNECTED`).
+   *
+   * @example Pattern to block a specific domain:
+   * `*://example.com/*`
+   *
+   * @example Pattern to block all subdomains:
+   * `*://*.evil.com/*`
+   *
+   * @remarks
+   * Currently only supported for CDP connections.
+   *
    * @experimental
    */
   blockList?: string[];

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -161,4 +161,9 @@ export interface ConnectOptions {
    * Only works for `protocol="webDriverBiDi"` and {@link Puppeteer.connect}.
    */
   capabilities?: SupportedWebDriverCapabilities;
+
+  /**
+   * @experimental
+   */
+  blockList?: string[];
 }

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -94,6 +94,7 @@ export abstract class BrowserLauncher {
       protocolTimeout,
       handleDevToolsAsPage,
       idGenerator = createIncrementalIdGenerator(),
+      blockList,
     } = options;
 
     let {protocol} = options;
@@ -220,6 +221,7 @@ export abstract class BrowserLauncher {
             networkEnabled,
             issuesEnabled,
             handleDevToolsAsPage,
+            blockList,
           );
         }
       }

--- a/packages/puppeteer-core/third_party/urlpattern-polyfill/urlpattern-polyfill.ts
+++ b/packages/puppeteer-core/third_party/urlpattern-polyfill/urlpattern-polyfill.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @puppeteer/check-license
+export * from 'urlpattern-polyfill';

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -628,6 +628,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should detach from targets violating blocklist when connecting to a running browser",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["pipe"],
+    "expectations": ["SKIP"],
+    "comment": "Verifies URL blocklist enforcement when connecting to a browser via WebSocket, which is not applicable for pipe mode"
+  },
+  {
     "testIdPattern": "[network.spec] network Network Events should support redirects",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -147,6 +147,13 @@
     "comment": "CDP-specific feature, not supported in WebDriver BiDi"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["SKIP"],
+    "comment": "Not supported by chrome-headless-shell"
+  },
+  {
     "testIdPattern": "[network.spec] network Page.setBypassServiceWorker *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -133,6 +133,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"],
+    "comment": "CDP-specific feature, not supported in Firefox"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "CDP-specific feature, not supported in WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[network.spec] network Page.setBypassServiceWorker *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -19,18 +19,21 @@ describe('Network Restrictions', function () {
       {createContext: true},
     );
 
-    const allowedUrl = server.PREFIX + '/title.html';
-    const blockedUrl = server.PREFIX + '/empty.html';
+    try {
+      const allowedUrl = server.PREFIX + '/title.html';
+      const blockedUrl = server.PREFIX + '/empty.html';
 
-    await page.goto(allowedUrl);
-    let error: Error | undefined;
-    await page.goto(blockedUrl).catch(e => {
-      return (error = e);
-    });
+      await page.goto(allowedUrl);
+      let error: Error | undefined;
+      await page.goto(blockedUrl).catch(e => {
+        return (error = e);
+      });
 
-    expect(error).toBeDefined();
-    expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
-    await close();
+      expect(error).toBeDefined();
+      expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
+    } finally {
+      await close();
+    }
   });
 
   it('should block window.location.href navigation to URLs in the blocklist', async () => {
@@ -41,21 +44,24 @@ describe('Network Restrictions', function () {
       {createContext: true},
     );
 
-    const allowedUrl = server.PREFIX + '/title.html';
-    const blockedUrl = server.PREFIX + '/empty.html';
+    try {
+      const allowedUrl = server.PREFIX + '/title.html';
+      const blockedUrl = server.PREFIX + '/empty.html';
 
-    await page.goto(allowedUrl);
-    const navPromise = page.waitForNavigation({timeout: 2000}).catch(e => {
-      return e;
-    });
-    await page.evaluate(url => {
-      window.location.href = url;
-    }, blockedUrl);
+      await page.goto(allowedUrl);
+      const navPromise = page.waitForNavigation({timeout: 2000}).catch(e => {
+        return e;
+      });
+      await page.evaluate(url => {
+        window.location.href = url;
+      }, blockedUrl);
 
-    await navPromise;
-    const finalUrl = page.url();
-    expect(finalUrl).not.toBe(blockedUrl);
-    await close();
+      await navPromise;
+      const finalUrl = page.url();
+      expect(finalUrl).not.toBe(blockedUrl);
+    } finally {
+      await close();
+    }
   });
 
   it('should fail fetch requests to URLs in the blocklist', async () => {
@@ -66,22 +72,25 @@ describe('Network Restrictions', function () {
       {createContext: true},
     );
 
-    const allowedUrl = server.PREFIX + '/title.html';
-    const blockedUrl = server.PREFIX + '/empty.html';
+    try {
+      const allowedUrl = server.PREFIX + '/title.html';
+      const blockedUrl = server.PREFIX + '/empty.html';
 
-    await page.goto(allowedUrl);
-    const fetchError = await page.evaluate(async url => {
-      try {
-        await fetch(url);
-        return null;
-      } catch (e) {
-        return (e as Error).message;
-      }
-    }, blockedUrl);
+      await page.goto(allowedUrl);
+      const fetchError = await page.evaluate(async url => {
+        try {
+          await fetch(url);
+          return null;
+        } catch (e) {
+          return (e as Error).message;
+        }
+      }, blockedUrl);
 
-    expect(fetchError).toBeTruthy();
-    expect(fetchError).toContain('Failed to fetch');
-    await close();
+      expect(fetchError).toBeTruthy();
+      expect(fetchError).toContain('Failed to fetch');
+    } finally {
+      await close();
+    }
   });
 
   it('should prevent loading of blocklisted subresources (e.g., images)', async () => {
@@ -92,57 +101,41 @@ describe('Network Restrictions', function () {
       {createContext: true},
     );
 
-    const allowedUrl = server.PREFIX + '/one-style.css';
-    const blockedUrl = server.PREFIX + '/pptr.png';
+    try {
+      const allowedUrl = server.PREFIX + '/one-style.css';
+      const blockedUrl = server.PREFIX + '/pptr.png';
 
-    const imageBlockedErrorPromise = new Promise<string | undefined>(
-      resolve => {
-        page.on('requestfailed', request => {
-          if (request.url().endsWith('/pptr.png')) {
-            resolve(request.failure()?.errorText);
-          }
-        });
-      },
-    );
-    const cssFinishedPromise = new Promise<boolean>(resolve => {
-      page.on('requestfinished', request => {
-        if (request.url().endsWith('/one-style.css')) {
-          resolve(true);
-        }
+      const failedRequests = new Map<string, string | undefined>();
+      const finishedRequests = new Set<string>();
+
+      page.on('requestfailed', request => {
+        failedRequests.set(request.url(), request.failure()?.errorText);
       });
-    });
+      page.on('requestfinished', request => {
+        finishedRequests.add(request.url());
+      });
 
-    await page.goto(server.PREFIX + '/empty.html');
-    await page.setContent(html`
-      <img src="${blockedUrl}" />
-      <link
-        rel="stylesheet"
-        href="${allowedUrl}"
-      />
-    `);
+      await page.goto(server.PREFIX + '/empty.html');
 
-    const imageError = await Promise.race([
-      imageBlockedErrorPromise,
-      new Promise<string | undefined>(r => {
-        return setTimeout(() => {
-          return r(undefined);
-        }, 3000);
-      }),
-    ]);
-    const cssFinished = await Promise.race([
-      cssFinishedPromise,
-      new Promise<boolean>(r => {
-        return setTimeout(() => {
-          return r(false);
-        }, 3000);
-      }),
-    ]);
+      await page.setContent(
+        html`
+          <img src="${blockedUrl}" />
+          <link
+            rel="stylesheet"
+            href="${allowedUrl}"
+          />
+        `,
+        {waitUntil: 'networkidle0'},
+      );
 
-    expect(imageError).toBeDefined();
-    expect(imageError).toContain('net::ERR_INTERNET_DISCONNECTED');
-    expect(cssFinished).toBe(true);
-
-    await close();
+      expect(failedRequests.has(blockedUrl)).toBe(true);
+      expect(failedRequests.get(blockedUrl)).toContain(
+        'net::ERR_INTERNET_DISCONNECTED',
+      );
+      expect(finishedRequests.has(allowedUrl)).toBe(true);
+    } finally {
+      await close();
+    }
   });
 
   it('should detach from targets violating blocklist when connecting to a running browser', async () => {
@@ -151,26 +144,51 @@ describe('Network Restrictions', function () {
       server,
       close,
     } = await launch({}, {createContext: false, createPage: false});
-    const page = await originalBrowser.newPage();
-    const blockedUrl = server.PREFIX + '/empty.html';
 
-    await page.goto(blockedUrl);
+    let connectedBrowser: any;
+    try {
+      const page = await originalBrowser.newPage();
+      const blockedUrl = server.PREFIX + '/empty.html';
 
-    const wsEndpoint = originalBrowser.wsEndpoint();
+      await page.goto(blockedUrl);
 
-    const connectedBrowser = await puppeteer.connect({
-      browserWSEndpoint: wsEndpoint,
-      blockList: ['*://*:*/empty.html'],
-    });
+      const wsEndpoint = originalBrowser.wsEndpoint();
 
-    const targets = connectedBrowser.targets();
-    const blockedTarget = targets.find(t => {
-      return t.url() === blockedUrl;
-    });
+      connectedBrowser = await puppeteer.connect({
+        browserWSEndpoint: wsEndpoint,
+        blockList: ['*://*:*/empty.html'],
+      });
 
-    expect(blockedTarget).toBeUndefined();
+      const targets = connectedBrowser.targets();
+      const blockedTarget = targets.find((t: any) => {
+        return t.url() === blockedUrl;
+      });
 
-    await connectedBrowser.disconnect();
-    await close();
+      expect(blockedTarget).toBeUndefined();
+    } finally {
+      if (connectedBrowser) {
+        await connectedBrowser.disconnect();
+      }
+      await close();
+    }
+  });
+
+  it('should not block chrome://version/ even if it matches blocklist', async () => {
+    const chromeUrl = 'chrome://version/';
+    const {page, close} = await launch(
+      {
+        blockList: [chromeUrl],
+      },
+      {createContext: true},
+    );
+
+    try {
+      await page.goto(chromeUrl);
+
+      // Navigation should succeed as chrome:// URLs usually bypass the network
+      expect(page.url()).toBe(chromeUrl);
+    } finally {
+      await close();
+    }
   });
 });

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -7,8 +7,8 @@
 import expect from 'expect';
 import puppeteer from 'puppeteer/internal/puppeteer.js';
 
-import {launch} from './mocha-utils.js';
-import {html} from './utils.js';
+import {launch} from '../mocha-utils.js';
+import {html} from '../utils.js';
 
 describe('Network Restrictions', function () {
   it('should block page.goto when the destination is in the blocklist', async () => {

--- a/test/src/network_restrictions.spec.ts
+++ b/test/src/network_restrictions.spec.ts
@@ -11,7 +11,7 @@ import {launch} from './mocha-utils.js';
 import {html} from './utils.js';
 
 describe('Network Restrictions', function () {
-  it.only('should block page.goto when the destination is in the blocklist', async () => {
+  it('should block page.goto when the destination is in the blocklist', async () => {
     const {page, close, server} = await launch(
       {
         blockList: ['*://*:*/empty.html'],

--- a/test/src/network_restrictions.spec.ts
+++ b/test/src/network_restrictions.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import expect from 'expect';
+import puppeteer from 'puppeteer/internal/puppeteer.js';
+
+import {launch} from './mocha-utils.js';
+import {html} from './utils.js';
+
+describe('Network Restrictions', function () {
+  it('should block page.goto when the destination is in the blocklist', async () => {
+    const {page, close, server} = await launch(
+      {
+        acceptInsecureCerts: true,
+        blockList: ['*://*:*/empty.html'],
+      },
+      {createContext: true},
+    );
+
+    const allowedUrl = server.PREFIX + '/title.html';
+    const blockedUrl = server.PREFIX + '/empty.html';
+
+    await page.goto(allowedUrl);
+    let error: Error | undefined;
+    await page.goto(blockedUrl).catch(e => {
+      return (error = e);
+    });
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
+    await close();
+  });
+
+  it('should block window.location.href navigation to URLs in the blocklist', async () => {
+    const {page, close, server} = await launch(
+      {
+        blockList: ['*://*:*/empty.html'],
+      },
+      {createContext: true},
+    );
+
+    const allowedUrl = server.PREFIX + '/title.html';
+    const blockedUrl = server.PREFIX + '/empty.html';
+
+    await page.goto(allowedUrl);
+    const navPromise = page.waitForNavigation({timeout: 2000}).catch(e => {
+      return e;
+    });
+    await page.evaluate(url => {
+      window.location.href = url;
+    }, blockedUrl);
+
+    await navPromise;
+    const finalUrl = page.url();
+    expect(finalUrl).not.toBe(blockedUrl);
+    await close();
+  });
+
+  it('should fail fetch requests to URLs in the blocklist', async () => {
+    const {page, close, server} = await launch(
+      {
+        blockList: ['*://*:*/empty.html'],
+      },
+      {createContext: true},
+    );
+
+    const allowedUrl = server.PREFIX + '/title.html';
+    const blockedUrl = server.PREFIX + '/empty.html';
+
+    await page.goto(allowedUrl);
+    const fetchError = await page.evaluate(async url => {
+      try {
+        await fetch(url);
+        return null;
+      } catch (e) {
+        return (e as Error).message;
+      }
+    }, blockedUrl);
+
+    expect(fetchError).toBeTruthy();
+    expect(fetchError).toContain('Failed to fetch');
+    await close();
+  });
+
+  it('should prevent loading of blocklisted subresources (e.g., images)', async () => {
+    const {page, close, server} = await launch(
+      {
+        blockList: ['*://*:*/pptr.png'],
+      },
+      {createContext: true},
+    );
+
+    const allowedUrl = server.PREFIX + '/one-style.css';
+    const blockedUrl = server.PREFIX + '/pptr.png';
+
+    const imageBlockedErrorPromise = new Promise<string | undefined>(
+      resolve => {
+        page.on('requestfailed', request => {
+          if (request.url().endsWith('/pptr.png')) {
+            resolve(request.failure()?.errorText);
+          }
+        });
+      },
+    );
+    const cssFinishedPromise = new Promise<boolean>(resolve => {
+      page.on('requestfinished', request => {
+        if (request.url().endsWith('/one-style.css')) {
+          resolve(true);
+        }
+      });
+    });
+
+    await page.goto(server.PREFIX + '/empty.html');
+    await page.setContent(html`
+      <img src="${blockedUrl}" />
+      <link
+        rel="stylesheet"
+        href="${allowedUrl}"
+      />
+    `);
+
+    const imageError = await Promise.race([
+      imageBlockedErrorPromise,
+      new Promise<string | undefined>(r => {
+        return setTimeout(() => {
+          return r(undefined);
+        }, 3000);
+      }),
+    ]);
+    const cssFinished = await Promise.race([
+      cssFinishedPromise,
+      new Promise<boolean>(r => {
+        return setTimeout(() => {
+          return r(false);
+        }, 3000);
+      }),
+    ]);
+
+    expect(imageError).toBeDefined();
+    expect(imageError).toContain('net::ERR_INTERNET_DISCONNECTED');
+    expect(cssFinished).toBe(true);
+
+    await close();
+  });
+
+  it('should detach from targets violating blocklist when connecting to a running browser', async () => {
+    const {
+      browser: originalBrowser,
+      server,
+      close,
+    } = await launch({}, {createContext: false, createPage: false});
+    const page = await originalBrowser.newPage();
+    const blockedUrl = server.PREFIX + '/empty.html';
+
+    await page.goto(blockedUrl);
+
+    const wsEndpoint = originalBrowser.wsEndpoint();
+
+    const connectedBrowser = await puppeteer.connect({
+      browserWSEndpoint: wsEndpoint,
+      blockList: ['*://*:*/empty.html'],
+    });
+
+    const targets = connectedBrowser.targets();
+    const blockedTarget = targets.find(t => {
+      return t.url() === blockedUrl;
+    });
+
+    expect(blockedTarget).toBeUndefined();
+
+    await connectedBrowser.disconnect();
+    await close();
+  });
+});

--- a/test/src/network_restrictions.spec.ts
+++ b/test/src/network_restrictions.spec.ts
@@ -11,10 +11,9 @@ import {launch} from './mocha-utils.js';
 import {html} from './utils.js';
 
 describe('Network Restrictions', function () {
-  it('should block page.goto when the destination is in the blocklist', async () => {
+  it.only('should block page.goto when the destination is in the blocklist', async () => {
     const {page, close, server} = await launch(
       {
-        acceptInsecureCerts: true,
         blockList: ['*://*:*/empty.html'],
       },
       {createContext: true},


### PR DESCRIPTION
# Feature: URL Blocklist for Puppeteer

This PR introduces a URL blocklist feature for Puppeteer, allowing developers to restrict network access to specific URLs or origins. This is useful for security-sensitive automation environments where access to certain domains must be strictly controlled.

## How it works

The feature is exposed via a new experimental `blockList` option in `ConnectOptions`. It uses the standard [URLPattern](https://urlpattern.spec.whatwg.org/) API for matching URLs.

The blocklist enforces restrictions in two ways:

1.  **On Connection**: When connecting to an existing browser, Puppeteer will silently detach from any already open targets (tabs, workers, etc.) that violate the patterns. This ensures that access to restricted content is neutralized immediately upon attachment.
2.  **During Operation**: For any network requests made by the browser (including main frame navigations and subresources like images, scripts, or stylesheets), the request will fail with an error if the URL matches a blocked pattern.

## Example Usage

```typescript
const browser = await puppeteer.connect({
  blockList: [
    '*://example.com/*', // Block a specific domain
    '*://*.evil.com/*',  // Block all subdomains
  ],
});
