### PR TITLE
perf(browsers): update logger signature

### DIFF
--- a/packages/browsers/src/Cache.ts
+++ b/packages/browsers/src/Cache.ts
@@ -8,14 +8,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import debug from 'debug';
-
 import {
   Browser,
   type BrowserPlatform,
   executablePathByBrowser,
   getVersionComparator,
 } from './browser-data/browser-data.js';
+import {debug} from './debug.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
 
 const debugCache = debug('puppeteer:browsers:cache');
@@ -277,7 +276,7 @@ export class Cache {
       options.buildId =
         this.resolveAlias(options.browser, options.buildId) ?? options.buildId;
     } catch {
-      debugCache('could not read .metadata file for the browser');
+      debugCache?.('could not read .metadata file for the browser');
     }
     const installationDir = this.installationDir(
       options.browser,

--- a/packages/browsers/src/debug.ts
+++ b/packages/browsers/src/debug.ts
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import debug from 'debug';
+import type {Debugger} from 'debug';
+import debugModule from 'debug';
 
-export {debug};
+export const debug = (prefix: string): Debugger | undefined => {
+  const log = debugModule(prefix);
+  return log.enabled ? log : undefined;
+};

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -13,7 +13,7 @@ import type {Readable, Transform, Writable} from 'node:stream';
 import {Stream} from 'node:stream';
 import {promisify} from 'node:util';
 
-import debug from 'debug';
+import {debug} from './debug.js';
 
 const execFileAsync = promisify(execFile);
 const debugFileUtil = debug('puppeteer:browsers:fileUtil');
@@ -141,7 +141,7 @@ async function extractTar(
     )
       .once('error', handleError(decompressUtilityName))
       .once('exit', code => {
-        debugFileUtil(`${decompressUtilityName} exited, code=${code}`);
+        debugFileUtil?.(`${decompressUtilityName} exited, code=${code}`);
       });
 
     const tar = tarFs.extract(folderPath);

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -41,7 +41,7 @@ function debugTimeEnd(label: string) {
   }
   const duration =
     end[0] * 1000 + end[1] / 1e6 - (start[0] * 1000 + start[1] / 1e6); // calculate duration in milliseconds
-  debugInstall(`Duration for ${label}: ${duration}ms`);
+  debugInstall?.(`Duration for ${label}: ${duration}ms`);
 }
 
 /**
@@ -208,7 +208,7 @@ async function installWithProviders(
     try {
       // Check: does this provider support this browser/platform?
       if (!(await provider.supports(downloadOptions))) {
-        debugInstall(
+        debugInstall?.(
           `Provider ${provider.getName()} does not support ${options.browser} on ${options.platform}`,
         );
         continue;
@@ -216,26 +216,26 @@ async function installWithProviders(
 
       // Warn if using non-default provider
       if (!(provider instanceof DefaultProvider)) {
-        debugInstall(`⚠️  Using custom downloader: ${provider.getName()}`);
-        debugInstall(
+        debugInstall?.(`⚠️  Using custom downloader: ${provider.getName()}`);
+        debugInstall?.(
           `⚠️  Puppeteer does not guarantee compatibility with non-default providers`,
         );
       }
 
-      debugInstall(
+      debugInstall?.(
         `Trying provider: ${provider.getName()} for ${options.browser} ${options.buildId}`,
       );
 
       // Get download URL from provider
       const url = await provider.getDownloadUrl(downloadOptions);
       if (!url) {
-        debugInstall(
+        debugInstall?.(
           `Provider ${provider.getName()} returned no URL for ${options.browser} ${options.buildId}`,
         );
         continue;
       }
 
-      debugInstall(`Successfully got URL from ${provider.getName()}: ${url}`);
+      debugInstall?.(`Successfully got URL from ${provider.getName()}: ${url}`);
 
       if (!existsSync(browserRoot)) {
         await mkdir(browserRoot, {recursive: true});
@@ -244,7 +244,7 @@ async function installWithProviders(
       // Download and install using the URL from the provider
       return await installUrl(url, options, provider);
     } catch (err) {
-      debugInstall(
+      debugInstall?.(
         `Provider ${provider.getName()} failed: ${(err as Error).message}`,
       );
       errors.push({
@@ -317,7 +317,7 @@ async function installDeps(installedBrowser: InstalledBrowser) {
     'deb.deps',
   );
   if (!existsSync(depsPath)) {
-    debugInstall(`deb.deps file was not found at ${depsPath}`);
+    debugInstall?.(`deb.deps file was not found at ${depsPath}`);
     return;
   }
   const data = readFileSync(depsPath, 'utf-8').split('\n').join(',');
@@ -330,7 +330,7 @@ async function installDeps(installedBrowser: InstalledBrowser) {
       'Failed to install system dependencies: apt-get does not seem to be available',
     );
   }
-  debugInstall(`Trying to install dependencies: ${data}`);
+  debugInstall?.(`Trying to install dependencies: ${data}`);
   result = spawnSync('apt-get', [
     'satisfy',
     '-y',
@@ -342,7 +342,7 @@ async function installDeps(installedBrowser: InstalledBrowser) {
       `Failed to install system dependencies: status=${result.status},error=${result.error},stdout=${result.stdout.toString('utf8')},stderr=${result.stderr.toString('utf8')}`,
     );
   }
-  debugInstall(`Installed system dependencies ${data}`);
+  debugInstall?.(`Installed system dependencies ${data}`);
 }
 
 async function installUrl(
@@ -379,7 +379,7 @@ async function installUrl(
     if (existsSync(archivePath)) {
       return archivePath;
     }
-    debugInstall(`Downloading binary from ${url}`);
+    debugInstall?.(`Downloading binary from ${url}`);
     debugTime('download');
     await downloadFile(url, archivePath, downloadProgressCallback);
     debugTimeEnd('download');
@@ -398,7 +398,7 @@ async function installUrl(
     buildId: options.buildId,
     platform: options.platform,
   });
-  debugInstall(
+  debugInstall?.(
     `Using executable path from provider: ${relativeExecutablePath}`,
   );
 
@@ -435,7 +435,7 @@ async function installUrl(
 
     // Check if archive already exists (e.g., from a custom provider)
     if (!existsSync(archivePath)) {
-      debugInstall(`Downloading binary from ${url}`);
+      debugInstall?.(`Downloading binary from ${url}`);
       try {
         debugTime('download');
         await downloadFile(url, archivePath, downloadProgressCallback);
@@ -443,10 +443,10 @@ async function installUrl(
         debugTimeEnd('download');
       }
     } else {
-      debugInstall(`Using existing archive at ${archivePath}`);
+      debugInstall?.(`Using existing archive at ${archivePath}`);
     }
 
-    debugInstall(`Installing ${archivePath} to ${outputPath}`);
+    debugInstall?.(`Installing ${archivePath} to ${outputPath}`);
     try {
       debugTime('extract');
       await unpackArchive(archivePath, outputPath);

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -321,7 +321,7 @@ export class Process {
 
     const env = opts.env || {};
 
-    debugLaunch(`Launching ${this.#executablePath} ${this.#args.join(' ')}`, {
+    debugLaunch?.(`Launching ${this.#executablePath} ${this.#args.join(' ')}`, {
       detached: opts.detached,
       env: Object.keys(env).reduce<Record<string, string | undefined>>(
         (res, key) => {
@@ -347,7 +347,7 @@ export class Process {
     this.#recordStream(this.#browserProcess.stderr!);
     this.#recordStream(this.#browserProcess.stdout!);
 
-    debugLaunch(`Launched ${this.#browserProcess.pid}`);
+    debugLaunch?.(`Launched ${this.#browserProcess.pid}`);
     if (opts.dumpio) {
       this.#browserProcess.stderr?.pipe(process.stderr);
       this.#browserProcess.stdout?.pipe(process.stdout);
@@ -367,7 +367,7 @@ export class Process {
     }
     this.#browserProcessExiting = new Promise((resolve, reject) => {
       this.#browserProcess.once('exit', async () => {
-        debugLaunch(`Browser process ${this.#browserProcess.pid} onExit`);
+        debugLaunch?.(`Browser process ${this.#browserProcess.pid} onExit`);
         this.#clearListeners();
         this.#exited = true;
         try {
@@ -438,7 +438,7 @@ export class Process {
   }
 
   kill(): void {
-    debugLaunch(`Trying to kill ${this.#browserProcess.pid}`);
+    debugLaunch?.(`Trying to kill ${this.#browserProcess.pid}`);
     // If the process failed to launch (for example if the browser executable path
     // is invalid), then the process does not get a pid assigned. A call to
     // `proc.kill` would error, as the `pid` to-be-killed can not be found.
@@ -448,14 +448,14 @@ export class Process {
       pidExists(this.#browserProcess.pid)
     ) {
       try {
-        debugLaunch(`Browser process ${this.#browserProcess.pid} exists`);
+        debugLaunch?.(`Browser process ${this.#browserProcess.pid} exists`);
         if (process.platform === 'win32') {
           try {
             childProcess.execSync(
               `taskkill /pid ${this.#browserProcess.pid} /T /F`,
             );
           } catch (error) {
-            debugLaunch(
+            debugLaunch?.(
               `Killing ${this.#browserProcess.pid} using taskkill failed`,
               error,
             );
@@ -472,7 +472,7 @@ export class Process {
           try {
             process.kill(processGroupId, 'SIGKILL');
           } catch (error) {
-            debugLaunch(
+            debugLaunch?.(
               `Killing ${this.#browserProcess.pid} using process.kill failed`,
               error,
             );


### PR DESCRIPTION
This make it so that if the logger is not enabled we won't create intermediate object, or concat strings saving some memory and/or compute. 