### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -128,6 +128,7 @@ const config = {
         ],
       }),
     ],
+    'docusaurus-plugin-copy-page-button',
   ],
   presets: [
     [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,6 +18,7 @@
         "@mdx-js/react": "3.1.1",
         "algoliasearch-helper": "3.29.1",
         "clsx": "2.1.1",
+        "docusaurus-plugin-copy-page-button": "0.5.2",
         "prism-react-renderer": "2.4.1",
         "react": "19.2.6",
         "react-cookie-consent": "10.0.1",
@@ -9646,6 +9647,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.5.2.tgz",
+      "integrity": "sha512-k1zdpHWPSktyxTnKfi5kN4ObDDYXQ7HEJBBL5euSTuQfE+SKryvGeDyt8uDhS0FFNcWjTbYPU+AxNWSgqe2Zfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/dom-serializer": {

--- a/website/package.json
+++ b/website/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "3.1.1",
     "algoliasearch-helper": "3.29.1",
     "clsx": "2.1.1",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "0.5.2",
     "prism-react-renderer": "2.4.1",
     "react": "19.2.6",
     "react-cookie-consent": "10.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "@mdx-js/react": "3.1.1",
     "algoliasearch-helper": "3.29.1",
     "clsx": "2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "prism-react-renderer": "2.4.1",
     "react": "19.2.6",
     "react-cookie-consent": "10.0.1",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Puppeteer docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Puppeteer

Puppeteer's API surface is exactly the kind of material that ends up in AI prompts — `page.evaluate`, locators, network interception, `waitForSelector` edge cases, headless-mode quirks. Developers automate browsers because they're stuck on something specific, and the next step after reading the docs is often pasting them into Claude or ChatGPT with the failing script. This plugin makes that one click instead of a manual select-and-copy.

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, and Cardano docs. Listed in the [official Docusaurus community plugins](https://docusaurus.io/community/resources#plugins).

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies` in `website/package.json` (^0.4.2, alphabetical)
- Appends the plugin string to the `plugins` array in `website/docusaurus.config.js`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly, ~5kb client.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.