### PR TITLE
fix(webmcp): avoid hanging execute() calls after early tool responses

### DIFF
--- a/packages/puppeteer-core/src/cdp/WebMCP.test.ts
+++ b/packages/puppeteer-core/src/cdp/WebMCP.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import type {CDPSessionEvents} from '../api/CDPSession.js';
+import {EventEmitter} from '../common/EventEmitter.js';
+
+import {WebMCP} from './WebMCP.js';
+
+class MockCDPSession extends EventEmitter<CDPSessionEvents> {
+  #webmcp?: WebMCP;
+
+  setWebMCP(webmcp: WebMCP): void {
+    this.#webmcp = webmcp;
+  }
+
+  async send(method: string): Promise<any> {
+    if (method === 'WebMCP.enable') {
+      return;
+    }
+    if (method === 'WebMCP.invokeTool') {
+      this.emit('WebMCP.toolResponded', {
+        invocationId: 'invocation-id',
+        status: 'Completed',
+        output: 'early-result',
+      });
+      return {invocationId: 'invocation-id'};
+    }
+    throw new Error(`Unexpected CDP method: ${method}`);
+  }
+  connection() {
+    return undefined;
+  }
+  readonly detached = false;
+  async detach() {}
+  id() {
+    return '1';
+  }
+  parentSession() {
+    return undefined;
+  }
+}
+
+describe('WebMCP', () => {
+  it('should resolve execute() when toolresponded fires before the listener is attached', async () => {
+    const client = new MockCDPSession();
+    const frame = {_id: 'frame-id'};
+    const frameManager = {
+      on() {},
+      frame(frameId: string) {
+        return frameId === frame._id ? frame : undefined;
+      },
+    };
+
+    const webmcp = new WebMCP(client, frameManager as never);
+    client.setWebMCP(webmcp);
+    client.emit('WebMCP.toolsAdded', {
+      tools: [
+        {
+          name: 'tool-name',
+          description: 'tool-description',
+          frameId: frame._id,
+        },
+      ],
+    });
+
+    const [tool] = webmcp.tools();
+    expect(tool).toBeDefined();
+
+    const result = await Promise.race([
+      tool!.execute({value: 1}),
+      new Promise(resolve => {
+        setTimeout(() => {
+          resolve('timeout');
+        }, 25);
+      }),
+    ]);
+
+    expect(result).not.toBe('timeout');
+    expect(result).toMatchObject({
+      id: 'invocation-id',
+      status: 'Completed',
+      output: 'early-result',
+    });
+  });
+});

--- a/packages/puppeteer-core/src/cdp/WebMCP.ts
+++ b/packages/puppeteer-core/src/cdp/WebMCP.ts
@@ -163,11 +163,15 @@ export class WebMCPTool extends EventEmitter<{
    */
   async execute(input: object = {}): Promise<WebMCPToolCallResult> {
     const {invocationId} = await this.#webmcp.invokeTool(this, input);
+    const completedResponse = this.#webmcp.consumeToolResponse(invocationId);
+    if (completedResponse) {
+      return completedResponse;
+    }
     return await new Promise<WebMCPToolCallResult>(resolve => {
       const handler = (event: WebMCPToolCallResult) => {
         if (event.id === invocationId) {
           this.#webmcp.off('toolresponded', handler);
-          resolve(event);
+          resolve(this.#webmcp.consumeToolResponse(invocationId) ?? event);
         }
       };
       this.#webmcp.on('toolresponded', handler);
@@ -292,6 +296,7 @@ export class WebMCP extends EventEmitter<{
   #frameManager: FrameManager;
   #tools = new Map<string, Map<string, WebMCPTool>>();
   #pendingCalls = new Map<string, WebMCPToolCall>();
+  #respondedCalls = new Map<string, WebMCPToolCallResult>();
 
   #onToolsAdded = (event: ProtocolWebMCPToolsAddedEvent) => {
     const tools: WebMCPTool[] = [];
@@ -350,11 +355,13 @@ export class WebMCP extends EventEmitter<{
       errorText: event.errorText,
       exception: event.exception,
     };
+    this.#respondedCalls.set(event.invocationId, response);
     this.emit('toolresponded', response);
   };
 
   #onFrameNavigated = (frame: Frame) => {
     this.#pendingCalls.clear();
+    this.#respondedCalls.clear();
     const frameTools = this.#tools.get(frame._id);
     if (!frameTools) {
       return;
@@ -401,6 +408,17 @@ export class WebMCP extends EventEmitter<{
       toolName: tool.name,
       input,
     });
+  }
+
+  /**
+   * @internal
+   */
+  consumeToolResponse(invocationId: string): WebMCPToolCallResult | undefined {
+    const response = this.#respondedCalls.get(invocationId);
+    if (response) {
+      this.#respondedCalls.delete(invocationId);
+    }
+    return response;
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**Did you add tests for your changes?**

Yes.

**If relevant, did you update the documentation?**

No.

**Summary**

Fixes #14878.

`WebMCPTool.execute()` attached its `toolresponded` listener only after `invokeTool()` resolved. If CDP delivered `toolResponded` during `invokeTool()`, `execute()` could miss the response and wait forever.

This PR keeps the change narrowly scoped to the WebMCP response path:
- cache `toolresponded` results long enough for `execute()` to consume an already-arrived response
- add a deterministic unit test that emits `WebMCP.toolResponded` during `WebMCP.invokeTool`

**Does this PR introduce a breaking change?**

No.

**Other information**

The behavior is on the experimental WebMCP API, but `tool.execute()` is documented as returning a promise with the tool result, so hanging after an already-delivered response still looks like a correctness bug.
