### PR TITLE
feat: add page locale emulation

### DIFF
--- a/docs/api/puppeteer.page.emulatelocale.md
+++ b/docs/api/puppeteer.page.emulatelocale.md
@@ -1,0 +1,47 @@
+---
+sidebar_label: Page.emulateLocale
+---
+
+# Page.emulateLocale() method
+
+### Signature
+
+```typescript
+class Page {
+  abstract emulateLocale(locale?: string): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+locale
+
+</td><td>
+
+string
+
+</td><td>
+
+_(Optional)_ Locale to emulate on the page. Passing no locale disables locale emulation.
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -593,6 +593,15 @@ Emulates the idle state. If no arguments set, clears idle state emulation.
 </td></tr>
 <tr><td>
 
+<span id="emulatelocale">[emulateLocale(locale)](./puppeteer.page.emulatelocale.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="emulatemediafeatures">[emulateMediaFeatures(features)](./puppeteer.page.emulatemediafeatures.md)</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2221,6 +2221,12 @@ export abstract class Page extends EventEmitter<PageEvents> {
   abstract emulateMediaFeatures(features?: MediaFeature[]): Promise<void>;
 
   /**
+   * @param locale - Locale to emulate on the page. Passing no locale disables
+   * locale emulation.
+   */
+  abstract emulateLocale(locale?: string): Promise<void>;
+
+  /**
    * @param timezoneId - Changes the timezone of the page. See
    * {@link https://source.chromium.org/chromium/chromium/deps/icu.git/+/faee8bc70570192d82d2978a71e2a615788597d1:source/data/misc/metaZones.txt | ICU’s metaZones.txt}
    * for a list of supported timezone IDs. Passing

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -382,6 +382,10 @@ export class BidiPage extends Page {
     return await this.#frame.browsingContext.setTimezoneOverride(timezoneId);
   }
 
+  override async emulateLocale(locale?: string): Promise<void> {
+    return await this.#frame.browsingContext.setLocaleOverride(locale);
+  }
+
   override async emulateIdleState(overrides?: {
     isUserActive: boolean;
     isScreenUnlocked: boolean;

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -610,6 +610,17 @@ export class BrowsingContext extends EventEmitter<{
     // SAFETY: Disposal implies this exists.
     return context.#reason!;
   })
+  async setLocaleOverride(locale?: string): Promise<void> {
+    await this.userContext.browser.session.send('emulation.setLocaleOverride', {
+      locale: locale ?? null,
+      contexts: [this.id],
+    });
+  }
+
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
   async setScreenOrientationOverride(
     screenOrientation: Bidi.Emulation.ScreenOrientation | null,
   ): Promise<void> {

--- a/packages/puppeteer-core/src/cdp/EmulationManager.ts
+++ b/packages/puppeteer-core/src/cdp/EmulationManager.ts
@@ -31,6 +31,11 @@ interface TimezoneState {
   active: boolean;
 }
 
+interface LocaleState {
+  locale?: string;
+  active: boolean;
+}
+
 interface VisionDeficiencyState {
   visionDeficiency?: Protocol.Emulation.SetEmulatedVisionDeficiencyRequest['type'];
   active: boolean;
@@ -147,6 +152,13 @@ export class EmulationManager implements ClientProvider {
     },
     this,
     this.#emulateTimezone,
+  );
+  #localeState = new EmulatedState<LocaleState>(
+    {
+      active: false,
+    },
+    this,
+    this.#emulateLocale,
   );
   #visionDeficiencyState = new EmulatedState<VisionDeficiencyState>(
     {
@@ -370,6 +382,26 @@ export class EmulationManager implements ClientProvider {
   async emulateTimezone(timezoneId?: string): Promise<void> {
     await this.#timezoneState.setState({
       timezoneId,
+      active: true,
+    });
+  }
+
+  @invokeAtMostOnceForArguments
+  async #emulateLocale(
+    client: CDPSession,
+    localeState: LocaleState,
+  ): Promise<void> {
+    if (!localeState.active) {
+      return;
+    }
+    await client.send('Emulation.setLocaleOverride', {
+      locale: localeState.locale || '',
+    });
+  }
+
+  async emulateLocale(locale?: string): Promise<void> {
+    await this.#localeState.setState({
+      locale,
       active: true,
     });
   }

--- a/packages/puppeteer-core/src/cdp/EmulationManager.ts
+++ b/packages/puppeteer-core/src/cdp/EmulationManager.ts
@@ -395,7 +395,7 @@ export class EmulationManager implements ClientProvider {
       return;
     }
     await client.send('Emulation.setLocaleOverride', {
-      locale: localeState.locale || '',
+      locale: localeState.locale,
     });
   }
 

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -87,6 +87,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     client: CdpCDPSession,
     page: CdpPage,
     timeoutSettings: TimeoutSettings,
+    defaultUserAgent?: string,
   ) {
     super();
     this.#client = client;
@@ -94,6 +95,7 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     this.#networkManager = new NetworkManager(
       this,
       page.browser().isNetworkEnabled(),
+      defaultUserAgent,
     );
     this.#timeoutSettings = timeoutSettings;
     this.setupEventListeners(this.#client);

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -102,10 +102,15 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #clients = new Map<CDPSession, DisposableStack>();
   #networkEnabled = true;
 
-  constructor(frameManager: FrameProvider, networkEnabled?: boolean) {
+  constructor(
+    frameManager: FrameProvider,
+    networkEnabled?: boolean,
+    defaultUserAgent?: string,
+  ) {
     super();
     this.#frameManager = frameManager;
     this.#networkEnabled = networkEnabled ?? true;
+    this.#defaultUserAgent = defaultUserAgent;
   }
 
   #canIgnoreError(error: unknown) {
@@ -279,14 +284,8 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     await this.#applyToAllClients(this.#applyUserAgent.bind(this));
   }
 
-  async setAcceptLanguage(
-    acceptLanguage: string | undefined,
-    defaultUserAgent?: string,
-  ): Promise<void> {
+  async setAcceptLanguage(acceptLanguage: string | undefined): Promise<void> {
     this.#acceptLanguage = acceptLanguage;
-    if (defaultUserAgent !== undefined) {
-      this.#defaultUserAgent = defaultUserAgent;
-    }
     await this.#applyToAllClients(this.#applyUserAgent.bind(this));
   }
 

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -81,8 +81,10 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #userCacheDisabled?: boolean;
   #emulatedNetworkConditions?: InternalNetworkConditions;
   #userAgent?: string;
+  #defaultUserAgent?: string;
   #userAgentMetadata?: Protocol.Emulation.UserAgentMetadata;
   #platform?: string;
+  #acceptLanguage?: string;
 
   readonly #handlers = [
     ['Fetch.requestPaused', this.#onRequestPaused],
@@ -277,13 +279,24 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
     await this.#applyToAllClients(this.#applyUserAgent.bind(this));
   }
 
+  async setAcceptLanguage(
+    acceptLanguage: string | undefined,
+    defaultUserAgent: string,
+  ): Promise<void> {
+    this.#acceptLanguage = acceptLanguage;
+    this.#defaultUserAgent = defaultUserAgent;
+    await this.#applyToAllClients(this.#applyUserAgent.bind(this));
+  }
+
   async #applyUserAgent(client: CDPSession) {
-    if (this.#userAgent === undefined) {
+    const userAgent = this.#userAgent ?? this.#defaultUserAgent;
+    if (userAgent === undefined) {
       return;
     }
     try {
       await client.send('Network.setUserAgentOverride', {
-        userAgent: this.#userAgent,
+        userAgent,
+        acceptLanguage: this.#acceptLanguage,
         userAgentMetadata: this.#userAgentMetadata,
         platform: this.#platform,
       });

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -281,10 +281,12 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
 
   async setAcceptLanguage(
     acceptLanguage: string | undefined,
-    defaultUserAgent: string,
+    defaultUserAgent?: string,
   ): Promise<void> {
     this.#acceptLanguage = acceptLanguage;
-    this.#defaultUserAgent = defaultUserAgent;
+    if (defaultUserAgent !== undefined) {
+      this.#defaultUserAgent = defaultUserAgent;
+    }
     await this.#applyToAllClients(this.#applyUserAgent.bind(this));
   }
 

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -121,6 +121,10 @@ export class CdpPage extends Page {
     defaultViewport: Viewport | null,
   ): Promise<CdpPage> {
     const page = new CdpPage(client, target);
+    await page.#frameManager.networkManager.setAcceptLanguage(
+      undefined,
+      await page.browser().userAgent(),
+    );
     await page.#initialize();
     if (defaultViewport) {
       try {
@@ -1090,10 +1094,7 @@ export class CdpPage extends Page {
 
   override async emulateLocale(locale?: string): Promise<void> {
     await this.#emulationManager.emulateLocale(locale);
-    await this.#frameManager.networkManager.setAcceptLanguage(
-      locale,
-      await this.browser().userAgent(),
-    );
+    await this.#frameManager.networkManager.setAcceptLanguage(locale);
   }
 
   override async emulateIdleState(overrides?: {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -120,7 +120,11 @@ export class CdpPage extends Page {
     target: CdpTarget,
     defaultViewport: Viewport | null,
   ): Promise<CdpPage> {
-    const page = new CdpPage(client, target, await target.browser().userAgent());
+    const page = new CdpPage(
+      client,
+      target,
+      await target.browser().userAgent(),
+    );
     await page.#initialize();
     if (defaultViewport) {
       try {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -120,11 +120,7 @@ export class CdpPage extends Page {
     target: CdpTarget,
     defaultViewport: Viewport | null,
   ): Promise<CdpPage> {
-    const page = new CdpPage(client, target);
-    await page.#frameManager.networkManager.setAcceptLanguage(
-      undefined,
-      await page.browser().userAgent(),
-    );
+    const page = new CdpPage(client, target, await target.browser().userAgent());
     await page.#initialize();
     if (defaultViewport) {
       try {
@@ -165,7 +161,11 @@ export class CdpPage extends Page {
   #serviceWorkerBypassed = false;
   #userDragInterceptionEnabled = false;
 
-  constructor(client: CdpCDPSession, target: CdpTarget) {
+  constructor(
+    client: CdpCDPSession,
+    target: CdpTarget,
+    defaultUserAgent?: string,
+  ) {
     super();
     this.#primaryTargetClient = client;
     this.#tabTargetClient = client.parentSession()!;
@@ -178,7 +178,12 @@ export class CdpPage extends Page {
     this.#keyboard = new CdpKeyboard(client);
     this.#mouse = new CdpMouse(client, this.#keyboard);
     this.#touchscreen = new CdpTouchscreen(client, this.#keyboard);
-    this.#frameManager = new FrameManager(client, this, this._timeoutSettings);
+    this.#frameManager = new FrameManager(
+      client,
+      this,
+      this._timeoutSettings,
+      defaultUserAgent,
+    );
     this.#emulationManager = new EmulationManager(client);
     this.#tracing = new Tracing(client);
     this.#webmcp = new WebMCP(client, this.#frameManager);

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -1088,6 +1088,14 @@ export class CdpPage extends Page {
     return await this.#emulationManager.emulateTimezone(timezoneId);
   }
 
+  override async emulateLocale(locale?: string): Promise<void> {
+    await this.#emulationManager.emulateLocale(locale);
+    await this.#frameManager.networkManager.setAcceptLanguage(
+      locale,
+      await this.browser().userAgent(),
+    );
+  }
+
   override async emulateIdleState(overrides?: {
     isUserActive: boolean;
     isScreenUnlocked: boolean;

--- a/test/src/emulation.test.ts
+++ b/test/src/emulation.test.ts
@@ -496,6 +496,59 @@ describe('Emulation', () => {
     });
   });
 
+  describe('Page.emulateLocale', function () {
+    it('should work', async () => {
+      const {page} = await getTestState();
+      const defaultLocale = await page.evaluate(() => {
+        return Intl.NumberFormat().resolvedOptions().locale;
+      });
+      const defaultLanguage = await page.evaluate(() => {
+        return navigator.language;
+      });
+
+      await page.emulateLocale('de-DE');
+      expect(
+        await page.evaluate(() => {
+          return Intl.NumberFormat().resolvedOptions().locale;
+        }),
+      ).toBe('de-DE');
+      expect(
+        await page.evaluate(() => {
+          return new Intl.NumberFormat().format(123456.78);
+        }),
+      ).toBe('123.456,78');
+      expect(
+        await page.evaluate(() => {
+          return navigator.language;
+        }),
+      ).toBe('de-DE');
+      expect(
+        await page.evaluate(() => {
+          return navigator.languages[0];
+        }),
+      ).toBe('de-DE');
+
+      await page.emulateLocale('fr-FR');
+      expect(
+        await page.evaluate(() => {
+          return Intl.DateTimeFormat().resolvedOptions().locale;
+        }),
+      ).toBe('fr-FR');
+
+      await page.emulateLocale();
+      expect(
+        await page.evaluate(() => {
+          return Intl.NumberFormat().resolvedOptions().locale;
+        }),
+      ).toBe(defaultLocale);
+      expect(
+        await page.evaluate(() => {
+          return navigator.language;
+        }),
+      ).toBe(defaultLanguage);
+    });
+  });
+
   describe('Page.emulateVisionDeficiency', function () {
     it('should work', async () => {
       const {page, server} = await getTestState();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature

**Did you add tests for your changes?**

Yes. Added coverage for `page.emulateLocale()` in `test/src/emulation.spec.ts`, and verified it in both Chrome CDP and Chrome WebDriver BiDi modes.

**If relevant, did you update the documentation?**

Yes. Regenerated API docs for `Page.emulateLocale()`.

**Summary**

Closes #11303.

Adds a page-level `page.emulateLocale(locale?: string)` API matching Puppeteer's existing emulation methods.

- CDP applies `Emulation.setLocaleOverride` for Intl locale behavior.
- CDP also applies `acceptLanguage` through the existing user-agent override path so `navigator.language` and `navigator.languages` reflect the emulated locale.
- WebDriver BiDi applies `emulation.setLocaleOverride`.
- Calling `page.emulateLocale()` without a locale clears the override.

**Does this PR introduce a breaking change?**

No.

**Other information**

Validation run locally:

- `npm run build --workspace puppeteer-core`
- `npm run docs`
- `./node_modules/.bin/prettier --check docs/api/puppeteer.page.md docs/api/puppeteer.page.emulatelocale.md packages/puppeteer-core/src/api/Page.ts packages/puppeteer-core/src/bidi/Page.ts packages/puppeteer-core/src/bidi/core/BrowsingContext.ts packages/puppeteer-core/src/cdp/EmulationManager.ts packages/puppeteer-core/src/cdp/NetworkManager.ts packages/puppeteer-core/src/cdp/Page.ts test/src/emulation.spec.ts`
- `./node_modules/.bin/eslint packages/puppeteer-core/src/api/Page.ts packages/puppeteer-core/src/bidi/Page.ts packages/puppeteer-core/src/bidi/core/BrowsingContext.ts packages/puppeteer-core/src/cdp/EmulationManager.ts packages/puppeteer-core/src/cdp/NetworkManager.ts packages/puppeteer-core/src/cdp/Page.ts test/src/emulation.spec.ts`
- `BINARY="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm --cache /private/tmp/npm-cache test -- --test-suite chrome-headless --grep "Page.emulateLocale"`
- `BINARY="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm --cache /private/tmp/npm-cache test -- --test-suite chrome-bidi --grep "Page.emulateLocale"`
