### PR TITLE
fix: Disable WebUIReloadButton experiment

### DIFF
--- a/packages/browsers/test/src/chrome/launch.spec.ts
+++ b/packages/browsers/test/src/chrome/launch.spec.ts
@@ -69,7 +69,7 @@ describe('Chrome', () => {
         '--disable-default-apps',
         '--disable-dev-shm-usage',
         '--disable-extensions',
-        '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider',
+        '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider,WebUIReloadButton',
         '--disable-hang-monitor',
         '--disable-ipc-flooding-protection',
         '--disable-popup-blocking',

--- a/packages/browsers/test/src/chromium/launch.spec.ts
+++ b/packages/browsers/test/src/chromium/launch.spec.ts
@@ -69,7 +69,7 @@ describe('Chromium', () => {
         '--disable-default-apps',
         '--disable-dev-shm-usage',
         '--disable-extensions',
-        '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider',
+        '--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints,DialMediaRouteProvider,WebUIReloadButton',
         '--disable-hang-monitor',
         '--disable-ipc-flooding-protection',
         '--disable-popup-blocking',

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -177,6 +177,7 @@ export class ChromeLauncher extends BrowserLauncher {
       'AcceptCHFrame',
       'MediaRouter',
       'OptimizationHints',
+      'WebUIReloadButton',
       ...(turnOnExperimentalFeaturesForTesting
         ? []
         : [


### PR DESCRIPTION
The WebUIReloadButton experiment does affect CDP. Additional targets are created, one of type `browser_ui` (which we could filter out) and it seems also a corresponding tab target. This causes test failures (e.g. TargetManager.spec.ts) (see https://github.com/puppeteer/puppeteer/actions/runs/25040638169).

This disables the experiment for now.
