### PR TITLE
feat: Implement allowlist

### DIFF
--- a/docs/api/puppeteer.connectoptions.md
+++ b/docs/api/puppeteer.connectoptions.md
@@ -58,7 +58,40 @@ Whether to ignore HTTPS errors during navigation.
 </td></tr>
 <tr><td>
 
-<span id="blocklist">blockList</span>
+<span id="allowlist">allowlist</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string\[\]
+
+</td><td>
+
+**_(Experimental)_** A list of URL patterns to allow.
+
+This option allows you to restrict the browser from accessing any URLs except for those that match the patterns in the allowList. It uses the standard \[URLPattern\](https://urlpattern.spec.whatwg.org/) API to match URLs.
+
+When connecting to an existing browser, Puppeteer will silently detach from any already open targets that violate the patterns.
+
+For any network requests made by the browser (including navigations and subresources like images or scripts), the request will fail with an error if the URL does not match any pattern in the allowlist.
+
+**Remarks:**
+
+Currently only supported for CDP connections.
+
+Requires Chrome 149+.
+
+Cannot be used along with [ConnectOptions.blocklist](./puppeteer.connectoptions.md#blocklist).
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="blocklist">blocklist</span>
 
 </td><td>
 
@@ -81,6 +114,8 @@ For any network requests made by the browser (including navigations and subresou
 **Remarks:**
 
 Currently only supported for CDP connections.
+
+Cannot be used along with [ConnectOptions.allowlist](./puppeteer.connectoptions.md#allowlist).
 
 </td><td>
 

--- a/docs/api/puppeteer.connectoptions.md
+++ b/docs/api/puppeteer.connectoptions.md
@@ -72,6 +72,8 @@ string\[\]
 
 **_(Experimental)_** A list of URL patterns to allow.
 
+**Requires Chrome 149+.**
+
 This option allows you to restrict the browser from accessing any URLs except for those that match the patterns in the allowList. It uses the standard \[URLPattern\](https://urlpattern.spec.whatwg.org/) API to match URLs.
 
 When connecting to an existing browser, Puppeteer will silently detach from any already open targets that violate the patterns.
@@ -81,8 +83,6 @@ For any network requests made by the browser (including navigations and subresou
 **Remarks:**
 
 Currently only supported for CDP connections.
-
-Requires Chrome 149+.
 
 Cannot be used along with [ConnectOptions.blocklist](./puppeteer.connectoptions.md#blocklist).
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -89,6 +89,11 @@ export class CdpBrowser extends BrowserBase {
       blocklist,
       allowlist,
     );
+    const version = await browser.#getVersion();
+    const majorVersion = parseInt(version.product.match(/\d+/)?.[0] ?? '0', 10);
+    if (allowlist && majorVersion < 149) {
+      throw new Error('The allowlist option require Chrome 149 or greater.');
+    }
     if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {
         ignore: true,

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -71,8 +71,8 @@ export class CdpBrowser extends BrowserBase {
     networkEnabled = true,
     issuesEnabled = true,
     handleDevToolsAsPage = false,
-    blockList?: string[],
-    allowList?: string[],
+    blocklist?: string[],
+    allowlist?: string[],
   ): Promise<CdpBrowser> {
     const browser = new CdpBrowser(
       connection,
@@ -86,8 +86,8 @@ export class CdpBrowser extends BrowserBase {
       networkEnabled,
       issuesEnabled,
       handleDevToolsAsPage,
-      blockList,
-      allowList,
+      blocklist,
+      allowlist,
     );
     if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {
@@ -123,8 +123,8 @@ export class CdpBrowser extends BrowserBase {
     networkEnabled = true,
     issuesEnabled = true,
     handleDevToolsAsPage = false,
-    blockList?: string[],
-    allowList?: string[],
+    blocklist?: string[],
+    allowlist?: string[],
   ) {
     super();
     this.#networkEnabled = networkEnabled;
@@ -145,8 +145,8 @@ export class CdpBrowser extends BrowserBase {
       this.#createTarget,
       this.#targetFilterCallback,
       waitForInitiallyDiscoveredTargets,
-      blockList,
-      allowList,
+      blocklist,
+      allowlist,
     );
     this.#defaultContext = new CdpBrowserContext(this.#connection, this);
     for (const contextId of contextIds) {

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -89,10 +89,16 @@ export class CdpBrowser extends BrowserBase {
       blocklist,
       allowlist,
     );
-    const version = await browser.#getVersion();
-    const majorVersion = parseInt(version.product.match(/\d+/)?.[0] ?? '0', 10);
-    if (allowlist && majorVersion < 149) {
-      throw new Error('The allowlist option require Chrome 149 or greater.');
+
+    if (allowlist) {
+      const version = await browser.#getVersion();
+      const majorVersion = parseInt(
+        version.product.match(/\d+/)?.[0] ?? '0',
+        10,
+      );
+      if (majorVersion < 149) {
+        throw new Error('The allowlist option require Chrome 149 or greater.');
+      }
     }
     if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -72,6 +72,7 @@ export class CdpBrowser extends BrowserBase {
     issuesEnabled = true,
     handleDevToolsAsPage = false,
     blockList?: string[],
+    allowList?: string[],
   ): Promise<CdpBrowser> {
     const browser = new CdpBrowser(
       connection,
@@ -86,6 +87,7 @@ export class CdpBrowser extends BrowserBase {
       issuesEnabled,
       handleDevToolsAsPage,
       blockList,
+      allowList,
     );
     if (acceptInsecureCerts) {
       await connection.send('Security.setIgnoreCertificateErrors', {
@@ -121,7 +123,8 @@ export class CdpBrowser extends BrowserBase {
     networkEnabled = true,
     issuesEnabled = true,
     handleDevToolsAsPage = false,
-    networkConditions?: string[],
+    blockList?: string[],
+    allowList?: string[],
   ) {
     super();
     this.#networkEnabled = networkEnabled;
@@ -142,7 +145,8 @@ export class CdpBrowser extends BrowserBase {
       this.#createTarget,
       this.#targetFilterCallback,
       waitForInitiallyDiscoveredTargets,
-      networkConditions,
+      blockList,
+      allowList,
     );
     this.#defaultContext = new CdpBrowserContext(this.#connection, this);
     for (const contextId of contextIds) {

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -35,8 +35,8 @@ export async function _connectToCdpBrowser(
     protocolTimeout,
     handleDevToolsAsPage,
     idGenerator = createIncrementalIdGenerator(),
-    blockList,
-    allowList,
+    blocklist,
+    allowlist,
   } = options;
 
   const connection = new Connection(
@@ -67,8 +67,8 @@ export async function _connectToCdpBrowser(
     networkEnabled,
     issuesEnabled,
     handleDevToolsAsPage,
-    blockList,
-    allowList,
+    blocklist,
+    allowlist,
   );
   return browser;
 }

--- a/packages/puppeteer-core/src/cdp/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/cdp/BrowserConnector.ts
@@ -36,6 +36,7 @@ export async function _connectToCdpBrowser(
     handleDevToolsAsPage,
     idGenerator = createIncrementalIdGenerator(),
     blockList,
+    allowList,
   } = options;
 
   const connection = new Connection(
@@ -67,6 +68,7 @@ export async function _connectToCdpBrowser(
     issuesEnabled,
     handleDevToolsAsPage,
     blockList,
+    allowList,
   );
   return browser;
 }

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -107,19 +107,19 @@ export class TargetManager
   // done. It indicates whethere we are running the initial auto-attach step or
   // if we are handling targets after that.
   #initialAttachDone = false;
-  #blockList: Array<{pattern: URLPattern; rule: string}> = [];
-  #allowList: Array<{pattern: URLPattern; rule: string}> = [];
+  #blocklist: Array<{pattern: URLPattern; rule: string}> = [];
+  #allowlist: Array<{pattern: URLPattern; rule: string}> = [];
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
     targetFilterCallback?: TargetFilterCallback,
     waitForInitiallyDiscoveredTargets = true,
-    blockList?: string[],
-    allowList?: string[],
+    blocklist?: string[],
+    allowlist?: string[],
   ) {
     super();
-    if (blockList && allowList) {
+    if (blocklist && allowlist) {
       throw new Error('Cannot specify both blockList and allowList');
     }
 
@@ -128,8 +128,8 @@ export class TargetManager
     this.#targetFactory = targetFactory;
     this.#waitForInitiallyDiscoveredTargets = waitForInitiallyDiscoveredTargets;
 
-    this.#blockList = this.#mapPatterns(blockList);
-    this.#allowList = this.#mapPatterns(allowList);
+    this.#blocklist = this.#mapPatterns(blocklist);
+    this.#allowlist = this.#mapPatterns(allowlist);
 
     this.#connection.on('Target.targetCreated', this.#onTargetCreated);
     this.#connection.on('Target.targetDestroyed', this.#onTargetDestroyed);
@@ -477,7 +477,7 @@ export class TargetManager
    * Helper to validate URL against blocklist patterns
    */
   #isUrlAllowed = (url: string): boolean => {
-    if (this.#blockList.length === 0 && this.#allowList.length === 0) {
+    if (this.#blocklist.length === 0 && this.#allowlist.length === 0) {
       return true;
     }
 
@@ -486,14 +486,14 @@ export class TargetManager
       return true;
     }
 
-    for (const item of this.#blockList) {
+    for (const item of this.#blocklist) {
       if (item.pattern.test(url)) {
         return false;
       }
     }
 
-    if (this.#allowList.length > 0) {
-      for (const item of this.#allowList) {
+    if (this.#allowlist.length > 0) {
+      for (const item of this.#allowlist) {
         if (item.pattern.test(url)) {
           return true;
         }
@@ -513,12 +513,12 @@ export class TargetManager
   }
 
   #maybeSetupNetworkConditions = async (session: CDPSession): Promise<void> => {
-    if (this.#blockList.length === 0 && this.#allowList.length === 0) {
+    if (this.#blocklist.length === 0 && this.#allowlist.length === 0) {
       return;
     }
 
     const matchedNetworkConditions = [];
-    for (const item of this.#blockList) {
+    for (const item of this.#blocklist) {
       matchedNetworkConditions.push({
         urlPattern: item.rule,
         offline: true,
@@ -528,8 +528,8 @@ export class TargetManager
       });
     }
 
-    if (this.#allowList.length > 0) {
-      for (const item of this.#allowList) {
+    if (this.#allowlist.length > 0) {
+      for (const item of this.#allowlist) {
         matchedNetworkConditions.push({
           urlPattern: item.rule,
           offline: false,
@@ -548,6 +548,7 @@ export class TargetManager
     }
 
     await session.send('Network.emulateNetworkConditionsByRule', {
+      offline: true, // 'offline' will be deprecated in Chrome 149. Retained for compatibility with existing blocklist functionality.
       matchedNetworkConditions,
     });
   };

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -107,21 +107,29 @@ export class TargetManager
   // done. It indicates whethere we are running the initial auto-attach step or
   // if we are handling targets after that.
   #initialAttachDone = false;
-  #blockList?: string[];
+  #blockList: Array<{pattern: URLPattern; rule: string}> = [];
+  #allowList: Array<{pattern: URLPattern; rule: string}> = [];
 
   constructor(
     connection: Connection,
     targetFactory: TargetFactory,
     targetFilterCallback?: TargetFilterCallback,
     waitForInitiallyDiscoveredTargets = true,
-    networkConditions?: string[],
+    blockList?: string[],
+    allowList?: string[],
   ) {
     super();
+    if (blockList && allowList) {
+      throw new Error('Cannot specify both blockList and allowList');
+    }
+
     this.#connection = connection;
     this.#targetFilterCallback = targetFilterCallback;
     this.#targetFactory = targetFactory;
     this.#waitForInitiallyDiscoveredTargets = waitForInitiallyDiscoveredTargets;
-    this.#blockList = networkConditions;
+
+    this.#blockList = this.#mapPatterns(blockList);
+    this.#allowList = this.#mapPatterns(allowList);
 
     this.#connection.on('Target.targetCreated', this.#onTargetCreated);
     this.#connection.on('Target.targetDestroyed', this.#onTargetDestroyed);
@@ -469,7 +477,7 @@ export class TargetManager
    * Helper to validate URL against blocklist patterns
    */
   #isUrlAllowed = (url: string): boolean => {
-    if (!this.#blockList) {
+    if (this.#blockList.length === 0 && this.#allowList.length === 0) {
       return true;
     }
 
@@ -478,37 +486,69 @@ export class TargetManager
       return true;
     }
 
-    for (const rule of this.#blockList) {
-      try {
-        const pattern = new URLPattern(rule);
-        if (pattern.test(url)) {
-          return false; // return false as url matches pattern from blockList
-        }
-      } catch {
-        debugError(`Invalid URL pattern: ${rule}`);
+    for (const item of this.#blockList) {
+      if (item.pattern.test(url)) {
+        return false;
       }
+    }
+
+    if (this.#allowList.length > 0) {
+      for (const item of this.#allowList) {
+        if (item.pattern.test(url)) {
+          return true;
+        }
+      }
+      return false;
     }
 
     return true;
   };
 
+  #mapPatterns(rules?: string[]): Array<{pattern: URLPattern; rule: string}> {
+    const result: Array<{pattern: URLPattern; rule: string}> = [];
+    for (const rule of rules ?? []) {
+      result.push({pattern: new URLPattern(rule), rule});
+    }
+    return result;
+  }
+
   #maybeSetupNetworkConditions = async (session: CDPSession): Promise<void> => {
-    if (!this.#blockList?.length) {
+    if (this.#blockList.length === 0 && this.#allowList.length === 0) {
       return;
     }
 
-    const matchedNetworkConditions = this.#blockList.map(pattern => {
-      return {
-        urlPattern: pattern,
+    const matchedNetworkConditions = [];
+    for (const item of this.#blockList) {
+      matchedNetworkConditions.push({
+        urlPattern: item.rule,
+        offline: true,
         latency: 0,
         downloadThroughput: -1,
         uploadThroughput: -1,
-      };
-    });
+      });
+    }
+
+    if (this.#allowList.length > 0) {
+      for (const item of this.#allowList) {
+        matchedNetworkConditions.push({
+          urlPattern: item.rule,
+          offline: false,
+          latency: 0,
+          downloadThroughput: -1,
+          uploadThroughput: -1,
+        });
+      }
+      matchedNetworkConditions.push({
+        urlPattern: '',
+        offline: true,
+        latency: 0,
+        downloadThroughput: -1,
+        uploadThroughput: -1,
+      });
+    }
 
     await session.send('Network.emulateNetworkConditionsByRule', {
       matchedNetworkConditions,
-      offline: true,
     });
   };
 }

--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2024 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {_connectToBrowser} from './BrowserConnector.js';
+
+describe('BrowserConnector', () => {
+  describe('_connectToBrowser', () => {
+    it('should throw an error when both blocklist and allowlist are specified', async () => {
+      await expect(
+        _connectToBrowser({
+          browserWSEndpoint: 'ws://localhost:1234',
+          blocklist: ['test'],
+          allowlist: ['test'],
+        }),
+      ).rejects.toThrow('Cannot specify both blocklist and allowlist');
+    });
+  });
+});

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -30,8 +30,8 @@ const getWebSocketTransportClass = async () => {
 export async function _connectToBrowser(
   options: ConnectOptions,
 ): Promise<Browser> {
-  if (options.blockList && options.allowList) {
-    throw new Error('Cannot specify both blockList and allowList');
+  if (options.blocklist && options.allowlist) {
+    throw new Error('Cannot specify both blocklist and allowlist');
   }
   const {connectionTransport, endpointUrl} =
     await getConnectionTransport(options);

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -30,6 +30,9 @@ const getWebSocketTransportClass = async () => {
 export async function _connectToBrowser(
   options: ConnectOptions,
 ): Promise<Browser> {
+  if (options.blockList && options.allowList) {
+    throw new Error('Cannot specify both blockList and allowList');
+  }
   const {connectionTransport, endpointUrl} =
     await getConnectionTransport(options);
 

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -192,6 +192,8 @@ export interface ConnectOptions {
   /**
    * A list of URL patterns to allow.
    *
+   * **Requires Chrome 149+.**
+   *
    * This option allows you to restrict the browser from accessing any URLs
    * except for those that match the patterns in the allowList.
    * It uses the standard [URLPattern](https://urlpattern.spec.whatwg.org/) API to match URLs.
@@ -212,11 +214,16 @@ export interface ConnectOptions {
    * @remarks
    * Currently only supported for CDP connections.
    *
-   * Requires Chrome 149+.
-   *
    * Cannot be used along with {@link ConnectOptions.blocklist}.
    *
    * @experimental
    */
   allowlist?: string[];
+
+  /**
+   * Specify browser version to connect to.
+   *
+   * @experimental
+   */
+  browserVersion?: string;
 }

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -184,7 +184,37 @@ export interface ConnectOptions {
    * @remarks
    * Currently only supported for CDP connections.
    *
+   * Cannot be used along with {@link ConnectOptions.allowList}.
+   *
    * @experimental
    */
   blockList?: string[];
+  /**
+   * A list of URL patterns to allow.
+   *
+   * This option allows you to restrict the browser from accessing any URLs
+   * except for those that match the patterns in the allowList.
+   * It uses the standard [URLPattern](https://urlpattern.spec.whatwg.org/) API to match URLs.
+   *
+   * When connecting to an existing browser, Puppeteer will silently detach from any
+   * already open targets that violate the patterns.
+   *
+   * For any network requests made by the browser (including navigations and
+   * subresources like images or scripts), the request will fail with an error
+   * if the URL does not match any pattern in the allowList.
+   *
+   * @example Pattern to allow a specific domain:
+   * `*://example.com/*`
+   *
+   * @example Pattern to allow all subdomains:
+   * `*://*.example.com/*`
+   *
+   * @remarks
+   * Currently only supported for CDP connections.
+   *
+   * Cannot be used along with {@link ConnectOptions.blockList}.
+   *
+   * @experimental
+   */
+  allowList?: string[];
 }

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -219,11 +219,4 @@ export interface ConnectOptions {
    * @experimental
    */
   allowlist?: string[];
-
-  /**
-   * Specify browser version to connect to.
-   *
-   * @experimental
-   */
-  browserVersion?: string;
 }

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -184,11 +184,11 @@ export interface ConnectOptions {
    * @remarks
    * Currently only supported for CDP connections.
    *
-   * Cannot be used along with {@link ConnectOptions.allowList}.
+   * Cannot be used along with {@link ConnectOptions.allowlist}.
    *
    * @experimental
    */
-  blockList?: string[];
+  blocklist?: string[];
   /**
    * A list of URL patterns to allow.
    *
@@ -201,7 +201,7 @@ export interface ConnectOptions {
    *
    * For any network requests made by the browser (including navigations and
    * subresources like images or scripts), the request will fail with an error
-   * if the URL does not match any pattern in the allowList.
+   * if the URL does not match any pattern in the allowlist.
    *
    * @example Pattern to allow a specific domain:
    * `*://example.com/*`
@@ -212,9 +212,11 @@ export interface ConnectOptions {
    * @remarks
    * Currently only supported for CDP connections.
    *
-   * Cannot be used along with {@link ConnectOptions.blockList}.
+   * Requires Chrome 149+.
+   *
+   * Cannot be used along with {@link ConnectOptions.blocklist}.
    *
    * @experimental
    */
-  allowList?: string[];
+  allowlist?: string[];
 }

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -76,6 +76,9 @@ export abstract class BrowserLauncher {
   }
 
   async launch(options: LaunchOptions = {}): Promise<Browser> {
+    if (options.blockList && options.allowList) {
+      throw new Error('Cannot specify both blockList and allowList');
+    }
     const {
       dumpio = false,
       enableExtensions = false,
@@ -95,6 +98,7 @@ export abstract class BrowserLauncher {
       handleDevToolsAsPage,
       idGenerator = createIncrementalIdGenerator(),
       blockList,
+      allowList,
     } = options;
 
     let {protocol} = options;
@@ -222,6 +226,7 @@ export abstract class BrowserLauncher {
             issuesEnabled,
             handleDevToolsAsPage,
             blockList,
+            allowList,
           );
         }
       }

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -76,8 +76,8 @@ export abstract class BrowserLauncher {
   }
 
   async launch(options: LaunchOptions = {}): Promise<Browser> {
-    if (options.blockList && options.allowList) {
-      throw new Error('Cannot specify both blockList and allowList');
+    if (options.blocklist && options.allowlist) {
+      throw new Error('Cannot specify both blocklist and allowlist');
     }
     const {
       dumpio = false,
@@ -97,8 +97,8 @@ export abstract class BrowserLauncher {
       protocolTimeout,
       handleDevToolsAsPage,
       idGenerator = createIncrementalIdGenerator(),
-      blockList,
-      allowList,
+      blocklist,
+      allowlist,
     } = options;
 
     let {protocol} = options;
@@ -225,8 +225,8 @@ export abstract class BrowserLauncher {
             networkEnabled,
             issuesEnabled,
             handleDevToolsAsPage,
-            blockList,
-            allowList,
+            blocklist,
+            allowlist,
           );
         }
       }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1432,6 +1432,13 @@
     "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=1908952#c4 historyUpdated from beforeunload incorrectly comes before navigationStarted"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["cdp", "chrome"],
+    "expectations": ["FAIL"],
+    "comment": "allowlist option requires at least chrome 149 version"
+  },
+  {
     "testIdPattern": "[network.spec] network Network Events Page.Events.Request",
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome"],
@@ -1967,13 +1974,6 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["FAIL"],
     "comment": "TODO: started to fail with Chrome headless shell 135 on Windows"
-  },
-  {
-    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
-    "platforms": ["linux", "win32", "darwin"],
-    "parameters": ["cdp", "chrome"],
-    "expectations": ["FAIL"],
-    "comment": "allowlist option requires at least chrome 149 version"
   },
   {
     "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1969,6 +1969,34 @@
     "comment": "TODO: started to fail with Chrome headless shell 135 on Windows"
   },
   {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
+    "platforms": ["linux"],
+    "parameters": ["cdp", "chrome", "headless"],
+    "expectations": ["FAIL"],
+    "comment": "allowlist option requires at least chrome 149 version"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
+    "platforms": ["linux"],
+    "parameters": ["cdp", "chrome", "headful"],
+    "expectations": ["FAIL"],
+    "comment": "allowlist option requires at least chrome 149 version"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
+    "platforms": ["linux"],
+    "parameters": ["chrome", "headless", "webDriverBiDiOnly"],
+    "expectations": ["FAIL"],
+    "comment": "allowlist option requires at least chrome 149 version"
+  },
+  {
+    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
+    "platforms": ["linux"],
+    "parameters": ["cdp", "chrome", "chrome-headless-shell"],
+    "expectations": ["FAIL"],
+    "comment": "allowlist option requires at least chrome 149 version"
+  },
+  {
     "testIdPattern": "[network.spec] network Network Events Page.Events.Request",
     "platforms": ["linux"],
     "parameters": ["cdp", "chrome", "headless"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1970,15 +1970,8 @@
   },
   {
     "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
-    "platforms": ["linux"],
-    "parameters": ["cdp", "chrome", "headless"],
-    "expectations": ["FAIL"],
-    "comment": "allowlist option requires at least chrome 149 version"
-  },
-  {
-    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
-    "platforms": ["linux"],
-    "parameters": ["cdp", "chrome", "headful"],
+    "platforms": ["linux", "win32", "darwin"],
+    "parameters": ["cdp", "chrome"],
     "expectations": ["FAIL"],
     "comment": "allowlist option requires at least chrome 149 version"
   },
@@ -1986,14 +1979,7 @@
     "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
     "platforms": ["linux"],
     "parameters": ["chrome", "headless", "webDriverBiDiOnly"],
-    "expectations": ["FAIL"],
-    "comment": "allowlist option requires at least chrome 149 version"
-  },
-  {
-    "testIdPattern": "[network_restrictions.spec] Network Restrictions should only allow navigation to URLs in the allowlist",
-    "platforms": ["linux"],
-    "parameters": ["cdp", "chrome", "chrome-headless-shell"],
-    "expectations": ["FAIL"],
+    "expectations": ["SKIP"],
     "comment": "allowlist option requires at least chrome 149 version"
   },
   {

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -239,7 +239,7 @@ describe('Network Restrictions', function () {
     }
   });
 
-  it.only('should throw an error for an invalid pattern', async () => {
+  it('should throw an error for an invalid pattern', async () => {
     let error: Error | undefined;
     await launch(
       {

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -173,6 +173,87 @@ describe('Network Restrictions', function () {
     }
   });
 
+  it('should only allow navigation to URLs in the allowList', async () => {
+    const {page, close, server} = await launch(
+      {
+        allowList: ['*://*:*/empty.html'],
+      },
+      {createContext: true},
+    );
+
+    try {
+      const allowedUrl = server.PREFIX + '/empty.html';
+      const blockedUrl = server.PREFIX + '/title.html';
+
+      await page.goto(allowedUrl);
+      let error: Error | undefined;
+      await page.goto(blockedUrl).catch(e => {
+        return (error = e);
+      });
+      expect(page.url()).not.toBe(blockedUrl);
+      console.log('page url', page.url());
+      expect(error).toBeDefined();
+      expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
+    } finally {
+      await close();
+    }
+  });
+
+  it('should throw an error when both blockList and allowList are specified', async () => {
+    let error: Error | undefined;
+    await launch(
+      {
+        blockList: ['*://*:*/empty.html'],
+        allowList: ['*://*:*/empty.html'],
+      },
+      {createContext: true},
+    ).catch(e => {
+      return (error = e);
+    });
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain(
+      'Cannot specify both blockList and allowList',
+    );
+
+    const {browser, close} = await launch({}, {createContext: false});
+    try {
+      const wsEndpoint = browser.wsEndpoint();
+      let connectError: Error | undefined;
+      await puppeteer
+        .connect({
+          browserWSEndpoint: wsEndpoint,
+          blockList: ['*://*:*/empty.html'],
+          allowList: ['*://*:*/empty.html'],
+        })
+        .catch(e => {
+          return (connectError = e);
+        });
+
+      expect(connectError).toBeDefined();
+      expect(connectError?.message).toContain(
+        'Cannot specify both blockList and allowList',
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it.only('should throw an error for an invalid pattern', async () => {
+    let error: Error | undefined;
+    await launch(
+      {
+        blockList: ['(invalid pattern'],
+      },
+      {createContext: true},
+    ).catch(e => {
+      return (error = e);
+    });
+
+    expect(error).toBeDefined();
+    expect(error?.message.includes('URLPattern')).toBeTruthy();
+  });
+
   it('should not block chrome://version/ even if it matches blocklist', async () => {
     const chromeUrl = 'chrome://version/';
     const {page, close} = await launch(

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -14,7 +14,7 @@ describe('Network Restrictions', function () {
   it('should block page.goto when the destination is in the blocklist', async () => {
     const {page, close, server} = await launch(
       {
-        blockList: ['*://*:*/empty.html'],
+        blocklist: ['*://*:*/empty.html'],
       },
       {createContext: true},
     );
@@ -39,7 +39,7 @@ describe('Network Restrictions', function () {
   it('should block window.location.href navigation to URLs in the blocklist', async () => {
     const {page, close, server} = await launch(
       {
-        blockList: ['*://*:*/empty.html'],
+        blocklist: ['*://*:*/empty.html'],
       },
       {createContext: true},
     );
@@ -67,7 +67,7 @@ describe('Network Restrictions', function () {
   it('should fail fetch requests to URLs in the blocklist', async () => {
     const {page, close, server} = await launch(
       {
-        blockList: ['*://*:*/empty.html'],
+        blocklist: ['*://*:*/empty.html'],
       },
       {createContext: true},
     );
@@ -96,7 +96,7 @@ describe('Network Restrictions', function () {
   it('should prevent loading of blocklisted subresources (e.g., images)', async () => {
     const {page, close, server} = await launch(
       {
-        blockList: ['*://*:*/pptr.png'],
+        blocklist: ['*://*:*/pptr.png'],
       },
       {createContext: true},
     );
@@ -156,7 +156,7 @@ describe('Network Restrictions', function () {
 
       connectedBrowser = await puppeteer.connect({
         browserWSEndpoint: wsEndpoint,
-        blockList: ['*://*:*/empty.html'],
+        blocklist: ['*://*:*/empty.html'],
       });
 
       const targets = connectedBrowser.targets();
@@ -173,10 +173,10 @@ describe('Network Restrictions', function () {
     }
   });
 
-  it('should only allow navigation to URLs in the allowList', async () => {
+  it('should only allow navigation to URLs in the allowlist', async () => {
     const {page, close, server} = await launch(
       {
-        allowList: ['*://*:*/empty.html'],
+        allowlist: ['*://*:*/empty.html'],
       },
       {createContext: true},
     );
@@ -191,7 +191,6 @@ describe('Network Restrictions', function () {
         return (error = e);
       });
       expect(page.url()).not.toBe(blockedUrl);
-      console.log('page url', page.url());
       expect(error).toBeDefined();
       expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
     } finally {
@@ -199,12 +198,12 @@ describe('Network Restrictions', function () {
     }
   });
 
-  it('should throw an error when both blockList and allowList are specified', async () => {
+  it('should throw an error when both blocklist and allowlist are specified', async () => {
     let error: Error | undefined;
     await launch(
       {
-        blockList: ['*://*:*/empty.html'],
-        allowList: ['*://*:*/empty.html'],
+        blocklist: ['*://*:*/empty.html'],
+        allowlist: ['*://*:*/empty.html'],
       },
       {createContext: true},
     ).catch(e => {
@@ -213,7 +212,7 @@ describe('Network Restrictions', function () {
 
     expect(error).toBeDefined();
     expect(error?.message).toContain(
-      'Cannot specify both blockList and allowList',
+      'Cannot specify both blocklist and allowlist',
     );
 
     const {browser, close} = await launch({}, {createContext: false});
@@ -223,8 +222,8 @@ describe('Network Restrictions', function () {
       await puppeteer
         .connect({
           browserWSEndpoint: wsEndpoint,
-          blockList: ['*://*:*/empty.html'],
-          allowList: ['*://*:*/empty.html'],
+          blocklist: ['*://*:*/empty.html'],
+          allowlist: ['*://*:*/empty.html'],
         })
         .catch(e => {
           return (connectError = e);
@@ -232,7 +231,7 @@ describe('Network Restrictions', function () {
 
       expect(connectError).toBeDefined();
       expect(connectError?.message).toContain(
-        'Cannot specify both blockList and allowList',
+        'Cannot specify both blocklist and allowlist',
       );
     } finally {
       await close();
@@ -243,7 +242,7 @@ describe('Network Restrictions', function () {
     let error: Error | undefined;
     await launch(
       {
-        blockList: ['(invalid pattern'],
+        blocklist: ['(invalid pattern'],
       },
       {createContext: true},
     ).catch(e => {
@@ -258,7 +257,7 @@ describe('Network Restrictions', function () {
     const chromeUrl = 'chrome://version/';
     const {page, close} = await launch(
       {
-        blockList: [chromeUrl],
+        blocklist: [chromeUrl],
       },
       {createContext: true},
     );


### PR DESCRIPTION
# Feature: URL allowlist for Puppeteer

This PR introduces a URL allowlist feature for Puppeteer, allowing developers to restrict network access to **only** a specific set of URLs or origins. This provides a "walled garden" approach, ensuring the browser cannot access any content outside of the trusted patterns provided.

**This feature will be available starting with the Chrome 149 major release.**

## How it works

The feature is exposed via a new experimental `allowlist` option in `ConnectOptions` and `LaunchOptions`. It uses the standard [URLPattern](https://urlpattern.spec.whatwg.org/) API for matching URLs.

The allowlist enforces restrictions in two ways:

1.  **On Connection/Discovery**: When connecting to an existing browser or discovering new targets, Puppeteer will silently detach from any target whose URL does not match at least one pattern in the `allowlist`. This ensures the browser session is restricted to authorized content immediately.
2.  **During Operation**: For any network requests made by the browser (including main frame navigations and subresources like images, scripts, or stylesheets), the request will fail with a `net::ERR_INTERNET_DISCONNECTED` error if the URL does not match any pattern in the allowlist.

**Note**: The `allowlist` cannot be used in conjunction with the `blocklist` option.

## Example Usage

```typescript
// Restrict the browser to only interact with trusted domains
const browser = await puppeteer.launch({
  allowlist: [
    '*://google.com/*',        // Allow Google
    '*://*.google.com/*',      // Allow all Google subdomains
    '*://github.com/puppeteer/*', // Allow only the Puppeteer repo on GitHub
  ],
});

const page = await browser.newPage();

// This navigation will succeed
await page.goto('https://google.com');

// This navigation will fail with net::ERR_INTERNET_DISCONNECTED
await page.goto('https://example.com');
```