### PR TITLE
perf: optimize url blocking on navigation

### DIFF
--- a/docs/api/puppeteer.frame.goto.md
+++ b/docs/api/puppeteer.frame.goto.md
@@ -80,6 +80,8 @@ If:
 
 - the main resource failed to load.
 
+- the URL is blocked by blocklist/allowlist rules.
+
 ## Remarks
 
 Navigation to `about:blank` or navigation to the same URL with a different hash will succeed and return `null`.

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -348,6 +348,8 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
    * - the remote server does not respond or is unreachable.
    *
    * - the main resource failed to load.
+   *
+   * - the URL is blocked by blocklist/allowlist rules.
    */
   abstract goto(
     url: string,

--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -145,6 +145,12 @@ export class CdpFrame extends Frame {
       waitUntil?: PuppeteerLifeCycleEvent | PuppeteerLifeCycleEvent[];
     } = {},
   ): Promise<HTTPResponse | null> {
+    if (!this.page()._isUrlAllowed(url)) {
+      throw new Error(
+        `Navigation to ${url} is blocked by blocklist/allowlist rules`,
+      );
+    }
+
     const {
       referer = this._frameManager.networkManager.extraHTTPHeaders()['referer'],
       referrerPolicy = this._frameManager.networkManager.extraHTTPHeaders()[

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -458,6 +458,10 @@ export class CdpPage extends Page {
     return this.#primaryTargetClient;
   }
 
+  _isUrlAllowed(url: string): boolean {
+    return this.#targetManager.isUrlAllowed(url);
+  }
+
   override isServiceWorkerBypassed(): boolean {
     return this.#serviceWorkerBypassed;
   }

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -347,7 +347,7 @@ export class TargetManager
 
     // If we connect to a browser that is already open,
     // immediately detach from any tab that is on the blocklist.
-    if (!this.#initialAttachDone && !this.#isUrlAllowed(targetInfo.url)) {
+    if (!this.#initialAttachDone && !this.isUrlAllowed(targetInfo.url)) {
       await this.#silentDetach(session, parentSession);
       return;
     }
@@ -476,7 +476,7 @@ export class TargetManager
   /**
    * Helper to validate URL against blocklist patterns
    */
-  #isUrlAllowed = (url: string): boolean => {
+  isUrlAllowed = (url: string): boolean => {
     if (this.#blocklist.length === 0 && this.#allowlist.length === 0) {
       return true;
     }

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -493,7 +493,11 @@ export class TargetManager
       return true;
     }
 
-    if (ALLOWED_SCHEMES.some(scheme => url.startsWith(scheme + '//'))) {
+    if (
+      ALLOWED_SCHEMES.some(scheme => {
+        return url.startsWith(scheme + '//');
+      })
+    ) {
       return true;
     }
 

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -482,22 +482,7 @@ export class TargetManager
     }
 
     // Always allow internal or setup pages
-    const ALLOWED_URLS = ['about:blank'];
-    const ALLOWED_SCHEMES = ['chrome:'];
-
-    if (!url) {
-      return true;
-    }
-
-    if (ALLOWED_URLS.includes(url)) {
-      return true;
-    }
-
-    if (
-      ALLOWED_SCHEMES.some(scheme => {
-        return url.startsWith(scheme + '//');
-      })
-    ) {
+    if (!url || url === 'about:blank') {
       return true;
     }
 

--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -482,7 +482,18 @@ export class TargetManager
     }
 
     // Always allow internal or setup pages
-    if (!url || url === 'about:blank') {
+    const ALLOWED_URLS = ['about:blank'];
+    const ALLOWED_SCHEMES = ['chrome:'];
+
+    if (!url) {
+      return true;
+    }
+
+    if (ALLOWED_URLS.includes(url)) {
+      return true;
+    }
+
+    if (ALLOWED_SCHEMES.some(scheme => url.startsWith(scheme + '//'))) {
       return true;
     }
 

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -394,20 +394,24 @@ describe('Network Restrictions', function () {
     expect(error?.message.includes('URLPattern')).toBeTruthy();
   });
 
-  it('should not block chrome://version/ even if it matches blocklist', async () => {
-    const chromeUrl = 'chrome://version/';
+  it('should block chrome://version/ when it matches blocklist', async () => {
+    const blockedUrl = 'chrome://version/';
     const {page, close} = await launch(
       {
-        blocklist: [chromeUrl],
+        blocklist: [blockedUrl],
       },
       {createContext: true},
     );
 
     try {
-      await page.goto(chromeUrl);
+      const result = await page.goto(blockedUrl).catch(e => {
+        return e;
+      });
 
-      // Navigation should succeed as chrome:// URLs usually bypass the network
-      expect(page.url()).toBe(chromeUrl);
+      expect(result).toBeInstanceOf(Error);
+      expect(result?.message).toContain(
+        'is blocked by blocklist/allowlist rules',
+      );
     } finally {
       await close();
     }

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -30,7 +30,9 @@ describe('Network Restrictions', function () {
       });
 
       expect(error).toBeDefined();
-      expect(error?.message).toContain('is blocked by blocklist/allowlist rules');
+      expect(error?.message).toContain(
+        'is blocked by blocklist/allowlist rules',
+      );
     } finally {
       await close();
     }
@@ -191,7 +193,9 @@ describe('Network Restrictions', function () {
       });
       expect(page.url()).not.toBe(blockedUrl);
       expect(error).toBeDefined();
-      expect(error?.message).toContain('is blocked by blocklist/allowlist rules');
+      expect(error?.message).toContain(
+        'is blocked by blocklist/allowlist rules',
+      );
     } finally {
       await close();
     }
@@ -511,7 +515,9 @@ describe('Network Restrictions', function () {
       });
 
       expect(error).toBeDefined();
-      expect(error?.message).toContain('is blocked by blocklist/allowlist rules');
+      expect(error?.message).toContain(
+        'is blocked by blocklist/allowlist rules',
+      );
     } finally {
       await close();
     }

--- a/test/src/cdp/network_restrictions.spec.ts
+++ b/test/src/cdp/network_restrictions.spec.ts
@@ -30,7 +30,7 @@ describe('Network Restrictions', function () {
       });
 
       expect(error).toBeDefined();
-      expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
+      expect(error?.message).toContain('is blocked by blocklist/allowlist rules');
     } finally {
       await close();
     }
@@ -191,7 +191,7 @@ describe('Network Restrictions', function () {
       });
       expect(page.url()).not.toBe(blockedUrl);
       expect(error).toBeDefined();
-      expect(error?.message).toContain('net::ERR_INTERNET_DISCONNECTED');
+      expect(error?.message).toContain('is blocked by blocklist/allowlist rules');
     } finally {
       await close();
     }
@@ -485,6 +485,33 @@ describe('Network Restrictions', function () {
 
       expect(fetchError).toBeTruthy();
       expect(fetchError).toContain('Failed to fetch');
+    } finally {
+      await close();
+    }
+  });
+
+  it('should block frame.goto when the destination is in the blocklist', async () => {
+    const {page, close, server} = await launch(
+      {
+        blocklist: ['*://*:*/empty.html'],
+      },
+      {createContext: true},
+    );
+
+    try {
+      await page.goto(server.PREFIX + '/frames/one-frame.html');
+      const frame = page.frames().find(f => {
+        return f !== page.mainFrame();
+      })!;
+
+      const blockedUrl = server.PREFIX + '/empty.html';
+      let error: Error | undefined;
+      await frame.goto(blockedUrl).catch(e => {
+        return (error = e);
+      });
+
+      expect(error).toBeDefined();
+      expect(error?.message).toContain('is blocked by blocklist/allowlist rules');
     } finally {
       await close();
     }


### PR DESCRIPTION
This PR optimizes `allowlist` and `blocklist` checks by throwing an error immediately in `goto` if the URL is blocked, instead of waiting for the browser to fail the request. This saves a network roundtrip.