### PR TITLE
fix: support concurrency in progress bars

### DIFF
--- a/packages/browsers/src/ProgressBar.ts
+++ b/packages/browsers/src/ProgressBar.ts
@@ -4,68 +4,168 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * @internal
- */
-export interface ProgressBarOptions {
-  total: number;
-  stream?: NodeJS.WriteStream;
-}
+// Module-level active session. Concurrent bars share a session; a new session
+// starts whenever no bar is currently active (or the stream changes).
+let activeBar: ProgressBar | null = null;
 
 /**
+ * Manages one or more concurrent progress bars on separate terminal lines.
+ * Use {@link ProgressBar.createBarTicker} to add a bar; concurrent calls
+ * automatically share a session so bars don't overwrite each other.
+ *
  * @internal
  */
 export class ProgressBar {
-  #title: string;
-  #total: number;
   #stream: NodeJS.WriteStream;
-  #downloaded = 0;
-  #startTime = 0;
-  #lastDrawn = '';
+  #totalRows = 0;
+  #doneCount = 0;
+  #bars: Array<{
+    title: string;
+    total: number;
+    downloaded: number;
+    startTime: number;
+    lastRendered: string;
+  }> = [];
+  #renderScheduled = false;
+  #lastRenderTime = 0;
+  #allDone = false;
 
-  constructor(title: string, options: ProgressBarOptions) {
-    this.#title = title;
-    this.#total = options.total;
-    this.#stream = options.stream ?? process.stderr;
+  private constructor(stream: NodeJS.WriteStream) {
+    this.#stream = stream;
   }
 
-  tick(delta: number): void {
-    if (this.#startTime === 0) {
-      this.#startTime = Date.now();
+  /**
+   * Returns a `tick(delta)` function for a new progress bar. If another bar
+   * is already active on the same stream, the new bar appears on the next line
+   * and both update in place. The trailing newline is emitted automatically
+   * once every bar in the session has reached 100%.
+   */
+  static createBarTicker(
+    title: string,
+    total: number,
+    stream: NodeJS.WriteStream = process.stderr as NodeJS.WriteStream,
+  ): (delta: number) => void {
+    // Start a fresh session when none is active or the stream changed.
+    if (!activeBar || activeBar.#stream !== stream) {
+      activeBar = new ProgressBar(stream);
     }
-    this.#downloaded += delta;
+    return activeBar.#addBar(title, total);
+  }
 
-    this.#render();
-
-    if (this.#downloaded >= this.#total && this.#stream.isTTY) {
+  #claimRow(): number {
+    const row = this.#totalRows++;
+    if (row > 0 && this.#stream.isTTY) {
+      // Cursor is parked at col 0 of the previous bottom row; \n opens the
+      // new line and moves the cursor there, establishing the new bottom row.
       this.#stream.write('\n');
     }
+    return row;
   }
 
-  #render(): void {
-    if (!this.#stream.isTTY) {
-      return;
+  #addBar(title: string, total: number): (delta: number) => void {
+    const row = this.#claimRow();
+    this.#bars.push({
+      title,
+      total,
+      downloaded: 0,
+      startTime: 0,
+      lastRendered: '',
+    });
+    let doneNotified = false;
+
+    return (delta: number) => {
+      const bar = this.#bars[row]!;
+      if (bar.startTime === 0) {
+        bar.startTime = Date.now();
+      }
+      bar.downloaded += delta;
+
+      const isDone = bar.downloaded >= bar.total;
+      if (isDone || Date.now() - this.#lastRenderTime >= 100) {
+        this.#scheduleRender();
+      }
+
+      if (isDone && !doneNotified) {
+        doneNotified = true;
+        this.#onBarDone();
+      }
+    };
+  }
+
+  // Defers to a microtask so multiple ticks in the same turn share one render
+  // pass and the cursor only moves once.
+  #scheduleRender(): void {
+    if (!this.#renderScheduled) {
+      this.#renderScheduled = true;
+      queueMicrotask(() => {
+        this.#renderScheduled = false;
+        this.#lastRenderTime = Date.now();
+        this.#renderAll();
+      });
     }
+  }
 
-    const ratio = Math.min(1, Math.max(0, this.#downloaded / this.#total));
+  #computeRendered(row: number): string {
+    const bar = this.#bars[row]!;
+    const ratio = Math.min(1, Math.max(0, bar.downloaded / bar.total));
     const percent = Math.round(ratio * 100);
-    const elapsedMs = Date.now() - this.#startTime;
-    const rate = elapsedMs > 0 ? this.#downloaded / elapsedMs : 0; // bytes per millisecond
-    const remaining = this.#total - this.#downloaded;
-    const etaSec = rate > 0 ? remaining / rate / 1000 : 0;
-
+    const elapsedMs = bar.startTime > 0 ? Date.now() - bar.startTime : 0;
+    const rate = elapsedMs > 0 ? bar.downloaded / elapsedMs : 0; // bytes/ms
+    const etaSec = rate > 0 ? (bar.total - bar.downloaded) / rate / 1000 : 0;
     const width = 20;
     const completeCount = Math.round(width * ratio);
     const barStr =
       '='.repeat(completeCount) + ' '.repeat(width - completeCount);
+    const status =
+      ratio >= 1 ? 'unpacking' : `${percent}% ${etaSec.toFixed(1)}s`;
+    return `${bar.title} [${barStr}] ${status} `;
+  }
 
-    const rendered = `${this.#title} [${barStr}] ${percent}% ${etaSec.toFixed(1)}s `;
+  // Invariant: cursor is at col 0 of the bottom row before and after this call.
+  // Single top-down pass: go up to bar 0, render each bar, come back to bottom.
+  #renderAll(): void {
+    if (!this.#stream.isTTY) {
+      return;
+    }
+    const N = this.#totalRows;
+    if (N === 0) {
+      return;
+    }
 
-    if (this.#lastDrawn !== rendered) {
-      this.#stream.cursorTo(0);
-      this.#stream.write(rendered);
-      this.#stream.clearLine(1);
-      this.#lastDrawn = rendered;
+    // Move cursor to top of bar area.
+    if (N > 1) {
+      this.#stream.moveCursor(0, -(N - 1));
+    }
+
+    for (let row = 0; row < N; row++) {
+      const rendered = this.#computeRendered(row);
+      if (rendered !== this.#bars[row]!.lastRendered) {
+        this.#stream.cursorTo(0);
+        this.#stream.write(rendered);
+        this.#stream.clearLine(1);
+        this.#bars[row]!.lastRendered = rendered;
+      }
+      if (row < N - 1) {
+        this.#stream.moveCursor(0, 1);
+      }
+    }
+
+    // Park cursor at col 0 of the bottom row.
+    this.#stream.cursorTo(0);
+
+    if (this.#allDone) {
+      activeBar = null;
+      this.#stream.write('\n');
+    }
+  }
+
+  #onBarDone(): void {
+    this.#doneCount++;
+    if (this.#doneCount >= this.#totalRows && this.#totalRows > 0) {
+      this.#allDone = true;
+      // Don't emit \n here — the pending render microtask hasn't run yet.
+      // #renderAll() will emit it after the final pass so the cursor is
+      // already past the last bar line before the newline moves it.
     }
   }
 }

--- a/packages/browsers/src/fileUtil.ts
+++ b/packages/browsers/src/fileUtil.ts
@@ -155,14 +155,14 @@ async function extractTar(
  * @internal
  */
 async function installDMG(dmgPath: string, folderPath: string): Promise<void> {
-  const {stdout} = spawnSync(`hdiutil`, [
+  const {stdout} = await execFileAsync('hdiutil', [
     'attach',
     '-nobrowse',
     '-noautoopen',
     dmgPath,
   ]);
 
-  const volumes = stdout.toString('utf8').match(/\/Volumes\/(.*)/m);
+  const volumes = stdout.match(/\/Volumes\/(.*)/m);
   if (!volumes) {
     throw new Error(`Could not find volume path in ${stdout}`);
   }
@@ -178,9 +178,9 @@ async function installDMG(dmgPath: string, folderPath: string): Promise<void> {
     }
     const mountedPath = path.join(mountPath!, appName);
 
-    spawnSync('cp', ['-R', mountedPath, folderPath]);
+    await execFileAsync('cp', ['-R', mountedPath, folderPath]);
   } finally {
-    spawnSync('hdiutil', ['detach', mountPath, '-quiet']);
+    await execFileAsync('hdiutil', ['detach', mountPath, '-quiet']);
   }
 }
 

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -624,21 +624,19 @@ export async function makeProgressCallback(
   browser: Browser,
   buildId: string,
 ): Promise<(downloadedBytes: number, totalBytes: number) => void> {
-  let progressBar: ProgressBar;
-
+  let ticker: ((delta: number) => void) | undefined;
   let lastDownloadedBytes = 0;
+
   return (downloadedBytes: number, totalBytes: number) => {
-    if (!progressBar) {
-      progressBar = new ProgressBar(
+    if (!ticker) {
+      ticker = ProgressBar.createBarTicker(
         `Downloading ${browser} ${buildId} - ${toMegabytes(totalBytes)}`,
-        {
-          total: totalBytes,
-        },
+        totalBytes,
       );
     }
     const delta = downloadedBytes - lastDownloadedBytes;
     lastDownloadedBytes = downloadedBytes;
-    progressBar.tick(delta);
+    ticker(delta);
   };
 }
 

--- a/packages/browsers/test/src/ProgressBar.spec.ts
+++ b/packages/browsers/test/src/ProgressBar.spec.ts
@@ -33,66 +33,77 @@ describe('ProgressBar', () => {
         clearLineCalls.push(dir);
         return this;
       },
+      moveCursor(_dx: number, _dy: number) {
+        return this;
+      },
     } as unknown as NodeJS.WriteStream;
   }
 
-  it('should not render when isTTY is false', () => {
+  it('should not render when isTTY is false', async () => {
     const stream = createMockStream(false);
-    const bar = new ProgressBar('Downloading', {
-      total: 100,
-      stream,
-    });
+    const tick = ProgressBar.createBarTicker('Downloading', 100, stream);
 
-    bar.tick(50);
+    tick(50);
+    await Promise.resolve();
     assert.strictEqual(writes.length, 0);
   });
 
-  it('should not write newline on completion when isTTY is false', () => {
+  it('should not write newline on completion when isTTY is false', async () => {
     const stream = createMockStream(false);
-    const bar = new ProgressBar('Downloading', {
-      total: 100,
-      stream,
-    });
+    const tick = ProgressBar.createBarTicker('Downloading', 100, stream);
 
-    bar.tick(100);
+    tick(100);
+    await Promise.resolve();
     assert.strictEqual(writes.length, 0);
   });
 
-  it('should render bar and percent tokens on TTY streams', () => {
+  it('should render bar and percent tokens on TTY streams', async () => {
     const stream = createMockStream(true, 80);
-    const bar = new ProgressBar('Downloading', {
-      total: 10,
-      stream,
-    });
+    const tick = ProgressBar.createBarTicker('Downloading', 10, stream);
 
-    bar.tick(5);
+    tick(5);
+    await Promise.resolve();
     assert.strictEqual(writes.length, 1);
     assert.strictEqual(
       writes[0],
       'Downloading [==========          ] 50% 0.0s ',
     );
-    assert.deepStrictEqual(cursorToCalls, [0]);
+    assert.deepStrictEqual(cursorToCalls, [0, 0]); // write + park
     assert.deepStrictEqual(clearLineCalls, [1]);
   });
 
-  it('should complete the progress bar and print a newline', () => {
+  it('should complete the bar and print a newline when the last bar finishes', async () => {
     const stream = createMockStream(true, 80);
-    const bar = new ProgressBar('Downloading', {
-      total: 4,
-      stream,
-    });
+    const tick = ProgressBar.createBarTicker('Downloading', 4, stream);
 
-    bar.tick(2);
+    tick(2);
+    await Promise.resolve(); // flush microtask
     assert.strictEqual(
       writes[writes.length - 1],
       'Downloading [==========          ] 50% 0.0s ',
     );
 
-    bar.tick(2);
+    tick(2);
+    await Promise.resolve(); // flush microtask
     assert.strictEqual(
       writes[writes.length - 2],
-      'Downloading [====================] 100% 0.0s ',
+      'Downloading [====================] unpacking ',
     );
+    assert.strictEqual(writes[writes.length - 1], '\n');
+  });
+
+  it('should auto-group concurrent bars on separate lines', async () => {
+    const stream = createMockStream(true, 80);
+    const tick1 = ProgressBar.createBarTicker('Browser1', 10, stream);
+    const tick2 = ProgressBar.createBarTicker('Browser2', 10, stream);
+
+    // \n separates the two rows
+    assert.strictEqual(writes[0], '\n');
+
+    tick1(10); // bar1 done
+    tick2(10); // bar2 done — session ends, trailing \n emitted
+    await Promise.resolve();
+
     assert.strictEqual(writes[writes.length - 1], '\n');
   });
 });

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -33,7 +33,7 @@ async function downloadBrowser({
   configuration: ChromeSettings | ChromeHeadlessShellSettings | FirefoxSettings;
   platform: BrowserPlatform;
   cacheDir: string;
-}) {
+}): Promise<string> {
   const unresolvedBuildId =
     configuration?.version || PUPPETEER_REVISIONS[browser] || 'latest';
   const baseUrl = configuration?.downloadBaseUrl;
@@ -50,7 +50,7 @@ async function downloadBrowser({
       buildIdAlias:
         buildId !== unresolvedBuildId ? unresolvedBuildId : undefined,
     });
-    logPolitely(`${browser} (${result.buildId}) downloaded to ${result.path}`);
+    return `${browser} (${result.buildId}) downloaded to ${result.path}`;
   } catch (error) {
     throw new Error(
       `ERROR: Failed to set up ${browser} v${buildId}! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.`,
@@ -125,6 +125,15 @@ export async function downloadBrowsers(): Promise<void> {
   }
 
   const results = await Promise.allSettled(installationJobs);
+
+  // Log success messages only after all downloads+extraction complete so they
+  // never land mid-progress-bar while the cursor is on a bar line.
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      logPolitely(result.value);
+    }
+  }
+
   const failures = results.filter(r => {
     return r.status === 'rejected';
   });


### PR DESCRIPTION
- fixes broken progress bar on parallel downloads
- fixed blocking caused by Firefox downloads on Mac
- added unpacking indicator
- moves logging to after download to avoid interfering with the progress bar.