### PR TITLE
chore(webmcp): Update list tools test with fixed declarative behavior

### DIFF
--- a/test/src/cdp/webmcp.spec.ts
+++ b/test/src/cdp/webmcp.spec.ts
@@ -87,7 +87,11 @@ describe('Page.webmcp', function () {
 
     expect(tools[1]!.name).toBe('declarative tool name');
     expect(tools[1]!.description).toBe('tool description');
-    expect(tools[1]!.inputSchema).toStrictEqual({});
+    expect(tools[1]!.inputSchema).toStrictEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+    });
     expect(tools[1]!.annotations).toBeDefined();
     expect(tools[1]!.annotations!.autosubmit).toBe(true);
     expect(tools[1]!.frame).toBe(page.mainFrame());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

It makes sure tests comply with updated declarative behavior in Chromium

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR updates tests now that declarative tools schema is set properly with https://chromium-review.googlesource.com/c/chromium/src/+/7817087. This change is also backported to Chrome 149.

**Does this PR introduce a breaking change?**

None that I'm aware of.

**Other information**

This is still experimental.

cc @OrKoN 