### PR TITLE
fix: reject BiDi URL restrictions

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -21,5 +21,29 @@ describe('BrowserConnector', () => {
         }),
       ).rejects.toThrow('Cannot specify both blocklist and allowlist');
     });
+
+    it('should reject blocklist for WebDriver BiDi connections', async () => {
+      await expect(
+        _connectToBrowser({
+          browserWSEndpoint: 'ws://localhost:1234',
+          protocol: 'webDriverBiDi',
+          blocklist: ['https://example.com/*'],
+        }),
+      ).rejects.toThrow(
+        'blocklist and allowlist are only supported with the CDP protocol',
+      );
+    });
+
+    it('should reject allowlist for WebDriver BiDi connections', async () => {
+      await expect(
+        _connectToBrowser({
+          browserWSEndpoint: 'ws://localhost:1234',
+          protocol: 'webDriverBiDi',
+          allowlist: ['https://example.com/*'],
+        }),
+      ).rejects.toThrow(
+        'blocklist and allowlist are only supported with the CDP protocol',
+      );
+    });
   });
 });

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -27,12 +27,28 @@ const getWebSocketTransportClass = async () => {
  *
  * @internal
  */
-export async function _connectToBrowser(
-  options: ConnectOptions,
-): Promise<Browser> {
+export function assertSupportedUrlRestrictions(options: {
+  allowlist?: string[];
+  blocklist?: string[];
+  protocol?: string;
+}): void {
   if (options.blocklist && options.allowlist) {
     throw new Error('Cannot specify both blocklist and allowlist');
   }
+  if (
+    options.protocol === 'webDriverBiDi' &&
+    (options.blocklist || options.allowlist)
+  ) {
+    throw new Error(
+      'blocklist and allowlist are only supported with the CDP protocol',
+    );
+  }
+}
+
+export async function _connectToBrowser(
+  options: ConnectOptions,
+): Promise<Browser> {
+  assertSupportedUrlRestrictions(options);
   const {connectionTransport, endpointUrl} =
     await getConnectionTransport(options);
 

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -26,6 +26,7 @@ import {
 import type {Browser, BrowserCloseCallback} from '../api/Browser.js';
 import {CdpBrowser} from '../cdp/Browser.js';
 import {Connection} from '../cdp/Connection.js';
+import {assertSupportedUrlRestrictions} from '../common/BrowserConnector.js';
 import {TimeoutError} from '../common/Errors.js';
 import type {SupportedBrowser} from '../common/SupportedBrowser.js';
 import {debugError, DEFAULT_VIEWPORT} from '../common/util.js';
@@ -76,9 +77,6 @@ export abstract class BrowserLauncher {
   }
 
   async launch(options: LaunchOptions = {}): Promise<Browser> {
-    if (options.blocklist && options.allowlist) {
-      throw new Error('Cannot specify both blocklist and allowlist');
-    }
     const {
       dumpio = false,
       enableExtensions = false,
@@ -107,6 +105,12 @@ export abstract class BrowserLauncher {
     if (this.#browser === 'firefox' && protocol === undefined) {
       protocol = 'webDriverBiDi';
     }
+
+    assertSupportedUrlRestrictions({
+      allowlist,
+      blocklist,
+      protocol,
+    });
 
     if (this.#browser === 'firefox' && protocol === 'cdp') {
       throw new Error('Connecting to Firefox using CDP is no longer supported');

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.test.ts
@@ -9,6 +9,7 @@ import {describe, it} from 'node:test';
 import expect from 'expect';
 
 import {FirefoxLauncher} from './FirefoxLauncher.js';
+import type {PuppeteerNode} from './PuppeteerNode.js';
 
 describe('FirefoxLauncher', function () {
   describe('getPreferences', function () {
@@ -19,6 +20,20 @@ describe('FirefoxLauncher', function () {
       expect(prefs['test']).toBe(1);
       expect(prefs['fission.bfcacheInParent']).toBe(undefined);
       expect(prefs['fission.webContentIsolationStrategy']).toBe(0);
+    });
+  });
+
+  describe('launch', function () {
+    it('should reject blocklist for the default Firefox WebDriver BiDi protocol', async () => {
+      const launcher = new FirefoxLauncher({} as PuppeteerNode);
+
+      await expect(
+        launcher.launch({
+          blocklist: ['https://example.com/*'],
+        }),
+      ).rejects.toThrow(
+        'blocklist and allowlist are only supported with the CDP protocol',
+      );
     });
   });
 });


### PR DESCRIPTION
### Summary
- Add a shared validation helper for URL restriction options.
- Reject `blocklist`/`allowlist` when `protocol: 'webDriverBiDi'` is used for `puppeteer.connect`.
- Apply the same validation after Firefox launch defaults to WebDriver BiDi.

### Why
URL restrictions are enforced by the CDP target/navigation path. Without an early validation error, BiDi connections and Firefox's default BiDi launch path can accept `blocklist` or `allowlist` even though those restrictions are not enforced there.

### Validation
- `npm run build --workspace puppeteer-core`
- `node --test --test-reporter=spec packages/puppeteer-core/lib/cjs/puppeteer/common/BrowserConnector.test.js packages/puppeteer-core/lib/cjs/puppeteer/node/FirefoxLauncher.test.js`
- `git diff --check origin/main...HEAD`

Supersedes my closed PR #14955, resubmitted from the GitHub account linked to my Google CLA identity.
