### PR TITLE
feat: expose Explicit Resource Management (`using`)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1546,11 +1546,25 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="asyncdisposesymbol">[asyncDisposeSymbol](./puppeteer.asyncdisposesymbol.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="default_intercept_resolution_priority">[DEFAULT\_INTERCEPT\_RESOLUTION\_PRIORITY](./puppeteer.default_intercept_resolution_priority.md)</span>
 
 </td><td>
 
 The default cooperative request interception resolution priority
+
+</td></tr>
+<tr><td>
+
+<span id="disposesymbol">[disposeSymbol](./puppeteer.disposesymbol.md)</span>
+
+</td><td>
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.asyncdisposesymbol.md
+++ b/docs/api/puppeteer.asyncdisposesymbol.md
@@ -1,0 +1,11 @@
+---
+sidebar_label: asyncDisposeSymbol
+---
+
+# asyncDisposeSymbol variable
+
+### Signature
+
+```typescript
+asyncDisposeSymbol: typeof Symbol.asyncDispose;
+```

--- a/docs/api/puppeteer.browser._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.browser._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Browser.[asyncDisposeSymbol]
+---
+
+# Browser.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class Browser {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browser._disposesymbol_.md
+++ b/docs/api/puppeteer.browser._disposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Browser.[disposeSymbol]
+---
+
+# Browser.\[disposeSymbol\]() method
+
+### Signature
+
+```typescript
+class Browser {
+  [disposeSymbol](): void;
+}
+```
+
+**Returns:**
+
+void

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -130,6 +130,24 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.browser._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="_disposesymbol_">[\[disposeSymbol\]()](./puppeteer.browser._disposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="addscreen">[addScreen(params)](./puppeteer.browser.addscreen.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.browsercontext._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.browsercontext._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: BrowserContext.[asyncDisposeSymbol]
+---
+
+# BrowserContext.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class BrowserContext {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.browsercontext._disposesymbol_.md
+++ b/docs/api/puppeteer.browsercontext._disposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: BrowserContext.[disposeSymbol]
+---
+
+# BrowserContext.\[disposeSymbol\]() method
+
+### Signature
+
+```typescript
+class BrowserContext {
+  [disposeSymbol](): void;
+}
+```
+
+**Returns:**
+
+void

--- a/docs/api/puppeteer.browsercontext.md
+++ b/docs/api/puppeteer.browsercontext.md
@@ -113,6 +113,24 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.browsercontext._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="_disposesymbol_">[\[disposeSymbol\]()](./puppeteer.browsercontext._disposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="browser">[browser()](./puppeteer.browsercontext.browser.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.disposesymbol.md
+++ b/docs/api/puppeteer.disposesymbol.md
@@ -1,0 +1,11 @@
+---
+sidebar_label: disposeSymbol
+---
+
+# disposeSymbol variable
+
+### Signature
+
+```typescript
+disposeSymbol: typeof Symbol.dispose;
+```

--- a/docs/api/puppeteer.eventemitter._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.eventemitter._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: EventEmitter.[asyncDisposeSymbol]
+---
+
+# EventEmitter.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class EventEmitter {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.eventemitter._disposesymbol_.md
+++ b/docs/api/puppeteer.eventemitter._disposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: EventEmitter.[disposeSymbol]
+---
+
+# EventEmitter.\[disposeSymbol\]() method
+
+### Signature
+
+```typescript
+class EventEmitter {
+  [disposeSymbol](): void;
+}
+```
+
+**Returns:**
+
+void

--- a/docs/api/puppeteer.eventemitter.md
+++ b/docs/api/puppeteer.eventemitter.md
@@ -37,6 +37,24 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.eventemitter._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="_disposesymbol_">[\[disposeSymbol\]()](./puppeteer.eventemitter._disposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="emit">[emit(type, event)](./puppeteer.eventemitter.emit.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.jshandle._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.jshandle._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: JSHandle.[asyncDisposeSymbol]
+---
+
+# JSHandle.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class JSHandle {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.jshandle._disposesymbol_.md
+++ b/docs/api/puppeteer.jshandle._disposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: JSHandle.[disposeSymbol]
+---
+
+# JSHandle.\[disposeSymbol\]() method
+
+### Signature
+
+```typescript
+class JSHandle {
+  [disposeSymbol](): void;
+}
+```
+
+**Returns:**
+
+void

--- a/docs/api/puppeteer.jshandle.md
+++ b/docs/api/puppeteer.jshandle.md
@@ -94,6 +94,24 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.jshandle._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="_disposesymbol_">[\[disposeSymbol\]()](./puppeteer.jshandle._disposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="aselement">[asElement()](./puppeteer.jshandle.aselement.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.page._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.page._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Page.[asyncDisposeSymbol]
+---
+
+# Page.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class Page {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.page._disposesymbol_.md
+++ b/docs/api/puppeteer.page._disposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Page.[disposeSymbol]
+---
+
+# Page.\[disposeSymbol\]() method
+
+### Signature
+
+```typescript
+class Page {
+  [disposeSymbol](): void;
+}
+```
+
+**Returns:**
+
+void

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -273,6 +273,24 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.page._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="_disposesymbol_">[\[disposeSymbol\]()](./puppeteer.page._disposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="_">[$(selector)](./puppeteer.page._.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.realm._disposesymbol_.md
+++ b/docs/api/puppeteer.realm._disposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Realm.[disposeSymbol]
+---
+
+# Realm.\[disposeSymbol\]() method
+
+### Signature
+
+```typescript
+class Realm {
+  [disposeSymbol](): void;
+}
+```
+
+**Returns:**
+
+void

--- a/docs/api/puppeteer.realm.md
+++ b/docs/api/puppeteer.realm.md
@@ -69,6 +69,15 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_disposesymbol_">[\[disposeSymbol\]()](./puppeteer.realm._disposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="evaluate">[evaluate(pageFunction, args)](./puppeteer.realm.evaluate.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.screenrecorder._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.screenrecorder._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: ScreenRecorder.[asyncDisposeSymbol]
+---
+
+# ScreenRecorder.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class ScreenRecorder {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.screenrecorder.md
+++ b/docs/api/puppeteer.screenrecorder.md
@@ -33,6 +33,15 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.screenrecorder._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="stop">[stop()](./puppeteer.screenrecorder.stop.md)</span>
 
 </td><td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@rollup/plugin-node-resolve": "16.0.3",
         "@stylistic/eslint-plugin": "5.10.0",
         "@types/mocha": "10.0.10",
-        "@types/node": "22.13.10",
+        "@types/node": "22.20.0",
         "@types/semver": "7.7.1",
         "@types/sinon": "22.0.0",
         "esbuild": "0.28.1",
@@ -4176,19 +4176,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -32073,6 +32073,59 @@
         }
       }
     },
+    "packages/ng-schematics/node_modules/@angular-devkit/core/node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/ng-schematics/node_modules/@angular-devkit/core/node_modules/ajv-formats/node_modules/ajv/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "packages/ng-schematics/node_modules/@angular-devkit/core/node_modules/ajv-formats/node_modules/ajv/node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "packages/ng-schematics/node_modules/@angular-devkit/core/node_modules/ajv-formats/node_modules/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "packages/ng-schematics/node_modules/@angular-devkit/core/node_modules/ajv-formats/node_modules/ajv/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "packages/ng-schematics/node_modules/@angular-devkit/core/node_modules/ajv/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -39705,7 +39758,7 @@
         "ws": "^8.21.0"
       },
       "devDependencies": {
-        "@types/chrome": "^0.2.2",
+        "@types/chrome": "0.2.2",
         "@types/node": "^18.17.15",
         "@types/ws": "8.18.1",
         "mitt": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "@rollup/plugin-node-resolve": "16.0.3",
     "@stylistic/eslint-plugin": "5.10.0",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.13.10",
+    "@types/node": "22.20.0",
     "@types/semver": "7.7.1",
     "@types/sinon": "22.0.0",
     "typescript-eslint": "8.62.1",

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -690,12 +690,10 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    */
   abstract get connected(): boolean;
 
-  /** @internal */
   override [disposeSymbol](): void {
     return void this[asyncDisposeSymbol]().catch(debugCatchError);
   }
 
-  /** @internal */
   override async [asyncDisposeSymbol](): Promise<void> {
     if (this.process()) {
       await this.close();

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -371,12 +371,10 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
     return undefined;
   }
 
-  /** @internal */
   override [disposeSymbol](): void {
     return void this[asyncDisposeSymbol]().catch(debugCatchError);
   }
 
-  /** @internal */
   override async [asyncDisposeSymbol](): Promise<void> {
     await this.close();
     await super[asyncDisposeSymbol]();

--- a/packages/puppeteer-core/src/api/JSHandle.ts
+++ b/packages/puppeteer-core/src/api/JSHandle.ts
@@ -193,12 +193,10 @@ export abstract class JSHandle<T = unknown> {
    */
   abstract remoteObject(): Protocol.Runtime.RemoteObject;
 
-  /** @internal */
   [disposeSymbol](): void {
     return void this[asyncDisposeSymbol]().catch(debugCatchError);
   }
 
-  /** @internal */
   [asyncDisposeSymbol](): Promise<void> {
     return this.dispose();
   }

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -3232,12 +3232,10 @@ export abstract class Page extends EventEmitter<PageEvents> {
    */
   abstract windowId(): Promise<WindowId>;
 
-  /** @internal */
   override [disposeSymbol](): void {
     return void this[asyncDisposeSymbol]().catch(debugCatchError);
   }
 
-  /** @internal */
   override async [asyncDisposeSymbol](): Promise<void> {
     await this.close();
     await super[asyncDisposeSymbol]();

--- a/packages/puppeteer-core/src/api/Realm.ts
+++ b/packages/puppeteer-core/src/api/Realm.ts
@@ -199,7 +199,6 @@ export abstract class Realm {
     );
   }
 
-  /** @internal */
   [disposeSymbol](): void {
     this.dispose();
   }

--- a/packages/puppeteer-core/src/common/EventEmitter.ts
+++ b/packages/puppeteer-core/src/common/EventEmitter.ts
@@ -181,16 +181,10 @@ export class EventEmitter<
     return this;
   }
 
-  /**
-   * @internal
-   */
   [disposeSymbol](): void {
     return void this[asyncDisposeSymbol]().catch(debugCatchError);
   }
 
-  /**
-   * @internal
-   */
   async [asyncDisposeSymbol](): Promise<void> {
     for (const [type, handlers] of this.#handlers) {
       for (const handler of handlers) {

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -375,9 +375,6 @@ export class ScreenRecorder extends PassThrough {
     });
   }
 
-  /**
-   * @internal
-   */
   override async [asyncDisposeSymbol](): Promise<void> {
     await this.stop();
     await super[asyncDisposeSymbol]();

--- a/packages/puppeteer-core/src/util/disposable.ts
+++ b/packages/puppeteer-core/src/util/disposable.ts
@@ -32,12 +32,12 @@ declare global {
 (Symbol as any).asyncDispose ??= Symbol('asyncDispose');
 
 /**
- * @internal
+ * @public
  */
 export const disposeSymbol: typeof Symbol.dispose = Symbol.dispose;
 
 /**
- * @internal
+ * @public
  */
 export const asyncDisposeSymbol: typeof Symbol.asyncDispose =
   Symbol.asyncDispose;

--- a/test/installation/src/util.ts
+++ b/test/installation/src/util.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {ExecFileException, ExecFileOptions} from 'node:child_process';
+import type {ExecFileOptions} from 'node:child_process';
 import {execFile as nodeExecFile} from 'node:child_process';
 import {readFile} from 'node:fs/promises';
 import {join} from 'node:path';
@@ -35,15 +35,17 @@ export const execFile = async (
     file,
     args,
     options,
-    (error: ExecFileException | null, stdout: string, stderr: string) => {
-      console.log('stdout', stdout);
-      console.log('stderr', stderr);
+    (error, stdout, stderr) => {
+      const stdoutStr = stdout.toString();
+      const stderrStr = stderr.toString();
+      console.log('stdout', stdoutStr);
+      console.log('stderr', stderrStr);
       if (error) {
         reject(error);
       }
       resolve({
-        stdout,
-        stderr,
+        stdout: stdoutStr,
+        stderr: stderrStr,
       });
     },
   );

--- a/test/installation/src/util.ts
+++ b/test/installation/src/util.ts
@@ -31,24 +31,19 @@ export const execFile = async (
     resolve = res;
     reject = rej;
   });
-  nodeExecFile(
-    file,
-    args,
-    options,
-    (error, stdout, stderr) => {
-      const stdoutStr = stdout.toString();
-      const stderrStr = stderr.toString();
-      console.log('stdout', stdoutStr);
-      console.log('stderr', stderrStr);
-      if (error) {
-        reject(error);
-      }
-      resolve({
-        stdout: stdoutStr,
-        stderr: stderrStr,
-      });
-    },
-  );
+  nodeExecFile(file, args, options, (error, stdout, stderr) => {
+    const stdoutStr = stdout.toString();
+    const stderrStr = stderr.toString();
+    console.log('stdout', stdoutStr);
+    console.log('stderr', stderrStr);
+    if (error) {
+      reject(error);
+    }
+    resolve({
+      stdout: stdoutStr,
+      stderr: stderrStr,
+    });
+  });
 
   return await promise;
 };


### PR DESCRIPTION
The Explicit Resource Management reached stage 4 with multiple vendors already supporting it (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using#browser_compatibility).

Once https://github.com/tc39/ecma262/pull/3000 is merged and part of the spec, we should make this publicly available.

Note: NodeJS v22 does not support the keyword `using`.