### PR TITLE
feat(webmcp): Add support for untrustedContent WebMCPAnnotation

### DIFF
--- a/docs/api/puppeteer.webmcpannotation.md
+++ b/docs/api/puppeteer.webmcpannotation.md
@@ -73,4 +73,23 @@ A hint indicating that the tool does not modify any state.
 </td><td>
 
 </td></tr>
+<tr><td>
+
+<span id="untrustedcontent">untrustedContent</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+A hint indicating that the tool output may contain untrusted content, ex: UGC, 3rd party data.
+
+</td><td>
+
+</td></tr>
 </tbody></table>

--- a/packages/puppeteer-core/src/cdp/WebMCP.ts
+++ b/packages/puppeteer-core/src/cdp/WebMCP.ts
@@ -29,6 +29,11 @@ export interface WebMCPAnnotation {
    */
   readOnly?: boolean;
   /**
+   * A hint indicating that the tool output may contain untrusted content, ex: UGC, 3rd
+   * party data.
+   */
+  untrustedContent?: boolean;
+  /**
    * If the declarative tool was declared with the autosubmit attribute.
    */
   autosubmit?: boolean;

--- a/test/src/cdp/webmcp.spec.ts
+++ b/test/src/cdp/webmcp.spec.ts
@@ -47,8 +47,10 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: () => {},
-        annotations: {readOnlyHint: true},
+        execute: (params: {text: string}) => {
+          return params.text;
+        },
+        annotations: {readOnlyHint: true, untrustedContentHint: true},
       });
     });
     // Register a declarative WebMCP tool.
@@ -75,6 +77,7 @@ describe('Page.webmcp', function () {
     });
     expect(tools[0]!.annotations).toBeDefined();
     expect(tools[0]!.annotations!.readOnly).toBe(true);
+    expect(tools[0]!.annotations!.untrustedContent).toBe(true);
     expect(tools[0]!.frame).toBe(page.mainFrame());
     expect(await tools[0]!.formElement).toBeUndefined();
     expect(tools[0]!.location).toBeDefined();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR updates the WebMCP API.

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Yes

**Summary**

It adds support for `untrustedContentHint` which has recently landed in https://chromium-review.googlesource.com/c/chromium/src/+/7759363

**Does this PR introduce a breaking change?**

None that I'm aware of.

**Other information**

This is highly experimental.

cc @OrKoN 