### PR TITLE
fix: restore the reading config `.puppeteerrc`

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -36,13 +36,19 @@ Puppeteer's configuration files and environment variables are ignored by `puppet
 Configuration files are the **recommended** choice for configuring Puppeteer.
 Puppeteer will look up the file tree for any of the following formats:
 
-- `.puppeteerrc.cjs`,
-- `.puppeteerrc.js`,
-- `.puppeteerrc` (YAML/JSON),
-- `.puppeteerrc.json`,
-- `.puppeteerrc.yaml`,
-- `puppeteer.config.js`, and
+- `package.json`
+- `.config/puppeteer.config.cjs`
+- `.config/puppeteer.config.js`
+- `.config/puppeteerrc.cjs`
+- `.config/puppeteerrc.js`
+- `.config/puppeteerrc.json`
+- `.config/puppeteerrc` (JSON)
+- `.puppeteerrc.cjs`
+- `.puppeteerrc.js`
+- `.puppeteerrc.json`
+- `.puppeteerrc` (JSON)
 - `puppeteer.config.cjs`
+- `puppeteer.config.js`
 
 See the [`Configuration`](../api/puppeteer.configuration) interface for possible
 options.

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -120,8 +120,8 @@
   "dependencies": {
     "@puppeteer/browsers": "3.0.4",
     "chromium-bidi": "16.0.1",
-    "lilconfig": "^3.1.3",
     "devtools-protocol": "0.0.1624250",
+    "lilconfig": "^3.1.3",
     "puppeteer-core": "25.1.0",
     "typed-query-selector": "^2.12.2"
   },

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -116,7 +116,23 @@ function getBrowserSetting(
  * @internal
  */
 export const getConfiguration = async (): Promise<Configuration> => {
-  const result = await lilconfig('puppeteer').search();
+  const result = await lilconfig('puppeteer', {
+    searchPlaces: [
+      'package.json',
+      '.config/puppeteer.config.cjs',
+      '.config/puppeteer.config.js',
+      '.config/puppeteerrc.cjs',
+      '.config/puppeteerrc.js',
+      '.config/puppeteerrc.json',
+      '.config/puppeteerrc',
+      '.puppeteerrc.cjs',
+      '.puppeteerrc.js',
+      '.puppeteerrc.json',
+      '.puppeteerrc',
+      'puppeteer.config.cjs',
+      'puppeteer.config.js',
+    ],
+  }).search();
   const configuration: Configuration = result ? {...result.config} : {};
 
   configuration.logLevel = getLogLevel(


### PR DESCRIPTION
PR update the search to match the current lilconfig defaults and include the previously accepted `.puppeteerrc`
Sadly the function to get default is private to the package so we can't re-use it.

Closes https://github.com/puppeteer/puppeteer/pull/15079
Fixes https://github.com/puppeteer/puppeteer/issues/15076