### PR TITLE
fix: Throw TargetCloseError when session ID not found

### DIFF
--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -89,6 +89,13 @@ export class CdpCDPSession extends CDPSession {
     return parent ?? undefined;
   }
 
+  /**
+   * @internal
+   */
+  getParentSessionId(): string | undefined {
+    return this.#parentSessionId;
+  }
+
   override send<T extends keyof ProtocolMapping.Commands>(
     method: T,
     params?: ProtocolMapping.Commands[T]['paramsType'][0],
@@ -101,20 +108,15 @@ export class CdpCDPSession extends CDPSession {
         ),
       );
     }
-    return this.#connection
-      ._rawSend(this.#callbacks, method, params, this.#sessionId, options)
-      .catch(error => {
-        if (
-          error instanceof Error &&
-          error.message.includes('Session with given id not found')
-        ) {
-          throw new TargetCloseError(
-            `Protocol error (${method}): Session with given id not found.`,
-          );
-        }
-        throw error;
-      });
+    return this.#connection._rawSend(
+      this.#callbacks,
+      method,
+      params,
+      this.#sessionId,
+      options,
+    );
   }
+
   /**
    * @internal
    */

--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -108,6 +108,7 @@ export class CdpCDPSession extends CDPSession {
           error instanceof Error &&
           error.message.includes('Session with given id not found')
         ) {
+          this.onClosed();
           throw new TargetCloseError(
             `Protocol error (${method}): Session with given id not found.`,
           );

--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -101,15 +101,20 @@ export class CdpCDPSession extends CDPSession {
         ),
       );
     }
-    return this.#connection._rawSend(
-      this.#callbacks,
-      method,
-      params,
-      this.#sessionId,
-      options,
-    );
+    return this.#connection
+      ._rawSend(this.#callbacks, method, params, this.#sessionId, options)
+      .catch(error => {
+        if (
+          error instanceof Error &&
+          error.message.includes('Session with given id not found')
+        ) {
+          throw new TargetCloseError(
+            `Protocol error (${method}): Session with given id not found.`,
+          );
+        }
+        throw error;
+      });
   }
-
   /**
    * @internal
    */

--- a/packages/puppeteer-core/src/cdp/CdpSession.ts
+++ b/packages/puppeteer-core/src/cdp/CdpSession.ts
@@ -89,13 +89,6 @@ export class CdpCDPSession extends CDPSession {
     return parent ?? undefined;
   }
 
-  /**
-   * @internal
-   */
-  getParentSessionId(): string | undefined {
-    return this.#parentSessionId;
-  }
-
   override send<T extends keyof ProtocolMapping.Commands>(
     method: T,
     params?: ProtocolMapping.Commands[T]['paramsType'][0],
@@ -108,15 +101,20 @@ export class CdpCDPSession extends CDPSession {
         ),
       );
     }
-    return this.#connection._rawSend(
-      this.#callbacks,
-      method,
-      params,
-      this.#sessionId,
-      options,
-    );
+    return this.#connection
+      ._rawSend(this.#callbacks, method, params, this.#sessionId, options)
+      .catch(error => {
+        if (
+          error instanceof Error &&
+          error.message.includes('Session with given id not found')
+        ) {
+          throw new TargetCloseError(
+            `Protocol error (${method}): Session with given id not found.`,
+          );
+        }
+        throw error;
+      });
   }
-
   /**
    * @internal
    */

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -217,13 +217,7 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
     } else if (object.method === 'Target.detachedFromTarget') {
       const session = this.#sessions.get(object.params.sessionId);
       if (session) {
-        session.onClosed();
-        this.#sessions.delete(object.params.sessionId);
-        this.emit(CDPSessionEvent.SessionDetached, session);
-        const parentSession = this.#sessions.get(object.sessionId);
-        if (parentSession) {
-          parentSession.emit(CDPSessionEvent.SessionDetached, session);
-        }
+        this.#onSessionDetached(session);
       }
     }
     if (object.sessionId) {
@@ -256,6 +250,28 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
       }
     } else {
       this.emit(object.method, object.params);
+    }
+  }
+
+  #onSessionDetached(session: CdpCDPSession): void {
+    const children = [];
+    for (const child of this.#sessions.values()) {
+      if (child.getParentSessionId() === session.id()) {
+        children.push(child);
+      }
+    }
+    for (const child of children) {
+      this.#onSessionDetached(child);
+    }
+    session.onClosed();
+    this.#sessions.delete(session.id());
+    this.emit(CDPSessionEvent.SessionDetached, session);
+    const parentSessionId = session.getParentSessionId();
+    const parentSession = parentSessionId
+      ? this.#sessions.get(parentSessionId)
+      : undefined;
+    if (parentSession) {
+      parentSession.emit(CDPSessionEvent.SessionDetached, session);
     }
   }
 

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -217,7 +217,13 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
     } else if (object.method === 'Target.detachedFromTarget') {
       const session = this.#sessions.get(object.params.sessionId);
       if (session) {
-        this.#onSessionDetached(session);
+        session.onClosed();
+        this.#sessions.delete(object.params.sessionId);
+        this.emit(CDPSessionEvent.SessionDetached, session);
+        const parentSession = this.#sessions.get(object.sessionId);
+        if (parentSession) {
+          parentSession.emit(CDPSessionEvent.SessionDetached, session);
+        }
       }
     }
     if (object.sessionId) {
@@ -250,28 +256,6 @@ export class Connection extends EventEmitter<CDPSessionEvents> {
       }
     } else {
       this.emit(object.method, object.params);
-    }
-  }
-
-  #onSessionDetached(session: CdpCDPSession): void {
-    const children = [];
-    for (const child of this.#sessions.values()) {
-      if (child.getParentSessionId() === session.id()) {
-        children.push(child);
-      }
-    }
-    for (const child of children) {
-      this.#onSessionDetached(child);
-    }
-    session.onClosed();
-    this.#sessions.delete(session.id());
-    this.emit(CDPSessionEvent.SessionDetached, session);
-    const parentSessionId = session.getParentSessionId();
-    const parentSession = parentSessionId
-      ? this.#sessions.get(parentSessionId)
-      : undefined;
-    if (parentSession) {
-      parentSession.emit(CDPSessionEvent.SessionDetached, session);
     }
   }
 

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -7,7 +7,6 @@
 import expect from 'expect';
 import type {Target} from 'puppeteer-core/internal/api/Target.js';
 import {CdpCDPSession} from 'puppeteer-core/internal/cdp/CdpSession.js';
-import {TargetCloseError} from 'puppeteer-core/internal/common/Errors.js';
 import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
 
 import {getTestState, setupTestBrowserHooks} from '../mocha-utils.js';
@@ -198,16 +197,34 @@ describe('Target.createCDPSession', function () {
     );
     connection._sessions.set('fake-session-id', fakeSession);
 
-    const error = await fakeSession
-      .send('Runtime.evaluate', {
+    await expect(
+      fakeSession.send('Runtime.evaluate', {
         expression: '1 + 1',
-      })
-      .catch(error => {
-        return error;
-      });
-    expect(error).toBeInstanceOf(TargetCloseError);
-    expect(error.message).toBe(
-      'Protocol error (Runtime.evaluate): Session with given id not found.',
+      }),
+    ).rejects.toThrow(/Session with given id not found/);
+  });
+
+  it('should detach child sessions when a parent session is detached', async () => {
+    const {page} = await getTestState();
+    const parentSession = (await page.createCDPSession()) as CdpCDPSession;
+    const connection = parentSession.connection()!;
+
+    const childSession = new CdpCDPSession(
+      connection,
+      'other',
+      'child-session-id',
+      parentSession.id(),
+      false,
     );
+    connection._sessions.set('child-session-id', childSession);
+
+    expect(connection._sessions.has('child-session-id')).toBe(true);
+    expect(childSession.detached).toBe(false);
+
+    await parentSession.detach();
+
+    expect(parentSession.detached).toBe(true);
+    expect(childSession.detached).toBe(true);
+    expect(connection._sessions.has('child-session-id')).toBe(false);
   });
 });

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -7,6 +7,7 @@
 import expect from 'expect';
 import type {Target} from 'puppeteer-core/internal/api/Target.js';
 import {CdpCDPSession} from 'puppeteer-core/internal/cdp/CdpSession.js';
+import {TargetCloseError} from 'puppeteer-core/internal/common/Errors.js';
 import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
 
 import {getTestState, setupTestBrowserHooks} from '../mocha-utils.js';
@@ -197,10 +198,16 @@ describe('Target.createCDPSession', function () {
     );
     connection._sessions.set('fake-session-id', fakeSession);
 
-    await expect(
-      fakeSession.send('Runtime.evaluate', {
+    const error = await fakeSession
+      .send('Runtime.evaluate', {
         expression: '1 + 1',
-      }),
-    ).rejects.toThrow(/Session with given id not found/);
+      })
+      .catch(error => {
+        return error;
+      });
+    expect(error).toBeInstanceOf(TargetCloseError);
+    expect(error.message).toBe(
+      'Protocol error (Runtime.evaluate): Session with given id not found.',
+    );
   });
 });

--- a/test/src/cdp/CDPSession.spec.ts
+++ b/test/src/cdp/CDPSession.spec.ts
@@ -7,6 +7,7 @@
 import expect from 'expect';
 import type {Target} from 'puppeteer-core/internal/api/Target.js';
 import {CdpCDPSession} from 'puppeteer-core/internal/cdp/CdpSession.js';
+import {TargetCloseError} from 'puppeteer-core/internal/common/Errors.js';
 import {isErrorLike} from 'puppeteer-core/internal/util/ErrorLike.js';
 
 import {getTestState, setupTestBrowserHooks} from '../mocha-utils.js';
@@ -197,34 +198,16 @@ describe('Target.createCDPSession', function () {
     );
     connection._sessions.set('fake-session-id', fakeSession);
 
-    await expect(
-      fakeSession.send('Runtime.evaluate', {
+    const error = await fakeSession
+      .send('Runtime.evaluate', {
         expression: '1 + 1',
-      }),
-    ).rejects.toThrow(/Session with given id not found/);
-  });
-
-  it('should detach child sessions when a parent session is detached', async () => {
-    const {page} = await getTestState();
-    const parentSession = (await page.createCDPSession()) as CdpCDPSession;
-    const connection = parentSession.connection()!;
-
-    const childSession = new CdpCDPSession(
-      connection,
-      'other',
-      'child-session-id',
-      parentSession.id(),
-      false,
+      })
+      .catch(error => {
+        return error;
+      });
+    expect(error).toBeInstanceOf(TargetCloseError);
+    expect(error.message).toBe(
+      'Protocol error (Runtime.evaluate): Session with given id not found.',
     );
-    connection._sessions.set('child-session-id', childSession);
-
-    expect(connection._sessions.has('child-session-id')).toBe(true);
-    expect(childSession.detached).toBe(false);
-
-    await parentSession.detach();
-
-    expect(parentSession.detached).toBe(true);
-    expect(childSession.detached).toBe(true);
-    expect(connection._sessions.has('child-session-id')).toBe(false);
   });
 });


### PR DESCRIPTION
This addresses https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/1797

When a parent session is detached or closed, any child target sessions attached underneath it are implicitly destroyed by the browser. Because the parent session is detached first, Puppeteer's `Connection` never receives or processes a `Target.detachedFromTarget` event specifically for the child session. This leaves the child session orphaned in the Connection's active `#sessions` map, still marked as active/attached (`session.detached === false`).

When Puppeteer attempts to perform global operations across all active clients—such as applying network conditions or disabling cache—it sends a CDP command to all sessions tracked in the map. The command sent to the orphaned session fails with: `Error: Protocol error (Network.emulateNetworkConditions): Session with given id not found`.

Since `#canIgnoreError` in `NetworkManager.ts` does not recognize this error string, Puppeteer throws a `ProtocolError`, causing the entire execution (such as Lighthouse audits or page throttling actions) to crash.

This fix makes it so that a `TargetCloseError` is thrown, which is ignored in `NetworkManger.ts`.