### PR TITLE
feat: support --disallow-code-generation-from-strings

### DIFF
--- a/packages/puppeteer-core/src/util/Function.test.ts
+++ b/packages/puppeteer-core/src/util/Function.test.ts
@@ -8,9 +8,33 @@ import {describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {interpolateFunction, stringifyFunction} from './Function.js';
+import {
+  createFunction,
+  interpolateFunction,
+  stringifyFunction,
+} from './Function.js';
 
 describe('Function', function () {
+  describe('createFunction', function () {
+    it('should return a placeholder that is not directly callable', () => {
+      const fn = createFunction('() => 42');
+      expect(() => fn()).toThrow(/serialization placeholder/);
+    });
+
+    it('should serialize back to the original source via toString', () => {
+      const source = '() => 42';
+      const fn = createFunction(source);
+      expect(fn.toString()).toBe(source);
+    });
+
+    it('should be evaluable into a real function via toString', () => {
+      const source = '() => 42';
+      const fn = createFunction(source);
+      const real = new Function(`return ${fn.toString()}`)() as () => number;
+      expect(real()).toBe(42);
+    });
+  });
+
   describe('interpolateFunction', function () {
     it('should work', async () => {
       const test = interpolateFunction(
@@ -20,7 +44,8 @@ describe('Function', function () {
         },
         {test: `() => 5`},
       );
-      expect(test()).toBe(5);
+      const real = new Function(`return ${test.toString()}`)() as () => number;
+      expect(real()).toBe(5);
     });
     it('should work inlined', async () => {
       const test = interpolateFunction(
@@ -30,7 +55,8 @@ describe('Function', function () {
         },
         {test: `() => 5`},
       );
-      expect(test()).toBe(5);
+      const real = new Function(`return ${test.toString()}`)() as () => number;
+      expect(real()).toBe(5);
     });
   });
 

--- a/packages/puppeteer-core/src/util/Function.ts
+++ b/packages/puppeteer-core/src/util/Function.ts
@@ -17,9 +17,12 @@ export const createFunction = (
   if (fn) {
     return fn;
   }
-  fn = new Function(`return ${functionValue}`)() as (
-    ...args: unknown[]
-  ) => unknown;
+  fn = function puppeteerBackendPlaceholder() {
+    throw new Error(
+      'This function is a serialization placeholder. It should not be called directly in the Node.js process -- it exists only to carry source code to the browser via CDP.',
+    );
+  } as (...args: unknown[]) => unknown;
+  fn.toString = () => functionValue;
   createdFunctions.set(functionValue, fn);
   return fn;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Changes the way functions are serialized, so they do not require the use of `new Function`. This supports running Puppeteer within a Node.js environment configured with [`--disallow-code-generation-from-strings`](https://nodejs.org/docs/latest/api/cli.html#disallow-code-generation-from-strings), which is an important security hardening measure.

This might not be the correct Conventional Commit; I am not well-versed in using this nomenclature. Feel free to suggest something other than `feat`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
N/A (I think)

**Summary**

This change allows Puppeteer to run within a Node.js environment which has been configured to [disallow code generation from strings](https://nodejs.org/docs/latest/api/cli.html#disallow-code-generation-from-strings). This is a defense-in-depth feature of the Node runtime which blocks the use of `eval`, `new Function`, and related features which convert strings into executable code. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

I do not believe so.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

I am verifying this functionality for Kibana via https://github.com/elastic/kibana/pull/241162, using `patch-package` to apply this change manually against our own test suites.