### PR TITLE
feat: allow configuring WebSocket max payload

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -66,6 +66,7 @@ async function getConnectionTransport(
     channel,
     transport,
     headers = {},
+    maxPayload,
   } = options;
 
   assert(
@@ -82,7 +83,7 @@ async function getConnectionTransport(
   } else if (browserWSEndpoint) {
     const WebSocketClass = await getWebSocketTransportClass();
     const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(browserWSEndpoint, headers);
+      await WebSocketClass.create(browserWSEndpoint, headers, maxPayload);
     return {
       connectionTransport: connectionTransport,
       endpointUrl: browserWSEndpoint,
@@ -91,7 +92,7 @@ async function getConnectionTransport(
     const connectionURL = await getWSEndpoint(browserURL);
     const WebSocketClass = await getWebSocketTransportClass();
     const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(connectionURL);
+      await WebSocketClass.create(connectionURL, undefined, maxPayload);
     return {
       connectionTransport: connectionTransport,
       endpointUrl: connectionURL,
@@ -137,6 +138,7 @@ async function getConnectionTransport(
       const connectionTransport = await WebSocketClass.create(
         browserWSEndpoint,
         headers,
+        maxPayload,
       );
       return {
         connectionTransport: connectionTransport,

--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
@@ -9,7 +9,11 @@ import type {ConnectionTransport} from './ConnectionTransport.js';
  * @internal
  */
 export class BrowserWebSocketTransport implements ConnectionTransport {
-  static create(url: string): Promise<BrowserWebSocketTransport> {
+  static create(
+    url: string,
+    _headers?: Record<string, string>,
+    _maxPayload?: number,
+  ): Promise<BrowserWebSocketTransport> {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(url);
 

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -155,6 +155,16 @@ export interface ConnectOptions {
   headers?: Record<string, string>;
 
   /**
+   * Maximum web socket payload size in bytes.
+   *
+   * @remarks
+   * Only works in the Node.js environment.
+   *
+   * @defaultValue `256 * 1024 * 1024`
+   */
+  maxPayload?: number;
+
+  /**
    * WebDriver BiDi capabilities passed to BiDi `session.new`.
    *
    * @remarks

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -178,6 +178,7 @@ export abstract class BrowserLauncher {
             defaultViewport,
             acceptInsecureCerts,
             networkEnabled,
+            maxPayload: options.maxPayload,
             idGenerator,
           },
         );
@@ -194,6 +195,7 @@ export abstract class BrowserLauncher {
             timeout,
             protocolTimeout,
             slowMo,
+            maxPayload: options.maxPayload,
             idGenerator,
           });
         }
@@ -361,6 +363,7 @@ export abstract class BrowserLauncher {
       timeout: number;
       protocolTimeout: number | undefined;
       slowMo: number;
+      maxPayload?: number;
       idGenerator: GetIdFn;
     },
   ): Promise<Connection> {
@@ -368,7 +371,11 @@ export abstract class BrowserLauncher {
       CDP_WEBSOCKET_ENDPOINT_REGEX,
       opts.timeout,
     );
-    const transport = await WebSocketTransport.create(browserWSEndpoint);
+    const transport = await WebSocketTransport.create(
+      browserWSEndpoint,
+      undefined,
+      opts.maxPayload,
+    );
     return new Connection(
       browserWSEndpoint,
       transport,
@@ -449,6 +456,7 @@ export abstract class BrowserLauncher {
       timeout: number;
       protocolTimeout: number | undefined;
       slowMo: number;
+      maxPayload?: number;
       idGenerator: GetIdFn;
       defaultViewport: Viewport | null;
       acceptInsecureCerts?: boolean;
@@ -461,7 +469,11 @@ export abstract class BrowserLauncher {
         WEBDRIVER_BIDI_WEBSOCKET_ENDPOINT_REGEX,
         opts.timeout,
       )) + '/session';
-    const transport = await WebSocketTransport.create(browserWSEndpoint);
+    const transport = await WebSocketTransport.create(
+      browserWSEndpoint,
+      undefined,
+      opts.maxPayload,
+    );
     const BiDi = await import(/* webpackIgnore: true */ '../bidi/bidi.js');
     const bidiConnection = new BiDi.BidiConnection(
       browserWSEndpoint,

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts
@@ -3,11 +3,14 @@
  * Copyright 2024 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
+import type {AddressInfo} from 'node:net';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
 import expect from 'expect';
 import type {WebSocket} from 'ws';
 import {WebSocketServer} from 'ws';
+
+import {Deferred} from '../util/Deferred.js';
 
 import {NodeWebSocketTransport} from './NodeWebSocketTransport.js';
 
@@ -17,11 +20,7 @@ describe('NodeWebSocketTransport', () => {
   let connection: WebSocket;
 
   beforeEach(async () => {
-    wss = new WebSocketServer({port: 8080});
-    wss.on('connection', c => {
-      connection = c;
-    });
-    transport = await NodeWebSocketTransport.create('ws://127.0.0.1:8080');
+    ({wss, transport, connection} = await getTestTransport());
   });
 
   afterEach(() => {
@@ -57,4 +56,57 @@ describe('NodeWebSocketTransport', () => {
       'microtask2 m2',
     ]);
   });
+
+  it('should use the custom maxPayload', async () => {
+    transport.close();
+    wss.close();
+
+    ({wss, transport, connection} = await getTestTransport(8));
+
+    const payload = 'x'.repeat(64);
+    const closePromise = waitForClose(transport);
+    connection.send(payload);
+    await closePromise;
+    wss.close();
+
+    ({wss, transport, connection} = await getTestTransport(128));
+
+    await new Promise<void>(resolve => {
+      transport.onmessage = message => {
+        expect(message).toBe(payload);
+        resolve();
+      };
+      connection.send(payload);
+    });
+  });
 });
+
+async function getTestTransport(maxPayload?: number): Promise<{
+  wss: WebSocketServer;
+  transport: NodeWebSocketTransport;
+  connection: WebSocket;
+}> {
+  const wss = new WebSocketServer({port: 0});
+  const connectionPromise = new Promise<WebSocket>(resolve => {
+    wss.on('connection', resolve);
+  });
+  const {port} = wss.address() as AddressInfo;
+  const transport = await NodeWebSocketTransport.create(
+    `ws://127.0.0.1:${port}`,
+    undefined,
+    maxPayload,
+  );
+  const connection = await connectionPromise;
+  return {wss, transport, connection};
+}
+
+async function waitForClose(transport: NodeWebSocketTransport): Promise<void> {
+  const closeDeferred = Deferred.create<void>({
+    message: 'Timed out waiting for web socket to close',
+    timeout: 1000,
+  });
+  transport.onclose = () => {
+    closeDeferred.resolve();
+  };
+  await closeDeferred.valueOrThrow();
+}

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
@@ -15,13 +15,14 @@ export class NodeWebSocketTransport implements ConnectionTransport {
   static create(
     url: string,
     headers?: Record<string, string>,
+    maxPayload = 256 * 1024 * 1024,
   ): Promise<NodeWebSocketTransport> {
     return new Promise((resolve, reject) => {
       const ws = new NodeWebSocket(url, [], {
         followRedirects: true,
         perMessageDeflate: false,
         allowSynchronousEvents: false,
-        maxPayload: 256 * 1024 * 1024, // 256Mb
+        maxPayload,
         headers: {
           'User-Agent': `Puppeteer ${packageVersion}`,
           ...headers,


### PR DESCRIPTION
### Summary
- add `ConnectOptions.maxPayload` for configuring the underlying WebSocket payload limit
- pass the option through connect and launch socket transports while preserving the 256 MiB default
- cover the Node WebSocket transport behavior with a small payload-limit test

Fixes #14012

### Tests
- `npm run build --workspace puppeteer-core`
- `node --test --test-reporter=spec packages/puppeteer-core/lib/cjs/puppeteer/node/NodeWebSocketTransport.test.js`
- `npx prettier --check packages/puppeteer-core/src/common/ConnectOptions.ts packages/puppeteer-core/src/common/BrowserConnector.ts packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts packages/puppeteer-core/src/node/BrowserLauncher.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts`
- `npx eslint packages/puppeteer-core/src/common/ConnectOptions.ts packages/puppeteer-core/src/common/BrowserConnector.ts packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts packages/puppeteer-core/src/node/BrowserLauncher.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.ts packages/puppeteer-core/src/node/NodeWebSocketTransport.test.ts`