### PR TITLE
perf(webdriver): remove intermediate object wrappers

### DIFF
--- a/packages/puppeteer-core/src/bidi/BrowserContext.ts
+++ b/packages/puppeteer-core/src/bidi/BrowserContext.ts
@@ -97,7 +97,7 @@ export class BidiBrowserContext extends BrowserContext {
       this.#createPage(browsingContext);
     }
 
-    this.userContext.on('browsingcontext', ({browsingContext}) => {
+    this.userContext.on('browsingcontext', browsingContext => {
       const page = this.#createPage(browsingContext);
 
       // We need to wait for the DOMContentLoaded as the

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -109,7 +109,7 @@ export class BidiFrame extends Frame {
       this.#createFrameTarget(browsingContext);
     }
 
-    this.browsingContext.on('browsingcontext', ({browsingContext}) => {
+    this.browsingContext.on('browsingcontext', browsingContext => {
       this.#createFrameTarget(browsingContext);
     });
     this.browsingContext.on('closed', () => {
@@ -121,7 +121,7 @@ export class BidiFrame extends Frame {
       this.page().trustedEmitter.emit(PageEvent.FrameDetached, this);
     });
 
-    this.browsingContext.on('request', ({request}) => {
+    this.browsingContext.on('request', request => {
       const httpRequest = BidiHTTPRequest.from(
         request,
         this,
@@ -137,7 +137,7 @@ export class BidiFrame extends Frame {
       void httpRequest.finalizeInterceptions();
     });
 
-    this.browsingContext.on('navigation', ({navigation}) => {
+    this.browsingContext.on('navigation', navigation => {
       navigation.once('fragment', () => {
         this.page().trustedEmitter.emit(PageEvent.FrameNavigated, this);
       });
@@ -151,14 +151,14 @@ export class BidiFrame extends Frame {
       this.page().trustedEmitter.emit(PageEvent.FrameNavigated, this);
     });
 
-    this.browsingContext.on('userprompt', ({userPrompt}) => {
+    this.browsingContext.on('userprompt', userPrompt => {
       this.page().trustedEmitter.emit(
         PageEvent.Dialog,
         BidiDialog.from(userPrompt),
       );
     });
 
-    this.browsingContext.on('log', ({entry}) => {
+    this.browsingContext.on('log', entry => {
       if (this._id !== entry.source.context) {
         return;
       }
@@ -204,7 +204,7 @@ export class BidiFrame extends Frame {
       }
     });
 
-    this.browsingContext.on('worker', ({realm}) => {
+    this.browsingContext.on('worker', realm => {
       const worker = BidiWebWorker.from(this, realm);
       realm.on('destroyed', () => {
         this.page().trustedEmitter.emit(PageEvent.WorkerDestroyed, worker);
@@ -363,13 +363,13 @@ export class BidiFrame extends Frame {
           fromEmitterEvent(this.browsingContext, 'navigation'),
           fromEmitterEvent(this.browsingContext, 'historyUpdated').pipe(
             map(() => {
-              return {navigation: null};
+              return null;
             }),
           ),
         )
           .pipe(first())
           .pipe(
-            switchMap(({navigation}) => {
+            switchMap(navigation => {
               if (navigation === null) {
                 return of(null);
               }

--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -59,7 +59,7 @@ export abstract class BidiRealm extends Realm {
   }
 
   protected initialize(): void {
-    this.realm.on('destroyed', ({reason}) => {
+    this.realm.on('destroyed', reason => {
       this.taskManager.terminateAll(new Error(reason));
       this.dispose();
     });

--- a/packages/puppeteer-core/src/bidi/core/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/core/Browser.ts
@@ -32,20 +32,11 @@ export type AddPreloadScriptOptions = Omit<
  */
 export class Browser extends EventEmitter<{
   /** Emitted before the browser closes. */
-  closed: {
-    /** The reason for closing the browser. */
-    reason: string;
-  };
+  closed: string;
   /** Emitted after the browser disconnects. */
-  disconnected: {
-    /** The reason for disconnecting the browser. */
-    reason: string;
-  };
+  disconnected: string;
   /** Emitted when a shared worker is created. */
-  sharedworker: {
-    /** The realm of the shared worker. */
-    realm: SharedWorkerRealm;
-  };
+  sharedworker: SharedWorkerRealm;
 }> {
   static async from(session: Session): Promise<Browser> {
     const browser = new Browser(session);
@@ -70,7 +61,7 @@ export class Browser extends EventEmitter<{
     const sessionEmitter = this.#disposables.use(
       new EventEmitter(this.session),
     );
-    sessionEmitter.once('ended', ({reason}) => {
+    sessionEmitter.once('ended', reason => {
       this.dispose(reason);
     });
 
@@ -320,9 +311,9 @@ export class Browser extends EventEmitter<{
     this.#reason ??=
       'Browser was disconnected, probably because the session ended.';
     if (this.closed) {
-      this.emit('closed', {reason: this.#reason});
+      this.emit('closed', this.#reason);
     }
-    this.emit('disconnected', {reason: this.#reason});
+    this.emit('disconnected', this.#reason);
 
     this.#disposables.dispose();
     super[disposeSymbol]();

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -91,37 +91,19 @@ export type SetGeoLocationOverrideOptions =
  */
 export class BrowsingContext extends EventEmitter<{
   /** Emitted when this context is closed. */
-  closed: {
-    /** The reason the browsing context was closed */
-    reason: string;
-  };
+  closed: string;
   /** Emitted when a child browsing context is created. */
-  browsingcontext: {
-    /** The newly created child browsing context. */
-    browsingContext: BrowsingContext;
-  };
+  browsingcontext: BrowsingContext;
   /** Emitted whenever a navigation occurs. */
-  navigation: {
-    /** The navigation that occurred. */
-    navigation: Navigation;
-  };
+  navigation: Navigation;
   /** Emitted whenever a file dialog is opened occurs. */
   filedialogopened: Bidi.Input.FileDialogInfo;
   /** Emitted whenever a request is made. */
-  request: {
-    /** The request that was made. */
-    request: Request;
-  };
+  request: Request;
   /** Emitted whenever a log entry is added. */
-  log: {
-    /** Entry added to the log. */
-    entry: Bidi.Log.Entry;
-  };
+  log: Bidi.Log.Entry;
   /** Emitted whenever a prompt is opened. */
-  userprompt: {
-    /** The prompt that was opened. */
-    userPrompt: UserPrompt;
-  };
+  userprompt: UserPrompt;
   /** Emitted whenever the frame history is updated. */
   historyUpdated: void;
   /** Emitted whenever the frame emits `DOMContentLoaded` */
@@ -129,10 +111,7 @@ export class BrowsingContext extends EventEmitter<{
   /** Emitted whenever the frame emits `load` */
   load: void;
   /** Emitted whenever a dedicated worker is created */
-  worker: {
-    /** The realm for the new dedicated worker */
-    realm: DedicatedWorkerRealm;
-  };
+  worker: DedicatedWorkerRealm;
 }> {
   static from(
     userContext: UserContext,
@@ -206,7 +185,7 @@ export class BrowsingContext extends EventEmitter<{
     const userContextEmitter = this.#disposables.use(
       new EventEmitter(this.userContext),
     );
-    userContextEmitter.once('closed', ({reason}) => {
+    userContextEmitter.once('closed', reason => {
       this.dispose(`Browsing context already closed: ${reason}`);
     });
 
@@ -243,7 +222,7 @@ export class BrowsingContext extends EventEmitter<{
         this.#children.delete(browsingContext.id);
       });
 
-      this.emit('browsingcontext', {browsingContext});
+      this.emit('browsingcontext', browsingContext);
     });
     sessionEmitter.on('browsingContext.contextDestroyed', info => {
       if (info.context !== this.id) {
@@ -303,7 +282,7 @@ export class BrowsingContext extends EventEmitter<{
         });
       }
 
-      this.emit('navigation', {navigation: this.#navigation});
+      this.emit('navigation', this.#navigation);
     });
     sessionEmitter.on('network.beforeRequestSent', event => {
       if (event.context !== this.id) {
@@ -316,7 +295,7 @@ export class BrowsingContext extends EventEmitter<{
       }
 
       const request = Request.from(this, event);
-      this.emit('request', {request});
+      this.emit('request', request);
     });
 
     sessionEmitter.on('log.entryAdded', entry => {
@@ -324,7 +303,7 @@ export class BrowsingContext extends EventEmitter<{
         return;
       }
 
-      this.emit('log', {entry});
+      this.emit('log', entry);
     });
 
     sessionEmitter.on('browsingContext.userPromptOpened', info => {
@@ -333,7 +312,7 @@ export class BrowsingContext extends EventEmitter<{
       }
 
       const userPrompt = UserPrompt.from(this, info);
-      this.emit('userprompt', {userPrompt});
+      this.emit('userprompt', userPrompt);
     });
   }
 
@@ -371,7 +350,7 @@ export class BrowsingContext extends EventEmitter<{
   #createWindowRealm(sandbox?: string) {
     const realm = WindowRealm.from(this, sandbox);
     realm.on('worker', realm => {
-      this.emit('worker', {realm});
+      this.emit('worker', realm);
     });
     return realm;
   }
@@ -707,7 +686,7 @@ export class BrowsingContext extends EventEmitter<{
   override [disposeSymbol](): void {
     this.#reason ??=
       'Browsing context already closed, probably because the user context closed.';
-    this.emit('closed', {reason: this.#reason});
+    this.emit('closed', this.#reason);
 
     this.#disposables.dispose();
     super[disposeSymbol]();

--- a/packages/puppeteer-core/src/bidi/core/Navigation.ts
+++ b/packages/puppeteer-core/src/bidi/core/Navigation.ts
@@ -62,7 +62,7 @@ export class Navigation extends EventEmitter<{
       this.dispose();
     });
 
-    browsingContextEmitter.on('request', ({request}) => {
+    browsingContextEmitter.on('request', request => {
       if (
         request.navigation === undefined ||
         // If a request with a navigation ID comes in, then the navigation ID is

--- a/packages/puppeteer-core/src/bidi/core/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/core/Realm.ts
@@ -38,7 +38,7 @@ export abstract class Realm extends EventEmitter<{
   /** Emitted whenever the realm has updated. */
   updated: Realm;
   /** Emitted when the realm is destroyed. */
-  destroyed: {reason: string};
+  destroyed: string;
   /** Emitted when a dedicated worker is created in the realm. */
   worker: DedicatedWorkerRealm;
   /** Emitted when a shared worker is created in the realm. */
@@ -139,7 +139,7 @@ export abstract class Realm extends EventEmitter<{
   override [disposeSymbol](): void {
     this.#reason ??=
       'Realm already destroyed, probably because all associated browsing contexts closed.';
-    this.emit('destroyed', {reason: this.#reason});
+    this.emit('destroyed', this.#reason);
 
     this.disposables.dispose();
     super[disposeSymbol]();
@@ -172,7 +172,7 @@ export class WindowRealm extends Realm {
     const browsingContextEmitter = this.disposables.use(
       new EventEmitter(this.browsingContext),
     );
-    browsingContextEmitter.on('closed', ({reason}) => {
+    browsingContextEmitter.on('closed', reason => {
       this.dispose(reason);
     });
 

--- a/packages/puppeteer-core/src/bidi/core/Request.ts
+++ b/packages/puppeteer-core/src/bidi/core/Request.ts
@@ -62,9 +62,9 @@ export class Request extends EventEmitter<{
     const browsingContextEmitter = this.#disposables.use(
       new EventEmitter(this.#browsingContext),
     );
-    browsingContextEmitter.once('closed', ({reason}) => {
+    browsingContextEmitter.once('closed', reason => {
       this.#error = reason;
-      this.emit('error', this.#error);
+      this.emit('error', reason);
       this.dispose();
     });
 

--- a/packages/puppeteer-core/src/bidi/core/Session.ts
+++ b/packages/puppeteer-core/src/bidi/core/Session.ts
@@ -21,8 +21,8 @@ import type {BidiEvents, Commands, Connection} from './Connection.js';
  * @internal
  */
 export class Session
-  extends EventEmitter<BidiEvents & {ended: {reason: string}}>
-  implements Connection<BidiEvents & {ended: {reason: string}}>
+  extends EventEmitter<BidiEvents & {ended: string}>
+  implements Connection<BidiEvents & {ended: string}>
 {
   static async from(
     connection: Connection,
@@ -56,7 +56,7 @@ export class Session
     (this as any).browser = await Browser.from(this);
 
     const browserEmitter = this.#disposables.use(this.browser);
-    browserEmitter.once('closed', ({reason}) => {
+    browserEmitter.once('closed', reason => {
       this.dispose(reason);
     });
 
@@ -154,7 +154,7 @@ export class Session
   override [disposeSymbol](): void {
     this.#reason ??=
       'Session already destroyed, probably because the connection broke.';
-    this.emit('ended', {reason: this.#reason});
+    this.emit('ended', this.#reason);
 
     this.#disposables.dispose();
     super[disposeSymbol]();

--- a/packages/puppeteer-core/src/bidi/core/UserContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserContext.ts
@@ -33,17 +33,11 @@ export class UserContext extends EventEmitter<{
   /**
    * Emitted when a new browsing context is created.
    */
-  browsingcontext: {
-    /** The new browsing context. */
-    browsingContext: BrowsingContext;
-  };
+  browsingcontext: BrowsingContext;
   /**
    * Emitted when the user context is closed.
    */
-  closed: {
-    /** The reason the user context was closed. */
-    reason: string;
-  };
+  closed: string;
 }> {
   static DEFAULT = 'default' as const;
 
@@ -71,10 +65,10 @@ export class UserContext extends EventEmitter<{
     const browserEmitter = this.#disposables.use(
       new EventEmitter(this.browser),
     );
-    browserEmitter.once('closed', ({reason}) => {
+    browserEmitter.once('closed', reason => {
       this.dispose(`User context was closed: ${reason}`);
     });
-    browserEmitter.once('disconnected', ({reason}) => {
+    browserEmitter.once('disconnected', reason => {
       this.dispose(`User context was closed: ${reason}`);
     });
 
@@ -109,7 +103,7 @@ export class UserContext extends EventEmitter<{
         this.#browsingContexts.delete(browsingContext.id);
       });
 
-      this.emit('browsingcontext', {browsingContext});
+      this.emit('browsingcontext', browsingContext);
     });
   }
 
@@ -236,7 +230,7 @@ export class UserContext extends EventEmitter<{
   override [disposeSymbol](): void {
     this.#reason ??=
       'User context already closed, probably because the browser disconnected/closed.';
-    this.emit('closed', {reason: this.#reason});
+    this.emit('closed', this.#reason);
 
     this.#disposables.dispose();
     super[disposeSymbol]();

--- a/packages/puppeteer-core/src/bidi/core/UserPrompt.ts
+++ b/packages/puppeteer-core/src/bidi/core/UserPrompt.ts
@@ -35,10 +35,7 @@ export class UserPrompt extends EventEmitter<{
   /** Emitted when the user prompt is handled. */
   handled: UserPromptResult;
   /** Emitted when the user prompt is closed. */
-  closed: {
-    /** The reason the user prompt was closed. */
-    reason: string;
-  };
+  closed: string;
 }> {
   static from(
     browsingContext: BrowsingContext,
@@ -69,7 +66,7 @@ export class UserPrompt extends EventEmitter<{
     const browserContextEmitter = this.#disposables.use(
       new EventEmitter(this.browsingContext),
     );
-    browserContextEmitter.once('closed', ({reason}) => {
+    browserContextEmitter.once('closed', reason => {
       this.dispose(`User prompt already closed: ${reason}`);
     });
 
@@ -130,7 +127,7 @@ export class UserPrompt extends EventEmitter<{
   override [disposeSymbol](): void {
     this.#reason ??=
       'User prompt already closed, probably because the associated browsing context was destroyed.';
-    this.emit('closed', {reason: this.#reason});
+    this.emit('closed', this.#reason);
 
     this.#disposables.dispose();
     super[disposeSymbol]();


### PR DESCRIPTION
While the wrapper provide a nice API that can be extended, we do only use the value directly we have to wrap the data to only unwrap it immediately.