### PR TITLE
fix: reuse the same Page instance across Target.asPage and Target.page

### DIFF
--- a/packages/puppeteer-core/src/cdp/Target.ts
+++ b/packages/puppeteer-core/src/cdp/Target.ts
@@ -259,6 +259,9 @@ export class PageTarget extends CdpTarget {
   }
 
   override async page(): Promise<Page | null> {
+    if (this._asPagePromise) {
+      this.pagePromise = this._asPagePromise;
+    }
     if (!this.pagePromise) {
       const session = this._session();
       this.pagePromise = (

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -33,6 +33,20 @@ describe('Target', function () {
     await page.close();
   });
 
+  it('Target.page() should reuse the page created via Target.asPage()', async () => {
+    const {browser} = await getTestState();
+    const page = await browser.newPage();
+    const target = page.target();
+
+    const pageFromAsPage = await target.asPage();
+    const pageFromPage = await target.page();
+
+    expect(pageFromAsPage).toBe(page);
+    expect(pageFromPage).toBe(page);
+
+    await page.close();
+  });
+
   it('Browser.targets should return all of the targets', async () => {
     const {browser} = await getTestState();
 

--- a/test/src/target.spec.ts
+++ b/test/src/target.spec.ts
@@ -33,18 +33,22 @@ describe('Target', function () {
     await page.close();
   });
 
-  it('Target.page() should reuse the page created via Target.asPage()', async () => {
-    const {browser} = await getTestState();
-    const page = await browser.newPage();
-    const target = page.target();
+  it('Target.page() should reuse the page created via Target.asPage() for a discovered target', async () => {
+    const {page, context} = await getTestState();
+    await page.goto('about:blank');
+
+    const newTargetPromise = waitEvent<Target>(context, 'targetcreated');
+    await page.evaluate(() => {
+      window.open('about:blank');
+    });
+    const target = await newTargetPromise;
 
     const pageFromAsPage = await target.asPage();
     const pageFromPage = await target.page();
 
-    expect(pageFromAsPage).toBe(page);
-    expect(pageFromPage).toBe(page);
+    expect(pageFromAsPage).toBe(pageFromPage);
 
-    await page.close();
+    await pageFromAsPage.close();
   });
 
   it('Browser.targets should return all of the targets', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**Did you add tests for your changes?**

Yes.

**If relevant, did you update the documentation?**

No.

**Summary**

Fixes #14877.

#14862 made repeated `Target.asPage()` calls return the same `Page` instance, but `Target.asPage()` followed by `Target.page()` could still diverge.

The root cause is that `CdpTarget.asPage()` and `PageTarget.page()` still used separate caches (`_asPagePromise` vs `pagePromise`). If `asPage()` ran first, `page()` could still create a second `Page`.

This PR keeps the fix intentionally small:
- reuse the `asPage()` promise from `PageTarget.page()` when it already exists
- add a regression test that covers `asPage()` followed by `page()`

**Does this PR introduce a breaking change?**

No.

**Other information**

This is intended as a narrow follow-up to #14843 / #14862 rather than a broader Target API refactor.
