### PR TITLE
fix: remove networkidle options from setContent

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1381,6 +1381,13 @@ Represents a Node and the properties of it that are relevant to Accessibility.
 </td></tr>
 <tr><td>
 
+<span id="setcontentwaitforoptions">[SetContentWaitForOptions](./puppeteer.setcontentwaitforoptions.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="snapshotoptions">[SnapshotOptions](./puppeteer.snapshotoptions.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.frame.setcontent.md
+++ b/docs/api/puppeteer.frame.setcontent.md
@@ -10,7 +10,10 @@ Set the content of the frame.
 
 ```typescript
 class Frame {
-  abstract setContent(html: string, options?: WaitForOptions): Promise<void>;
+  abstract setContent(
+    html: string,
+    options?: SetContentWaitForOptions,
+  ): Promise<void>;
 }
 ```
 
@@ -48,7 +51,7 @@ options
 
 </td><td>
 
-[WaitForOptions](./puppeteer.waitforoptions.md)
+[SetContentWaitForOptions](./puppeteer.setcontentwaitforoptions.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.page.setcontent.md
+++ b/docs/api/puppeteer.page.setcontent.md
@@ -10,7 +10,7 @@ Set the content of the page.
 
 ```typescript
 class Page {
-  setContent(html: string, options?: WaitForOptions): Promise<void>;
+  setContent(html: string, options?: SetContentWaitForOptions): Promise<void>;
 }
 ```
 
@@ -48,7 +48,7 @@ options
 
 </td><td>
 
-[WaitForOptions](./puppeteer.waitforoptions.md)
+[SetContentWaitForOptions](./puppeteer.setcontentwaitforoptions.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.setcontentwaitforoptions.md
+++ b/docs/api/puppeteer.setcontentwaitforoptions.md
@@ -1,0 +1,59 @@
+---
+sidebar_label: SetContentWaitForOptions
+---
+
+# SetContentWaitForOptions interface
+
+### Signature
+
+```typescript
+export interface SetContentWaitForOptions extends WaitForOptions
+```
+
+**Extends:** [WaitForOptions](./puppeteer.waitforoptions.md)
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="waituntil">waitUntil</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+Exclude&lt;[PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md), 'networkidle0' \| 'networkidle2'&gt; \| Array&lt;Exclude&lt;[PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md), 'networkidle0' \| 'networkidle2'&gt;&gt;
+
+</td><td>
+
+When to consider waiting succeeds. Given an array of event strings, waiting is considered to be successful after all events have been fired.
+
+</td><td>
+
+`'load'`
+
+</td></tr>
+</tbody></table>

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -91,6 +91,21 @@ export interface GoToOptions extends WaitForOptions {
 /**
  * @public
  */
+export interface SetContentWaitForOptions extends WaitForOptions {
+  /**
+   * When to consider waiting succeeds. Given an array of event strings, waiting
+   * is considered to be successful after all events have been fired.
+   *
+   * @defaultValue `'load'`
+   */
+  waitUntil?:
+    | Exclude<PuppeteerLifeCycleEvent, 'networkidle0' | 'networkidle2'>
+    | Array<Exclude<PuppeteerLifeCycleEvent, 'networkidle0' | 'networkidle2'>>;
+}
+
+/**
+ * @public
+ */
 export interface FrameWaitForFunctionOptions {
   /**
    * An interval at which the `pageFunction` is executed, defaults to `raf`. If
@@ -821,7 +836,10 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
    * @param options - Options to configure how long before timing out and at
    * what point to consider the content setting successful.
    */
-  abstract setContent(html: string, options?: WaitForOptions): Promise<void>;
+  abstract setContent(
+    html: string,
+    options?: SetContentWaitForOptions,
+  ): Promise<void>;
 
   /**
    * @internal

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -100,6 +100,7 @@ import type {
   FrameAddStyleTagOptions,
   FrameWaitForFunctionOptions,
   GoToOptions,
+  SetContentWaitForOptions,
   WaitForOptions,
 } from './Frame.js';
 import type {
@@ -1781,7 +1782,10 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @param html - HTML markup to assign to the page.
    * @param options - Parameters that has some properties.
    */
-  async setContent(html: string, options?: WaitForOptions): Promise<void> {
+  async setContent(
+    html: string,
+    options?: SetContentWaitForOptions,
+  ): Promise<void> {
     await this.mainFrame().setContent(html, options);
   }
 

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -26,6 +26,7 @@ import {
   Frame,
   throwIfDetached,
   type GoToOptions,
+  type SetContentWaitForOptions,
   type WaitForOptions,
 } from '../api/Frame.js';
 import {PageEvent, type WaitTimeoutOptions} from '../api/Page.js';
@@ -333,7 +334,7 @@ export class BidiFrame extends Frame {
   @throwIfDetached
   override async setContent(
     html: string,
-    options: WaitForOptions = {},
+    options: SetContentWaitForOptions = {},
   ): Promise<void> {
     await Promise.all([
       this.setFrameContent(html),

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -9,7 +9,7 @@ import type {Protocol} from 'devtools-protocol';
 import type {CDPSession} from '../api/CDPSession.js';
 import type {DeviceRequestPrompt} from '../api/DeviceRequestPrompt.js';
 import type {ElementHandle} from '../api/ElementHandle.js';
-import type {WaitForOptions} from '../api/Frame.js';
+import type {SetContentWaitForOptions, WaitForOptions} from '../api/Frame.js';
 import {Frame, FrameEvent, throwIfDetached} from '../api/Frame.js';
 import type {HTTPResponse} from '../api/HTTPResponse.js';
 import type {WaitTimeoutOptions} from '../api/Page.js';
@@ -273,10 +273,7 @@ export class CdpFrame extends Frame {
   @throwIfDetached
   override async setContent(
     html: string,
-    options: {
-      timeout?: number;
-      waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
-    } = {},
+    options: SetContentWaitForOptions = {},
   ): Promise<void> {
     const {
       waitUntil = ['load'],

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -116,16 +116,15 @@ describe('Network Restrictions', function () {
 
       await page.goto(server.PREFIX + '/empty.html');
 
-      await page.setContent(
-        html`
-          <img src="${blockedUrl}" />
-          <link
-            rel="stylesheet"
-            href="${allowedUrl}"
-          />
-        `,
-        {waitUntil: 'networkidle0'},
-      );
+      const idle = page.waitForNetworkIdle();
+      await page.setContent(html`
+        <img src="${blockedUrl}" />
+        <link
+          rel="stylesheet"
+          href="${allowedUrl}"
+        />
+      `);
+      await idle;
 
       expect(failedRequests.has(blockedUrl)).toBe(true);
       expect(failedRequests.get(blockedUrl)).toContain(
@@ -279,16 +278,15 @@ describe('Network Restrictions', function () {
 
       await page.goto(server.PREFIX + '/empty.html');
 
-      await page.setContent(
-        html`
-          <img src="${blockedUrl}" />
-          <link
-            rel="stylesheet"
-            href="${allowedUrl}"
-          />
-        `,
-        {waitUntil: 'networkidle0'},
-      );
+      const idle = page.waitForNetworkIdle();
+      await page.setContent(html`
+        <img src="${blockedUrl}" />
+        <link
+          rel="stylesheet"
+          href="${allowedUrl}"
+        />
+      `);
+      await idle;
 
       expect(failedRequests.has(blockedUrl)).toBe(true);
       expect(failedRequests.get(blockedUrl)).toContain(


### PR DESCRIPTION
Remove the network idle options from the setContent interface as these options never worked as demonstrated by https://crbug.com/498000321#comment10. Not marked as a breaking change because the options never worked.

Fixes https://github.com/puppeteer/puppeteer/issues/14759