### PR TITLE
fix: fix tar.exe invocation on Windows

### DIFF
--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -196,6 +196,7 @@ async function extractZip(
       // -x: extract files
       // -f: specify the archive file
       // -C: extract to the specified directory
+      // Relative dir to avoid disk paths.
       await execFileAsync('tar.exe', [
         '-xf',
         path.relative(process.cwd(), archivePath),

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -196,7 +196,12 @@ async function extractZip(
       // -x: extract files
       // -f: specify the archive file
       // -C: extract to the specified directory
-      await execFileAsync('tar.exe', ['-xf', archivePath, '-C', folderPath]);
+      await execFileAsync('tar.exe', [
+        '-xf',
+        path.relative(process.cwd(), archivePath),
+        '-C',
+        path.relative(process.cwd(), folderPath),
+      ]);
     } else {
       // -o: overwrite existing files without prompting
       // -d: extract files into the specified directory

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -196,13 +196,10 @@ async function extractZip(
       // -x: extract files
       // -f: specify the archive file
       // -C: extract to the specified directory
-      // Relative dir to avoid disk paths.
-      await execFileAsync('tar.exe', [
-        '-xf',
-        path.relative(process.cwd(), archivePath),
-        '-C',
-        path.relative(process.cwd(), folderPath),
-      ]);
+      const systemRoot =
+        process.env['SystemRoot'] ?? process.env['SYSTEMROOT'] ?? 'C:\\Windows';
+      const systemTar = `${systemRoot}\\System32\\tar.exe`;
+      await execFileAsync(systemTar, ['-xf', archivePath, '-C', folderPath]);
     } else {
       // -o: overwrite existing files without prompting
       // -d: extract files into the specified directory


### PR DESCRIPTION
Depending on the configuration tar.exe might have been pointing to the wrong tar.exe (e.g., the one from git bash). Tested on a local Windows.

This was not called by tests either due to caching or due to difference between GitHub actions configurations.

ANY_LGTM