### PR TITLE
feat(browsers): add unpacking progress indicator to install command

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -642,6 +642,7 @@ export class CLI {
       platform: args.platform,
       cacheDir: args.path ?? this.#cachePath,
       downloadProgressCallback: 'default',
+      unpackProgressCallback: 'default',
       baseUrl: args.baseUrl,
       buildIdAlias:
         originalBuildId !== args.browser.buildId ? originalBuildId : undefined,

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -93,6 +93,11 @@ export interface InstallOptions {
    */
   baseUrl?: string;
   /**
+   * Provides information about the progress of the unpacking.
+   * If set to 'default', a default spinner indicator will be used.
+   */
+  unpackProgressCallback?: 'default' | ((message: string) => void);
+  /**
    * Whether to unpack and install browser archives.
    *
    * @defaultValue `true`
@@ -447,11 +452,17 @@ async function installUrl(
     }
 
     debugInstall?.(`Installing ${archivePath} to ${outputPath}`);
+    const unpackCallback =
+      options.unpackProgressCallback === 'default'
+        ? makeDefaultUnpackCallback(options.browser, options.buildId)
+        : options.unpackProgressCallback;
+    unpackCallback?.(`Unpacking ${options.browser} ${options.buildId}`);
     try {
       debugTime('extract');
       await unpackArchive(archivePath, outputPath);
     } finally {
       debugTimeEnd('extract');
+      unpackCallback?.(`Unpacking ${options.browser} ${options.buildId} done`);
     }
 
     if (options.buildIdAlias) {
@@ -630,6 +641,43 @@ const importProgressBarIfNeeded = async () => {
 
   return ProgressBarClass;
 };
+
+/**
+ * @internal
+ */
+export function makeDefaultUnpackCallback(
+  browser: Browser,
+  buildId: string,
+): (message: string) => void {
+  const spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+  let frameIndex = 0;
+  let interval: ReturnType<typeof setInterval> | undefined;
+
+  return (message: string) => {
+    if (message.endsWith('done')) {
+      if (interval) {
+        clearInterval(interval);
+        interval = undefined;
+      }
+      process.stdout.write(
+        `\r${' '.repeat(60)}\r`,
+      );
+      process.stdout.write(
+        `Unpacking ${browser} ${buildId} done\n`,
+      );
+    } else {
+      process.stdout.write(
+        `\r${spinnerFrames[frameIndex]} ${message}`,
+      );
+      interval = setInterval(() => {
+        frameIndex = (frameIndex + 1) % spinnerFrames.length;
+        process.stdout.write(
+          `\r${spinnerFrames[frameIndex]} ${message}`,
+        );
+      }, 80);
+    }
+  };
+}
 
 /**
  * @internal

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -46,6 +46,7 @@ async function downloadBrowser({
       platform,
       buildId,
       downloadProgressCallback: 'default',
+      unpackProgressCallback: 'default',
       baseUrl,
       buildIdAlias:
         buildId !== unresolvedBuildId ? unresolvedBuildId : undefined,


### PR DESCRIPTION
## Summary

Adds a spinner-based progress indicator that displays during browser archive unpacking, so users know the process hasn't stalled after download completes.

Fixes #13083

## Changes

- Added `unpackProgressCallback` option to `InstallOptions` interface (supports `'default'` or custom callback)
- Implemented `makeDefaultUnpackCallback()` with an animated braille spinner that runs during extraction
- Wired up the callback in `installUrl()` around the `unpackArchive()` call
- Enabled the default unpack indicator in both `CLI.ts` and `packages/puppeteer/src/node/install.ts`

## Behavior

When `unpackProgressCallback` is set to `'default'`:
- A spinner animation displays `⠋ Unpacking chrome 131.0.6778.204` during extraction
- On completion, the line is replaced with `Unpacking chrome 131.0.6778.204 done`
- Custom callbacks receive string messages for start/done events

## Testing

- TypeScript compilation passes with no new errors (`tsc --noEmit --skipLibCheck`)
- The implementation follows the same pattern as the existing `downloadProgressCallback`/`makeProgressCallback`