### PR TITLE
chore(webmcp): Update tests to match new declarative behavior

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1929,18 +1929,6 @@
     "comment": "Experimental support for WebMCP is not supported in BiDi"
   },
   {
-    "testIdPattern": "[webmcp.spec] Page.webmcp should fire toolsadded events",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "chrome"],
-    "expectations": ["PASS"]
-  },
-  {
-    "testIdPattern": "[webmcp.spec] Page.webmcp should fire toolsremoved events",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["cdp", "chrome"],
-    "expectations": ["PASS"]
-  },
-  {
     "testIdPattern": "[webmcp.spec] Page.webmcp should remove tools on frame navigation",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp", "chrome"],

--- a/test/src/cdp/webmcp.spec.ts
+++ b/test/src/cdp/webmcp.spec.ts
@@ -132,12 +132,6 @@ describe('Page.webmcp', function () {
     expect(await addedTools[0]!.formElement).toBeUndefined();
     expect(addedTools[0]!.location).toBeDefined();
 
-    const declarativeToolAdded = new Promise<WebMCPTool[]>(resolve => {
-      page.webmcp.once('toolsadded', event => {
-        return resolve(event.tools);
-      });
-    });
-
     // Register a declarative WebMCP tool.
     await page.evaluate(() => {
       const form = document.createElement('form');
@@ -146,12 +140,22 @@ describe('Page.webmcp', function () {
       (window as any).document.body.appendChild(form);
     });
 
+    const declarativeToolAdded = new Promise<WebMCPTool[]>(resolve => {
+      page.webmcp.once('toolsadded', event => {
+        return resolve(event.tools);
+      });
+    });
+
     addedTools = await declarativeToolAdded;
     expect(addedTools.length).toBe(1);
     expect(addedTools[0]!.name).toBe('declarative tool name');
     expect(addedTools[0]!.description).toBe('tool description');
     expect(addedTools[0]!.annotations).toBeUndefined();
-    expect(addedTools[0]!.inputSchema).toStrictEqual({});
+    expect(addedTools[0]!.inputSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+    });
     expect(addedTools[0]!.frame).toBe(page.mainFrame());
     expect(await addedTools[0]!.formElement).toBeDefined();
     expect(addedTools[0]!.location).toBeUndefined();
@@ -184,14 +188,6 @@ describe('Page.webmcp', function () {
       return controller;
     });
 
-    // Register a declarative WebMCP tool.
-    await page.evaluate(() => {
-      const form = document.createElement('form');
-      form.setAttribute('toolname', 'declarative tool name');
-      form.setAttribute('tooldescription', 'tool description');
-      (window as any).document.body.appendChild(form);
-    });
-
     const imperativeToolRemoved = new Promise<WebMCPTool[]>(resolve => {
       page.webmcp.once('toolsremoved', event => {
         return resolve(event.tools);
@@ -220,6 +216,20 @@ describe('Page.webmcp', function () {
     expect(await removedTools[0]!.formElement).toBeUndefined();
     expect(removedTools[0]!.location).toBeDefined();
 
+    // Register a declarative WebMCP tool.
+    await page.evaluate(() => {
+      const form = document.createElement('form');
+      form.setAttribute('toolname', 'declarative tool name');
+      form.setAttribute('tooldescription', 'tool description');
+      (window as any).document.body.appendChild(form);
+    });
+
+    await new Promise<WebMCPTool[]>(resolve => {
+      page.webmcp.once('toolsadded', event => {
+        return resolve(event.tools);
+      });
+    });
+
     const declarativeToolRemoved = new Promise<WebMCPTool[]>(resolve => {
       page.webmcp.once('toolsremoved', event => {
         return resolve(event.tools);
@@ -235,7 +245,11 @@ describe('Page.webmcp', function () {
     expect(removedTools.length).toBe(1);
     expect(removedTools[0]!.name).toBe('declarative tool name');
     expect(removedTools[0]!.description).toBe('tool description');
-    expect(removedTools[0]!.inputSchema).toStrictEqual({});
+    expect(removedTools[0]!.inputSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+    });
     expect(removedTools[0]!.annotations).toBeUndefined();
     expect(removedTools[0]!.frame).toBe(page.mainFrame());
     expect(await removedTools[0]!.formElement).toBeDefined();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

It makes sure tests comply with new declarative behavior in Chromium.

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR updates tests so that declarative API form tools get their input schema well initialized after
https://chromium-review.googlesource.com/c/chromium/src/+/7758503

**Does this PR introduce a breaking change?**

None that I'm aware of.

**Other information**

This is highly experimental.

cc @OrKoN 