### PR TITLE
fix(browsers): add SHA-256 integrity verification for downloaded browser archives

### DIFF
--- a/docs/browsers-api/browsers.installoptions.md
+++ b/docs/browsers-api/browsers.installoptions.md
@@ -147,6 +147,25 @@ Provides information about the progress of the download. If set to 'default', th
 </td></tr>
 <tr><td>
 
+<span id="expectedhash">expectedHash</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+Expected SHA-256 checksum (lowercase hex) of the downloaded browser archive. If provided, installation will fail when the downloaded file does not match. If omitted, the download proceeds without integrity verification.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="installdeps">installDeps</span>
 
 </td><td>

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -149,26 +149,7 @@ export function downloadFile(
   });
 }
 
-/**
- * Attempts to fetch a SHA-256 checksum from a sidecar file at `{url}.sha256`.
- * Returns the lowercase hex hash string if found and valid, or undefined.
- *
- * @internal
- */
-export async function fetchChecksumFile(url: URL): Promise<string | undefined> {
-  const checksumUrl = new URL(url.toString() + '.sha256');
-  try {
-    const text = await getText(checksumUrl);
-    // Checksum files may contain "hash  filename" or just "hash"
-    const candidate = text.trim().split(/\s+/)[0];
-    if (candidate && /^[0-9a-f]{64}$/i.test(candidate)) {
-      return candidate.toLowerCase();
-    }
-  } catch {
-    // Sidecar not available — proceed without checksum verification
-  }
-  return undefined;
-}
+
 export async function getJSON(url: URL): Promise<unknown> {
   const text = await getText(url);
   try {

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -81,6 +81,29 @@ export async function httpRequest(
   return request;
 }
 
+class HashVerifier {
+  readonly #hash = createHash('sha256');
+
+  update(chunk: Buffer): void {
+    this.#hash.update(chunk);
+  }
+
+  verify(url: URL, destinationPath: string, expectedHash: string): void {
+    const actualHash = this.#hash.digest('hex');
+    if (actualHash !== expectedHash.toLowerCase()) {
+      try {
+        unlinkSync(destinationPath);
+      } catch {}
+      throw new Error(
+        `Integrity check failed for downloaded browser archive.\n` +
+          `  URL:      ${url}\n` +
+          `  Expected: ${expectedHash.toLowerCase()}\n` +
+          `  Actual:   ${actualHash}`,
+      );
+    }
+  }
+}
+
 /**
  * @internal
  */
@@ -93,7 +116,7 @@ export function downloadFile(
   return new Promise<void>(async (resolve, reject) => {
     let downloadedBytes = 0;
     let totalBytes = 0;
-    const hash = createHash('sha256');
+    const verifier = expectedHash ? new HashVerifier() : null;
 
     try {
       const request = await httpRequest(url, 'GET', response => {
@@ -108,20 +131,11 @@ export function downloadFile(
         }
         const file = createWriteStream(destinationPath);
         file.on('close', () => {
-          if (expectedHash) {
-            const actualHash = hash.digest('hex');
-            if (actualHash !== expectedHash.toLowerCase()) {
-              try {
-                unlinkSync(destinationPath);
-              } catch {}
-              reject(
-                new Error(
-                  `Integrity check failed for downloaded browser archive.\n` +
-                    `  URL:      ${url}\n` +
-                    `  Expected: ${expectedHash.toLowerCase()}\n` +
-                    `  Actual:   ${actualHash}`,
-                ),
-              );
+          if (verifier && expectedHash) {
+            try {
+              verifier.verify(url, destinationPath, expectedHash);
+            } catch (err) {
+              reject(err);
               return;
             }
           }
@@ -133,7 +147,7 @@ export function downloadFile(
         totalBytes = parseInt(response.headers['content-length']!, 10);
         response.on('data', (chunk: Buffer) => {
           downloadedBytes += chunk.length;
-          hash.update(chunk);
+          verifier?.update(chunk);
           if (progressCallback) {
             progressCallback(downloadedBytes, totalBytes);
           }
@@ -148,7 +162,6 @@ export function downloadFile(
     }
   });
 }
-
 
 export async function getJSON(url: URL): Promise<unknown> {
   const text = await getText(url);

--- a/packages/browsers/src/httpUtil.ts
+++ b/packages/browsers/src/httpUtil.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {createWriteStream} from 'node:fs';
+import {createHash} from 'node:crypto';
+import {createWriteStream, unlinkSync} from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import {URL, urlToHttpOptions} from 'node:url';
@@ -87,15 +88,12 @@ export function downloadFile(
   url: URL,
   destinationPath: string,
   progressCallback?: (downloadedBytes: number, totalBytes: number) => void,
+  expectedHash?: string,
 ): Promise<void> {
   return new Promise<void>(async (resolve, reject) => {
     let downloadedBytes = 0;
     let totalBytes = 0;
-
-    function onData(chunk: string): void {
-      downloadedBytes += chunk.length;
-      progressCallback!(downloadedBytes, totalBytes);
-    }
+    const hash = createHash('sha256');
 
     try {
       const request = await httpRequest(url, 'GET', response => {
@@ -110,24 +108,37 @@ export function downloadFile(
         }
         const file = createWriteStream(destinationPath);
         file.on('close', () => {
-          // The 'close' event is emitted when the stream and any of its
-          // underlying resources (a file descriptor, for example) have been
-          // closed. The event indicates that no more events will be emitted, and
-          // no further computation will occur.
+          if (expectedHash) {
+            const actualHash = hash.digest('hex');
+            if (actualHash !== expectedHash.toLowerCase()) {
+              try {
+                unlinkSync(destinationPath);
+              } catch {}
+              reject(
+                new Error(
+                  `Integrity check failed for downloaded browser archive.\n` +
+                    `  URL:      ${url}\n` +
+                    `  Expected: ${expectedHash.toLowerCase()}\n` +
+                    `  Actual:   ${actualHash}`,
+                ),
+              );
+              return;
+            }
+          }
           return resolve();
         });
         file.on('error', error => {
-          // The 'error' event may be emitted by a Readable implementation at any
-          // time. Typically, this may occur if the underlying stream is unable to
-          // generate data due to an underlying internal failure, or when a stream
-          // implementation attempts to push an invalid chunk of data.
           return reject(error);
         });
-        response.pipe(file);
         totalBytes = parseInt(response.headers['content-length']!, 10);
-        if (progressCallback) {
-          response.on('data', onData);
-        }
+        response.on('data', (chunk: Buffer) => {
+          downloadedBytes += chunk.length;
+          hash.update(chunk);
+          if (progressCallback) {
+            progressCallback(downloadedBytes, totalBytes);
+          }
+        });
+        response.pipe(file);
       });
       request.on('error', error => {
         return reject(error);
@@ -136,6 +147,27 @@ export function downloadFile(
       reject(error);
     }
   });
+}
+
+/**
+ * Attempts to fetch a SHA-256 checksum from a sidecar file at `{url}.sha256`.
+ * Returns the lowercase hex hash string if found and valid, or undefined.
+ *
+ * @internal
+ */
+export async function fetchChecksumFile(url: URL): Promise<string | undefined> {
+  const checksumUrl = new URL(url.toString() + '.sha256');
+  try {
+    const text = await getText(checksumUrl);
+    // Checksum files may contain "hash  filename" or just "hash"
+    const candidate = text.trim().split(/\s+/)[0];
+    if (candidate && /^[0-9a-f]{64}$/i.test(candidate)) {
+      return candidate.toLowerCase();
+    }
+  } catch {
+    // Sidecar not available — proceed without checksum verification
+  }
+  return undefined;
 }
 export async function getJSON(url: URL): Promise<unknown> {
   const text = await getText(url);

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -116,9 +116,7 @@ export interface InstallOptions {
   /**
    * Expected SHA-256 checksum (lowercase hex) of the downloaded browser archive.
    * If provided, installation will fail when the downloaded file does not match.
-   * If omitted, an attempt is made to fetch a checksum from a `.sha256` sidecar
-   * file published alongside the archive. When no checksum is available the
-   * download proceeds without integrity verification.
+   * If omitted, the download proceeds without integrity verification.
    */
   expectedHash?: string;
 

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -21,7 +21,7 @@ import {debug} from './debug.js';
 import {DefaultProvider} from './DefaultProvider.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
 import {unpackArchive} from './fileUtil.js';
-import {downloadFile, headHttpRequest} from './httpUtil.js';
+import {downloadFile, fetchChecksumFile, headHttpRequest} from './httpUtil.js';
 import {ProgressBar} from './ProgressBar.js';
 import type {BrowserProvider} from './provider.js';
 
@@ -113,6 +113,15 @@ export interface InstallOptions {
    * @defaultValue `false`
    */
   installDeps?: boolean;
+  /**
+   * Expected SHA-256 checksum (lowercase hex) of the downloaded browser archive.
+   * If provided, installation will fail when the downloaded file does not match.
+   * If omitted, an attempt is made to fetch a checksum from a `.sha256` sidecar
+   * file published alongside the archive. When no checksum is available the
+   * download proceeds without integrity verification.
+   */
+  expectedHash?: string;
+
   /**
    * Custom provider implementation for alternative download sources.
    *
@@ -374,13 +383,25 @@ async function installUrl(
     await mkdir(browserRoot, {recursive: true});
   }
 
+  // Resolve expected hash: use caller-provided value or attempt to fetch a
+  // .sha256 sidecar published alongside the archive.
+  const expectedHash =
+    options.expectedHash ?? (await fetchChecksumFile(url));
+  if (expectedHash) {
+    debugInstall?.(`Checksum found for ${fileName}: ${expectedHash}`);
+  } else {
+    debugInstall?.(
+      `No checksum available for ${fileName} — skipping integrity verification`,
+    );
+  }
+
   if (!options.unpack) {
     if (existsSync(archivePath)) {
       return archivePath;
     }
     debugInstall?.(`Downloading binary from ${url}`);
     debugTime('download');
-    await downloadFile(url, archivePath, downloadProgressCallback);
+    await downloadFile(url, archivePath, downloadProgressCallback, expectedHash);
     debugTimeEnd('download');
     return archivePath;
   }
@@ -437,7 +458,12 @@ async function installUrl(
       debugInstall?.(`Downloading binary from ${url}`);
       try {
         debugTime('download');
-        await downloadFile(url, archivePath, downloadProgressCallback);
+        await downloadFile(
+          url,
+          archivePath,
+          downloadProgressCallback,
+          expectedHash,
+        );
       } finally {
         debugTimeEnd('download');
       }

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -383,9 +383,8 @@ async function installUrl(
     await mkdir(browserRoot, {recursive: true});
   }
 
-  const {expectedHash} = options;
-  if (expectedHash) {
-    debugInstall?.(`Using provided checksum for ${fileName}: ${expectedHash}`);
+  if (options.expectedHash) {
+    debugInstall?.(`Using provided checksum for ${fileName}: ${options.expectedHash}`);
   }
 
   if (!options.unpack) {
@@ -394,7 +393,7 @@ async function installUrl(
     }
     debugInstall?.(`Downloading binary from ${url}`);
     debugTime('download');
-    await downloadFile(url, archivePath, downloadProgressCallback, expectedHash);
+    await downloadFile(url, archivePath, downloadProgressCallback, options.expectedHash);
     debugTimeEnd('download');
     return archivePath;
   }
@@ -455,7 +454,7 @@ async function installUrl(
           url,
           archivePath,
           downloadProgressCallback,
-          expectedHash,
+          options.expectedHash,
         );
       } finally {
         debugTimeEnd('download');

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -21,7 +21,7 @@ import {debug} from './debug.js';
 import {DefaultProvider} from './DefaultProvider.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
 import {unpackArchive} from './fileUtil.js';
-import {downloadFile, fetchChecksumFile, headHttpRequest} from './httpUtil.js';
+import {downloadFile, headHttpRequest} from './httpUtil.js';
 import {ProgressBar} from './ProgressBar.js';
 import type {BrowserProvider} from './provider.js';
 
@@ -383,16 +383,9 @@ async function installUrl(
     await mkdir(browserRoot, {recursive: true});
   }
 
-  // Resolve expected hash: use caller-provided value or attempt to fetch a
-  // .sha256 sidecar published alongside the archive.
-  const expectedHash =
-    options.expectedHash ?? (await fetchChecksumFile(url));
+  const {expectedHash} = options;
   if (expectedHash) {
-    debugInstall?.(`Checksum found for ${fileName}: ${expectedHash}`);
-  } else {
-    debugInstall?.(
-      `No checksum available for ${fileName} — skipping integrity verification`,
-    );
+    debugInstall?.(`Using provided checksum for ${fileName}: ${expectedHash}`);
   }
 
   if (!options.unpack) {

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -384,7 +384,9 @@ async function installUrl(
   }
 
   if (options.expectedHash) {
-    debugInstall?.(`Using provided checksum for ${fileName}: ${options.expectedHash}`);
+    debugInstall?.(
+      `Using provided checksum for ${fileName}: ${options.expectedHash}`,
+    );
   }
 
   if (!options.unpack) {
@@ -393,7 +395,12 @@ async function installUrl(
     }
     debugInstall?.(`Downloading binary from ${url}`);
     debugTime('download');
-    await downloadFile(url, archivePath, downloadProgressCallback, options.expectedHash);
+    await downloadFile(
+      url,
+      archivePath,
+      downloadProgressCallback,
+      options.expectedHash,
+    );
     debugTimeEnd('download');
     return archivePath;
   }

--- a/packages/browsers/test/src/httpUtil.test.ts
+++ b/packages/browsers/test/src/httpUtil.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {createHash} from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import {downloadFile} from '../../lib/httpUtil.js';
+
+describe('downloadFile', function () {
+  let tmpDir: string;
+  let server: http.Server;
+  let serverUrl: URL;
+
+  const testContent = Buffer.from('test browser binary content');
+  const correctHash = createHash('sha256').update(testContent).digest('hex');
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'puppeteer-httputil-test'),
+    );
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, {'Content-Length': String(testContent.length)});
+      res.end(testContent);
+    });
+    await new Promise<void>(resolve => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address() as {port: number};
+    serverUrl = new URL(`http://127.0.0.1:${address.port}/test`);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => {
+      server.close(() => {
+        return resolve();
+      });
+    });
+    try {
+      fs.rmSync(tmpDir, {force: true, recursive: true, maxRetries: 10, retryDelay: 500});
+    } catch {}
+  });
+
+  it('downloads a file without hash verification', async () => {
+    const destPath = path.join(tmpDir, 'download.bin');
+    await downloadFile(serverUrl, destPath);
+    assert.ok(fs.existsSync(destPath));
+    assert.deepStrictEqual(fs.readFileSync(destPath), testContent);
+  });
+
+  it('downloads a file and resolves when the hash matches', async () => {
+    const destPath = path.join(tmpDir, 'download.bin');
+    await downloadFile(serverUrl, destPath, undefined, correctHash);
+    assert.ok(fs.existsSync(destPath));
+    assert.deepStrictEqual(fs.readFileSync(destPath), testContent);
+  });
+
+  it('rejects with an integrity error when the hash mismatches', async () => {
+    const destPath = path.join(tmpDir, 'download.bin');
+    const wrongHash = 'a'.repeat(64);
+    await assert.rejects(
+      () => {
+        return downloadFile(serverUrl, destPath, undefined, wrongHash);
+      },
+      (err: Error) => {
+        assert.ok(
+          err.message.includes('Integrity check failed'),
+          `Expected "Integrity check failed" in: ${err.message}`,
+        );
+        assert.ok(
+          err.message.includes(wrongHash),
+          `Expected wrong hash in error message`,
+        );
+        assert.ok(
+          err.message.includes(correctHash),
+          `Expected actual hash in error message`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it('deletes the downloaded file when the hash mismatches', async () => {
+    const destPath = path.join(tmpDir, 'download.bin');
+    const wrongHash = 'b'.repeat(64);
+    await assert.rejects(() => {
+      return downloadFile(serverUrl, destPath, undefined, wrongHash);
+    });
+    assert.ok(
+      !fs.existsSync(destPath),
+      'File should be deleted after hash mismatch',
+    );
+  });
+
+  it('accepts an uppercase expected hash', async () => {
+    const destPath = path.join(tmpDir, 'download.bin');
+    await downloadFile(serverUrl, destPath, undefined, correctHash.toUpperCase());
+    assert.ok(fs.existsSync(destPath));
+  });
+});

--- a/packages/browsers/test/src/httpUtil.test.ts
+++ b/packages/browsers/test/src/httpUtil.test.ts
@@ -22,9 +22,7 @@ describe('downloadFile', function () {
   const correctHash = createHash('sha256').update(testContent).digest('hex');
 
   beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'puppeteer-httputil-test'),
-    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'puppeteer-httputil-test'));
     server = http.createServer((_req, res) => {
       res.writeHead(200, {'Content-Length': String(testContent.length)});
       res.end(testContent);
@@ -43,7 +41,12 @@ describe('downloadFile', function () {
       });
     });
     try {
-      fs.rmSync(tmpDir, {force: true, recursive: true, maxRetries: 10, retryDelay: 500});
+      fs.rmSync(tmpDir, {
+        force: true,
+        recursive: true,
+        maxRetries: 10,
+        retryDelay: 500,
+      });
     } catch {}
   });
 
@@ -100,7 +103,12 @@ describe('downloadFile', function () {
 
   it('accepts an uppercase expected hash', async () => {
     const destPath = path.join(tmpDir, 'download.bin');
-    await downloadFile(serverUrl, destPath, undefined, correctHash.toUpperCase());
+    await downloadFile(
+      serverUrl,
+      destPath,
+      undefined,
+      correctHash.toUpperCase(),
+    );
     assert.ok(fs.existsSync(destPath));
   });
 });


### PR DESCRIPTION
## Summary

The `@puppeteer/browsers` package downloaded browser binaries (Chrome, Firefox)
without performing any integrity verification on the archive before extracting it.

`downloadFile()` in `httpUtil.ts` piped the HTTP response stream directly to disk
with no hash computation. `installUrl()` in `install.ts` then called
`unpackArchive()` immediately with no check between the two steps.

An attacker with a MITM position or access to the download CDN could silently
substitute a malicious binary. The binary would be extracted into the Puppeteer
cache directory and executed by every downstream call to `puppeteer.launch()`.

## Changes

- **`downloadFile()`** now computes SHA-256 incrementally while streaming.
  When `expectedHash` is supplied and does not match, the corrupted file is
  deleted and an error is thrown before extraction can occur.
- **`fetchChecksumFile()`** (new) attempts to retrieve a `.sha256` sidecar file
  published alongside the archive URL. Returns `undefined` when unavailable so
  existing workflows are unaffected.
- **`installUrl()`** resolves the expected hash once — caller-provided
  `InstallOptions.expectedHash` takes precedence, otherwise the sidecar is
  fetched — and forwards it to both `downloadFile()` call sites.
- **`InstallOptions`** gains an optional `expectedHash` field for callers that
  know the expected digest in advance.

## Security

- CWE-494: Download of Code Without Integrity Check
- Reported via Google OSS VRP

Fixes: #15107