### PR TITLE
fix: log WebSocket transport errors

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {describe, it, afterEach} from 'node:test';
+
+import expect from 'expect';
+
+import {BrowserWebSocketTransport} from './BrowserWebSocketTransport.js';
+import {getCapturedLogs, setLogCapture} from './Debug.js';
+
+describe('BrowserWebSocketTransport', () => {
+  afterEach(() => {
+    setLogCapture(false);
+  });
+
+  it('should log WebSocket errors for debugging', () => {
+    const ws = new EventTarget() as WebSocket;
+    ws.send = () => {};
+    ws.close = () => {};
+
+    new BrowserWebSocketTransport(ws);
+
+    setLogCapture(true);
+    ws.dispatchEvent(new Event('error'));
+
+    expect(getCapturedLogs()).toHaveLength(1);
+    expect(getCapturedLogs()[0]).toContain('puppeteer:error');
+  });
+});

--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type {ConnectionTransport} from './ConnectionTransport.js';
+import {debugError} from './util.js';
 
 /**
  * @internal
@@ -36,8 +37,7 @@ export class BrowserWebSocketTransport implements ConnectionTransport {
         this.onclose.call(null);
       }
     });
-    // Silently ignore all errors - we don't know what to do with them.
-    this.#ws.addEventListener('error', () => {});
+    this.#ws.addEventListener('error', debugError);
   }
 
   send(message: string): void {

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts
@@ -6,8 +6,11 @@
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
 import expect from 'expect';
+import type NodeWebSocket from 'ws';
 import type {WebSocket} from 'ws';
 import {WebSocketServer} from 'ws';
+
+import {getCapturedLogs, setLogCapture} from '../common/Debug.js';
 
 import {NodeWebSocketTransport} from './NodeWebSocketTransport.js';
 
@@ -27,6 +30,7 @@ describe('NodeWebSocketTransport', () => {
   afterEach(() => {
     transport.close();
     wss.close();
+    setLogCapture(false);
   });
 
   it('should dispatch messages in order handling microtasks for each message first', async () => {
@@ -56,5 +60,16 @@ describe('NodeWebSocketTransport', () => {
       'microtask1 m2',
       'microtask2 m2',
     ]);
+  });
+
+  it('should log WebSocket errors for debugging', () => {
+    const ws = new EventTarget() as unknown as NodeWebSocket;
+    new NodeWebSocketTransport(ws);
+
+    setLogCapture(true);
+    (ws as unknown as EventTarget).dispatchEvent(new Event('error'));
+
+    expect(getCapturedLogs()).toHaveLength(1);
+    expect(getCapturedLogs()[0]).toContain('puppeteer:error');
   });
 });

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
@@ -6,6 +6,7 @@
 import NodeWebSocket from 'ws';
 
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
+import {debugError} from '../common/util.js';
 import {packageVersion} from '../util/version.js';
 
 /**
@@ -51,8 +52,7 @@ export class NodeWebSocketTransport implements ConnectionTransport {
         this.onclose.call(null);
       }
     });
-    // Silently ignore all errors - we don't know what to do with them.
-    this.#ws.addEventListener('error', () => {});
+    this.#ws.addEventListener('error', debugError);
   }
 
   send(message: string): void {


### PR DESCRIPTION
### Summary
- Log WebSocket transport `error` events through the existing `debugError` channel instead of silently ignoring them.
- Apply the same behavior to browser and Node WebSocket transports.
- Add focused unit coverage for both transports.

Fixes #13054.

### Tests
- `npm run build --workspace puppeteer-core`
- `node --test --test-reporter=spec packages/puppeteer-core/lib/cjs/puppeteer/common/BrowserWebSocketTransport.test.js packages/puppeteer-core/lib/cjs/puppeteer/node/NodeWebSocketTransport.test.js`
- `npx prettier --check packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts packages/puppeteer-core/src/common/BrowserWebSocketTransport.test.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts`
- `npx eslint packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts packages/puppeteer-core/src/common/BrowserWebSocketTransport.test.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts`