### PR TITLE
fix: improve progress bar and install

### DIFF
--- a/packages/browsers/src/ProgressBar.ts
+++ b/packages/browsers/src/ProgressBar.ts
@@ -37,7 +37,7 @@ export class ProgressBar {
 
     this.#render();
 
-    if (this.#downloaded >= this.#total) {
+    if (this.#downloaded >= this.#total && this.#stream.isTTY) {
       this.#stream.write('\n');
     }
   }

--- a/packages/browsers/test/src/ProgressBar.spec.ts
+++ b/packages/browsers/test/src/ProgressBar.spec.ts
@@ -47,6 +47,17 @@ describe('ProgressBar', () => {
     assert.strictEqual(writes.length, 0);
   });
 
+  it('should not write newline on completion when isTTY is false', () => {
+    const stream = createMockStream(false);
+    const bar = new ProgressBar('Downloading', {
+      total: 100,
+      stream,
+    });
+
+    bar.tick(100);
+    assert.strictEqual(writes.length, 0);
+  });
+
   it('should render bar and percent tokens on TTY streams', () => {
     const stream = createMockStream(true, 80);
     const bar = new ProgressBar('Downloading', {

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -124,10 +124,14 @@ export async function downloadBrowsers(): Promise<void> {
     );
   }
 
-  try {
-    await Promise.all(installationJobs);
-  } catch (error) {
-    console.error(error);
+  const results = await Promise.allSettled(installationJobs);
+  const failures = results.filter(r => {
+    return r.status === 'rejected';
+  });
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(failure.reason);
+    }
     process.exit(1);
   }
 }


### PR DESCRIPTION
- do not write newline in !this.#stream.isTTY
- wait for all installations to settle before closing the process

Closes https://github.com/puppeteer/puppeteer/issues/15039