### PR TITLE
chore: enable tests for target events in Firefox.

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1026,13 +1026,6 @@
     "comment": "We can't connect to a browser started with pipe:true"
   },
   {
-    "testIdPattern": "[browsercontext.spec] BrowserContext should fire target events",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "In BiDi currently more events than needed are fired (because target is updated more often). We probably need to adjust the test as the behavior is not broken per se"
-  },
-  {
     "testIdPattern": "[browsercontext.spec] BrowserContext should work across sessions",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -1273,13 +1266,6 @@
   {
     "testIdPattern": "[keyboard.spec] Keyboard should report modifiers",
     "platforms": ["darwin"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[launcher.spec] Launcher specs Browser target events should work",
-    "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

With https://bugzilla.mozilla.org/show_bug.cgi?id=1930594 being released in Firefox, two tests will start passing. 
This PR enables them.
