### PR TITLE
test: reenable flake 14774

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1229,13 +1229,6 @@
     "comment": "We can't connect to a browser started with pipe:true"
   },
   {
-    "testIdPattern": "[fixtures.spec] Fixtures should dump browser process stderr",
-    "platforms": ["win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["SKIP"],
-    "comment": "See https://github.com/puppeteer/puppeteer/issues/14774"
-  },
-  {
     "testIdPattern": "[frame.spec] Frame specs Frame Management should support framesets",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome", "webDriverBiDi"],


### PR DESCRIPTION
Closes #14774

This test is either a flake, or something changed and it started passing, see discussion in the linked bug.