### PR TITLE
refactor!: return a Promise for executablePath, defaultArgs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,4 +36,10 @@ RUN PUPPETEER_CACHE_DIR=/home/pptruser/.cache/puppeteer \
 
 USER $PPTRUSER_UID
 # Generate THIRD_PARTY_NOTICES using chrome --credits.
-RUN node -e "require('child_process').execSync(require('puppeteer').executablePath() + ' --credits', {stdio: 'inherit'})" > THIRD_PARTY_NOTICES
+ARG JS_CODE=" \
+  import { execSync } from 'node:child_process'; \
+  import puppeteer from 'puppeteer'; \
+  const executable = await puppeteer.executablePath(); \
+  execSync(executable + ' --credits', {stdio: 'inherit'}); \
+"
+RUN node --input-type=module -e "$JS_CODE" > THIRD_PARTY_NOTICES

--- a/docs/api/puppeteer.browserlauncher.executablepath.md
+++ b/docs/api/puppeteer.browserlauncher.executablepath.md
@@ -11,7 +11,7 @@ class BrowserLauncher {
   abstract executablePath(
     channel?: ChromeReleaseChannel,
     validatePath?: boolean,
-  ): string;
+  ): Promise<string>;
 }
 ```
 
@@ -60,4 +60,4 @@ _(Optional)_
 
 **Returns:**
 
-string
+Promise&lt;string&gt;

--- a/docs/api/puppeteer.defaultargs.md
+++ b/docs/api/puppeteer.defaultargs.md
@@ -7,7 +7,7 @@ sidebar_label: defaultArgs
 ### Signature
 
 ```typescript
-defaultArgs: (options?: PuppeteerCore.LaunchOptions) => string[]
+defaultArgs: (options?: PuppeteerCore.LaunchOptions) => Promise<string[]>;
 ```
 
 ## Parameters
@@ -42,4 +42,4 @@ _(Optional)_
 
 **Returns:**
 
-string\[\]
+Promise&lt;string\[\]&gt;

--- a/docs/api/puppeteer.executablepath.md
+++ b/docs/api/puppeteer.executablepath.md
@@ -8,8 +8,8 @@ sidebar_label: executablePath
 
 ```typescript
 executablePath: {
-    (channel: PuppeteerCore.ChromeReleaseChannel): string;
-    (options: PuppeteerCore.LaunchOptions): string;
-    (): string;
+    (channel: PuppeteerCore.ChromeReleaseChannel): Promise<string>;
+    (options: PuppeteerCore.LaunchOptions): Promise<string>;
+    (): Promise<string>;
 }
 ```

--- a/docs/api/puppeteer.puppeteernode.defaultargs.md
+++ b/docs/api/puppeteer.puppeteernode.defaultargs.md
@@ -8,7 +8,7 @@ sidebar_label: PuppeteerNode.defaultArgs
 
 ```typescript
 class PuppeteerNode {
-  defaultArgs(options?: LaunchOptions): string[];
+  defaultArgs(options?: LaunchOptions): Promise<string[]>;
 }
 ```
 
@@ -44,6 +44,6 @@ _(Optional)_ Set of configurable options to set on the browser.
 
 **Returns:**
 
-string\[\]
+Promise&lt;string\[\]&gt;
 
 The default arguments that the browser will be launched with.

--- a/docs/api/puppeteer.puppeteernode.defaultbrowser.md
+++ b/docs/api/puppeteer.puppeteernode.defaultbrowser.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: PuppeteerNode.defaultBrowser
+---
+
+# PuppeteerNode.defaultBrowser() method
+
+The name of the browser that will be launched by default. For `puppeteer`, this is influenced by your configuration. Otherwise, it's `chrome`.
+
+### Signature
+
+```typescript
+class PuppeteerNode {
+  defaultBrowser(): Promise<SupportedBrowser>;
+}
+```
+
+**Returns:**
+
+Promise&lt;[SupportedBrowser](./puppeteer.supportedbrowser.md)&gt;

--- a/docs/api/puppeteer.puppeteernode.executablepath.md
+++ b/docs/api/puppeteer.puppeteernode.executablepath.md
@@ -4,7 +4,7 @@ sidebar_label: PuppeteerNode.executablePath
 
 # PuppeteerNode.executablePath() method
 
-<h2 id="overload-1">executablePath(): string</h2>
+<h2 id="overload-1">executablePath(): Promise&lt;string&gt;</h2>
 
 The default executable path for a given ChromeReleaseChannel.
 
@@ -12,7 +12,7 @@ The default executable path for a given ChromeReleaseChannel.
 
 ```typescript
 class PuppeteerNode {
-  executablePath(channel: ChromeReleaseChannel): string;
+  executablePath(channel: ChromeReleaseChannel): Promise<string>;
 }
 ```
 
@@ -46,9 +46,9 @@ channel
 
 **Returns:**
 
-string
+Promise&lt;string&gt;
 
-<h2 id="overload-2">executablePath(): string</h2>
+<h2 id="overload-2">executablePath(): Promise&lt;string&gt;</h2>
 
 The default executable path given LaunchOptions.
 
@@ -56,7 +56,7 @@ The default executable path given LaunchOptions.
 
 ```typescript
 class PuppeteerNode {
-  executablePath(options: LaunchOptions): string;
+  executablePath(options: LaunchOptions): Promise<string>;
 }
 ```
 
@@ -90,9 +90,9 @@ options
 
 **Returns:**
 
-string
+Promise&lt;string&gt;
 
-<h2 id="overload-3">executablePath(): string</h2>
+<h2 id="overload-3">executablePath(): Promise&lt;string&gt;</h2>
 
 The default executable path.
 
@@ -100,10 +100,10 @@ The default executable path.
 
 ```typescript
 class PuppeteerNode {
-  executablePath(): string;
+  executablePath(): Promise<string>;
 }
 ```
 
 **Returns:**
 
-string
+Promise&lt;string&gt;

--- a/docs/api/puppeteer.puppeteernode.lastlaunchedbrowser.md
+++ b/docs/api/puppeteer.puppeteernode.lastlaunchedbrowser.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: PuppeteerNode.lastLaunchedBrowser
+---
+
+# PuppeteerNode.lastLaunchedBrowser() method
+
+The name of the browser that was last launched.
+
+### Signature
+
+```typescript
+class PuppeteerNode {
+  lastLaunchedBrowser(): Promise<SupportedBrowser>;
+}
+```
+
+**Returns:**
+
+Promise&lt;[SupportedBrowser](./puppeteer.supportedbrowser.md)&gt;

--- a/docs/api/puppeteer.puppeteernode.md
+++ b/docs/api/puppeteer.puppeteernode.md
@@ -61,55 +61,15 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-<span id="defaultbrowser">defaultBrowser</span>
+<span id="configuration">configuration</span>
 
 </td><td>
 
-`readonly`
-
 </td><td>
 
-Promise&lt;[SupportedBrowser](./puppeteer.supportedbrowser.md)&gt;
+() =&gt; Promise&lt;[Configuration](./puppeteer.configuration.md)&gt;
 
 </td><td>
-
-The name of the browser that will be launched by default. For `puppeteer`, this is influenced by your configuration. Otherwise, it's `chrome`.
-
-</td></tr>
-<tr><td>
-
-<span id="lastlaunchedbrowser">lastLaunchedBrowser</span>
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-Promise&lt;[SupportedBrowser](./puppeteer.supportedbrowser.md)&gt;
-
-</td><td>
-
-The name of the browser that was last launched.
-
-</td></tr>
-<tr><td>
-
-<span id="product">product</span>
-
-</td><td>
-
-`readonly, deprecated`
-
-</td><td>
-
-Promise&lt;string&gt;
-
-</td><td>
-
-**Deprecated:**
-
-Do not use as this field as it does not take into account multiple browsers of different types. Use [defaultBrowser](./puppeteer.puppeteernode.md#defaultbrowser) or [lastLaunchedBrowser](./puppeteer.puppeteernode.md#lastlaunchedbrowser).
 
 </td></tr>
 </tbody></table>
@@ -151,6 +111,17 @@ This method attaches Puppeteer to an existing browser instance.
 </td></tr>
 <tr><td>
 
+<span id="defaultbrowser">[defaultBrowser()](./puppeteer.puppeteernode.defaultbrowser.md)</span>
+
+</td><td>
+
+</td><td>
+
+The name of the browser that will be launched by default. For `puppeteer`, this is influenced by your configuration. Otherwise, it's `chrome`.
+
+</td></tr>
+<tr><td>
+
 <span id="executablepath">[executablePath(channel)](./puppeteer.puppeteernode.executablepath.md)</span>
 
 </td><td>
@@ -184,6 +155,17 @@ The default executable path.
 </td></tr>
 <tr><td>
 
+<span id="lastlaunchedbrowser">[lastLaunchedBrowser()](./puppeteer.puppeteernode.lastlaunchedbrowser.md)</span>
+
+</td><td>
+
+</td><td>
+
+The name of the browser that was last launched.
+
+</td></tr>
+<tr><td>
+
 <span id="launch">[launch(options)](./puppeteer.puppeteernode.launch.md)</span>
 
 </td><td>
@@ -197,6 +179,21 @@ When using with `puppeteer-core`, [options.executablePath](./puppeteer.launchopt
 **Remarks:**
 
 Puppeteer can also be used to control the Chrome browser, but it works best with the version of Chrome for Testing downloaded by default. There is no guarantee it will work with any other version. If Google Chrome (rather than Chrome for Testing) is preferred, a [Chrome Canary](https://www.google.com/chrome/browser/canary.html) or [Dev Channel](https://www.chromium.org/getting-involved/dev-channel) build is suggested. See [this article](https://www.howtogeek.com/202825/what%E2%80%99s-the-difference-between-chromium-and-chrome/) for a description of the differences between Chromium and Chrome. [This article](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/chromium_browser_vs_google_chrome.md) describes some differences for Linux users. See [this doc](https://developer.chrome.com/blog/chrome-for-testing/) for the description of Chrome for Testing.
+
+</td></tr>
+<tr><td>
+
+<span id="product">[product()](./puppeteer.puppeteernode.product.md)</span>
+
+</td><td>
+
+`deprecated`
+
+</td><td>
+
+**Deprecated:**
+
+Do not use as this field as it does not take into account multiple browsers of different types. Use [defaultBrowser](./puppeteer.puppeteernode.defaultbrowser.md) or [lastLaunchedBrowser](./puppeteer.puppeteernode.lastlaunchedbrowser.md).
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.puppeteernode.md
+++ b/docs/api/puppeteer.puppeteernode.md
@@ -69,7 +69,7 @@ Description
 
 </td><td>
 
-[SupportedBrowser](./puppeteer.supportedbrowser.md)
+Promise&lt;[SupportedBrowser](./puppeteer.supportedbrowser.md)&gt;
 
 </td><td>
 
@@ -86,7 +86,7 @@ The name of the browser that will be launched by default. For `puppeteer`, this 
 
 </td><td>
 
-[SupportedBrowser](./puppeteer.supportedbrowser.md)
+Promise&lt;[SupportedBrowser](./puppeteer.supportedbrowser.md)&gt;
 
 </td><td>
 
@@ -103,7 +103,7 @@ The name of the browser that was last launched.
 
 </td><td>
 
-string
+Promise&lt;string&gt;
 
 </td><td>
 

--- a/docs/api/puppeteer.puppeteernode.product.md
+++ b/docs/api/puppeteer.puppeteernode.product.md
@@ -1,0 +1,23 @@
+---
+sidebar_label: PuppeteerNode.product
+---
+
+# PuppeteerNode.product() method
+
+> Warning: This API is now obsolete.
+>
+> Do not use as this field as it does not take into account multiple browsers of different types. Use [defaultBrowser](./puppeteer.puppeteernode.defaultbrowser.md) or [lastLaunchedBrowser](./puppeteer.puppeteernode.lastlaunchedbrowser.md).
+
+### Signature
+
+```typescript
+class PuppeteerNode {
+  product(): Promise<string>;
+}
+```
+
+**Returns:**
+
+Promise&lt;string&gt;
+
+The name of the browser that is under automation.

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -535,8 +535,8 @@ export abstract class BrowserLauncher {
       headless,
     );
 
-    const defaultDownloadPath = await this.puppeteer.defaultDownloadPath;
-    const browserVersion = await this.puppeteer.browserVersion;
+    const defaultDownloadPath = await this.puppeteer.defaultDownloadPath();
+    const browserVersion = await this.puppeteer.browserVersion();
 
     executablePath = computeExecutablePath({
       cacheDir: defaultDownloadPath!,

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -286,7 +286,7 @@ export abstract class BrowserLauncher {
   abstract executablePath(
     channel?: ChromeReleaseChannel,
     validatePath?: boolean,
-  ): string;
+  ): Promise<string>;
 
   abstract defaultArgs(object: LaunchOptions): string[];
 
@@ -488,9 +488,10 @@ export abstract class BrowserLauncher {
   /**
    * @internal
    */
-  protected getProfilePath(): string {
+  protected async getProfilePath(): Promise<string> {
+    const config = await this.puppeteer.configuration();
     return join(
-      this.puppeteer.configuration.temporaryDirectory ?? tmpdir(),
+      config.temporaryDirectory ?? tmpdir(),
       `puppeteer_dev_${this.browser}_profile-`,
     );
   }
@@ -498,11 +499,12 @@ export abstract class BrowserLauncher {
   /**
    * @internal
    */
-  resolveExecutablePath(
+  async resolveExecutablePath(
     headless?: boolean | 'shell',
     validatePath = true,
-  ): string {
-    let executablePath = this.puppeteer.configuration.executablePath;
+  ): Promise<string> {
+    const config = await this.puppeteer.configuration();
+    let executablePath = config.executablePath;
     if (executablePath) {
       if (validatePath && !existsSync(executablePath)) {
         throw new Error(
@@ -533,15 +535,17 @@ export abstract class BrowserLauncher {
       headless,
     );
 
+    const defaultDownloadPath = await this.puppeteer.defaultDownloadPath;
+    const browserVersion = await this.puppeteer.browserVersion;
+
     executablePath = computeExecutablePath({
-      cacheDir: this.puppeteer.defaultDownloadPath!,
+      cacheDir: defaultDownloadPath!,
       browser: browserType,
-      buildId: this.puppeteer.browserVersion,
+      buildId: browserVersion,
     });
 
     if (validatePath && !existsSync(executablePath)) {
-      const configVersion =
-        this.puppeteer.configuration?.[this.browser]?.version;
+      const configVersion = config?.[this.browser]?.version;
       if (configVersion) {
         throw new Error(
           `Tried to find the browser at the configured path (${executablePath}) for version ${configVersion}, but no executable was found.`,
@@ -550,16 +554,16 @@ export abstract class BrowserLauncher {
       switch (this.browser) {
         case 'chrome':
           throw new Error(
-            `Could not find Chrome (ver. ${this.puppeteer.browserVersion}). This can occur if either\n` +
+            `Could not find Chrome (ver. ${browserVersion}). This can occur if either\n` +
               ` 1. you did not perform an installation before running the script (e.g. \`npx puppeteer browsers install ${browserType}\`) or\n` +
-              ` 2. your cache path is incorrectly configured (which is: ${this.puppeteer.configuration.cacheDirectory}).\n` +
+              ` 2. your cache path is incorrectly configured (which is: ${config.cacheDirectory}).\n` +
               'For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.',
           );
         case 'firefox':
           throw new Error(
-            `Could not find Firefox (rev. ${this.puppeteer.browserVersion}). This can occur if either\n` +
+            `Could not find Firefox (rev. ${browserVersion}). This can occur if either\n` +
               ' 1. you did not perform an installation for Firefox before running the script (e.g. `npx puppeteer browsers install firefox`) or\n' +
-              ` 2. your cache path is incorrectly configured (which is: ${this.puppeteer.configuration.cacheDirectory}).\n` +
+              ` 2. your cache path is incorrectly configured (which is: ${config.cacheDirectory}).\n` +
               'For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.',
           );
       }

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -34,9 +34,10 @@ export class ChromeLauncher extends BrowserLauncher {
     super(puppeteer, 'chrome');
   }
 
-  override launch(options: LaunchOptions = {}): Promise<Browser> {
+  override async launch(options: LaunchOptions = {}): Promise<Browser> {
+    const config = await this.puppeteer.configuration();
     if (
-      this.puppeteer.configuration.logLevel === 'warn' &&
+      config.logLevel === 'warn' &&
       process.platform === 'darwin' &&
       process.arch === 'x64'
     ) {
@@ -55,7 +56,7 @@ export class ChromeLauncher extends BrowserLauncher {
       }
     }
 
-    return super.launch(options);
+    return await super.launch(options);
   }
 
   /**
@@ -112,7 +113,7 @@ export class ChromeLauncher extends BrowserLauncher {
     if (userDataDirIndex < 0) {
       isTempUserDataDir = true;
       chromeArguments.push(
-        `--user-data-dir=${await mkdtemp(this.getProfilePath())}`,
+        `--user-data-dir=${await mkdtemp(await this.getProfilePath())}`,
       );
       userDataDirIndex = chromeArguments.length - 1;
     }
@@ -127,8 +128,8 @@ export class ChromeLauncher extends BrowserLauncher {
         `An \`executablePath\` or \`channel\` must be specified for \`puppeteer-core\``,
       );
       chromeExecutable = channel
-        ? this.executablePath(channel)
-        : this.resolveExecutablePath(options.headless ?? true);
+        ? await this.executablePath(channel)
+        : await this.resolveExecutablePath(options.headless ?? true);
     }
 
     return {
@@ -284,17 +285,17 @@ export class ChromeLauncher extends BrowserLauncher {
     return chromeArguments;
   }
 
-  override executablePath(
+  override async executablePath(
     channel?: ChromeReleaseChannel,
     validatePath = true,
-  ): string {
+  ): Promise<string> {
     if (channel) {
       return computeSystemExecutablePath({
         browser: SupportedBrowsers.CHROME,
         channel: convertPuppeteerChannelToBrowsersChannel(channel),
       });
     } else {
-      return this.resolveExecutablePath(undefined, validatePath);
+      return await this.resolveExecutablePath(undefined, validatePath);
     }
   }
 }

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -100,7 +100,8 @@ export class FirefoxLauncher extends BrowserLauncher {
       // with required preferences.
       isTempUserDataDir = false;
     } else {
-      userDataDir = await mkdtemp(this.getProfilePath());
+      const profilePath = await this.getProfilePath();
+      userDataDir = await mkdtemp(profilePath);
       firefoxArguments.push('--profile');
       firefoxArguments.push(userDataDir);
     }
@@ -118,7 +119,7 @@ export class FirefoxLauncher extends BrowserLauncher {
       );
       firefoxExecutable = executablePath;
     } else {
-      firefoxExecutable = this.executablePath(undefined);
+      firefoxExecutable = await this.executablePath(undefined);
     }
 
     return {
@@ -169,8 +170,11 @@ export class FirefoxLauncher extends BrowserLauncher {
     }
   }
 
-  override executablePath(_: unknown, validatePath = true): string {
-    return this.resolveExecutablePath(
+  override async executablePath(
+    _: unknown,
+    validatePath = true,
+  ): Promise<string> {
+    return await this.resolveExecutablePath(
       undefined,
       /* validatePath=*/ validatePath,
     );

--- a/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
@@ -24,17 +24,17 @@ describe('PuppeteerNode', () => {
   });
 
   describe('executablePath()', () => {
-    it('returns the default path', () => {
+    it('returns the default path', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
         configuration: {
           cacheDirectory: tmpDir,
         },
       });
-      expect(puppeteer.executablePath()).toContain('chrome');
+      expect(await puppeteer.executablePath()).toContain('chrome');
     });
 
-    it('returns the default path based on the default browser configuration', () => {
+    it('returns the default path based on the default browser configuration', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
         configuration: {
@@ -42,22 +42,12 @@ describe('PuppeteerNode', () => {
           defaultBrowser: 'firefox',
         },
       });
-      expect(puppeteer.executablePath().toLowerCase()).toContain('firefox');
-    });
-
-    it('returns the default path for a given Chrome channel', () => {
-      const puppeteer = new PuppeteerNode({
-        isPuppeteerCore: false,
-        configuration: {
-          cacheDirectory: tmpDir,
-        },
-      });
-      expect(puppeteer.executablePath('chrome').toLowerCase()).toContain(
-        'chrome',
+      expect((await puppeteer.executablePath()).toLowerCase()).toContain(
+        'firefox',
       );
     });
 
-    it('returns the default path for chrome-headless-shell', () => {
+    it('returns the default path for a given Chrome channel', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
         configuration: {
@@ -65,11 +55,23 @@ describe('PuppeteerNode', () => {
         },
       });
       expect(
-        puppeteer
-          .executablePath({
+        (await puppeteer.executablePath('chrome')).toLowerCase(),
+      ).toContain('chrome');
+    });
+
+    it('returns the default path for chrome-headless-shell', async () => {
+      const puppeteer = new PuppeteerNode({
+        isPuppeteerCore: false,
+        configuration: {
+          cacheDirectory: tmpDir,
+        },
+      });
+      expect(
+        (
+          await puppeteer.executablePath({
             headless: 'shell',
           })
-          .toLowerCase(),
+        ).toLowerCase(),
       ).toContain('chrome-headless-shell');
     });
   });

--- a/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
@@ -27,8 +27,10 @@ describe('PuppeteerNode', () => {
     it('returns the default path', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
-        configuration: {
-          cacheDirectory: tmpDir,
+        configuration: () => {
+          return Promise.resolve({
+            cacheDirectory: tmpDir,
+          });
         },
       });
       expect(await puppeteer.executablePath()).toContain('chrome');
@@ -37,9 +39,11 @@ describe('PuppeteerNode', () => {
     it('returns the default path based on the default browser configuration', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
-        configuration: {
-          cacheDirectory: tmpDir,
-          defaultBrowser: 'firefox',
+        configuration: () => {
+          return Promise.resolve({
+            cacheDirectory: tmpDir,
+            defaultBrowser: 'firefox',
+          });
         },
       });
       expect((await puppeteer.executablePath()).toLowerCase()).toContain(
@@ -50,8 +54,10 @@ describe('PuppeteerNode', () => {
     it('returns the default path for a given Chrome channel', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
-        configuration: {
-          cacheDirectory: tmpDir,
+        configuration: () => {
+          return Promise.resolve({
+            cacheDirectory: tmpDir,
+          });
         },
       });
       expect(
@@ -62,8 +68,10 @@ describe('PuppeteerNode', () => {
     it('returns the default path for chrome-headless-shell', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
-        configuration: {
-          cacheDirectory: tmpDir,
+        configuration: () => {
+          return Promise.resolve({
+            cacheDirectory: tmpDir,
+          });
         },
       });
       expect(
@@ -80,8 +88,10 @@ describe('PuppeteerNode', () => {
     it('returns the default args without arguments', () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
-        configuration: {
-          cacheDirectory: tmpDir,
+        configuration: () => {
+          return Promise.resolve({
+            cacheDirectory: tmpDir,
+          });
         },
       });
       expect(puppeteer.defaultArgs()).toBeInstanceOf(Array);

--- a/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.test.ts
@@ -85,7 +85,7 @@ describe('PuppeteerNode', () => {
   });
 
   describe('defaultArgs()', () => {
-    it('returns the default args without arguments', () => {
+    it('returns the default args without arguments', async () => {
       const puppeteer = new PuppeteerNode({
         isPuppeteerCore: false,
         configuration: () => {
@@ -94,7 +94,8 @@ describe('PuppeteerNode', () => {
           });
         },
       });
-      expect(puppeteer.defaultArgs()).toBeInstanceOf(Array);
+      const args = await puppeteer.defaultArgs();
+      expect(args).toBeInstanceOf(Array);
     });
   });
 });

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -65,11 +65,6 @@ export class PuppeteerNode extends Puppeteer {
   /**
    * @internal
    */
-  defaultBrowserRevision?: string;
-
-  /**
-   * @internal
-   */
   constructor(
     settings: {
       configuration?: () => Promise<Configuration>;
@@ -141,15 +136,8 @@ export class PuppeteerNode extends Puppeteer {
   async launch(options: LaunchOptions = {}): Promise<Browser> {
     const {browser = await this.defaultBrowser()} = options;
     this.#lastLaunchedBrowser = browser;
-    switch (browser) {
-      case 'chrome':
-        this.defaultBrowserRevision = PUPPETEER_REVISIONS.chrome;
-        break;
-      case 'firefox':
-        this.defaultBrowserRevision = PUPPETEER_REVISIONS.firefox;
-        break;
-      default:
-        throw new Error(`Unknown product: ${browser}`);
+    if (!['chrome', 'firefox'].includes(browser)) {
+      throw new Error(`Unknown product: ${browser}`);
     }
     this.#launcher = this.#getLauncher(browser);
     return await this.#launcher.launch(options);
@@ -209,11 +197,7 @@ export class PuppeteerNode extends Puppeteer {
   async browserVersion(): Promise<string> {
     const config = await this.configuration();
     const lastLaunched = await this.lastLaunchedBrowser();
-    return (
-      config?.[lastLaunched]?.version ??
-      this.defaultBrowserRevision ??
-      PUPPETEER_REVISIONS[lastLaunched]
-    );
+    return config?.[lastLaunched]?.version ?? PUPPETEER_REVISIONS[lastLaunched];
   }
 
   /**

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -139,7 +139,7 @@ export class PuppeteerNode extends Puppeteer {
    * @param options - Options to configure launching behavior.
    */
   async launch(options: LaunchOptions = {}): Promise<Browser> {
-    const {browser = await this.defaultBrowser} = options;
+    const {browser = await this.defaultBrowser()} = options;
     this.#lastLaunchedBrowser = browser;
     switch (browser) {
       case 'chrome':
@@ -189,7 +189,7 @@ export class PuppeteerNode extends Puppeteer {
   ): Promise<string> {
     if (optsOrChannel === undefined) {
       return await this.#getLauncher(
-        await this.lastLaunchedBrowser,
+        await this.lastLaunchedBrowser(),
       ).executablePath(undefined, /* validatePath= */ false);
     }
     if (typeof optsOrChannel === 'string') {
@@ -199,23 +199,21 @@ export class PuppeteerNode extends Puppeteer {
       );
     }
     return await this.#getLauncher(
-      optsOrChannel.browser ?? (await this.lastLaunchedBrowser),
+      optsOrChannel.browser ?? (await this.lastLaunchedBrowser()),
     ).resolveExecutablePath(optsOrChannel.headless, /* validatePath= */ false);
   }
 
   /**
    * @internal
    */
-  get browserVersion(): Promise<string> {
-    return (async () => {
-      const config = await this.configuration();
-      const lastLaunched = await this.lastLaunchedBrowser;
-      return (
-        config?.[lastLaunched]?.version ??
-        this.defaultBrowserRevision ??
-        PUPPETEER_REVISIONS[lastLaunched]
-      );
-    })();
+  async browserVersion(): Promise<string> {
+    const config = await this.configuration();
+    const lastLaunched = await this.lastLaunchedBrowser();
+    return (
+      config?.[lastLaunched]?.version ??
+      this.defaultBrowserRevision ??
+      PUPPETEER_REVISIONS[lastLaunched]
+    );
   }
 
   /**
@@ -224,20 +222,16 @@ export class PuppeteerNode extends Puppeteer {
    *
    * @internal
    */
-  get defaultDownloadPath(): Promise<string | undefined> {
-    return (async () => {
-      const config = await this.configuration();
-      return config.cacheDirectory;
-    })();
+  async defaultDownloadPath(): Promise<string | undefined> {
+    const config = await this.configuration();
+    return config.cacheDirectory;
   }
 
   /**
    * The name of the browser that was last launched.
    */
-  get lastLaunchedBrowser(): Promise<SupportedBrowser> {
-    return (async () => {
-      return this.#lastLaunchedBrowser ?? (await this.defaultBrowser);
-    })();
+  async lastLaunchedBrowser(): Promise<SupportedBrowser> {
+    return this.#lastLaunchedBrowser ?? (await this.defaultBrowser());
   }
 
   /**
@@ -245,11 +239,9 @@ export class PuppeteerNode extends Puppeteer {
    * `puppeteer`, this is influenced by your configuration. Otherwise, it's
    * `chrome`.
    */
-  get defaultBrowser(): Promise<SupportedBrowser> {
-    return (async () => {
-      const config = await this.configuration();
-      return config.defaultBrowser ?? 'chrome';
-    })();
+  async defaultBrowser(): Promise<SupportedBrowser> {
+    const config = await this.configuration();
+    return config.defaultBrowser ?? 'chrome';
   }
 
   /**
@@ -260,8 +252,8 @@ export class PuppeteerNode extends Puppeteer {
    *
    * @returns The name of the browser that is under automation.
    */
-  get product(): Promise<string> {
-    return this.lastLaunchedBrowser;
+  product(): Promise<string> {
+    return this.lastLaunchedBrowser();
   }
 
   /**
@@ -271,7 +263,7 @@ export class PuppeteerNode extends Puppeteer {
    */
   async defaultArgs(options: LaunchOptions = {}): Promise<string[]> {
     return this.#getLauncher(
-      options.browser ?? (await this.lastLaunchedBrowser),
+      options.browser ?? (await this.lastLaunchedBrowser()),
     ).defaultArgs(options);
   }
 

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -60,38 +60,29 @@ import type {ChromeReleaseChannel, LaunchOptions} from './LaunchOptions.js';
 export class PuppeteerNode extends Puppeteer {
   #launcher?: BrowserLauncher;
   #lastLaunchedBrowser?: SupportedBrowser;
+  configuration: () => Promise<Configuration>;
 
   /**
    * @internal
    */
-  defaultBrowserRevision: string;
-
-  /**
-   * @internal
-   */
-  configuration: Configuration = {};
+  defaultBrowserRevision?: string;
 
   /**
    * @internal
    */
   constructor(
     settings: {
-      configuration?: Configuration;
+      configuration?: () => Promise<Configuration>;
     } & CommonPuppeteerSettings,
   ) {
     const {configuration, ...commonSettings} = settings;
     super(commonSettings);
     if (configuration) {
       this.configuration = configuration;
-    }
-    switch (this.configuration.defaultBrowser) {
-      case 'firefox':
-        this.defaultBrowserRevision = PUPPETEER_REVISIONS.firefox;
-        break;
-      default:
-        this.configuration.defaultBrowser = 'chrome';
-        this.defaultBrowserRevision = PUPPETEER_REVISIONS.chrome;
-        break;
+    } else {
+      this.configuration = () => {
+        return Promise.resolve({});
+      };
     }
 
     this.connect = this.connect.bind(this);
@@ -147,8 +138,8 @@ export class PuppeteerNode extends Puppeteer {
    *
    * @param options - Options to configure launching behavior.
    */
-  launch(options: LaunchOptions = {}): Promise<Browser> {
-    const {browser = this.defaultBrowser} = options;
+  async launch(options: LaunchOptions = {}): Promise<Browser> {
+    const {browser = await this.defaultBrowser} = options;
     this.#lastLaunchedBrowser = browser;
     switch (browser) {
       case 'chrome':
@@ -161,7 +152,7 @@ export class PuppeteerNode extends Puppeteer {
         throw new Error(`Unknown product: ${browser}`);
     }
     this.#launcher = this.#getLauncher(browser);
-    return this.#launcher.launch(options);
+    return await this.#launcher.launch(options);
   }
 
   /**
@@ -184,41 +175,47 @@ export class PuppeteerNode extends Puppeteer {
   /**
    * The default executable path for a given ChromeReleaseChannel.
    */
-  executablePath(channel: ChromeReleaseChannel): string;
+  executablePath(channel: ChromeReleaseChannel): Promise<string>;
   /**
    * The default executable path given LaunchOptions.
    */
-  executablePath(options: LaunchOptions): string;
+  executablePath(options: LaunchOptions): Promise<string>;
   /**
    * The default executable path.
    */
-  executablePath(): string;
-  executablePath(optsOrChannel?: ChromeReleaseChannel | LaunchOptions): string {
+  executablePath(): Promise<string>;
+  async executablePath(
+    optsOrChannel?: ChromeReleaseChannel | LaunchOptions,
+  ): Promise<string> {
     if (optsOrChannel === undefined) {
-      return this.#getLauncher(this.lastLaunchedBrowser).executablePath(
-        undefined,
-        /* validatePath= */ false,
-      );
+      return await this.#getLauncher(
+        await this.lastLaunchedBrowser,
+      ).executablePath(undefined, /* validatePath= */ false);
     }
     if (typeof optsOrChannel === 'string') {
-      return this.#getLauncher('chrome').executablePath(
+      return await this.#getLauncher('chrome').executablePath(
         optsOrChannel,
         /* validatePath= */ false,
       );
     }
-    return this.#getLauncher(
-      optsOrChannel.browser ?? this.lastLaunchedBrowser,
+    return await this.#getLauncher(
+      optsOrChannel.browser ?? (await this.lastLaunchedBrowser),
     ).resolveExecutablePath(optsOrChannel.headless, /* validatePath= */ false);
   }
 
   /**
    * @internal
    */
-  get browserVersion(): string {
-    return (
-      this.configuration?.[this.lastLaunchedBrowser]?.version ??
-      this.defaultBrowserRevision!
-    );
+  get browserVersion(): Promise<string> {
+    return (async () => {
+      const config = await this.configuration();
+      const lastLaunched = await this.lastLaunchedBrowser;
+      return (
+        config?.[lastLaunched]?.version ??
+        this.defaultBrowserRevision ??
+        PUPPETEER_REVISIONS[lastLaunched]
+      );
+    })();
   }
 
   /**
@@ -227,15 +224,20 @@ export class PuppeteerNode extends Puppeteer {
    *
    * @internal
    */
-  get defaultDownloadPath(): string | undefined {
-    return this.configuration.cacheDirectory;
+  get defaultDownloadPath(): Promise<string | undefined> {
+    return (async () => {
+      const config = await this.configuration();
+      return config.cacheDirectory;
+    })();
   }
 
   /**
    * The name of the browser that was last launched.
    */
-  get lastLaunchedBrowser(): SupportedBrowser {
-    return this.#lastLaunchedBrowser ?? this.defaultBrowser;
+  get lastLaunchedBrowser(): Promise<SupportedBrowser> {
+    return (async () => {
+      return this.#lastLaunchedBrowser ?? (await this.defaultBrowser);
+    })();
   }
 
   /**
@@ -243,8 +245,11 @@ export class PuppeteerNode extends Puppeteer {
    * `puppeteer`, this is influenced by your configuration. Otherwise, it's
    * `chrome`.
    */
-  get defaultBrowser(): SupportedBrowser {
-    return this.configuration.defaultBrowser ?? 'chrome';
+  get defaultBrowser(): Promise<SupportedBrowser> {
+    return (async () => {
+      const config = await this.configuration();
+      return config.defaultBrowser ?? 'chrome';
+    })();
   }
 
   /**
@@ -255,7 +260,7 @@ export class PuppeteerNode extends Puppeteer {
    *
    * @returns The name of the browser that is under automation.
    */
-  get product(): string {
+  get product(): Promise<string> {
     return this.lastLaunchedBrowser;
   }
 
@@ -264,9 +269,9 @@ export class PuppeteerNode extends Puppeteer {
    *
    * @returns The default arguments that the browser will be launched with.
    */
-  defaultArgs(options: LaunchOptions = {}): string[] {
+  async defaultArgs(options: LaunchOptions = {}): Promise<string[]> {
     return this.#getLauncher(
-      options.browser ?? this.lastLaunchedBrowser,
+      options.browser ?? (await this.lastLaunchedBrowser),
     ).defaultArgs(options);
   }
 
@@ -290,7 +295,8 @@ export class PuppeteerNode extends Puppeteer {
       throw new Error('The current platform is not supported.');
     }
 
-    const cacheDir = this.configuration.cacheDirectory!;
+    const config = await this.configuration();
+    const cacheDir = config.cacheDirectory!;
     const installedBrowsers = await getInstalledBrowsers({
       cacheDir,
     });
@@ -316,8 +322,7 @@ export class PuppeteerNode extends Puppeteer {
     await Promise.all(
       puppeteerBrowsers.map(async item => {
         const tag =
-          this.configuration?.[item.product]?.version ??
-          PUPPETEER_REVISIONS[item.product];
+          config?.[item.product]?.version ?? PUPPETEER_REVISIONS[item.product];
 
         item.currentBuildId = await resolveBuildId(item.browser, platform, tag);
       }),

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -7,7 +7,7 @@
 import {homedir} from 'node:os';
 import {join} from 'node:path';
 
-import {cosmiconfigSync} from 'cosmiconfig';
+import {cosmiconfig} from 'cosmiconfig';
 import type {
   ChromeHeadlessShellSettings,
   ChromeSettings,
@@ -115,8 +115,8 @@ function getBrowserSetting(
 /**
  * @internal
  */
-export const getConfiguration = (): Configuration => {
-  const result = cosmiconfigSync('puppeteer', {
+export const getConfiguration = async (): Promise<Configuration> => {
+  const result = await cosmiconfig('puppeteer', {
     searchStrategy: 'global',
   }).search();
   const configuration: Configuration = result ? {...result.config} : {};

--- a/packages/puppeteer/src/node/cli.ts
+++ b/packages/puppeteer/src/node/cli.ts
@@ -13,11 +13,10 @@ import {packageVersion} from 'puppeteer-core/internal/util/version.js';
 
 import puppeteer from '../puppeteer.js';
 
-const cacheDir = (puppeteer as unknown as PuppeteerNode).configuration
-  .cacheDirectory!;
+const config = await (puppeteer as unknown as PuppeteerNode).configuration();
 
 void new CLI({
-  cachePath: cacheDir,
+  cachePath: config.cacheDirectory!,
   scriptName: 'puppeteer',
   version: packageVersion,
   prefixCommand: {
@@ -28,34 +27,20 @@ void new CLI({
   pinnedBrowsers: {
     [Browser.CHROME]: {
       buildId:
-        (puppeteer as unknown as PuppeteerNode).configuration.chrome?.version ||
-        PUPPETEER_REVISIONS['chrome'] ||
-        'latest',
-      skipDownload:
-        (puppeteer as unknown as PuppeteerNode).configuration.chrome
-          ?.skipDownload ?? false,
+        config.chrome?.version || PUPPETEER_REVISIONS['chrome'] || 'latest',
+      skipDownload: config.chrome?.skipDownload ?? false,
     },
     [Browser.FIREFOX]: {
       buildId:
-        (puppeteer as unknown as PuppeteerNode).configuration.firefox
-          ?.version ||
-        PUPPETEER_REVISIONS['firefox'] ||
-        'latest',
-      skipDownload:
-        (puppeteer as unknown as PuppeteerNode).configuration.firefox
-          ?.skipDownload ?? true,
+        config.firefox?.version || PUPPETEER_REVISIONS['firefox'] || 'latest',
+      skipDownload: config.firefox?.skipDownload ?? true,
     },
     [Browser.CHROMEHEADLESSSHELL]: {
       buildId:
-        (puppeteer as unknown as PuppeteerNode).configuration[
-          'chrome-headless-shell'
-        ]?.version ||
+        config['chrome-headless-shell']?.version ||
         PUPPETEER_REVISIONS['chrome-headless-shell'] ||
         'latest',
-      skipDownload:
-        (puppeteer as unknown as PuppeteerNode).configuration[
-          'chrome-headless-shell'
-        ]?.skipDownload ?? false,
+      skipDownload: config['chrome-headless-shell']?.skipDownload ?? false,
     },
   },
 }).run(process.argv);

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -67,7 +67,7 @@ async function downloadBrowser({
 export async function downloadBrowsers(): Promise<void> {
   overrideProxy();
 
-  const configuration = getConfiguration();
+  const configuration = await getConfiguration();
   if (configuration.skipDownload) {
     logPolitely('**INFO** Skipping downloading browsers as instructed.');
     return;

--- a/packages/puppeteer/src/puppeteer.docs.ts
+++ b/packages/puppeteer/src/puppeteer.docs.ts
@@ -14,14 +14,12 @@ import * as PuppeteerCore from 'puppeteer-core/internal/puppeteer-core.js';
 
 import {getConfiguration} from './getConfiguration.js';
 
-const configuration = getConfiguration();
-
 /**
  * @public
  */
 const puppeteer = new PuppeteerCore.PuppeteerNode({
   isPuppeteerCore: false,
-  configuration,
+  configuration: getConfiguration,
 });
 
 export const {

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -10,15 +10,13 @@ import {PuppeteerNode} from 'puppeteer-core';
 
 import {getConfiguration} from './getConfiguration.js';
 
-const configuration = getConfiguration();
-
 /**
  * @public
  */
 // @ts-expect-error using internal API.
 const puppeteer = new PuppeteerNode({
   isPuppeteerCore: false,
-  configuration,
+  configuration: getConfiguration,
 });
 
 export const {

--- a/test/installation/assets/puppeteer/configuration/puppeteer.config.ts
+++ b/test/installation/assets/puppeteer/configuration/puppeteer.config.ts
@@ -2,5 +2,5 @@ import {type Configuration} from 'puppeteer';
 import {join} from 'node:path';
 
 export default {
-  cacheDirectory: join(__dirname, '.cache', 'puppeteer'),
+  cacheDirectory: join(import.meta.dirname, '.cache', 'puppeteer'),
 } satisfies Configuration;

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -447,9 +447,9 @@ describe('Launcher specs', function () {
           skipLaunch: true,
         });
         if (isChrome) {
-          expect(puppeteer.product).toBe('chrome');
+          expect(await puppeteer.product()).toBe('chrome');
         } else if (isFirefox) {
-          expect(puppeteer.product).toBe('firefox');
+          expect(await puppeteer.product()).toBe('firefox');
         }
       });
       it('should filter out ignored default arguments in Chrome', async () => {

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -227,8 +227,9 @@ describe('Launcher specs', function () {
         const testTmpDir = await fs.promises.mkdtemp(
           path.join(os.tmpdir(), 'puppeteer_test_chrome_profile-'),
         );
-        const oldTmpDir = puppeteer.configuration.temporaryDirectory;
-        puppeteer.configuration.temporaryDirectory = testTmpDir;
+        const config = await puppeteer.configuration();
+        const oldTmpDir = config.temporaryDirectory;
+        config.temporaryDirectory = testTmpDir;
 
         // Path should be empty before starting the browser.
         expect(fs.readdirSync(testTmpDir)).toHaveLength(0);
@@ -252,7 +253,7 @@ describe('Launcher specs', function () {
         expect(fs.readdirSync(testTmpDir)).toHaveLength(0);
 
         // Restore env var
-        puppeteer.configuration.temporaryDirectory = oldTmpDir;
+        (await puppeteer.configuration()).temporaryDirectory = oldTmpDir;
       });
       it('userDataDir option restores preferences', async () => {
         const userDataDir = await mkdtemp(TMP_FOLDER);
@@ -404,37 +405,39 @@ describe('Launcher specs', function () {
         });
 
         if (isChrome) {
-          expect(puppeteer.defaultArgs()).toContain('--no-first-run');
-          expect(puppeteer.defaultArgs()).toContain('--headless=new');
-          expect(puppeteer.defaultArgs({headless: false})).not.toContain(
+          expect(await puppeteer.defaultArgs()).toContain('--no-first-run');
+          expect(await puppeteer.defaultArgs()).toContain('--headless=new');
+          expect(await puppeteer.defaultArgs({headless: false})).not.toContain(
             '--headless=new',
           );
-          expect(puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
+          expect(await puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
             `--user-data-dir=${path.resolve('foo')}`,
           );
         } else if (isFirefox) {
-          expect(puppeteer.defaultArgs()).toContain('--headless');
+          expect(await puppeteer.defaultArgs()).toContain('--headless');
           if (os.platform() === 'darwin') {
-            expect(puppeteer.defaultArgs()).toContain('--foreground');
+            expect(await puppeteer.defaultArgs()).toContain('--foreground');
           } else {
-            expect(puppeteer.defaultArgs()).not.toContain('--foreground');
+            expect(await puppeteer.defaultArgs()).not.toContain('--foreground');
           }
-          expect(puppeteer.defaultArgs({headless: false})).not.toContain(
+          expect(await puppeteer.defaultArgs({headless: false})).not.toContain(
             '--headless',
           );
-          expect(puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
+          expect(await puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
             '--profile',
           );
-          expect(puppeteer.defaultArgs({userDataDir: 'foo'})).toContain('foo');
+          expect(await puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
+            'foo',
+          );
         } else {
-          expect(puppeteer.defaultArgs()).toContain('-headless');
-          expect(puppeteer.defaultArgs({headless: false})).not.toContain(
+          expect(await puppeteer.defaultArgs()).toContain('-headless');
+          expect(await puppeteer.defaultArgs({headless: false})).not.toContain(
             '-headless',
           );
-          expect(puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
+          expect(await puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
             '-profile',
           );
-          expect(puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
+          expect(await puppeteer.defaultArgs({userDataDir: 'foo'})).toContain(
             path.resolve('foo'),
           );
         }
@@ -454,7 +457,7 @@ describe('Launcher specs', function () {
           skipLaunch: true,
         });
         // Make sure we launch with `--enable-automation` by default.
-        const defaultArgs = puppeteer.defaultArgs();
+        const defaultArgs = await puppeteer.defaultArgs();
         const {browser, close} = await launch(
           Object.assign({}, defaultBrowserOptions, {
             // Ignore first and third default argument.
@@ -478,7 +481,7 @@ describe('Launcher specs', function () {
           skipLaunch: true,
         });
 
-        const defaultArgs = puppeteer.defaultArgs();
+        const defaultArgs = await puppeteer.defaultArgs();
         const {browser, close} = await launch(
           Object.assign({}, defaultBrowserOptions, {
             // All arguments are optional.
@@ -877,7 +880,7 @@ describe('Launcher specs', function () {
           skipLaunch: true,
         });
 
-        const executablePath = puppeteer.executablePath();
+        const executablePath = await puppeteer.executablePath();
         expect(fs.existsSync(executablePath)).toBe(true);
         expect(fs.realpathSync(executablePath)).toBe(executablePath);
       });
@@ -886,7 +889,7 @@ describe('Launcher specs', function () {
           skipLaunch: true,
         });
 
-        const executablePath = puppeteer.executablePath('chrome');
+        const executablePath = await puppeteer.executablePath('chrome');
         expect(executablePath).toBeTruthy();
       });
       describe('when executable path is configured', () => {
@@ -897,8 +900,8 @@ describe('Launcher specs', function () {
             skipLaunch: true,
           });
           sandbox
-            .stub(puppeteer.configuration, 'executablePath')
-            .value('SOME_CUSTOM_EXECUTABLE');
+            .stub(puppeteer, 'configuration')
+            .resolves({executablePath: 'SOME_CUSTOM_EXECUTABLE'});
         });
 
         afterEach(() => {
@@ -910,7 +913,7 @@ describe('Launcher specs', function () {
             skipLaunch: true,
           });
           try {
-            puppeteer.executablePath();
+            await puppeteer.executablePath();
           } catch (error) {
             expect((error as Error).message).toContain(
               'SOME_CUSTOM_EXECUTABLE',

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -219,7 +219,7 @@ describe('Launcher specs', function () {
           rmSync(userDataDir);
         } catch {}
       });
-      it.only('tmp profile should be cleaned up', async () => {
+      it('tmp profile should be cleaned up', async () => {
         const {puppeteer, isFirefox} = await getTestState({skipLaunch: true});
 
         // Set a custom test tmp dir so that we can validate that

--- a/test/src/launcher.spec.ts
+++ b/test/src/launcher.spec.ts
@@ -219,7 +219,7 @@ describe('Launcher specs', function () {
           rmSync(userDataDir);
         } catch {}
       });
-      it('tmp profile should be cleaned up', async () => {
+      it.only('tmp profile should be cleaned up', async () => {
         const {puppeteer, isFirefox} = await getTestState({skipLaunch: true});
 
         // Set a custom test tmp dir so that we can validate that
@@ -228,8 +228,10 @@ describe('Launcher specs', function () {
           path.join(os.tmpdir(), 'puppeteer_test_chrome_profile-'),
         );
         const config = await puppeteer.configuration();
-        const oldTmpDir = config.temporaryDirectory;
-        config.temporaryDirectory = testTmpDir;
+        sinon.stub(puppeteer, 'configuration').resolves({
+          ...config,
+          temporaryDirectory: testTmpDir,
+        });
 
         // Path should be empty before starting the browser.
         expect(fs.readdirSync(testTmpDir)).toHaveLength(0);
@@ -251,9 +253,6 @@ describe('Launcher specs', function () {
 
         // Profile should be deleted after closing the browser
         expect(fs.readdirSync(testTmpDir)).toHaveLength(0);
-
-        // Restore env var
-        (await puppeteer.configuration()).temporaryDirectory = oldTmpDir;
       });
       it('userDataDir option restores preferences', async () => {
         const userDataDir = await mkdtemp(TMP_FOLDER);

--- a/test/src/mocha-utils.ts
+++ b/test/src/mocha-utils.ts
@@ -112,7 +112,7 @@ defaultBrowserOptions.args!.push(
 defaultBrowserOptions.args!.push(`--force-device-scale-factor=1`);
 
 let executableExists = false;
-function verifyExecutable() {
+async function verifyExecutable() {
   if (executableExists) {
     return;
   }
@@ -127,7 +127,7 @@ function verifyExecutable() {
       );
     }
   } else {
-    const executablePath = puppeteer.executablePath();
+    const executablePath = await puppeteer.executablePath();
     if (!fs.existsSync(executablePath)) {
       throw new Error(
         `Browser is not downloaded at ${executablePath}. Run 'npm install' and try to re-run tests`,
@@ -195,7 +195,7 @@ export const setupTestBrowserHooks = (): void => {
     const defaultTimeout = this.timeout() || 10_000;
     // Let mocha fail after the 1s of timeout.
     this.timeout(defaultTimeout + 1_000);
-    verifyExecutable();
+    await verifyExecutable();
     try {
       if (!state.browser) {
         if (!browserPromise) {
@@ -371,7 +371,7 @@ if (
     processVariables.defaultBrowserOptions.executablePath ||
     path.relative(
       process.cwd(),
-      puppeteer.executablePath({
+      await puppeteer.executablePath({
         headless: isHeadless
           ? processVariables.headless === 'shell'
             ? 'shell'


### PR DESCRIPTION
This allows us to switch the configuration to async which in turn allows us to support ESM config files.

Closes https://github.com/puppeteer/puppeteer/issues/14268