### PR TITLE
refactor: remove progress dependency

### DIFF
--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -83,7 +83,6 @@
     "!*.tsbuildinfo"
   ],
   "dependencies": {
-    "progress": "^2.0.3",
     "tar-fs": "^3.1.1",
     "yargs": "^17.7.2",
     "semver": "^7.7.4"
@@ -98,9 +97,7 @@
   },
   "devDependencies": {
     "proxy-agent": ">=8.0.1",
-    "@types/progress": "2.0.7",
     "@types/tar-fs": "2.0.4",
-    "@types/yargs": "17.0.33",
-    "@types/ws": "8.18.1"
+    "@types/yargs": "17.0.33"
   }
 }

--- a/packages/browsers/src/ProgressBar.ts
+++ b/packages/browsers/src/ProgressBar.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @internal
+ */
 export interface ProgressBarOptions {
   total: number;
   stream?: NodeJS.WriteStream;

--- a/packages/browsers/src/ProgressBar.ts
+++ b/packages/browsers/src/ProgressBar.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ProgressBarOptions {
+  total: number;
+  stream?: NodeJS.WriteStream;
+}
+
+/**
+ * @internal
+ */
+export class ProgressBar {
+  #title: string;
+  #total: number;
+  #stream: NodeJS.WriteStream;
+  #downloaded = 0;
+  #startTime = 0;
+  #lastDrawn = '';
+
+  constructor(title: string, options: ProgressBarOptions) {
+    this.#title = title;
+    this.#total = options.total;
+    this.#stream = options.stream ?? process.stderr;
+  }
+
+  tick(delta: number): void {
+    if (this.#startTime === 0) {
+      this.#startTime = Date.now();
+    }
+    this.#downloaded += delta;
+
+    this.#render();
+
+    if (this.#downloaded >= this.#total) {
+      this.#stream.write('\n');
+    }
+  }
+
+  #render(): void {
+    if (!this.#stream.isTTY) {
+      return;
+    }
+
+    const ratio = Math.min(1, Math.max(0, this.#downloaded / this.#total));
+    const percent = Math.round(ratio * 100);
+    const elapsedMs = Date.now() - this.#startTime;
+    const rate = elapsedMs > 0 ? this.#downloaded / elapsedMs : 0; // bytes per millisecond
+    const remaining = this.#total - this.#downloaded;
+    const etaSec = rate > 0 ? remaining / rate / 1000 : 0;
+
+    const width = 20;
+    const completeCount = Math.round(width * ratio);
+    const barStr =
+      '='.repeat(completeCount) + ' '.repeat(width - completeCount);
+
+    const rendered = `${this.#title} [${barStr}] ${percent}% ${etaSec.toFixed(1)}s `;
+
+    if (this.#lastDrawn !== rendered) {
+      this.#stream.cursorTo(0);
+      this.#stream.write(rendered);
+      this.#stream.clearLine(1);
+      this.#lastDrawn = rendered;
+    }
+  }
+}

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -11,8 +11,6 @@ import {mkdir, unlink} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import type * as ProgressBar from 'progress';
-
 import {
   Browser,
   BrowserPlatform,
@@ -24,6 +22,7 @@ import {DefaultProvider} from './DefaultProvider.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
 import {unpackArchive} from './fileUtil.js';
 import {downloadFile, headHttpRequest} from './httpUtil.js';
+import {ProgressBar} from './ProgressBar.js';
 import type {BrowserProvider} from './provider.js';
 
 const debugInstall = debug('puppeteer:browsers:install');
@@ -618,19 +617,6 @@ export function getDownloadUrl(
 ): URL {
   return new URL(downloadUrls[browser](platform, buildId, baseUrl));
 }
-
-let ProgressBarClass: new (
-  format: string,
-  options: ProgressBar.ProgressBarOptions,
-) => ProgressBar;
-const importProgressBarIfNeeded = async () => {
-  if (!ProgressBarClass) {
-    ProgressBarClass = (await import('progress')).default;
-  }
-
-  return ProgressBarClass;
-};
-
 /**
  * @internal
  */
@@ -638,18 +624,14 @@ export async function makeProgressCallback(
   browser: Browser,
   buildId: string,
 ): Promise<(downloadedBytes: number, totalBytes: number) => void> {
-  const ProgressBarClass = await importProgressBarIfNeeded();
   let progressBar: ProgressBar;
 
   let lastDownloadedBytes = 0;
   return (downloadedBytes: number, totalBytes: number) => {
     if (!progressBar) {
-      progressBar = new ProgressBarClass(
-        `Downloading ${browser} ${buildId} - ${toMegabytes(totalBytes)} [:bar] :percent :etas `,
+      progressBar = new ProgressBar(
+        `Downloading ${browser} ${buildId} - ${toMegabytes(totalBytes)}`,
         {
-          complete: '=',
-          incomplete: ' ',
-          width: 20,
           total: totalBytes,
         },
       );

--- a/packages/browsers/test/src/ProgressBar.spec.ts
+++ b/packages/browsers/test/src/ProgressBar.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+
+import {ProgressBar} from '../../lib/ProgressBar.js';
+
+describe('ProgressBar', () => {
+  let writes: string[] = [];
+  let cursorToCalls: number[] = [];
+  let clearLineCalls: number[] = [];
+
+  function createMockStream(isTTY: boolean, columns = 80) {
+    writes = [];
+    cursorToCalls = [];
+    clearLineCalls = [];
+
+    return {
+      isTTY,
+      columns,
+      write(str: string) {
+        writes.push(str);
+        return true;
+      },
+      cursorTo(x: number) {
+        cursorToCalls.push(x);
+        return this;
+      },
+      clearLine(dir: number) {
+        clearLineCalls.push(dir);
+        return this;
+      },
+    } as unknown as NodeJS.WriteStream;
+  }
+
+  it('should not render when isTTY is false', () => {
+    const stream = createMockStream(false);
+    const bar = new ProgressBar('Downloading', {
+      total: 100,
+      stream,
+    });
+
+    bar.tick(50);
+    assert.strictEqual(writes.length, 0);
+  });
+
+  it('should render bar and percent tokens on TTY streams', () => {
+    const stream = createMockStream(true, 80);
+    const bar = new ProgressBar('Downloading', {
+      total: 10,
+      stream,
+    });
+
+    bar.tick(5);
+    assert.strictEqual(writes.length, 1);
+    assert.strictEqual(
+      writes[0],
+      'Downloading [==========          ] 50% 0.0s ',
+    );
+    assert.deepStrictEqual(cursorToCalls, [0]);
+    assert.deepStrictEqual(clearLineCalls, [1]);
+  });
+
+  it('should complete the progress bar and print a newline', () => {
+    const stream = createMockStream(true, 80);
+    const bar = new ProgressBar('Downloading', {
+      total: 4,
+      stream,
+    });
+
+    bar.tick(2);
+    assert.strictEqual(
+      writes[writes.length - 1],
+      'Downloading [==========          ] 50% 0.0s ',
+    );
+
+    bar.tick(2);
+    assert.strictEqual(
+      writes[writes.length - 2],
+      'Downloading [====================] 100% 0.0s ',
+    );
+    assert.strictEqual(writes[writes.length - 1], '\n');
+  });
+});


### PR DESCRIPTION
Implements just the things we need. Drive-by: removes ws types.