### PR TITLE
fix: do not open DevTools if it is already open

### DIFF
--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -946,7 +946,7 @@ All timestamps are in monotonic time: monotonically increasing time in seconds s
 
 </td><td>
 
-Opens DevTools for the current Page and returns the DevTools Page. This method is only available in Chrome.
+Opens DevTools for the this page if not already open and returns the DevTools page. This method is only available in Chrome.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.opendevtools.md
+++ b/docs/api/puppeteer.page.opendevtools.md
@@ -4,7 +4,7 @@ sidebar_label: Page.openDevTools
 
 # Page.openDevTools() method
 
-Opens DevTools for the current Page and returns the DevTools Page. This method is only available in Chrome.
+Opens DevTools for the this page if not already open and returns the DevTools page. This method is only available in Chrome.
 
 ### Signature
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -3233,8 +3233,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
   }
 
   /**
-   * Opens DevTools for the current Page and returns the DevTools Page. This
-   * method is only available in Chrome.
+   * Opens DevTools for the this page if not already open and returns the DevTools page.
+   * This method is only available in Chrome.
    */
   abstract openDevTools(): Promise<Page>;
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -435,12 +435,16 @@ export class CdpBrowser extends BrowserBase {
         targetId: pageTargetId,
       },
     );
+    return await this._getDevToolsTargetPage(openDevToolsResponse.targetId);
+  }
+
+  async _getDevToolsTargetPage(devtoolsTargetId: string): Promise<Page> {
     const target = (await this.waitForTarget(t => {
-      return (t as CdpTarget)._targetId === openDevToolsResponse.targetId;
+      return (t as CdpTarget)._targetId === devtoolsTargetId;
     })) as CdpTarget;
     if (!target) {
       throw new Error(
-        `Missing target for DevTools page (id = ${pageTargetId})`,
+        `Missing target for DevTools page (id = ${devtoolsTargetId})`,
       );
     }
     const initialized =
@@ -448,13 +452,13 @@ export class CdpBrowser extends BrowserBase {
       InitializationStatus.SUCCESS;
     if (!initialized) {
       throw new Error(
-        `Failed to create target for DevTools page (id = ${pageTargetId})`,
+        `Failed to create target for DevTools page (id = ${devtoolsTargetId})`,
       );
     }
     const page = await target.page();
     if (!page) {
       throw new Error(
-        `Failed to create a DevTools Page for target (id = ${pageTargetId})`,
+        `Failed to create a DevTools Page for target (id = ${devtoolsTargetId})`,
       );
     }
     return page;

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -473,6 +473,12 @@ export class CdpPage extends Page {
   override async openDevTools(): Promise<Page> {
     const pageTargetId = this.target()._targetId;
     const browser = this.browser() as CdpBrowser;
+    const devtoolsTargetId = await browser._hasDevToolsTarget(
+      this.target()._targetId,
+    );
+    if (devtoolsTargetId) {
+      return await browser._getDevToolsTargetPage(devtoolsTargetId);
+    }
     const devtoolsPage = await browser._createDevToolsPage(pageTargetId);
     return devtoolsPage;
   }


### PR DESCRIPTION
Opening DevTools steals focus if it happens in the background.