### PR TITLE
fix(browsers): avoid cache corruption on concurrent installs

### DIFF
--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -7,7 +7,7 @@
 import assert from 'node:assert';
 import {spawnSync} from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
-import {mkdir, unlink} from 'node:fs/promises';
+import {mkdir, rename, rm, unlink} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -43,6 +43,25 @@ function debugTimeEnd(label: string) {
   const duration =
     end[0] * 1000 + end[1] / 1e6 - (start[0] * 1000 + start[1] / 1e6); // calculate duration in milliseconds
   debugInstall(`Duration for ${label}: ${duration}ms`);
+}
+
+function createTemporaryInstallationId(): string {
+  return `${process.pid}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function unlinkIfExists(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+function isExistingDestinationError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EEXIST' || code === 'ENOTEMPTY' || code === 'EPERM';
 }
 
 /**
@@ -372,6 +391,11 @@ async function installUrl(
   const cache = new Cache(options.cacheDir);
   const browserRoot = cache.browserRoot(options.browser);
   const archivePath = path.join(browserRoot, `${options.buildId}-${fileName}`);
+  const installationId = createTemporaryInstallationId();
+  const temporaryArchivePath = path.join(
+    browserRoot,
+    `${options.buildId}-${installationId}-${fileName}`,
+  );
   if (!existsSync(browserRoot)) {
     await mkdir(browserRoot, {recursive: true});
   }
@@ -392,6 +416,7 @@ async function installUrl(
     options.platform,
     options.buildId,
   );
+  const temporaryOutputPath = `${outputPath}.installing-${installationId}`;
 
   // Get executable path from provider once (used for both cached and new installations)
   const relativeExecutablePath = await provider.getExecutablePath({
@@ -434,25 +459,29 @@ async function installUrl(
       return installedBrowser;
     }
 
-    // Check if archive already exists (e.g., from a custom provider)
-    if (!existsSync(archivePath)) {
-      debugInstall(`Downloading binary from ${url}`);
-      try {
-        debugTime('download');
-        await downloadFile(url, archivePath, downloadProgressCallback);
-      } finally {
-        debugTimeEnd('download');
-      }
-    } else {
-      debugInstall(`Using existing archive at ${archivePath}`);
+    debugInstall(`Downloading binary from ${url}`);
+    try {
+      debugTime('download');
+      await downloadFile(url, temporaryArchivePath, downloadProgressCallback);
+    } finally {
+      debugTimeEnd('download');
     }
 
-    debugInstall(`Installing ${archivePath} to ${outputPath}`);
+    debugInstall(`Installing ${temporaryArchivePath} to ${temporaryOutputPath}`);
     try {
       debugTime('extract');
-      await unpackArchive(archivePath, outputPath);
+      await unpackArchive(temporaryArchivePath, temporaryOutputPath);
     } finally {
       debugTimeEnd('extract');
+    }
+
+    try {
+      await rename(temporaryOutputPath, outputPath);
+    } catch (error) {
+      if (!isExistingDestinationError(error) || !existsSync(outputPath)) {
+        throw error;
+      }
+      await rm(temporaryOutputPath, {recursive: true, force: true});
     }
 
     if (options.buildIdAlias) {
@@ -467,9 +496,10 @@ async function installUrl(
     }
     return installedBrowser;
   } finally {
-    if (existsSync(archivePath)) {
-      await unlink(archivePath);
+    if (existsSync(temporaryOutputPath)) {
+      await rm(temporaryOutputPath, {recursive: true, force: true});
     }
+    await unlinkIfExists(temporaryArchivePath);
   }
 }
 

--- a/packages/browsers/test/src/installWithProviders.spec.ts
+++ b/packages/browsers/test/src/installWithProviders.spec.ts
@@ -6,6 +6,7 @@
 
 import assert from 'node:assert';
 import fs from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -214,6 +215,92 @@ describe('Install with providers', () => {
         // Verify both provider errors are included
         assert(error.message.includes('Network error'));
         assert(error.message.includes('Server error'));
+      }
+    });
+
+    it('should handle concurrent installs for the same browser build', async function () {
+      this.timeout(30000);
+
+      const fixturePath = path.join(
+        import.meta.dirname,
+        '..',
+        'fixtures',
+        'test.tar.bz2',
+      );
+      const fixture = fs.readFileSync(fixturePath);
+
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, {
+          'Content-Type': 'application/x-bzip2',
+          'Content-Length': fixture.length,
+        });
+
+        const halfway = Math.floor(fixture.length / 2);
+        res.write(fixture.subarray(0, halfway));
+        setTimeout(() => {
+          res.end(fixture.subarray(halfway));
+        }, 100);
+      });
+
+      await new Promise<void>(resolve => {
+        server.listen(0, '127.0.0.1', () => {
+          resolve();
+        });
+      });
+
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+
+      const provider = new MockProvider({
+        supports: true,
+        getDownloadUrlResult: new URL(
+          `http://127.0.0.1:${address.port}/test.tar.bz2`,
+        ),
+        getExecutablePath: 'test/run.sh',
+      });
+
+      try {
+        for (let iteration = 0; iteration < 20; iteration++) {
+          const cacheDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'puppeteer-concurrent-install'),
+          );
+          try {
+            const results = await Promise.all(
+              Array.from({length: 4}, () => {
+                return install({
+                  cacheDir,
+                  browser: Browser.CHROME,
+                  platform: BrowserPlatform.LINUX,
+                  buildId: '123.0.0.1',
+                  providers: [provider],
+                });
+              }),
+            );
+
+            for (const result of results) {
+              assert.ok(fs.existsSync(result.path));
+            }
+
+            const installedBrowsers = await getInstalledBrowsers({cacheDir});
+            const matchingBrowsers = installedBrowsers.filter(browser => {
+              return (
+                browser.browser === Browser.CHROME &&
+                browser.buildId === '123.0.0.1'
+              );
+            });
+
+            assert.strictEqual(matchingBrowsers.length, 1);
+            assert.ok(fs.existsSync(matchingBrowsers[0]!.executablePath));
+          } finally {
+            fs.rmSync(cacheDir, {recursive: true, force: true});
+          }
+        }
+      } finally {
+        await new Promise<void>(resolve => {
+          server.close(() => {
+            resolve();
+          });
+        });
       }
     });
   });


### PR DESCRIPTION
Fixes #14417

## Summary
Concurrent installs for the same browser build were sharing both the downloaded archive path and the final extraction directory in the cache. That let one install remove the archive while another was still reading it, and it also exposed partially extracted output directories to concurrent installs.

This change makes each install attempt use its own temporary archive path and temporary extraction directory, and only renames the completed extraction into the shared cache location once unpacking has finished. Temporary paths are cleaned up after each attempt.

## Validation
- `npm run build:test --workspace @puppeteer/browsers`
- `../../node_modules/.bin/mocha --grep "concurrent installs for the same browser build"` from `packages/browsers`
