### PR TITLE
fix(browsers): validate channel in CLI launch for system browsers

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -17,8 +17,7 @@ import {
   Browser,
   resolveBuildId,
   BrowserPlatform,
-  type ChromeReleaseChannel,
-  isChromeReleaseChannel,
+  verifyChromeReleaseChannel,
 } from './browser-data/browser-data.js';
 import {Cache} from './Cache.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
@@ -425,16 +424,10 @@ export class CLI {
             args.browser.name,
           );
 
-          if (args.system && !isChromeReleaseChannel(args.browser.buildId)) {
-            throw new Error(
-              `Cannot launch a system browser for the provided release channel: ${args.browser.buildId}`,
-            );
-          }
-
           const executablePath = args.system
             ? computeSystemExecutablePath({
                 browser: args.browser.name,
-                channel: args.browser.buildId as ChromeReleaseChannel,
+                channel: verifyChromeReleaseChannel(args.browser.buildId),
                 platform: args.platform,
               })
             : computeExecutablePath({

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -17,7 +17,8 @@ import {
   Browser,
   resolveBuildId,
   BrowserPlatform,
-  ChromeReleaseChannel,
+  type ChromeReleaseChannel,
+  isChromeReleaseChannel,
 } from './browser-data/browser-data.js';
 import {Cache} from './Cache.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
@@ -424,12 +425,7 @@ export class CLI {
             args.browser.name,
           );
 
-          if (
-            args.system &&
-            !Object.values(ChromeReleaseChannel).includes(
-              args.browser.buildId as ChromeReleaseChannel,
-            )
-          ) {
+          if (args.system && !isChromeReleaseChannel(args.browser.buildId)) {
             throw new Error(
               `Cannot launch a system browser for the provided release channel: ${args.browser.buildId}`,
             );

--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -17,7 +17,7 @@ import {
   Browser,
   resolveBuildId,
   BrowserPlatform,
-  type ChromeReleaseChannel,
+  ChromeReleaseChannel,
 } from './browser-data/browser-data.js';
 import {Cache} from './Cache.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
@@ -424,10 +424,20 @@ export class CLI {
             args.browser.name,
           );
 
+          if (
+            args.system &&
+            !Object.values(ChromeReleaseChannel).includes(
+              args.browser.buildId as ChromeReleaseChannel,
+            )
+          ) {
+            throw new Error(
+              `Cannot launch a system browser for the provided release channel: ${args.browser.buildId}`,
+            );
+          }
+
           const executablePath = args.system
             ? computeSystemExecutablePath({
                 browser: args.browser.name,
-                // TODO: throw an error if not a ChromeReleaseChannel is provided.
                 channel: args.browser.buildId as ChromeReleaseChannel,
                 platform: args.platform,
               })

--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -14,6 +14,7 @@ import {
   BrowserPlatform,
   BrowserTag,
   ChromeReleaseChannel,
+  isChromeReleaseChannel,
   type ProfileOptions,
 } from './types.js';
 
@@ -51,7 +52,7 @@ export const versionComparators = {
   [Browser.FIREFOX]: firefox.compareVersions,
 };
 
-export {Browser, BrowserPlatform, ChromeReleaseChannel};
+export {Browser, BrowserPlatform, ChromeReleaseChannel, isChromeReleaseChannel};
 
 /**
  * @internal

--- a/packages/browsers/src/browser-data/browser-data.ts
+++ b/packages/browsers/src/browser-data/browser-data.ts
@@ -14,7 +14,7 @@ import {
   BrowserPlatform,
   BrowserTag,
   ChromeReleaseChannel,
-  isChromeReleaseChannel,
+  verifyChromeReleaseChannel,
   type ProfileOptions,
 } from './types.js';
 
@@ -52,7 +52,12 @@ export const versionComparators = {
   [Browser.FIREFOX]: firefox.compareVersions,
 };
 
-export {Browser, BrowserPlatform, ChromeReleaseChannel, isChromeReleaseChannel};
+export {
+  Browser,
+  BrowserPlatform,
+  ChromeReleaseChannel,
+  verifyChromeReleaseChannel,
+};
 
 /**
  * @internal

--- a/packages/browsers/src/browser-data/types.ts
+++ b/packages/browsers/src/browser-data/types.ts
@@ -72,8 +72,11 @@ export enum ChromeReleaseChannel {
 /**
  * @internal
  */
-export function isChromeReleaseChannel(
+export function verifyChromeReleaseChannel(
   value: unknown,
-): value is ChromeReleaseChannel {
-  return Object.values(ChromeReleaseChannel).includes(value as any);
+): ChromeReleaseChannel {
+  if (Object.values(ChromeReleaseChannel).includes(value as any)) {
+    return value as ChromeReleaseChannel;
+  }
+  throw new Error(`Invalid Chrome channel: ${value}`);
 }

--- a/packages/browsers/src/browser-data/types.ts
+++ b/packages/browsers/src/browser-data/types.ts
@@ -68,3 +68,12 @@ export enum ChromeReleaseChannel {
   CANARY = 'canary',
   BETA = 'beta',
 }
+
+/**
+ * @internal
+ */
+export function isChromeReleaseChannel(
+  value: unknown,
+): value is ChromeReleaseChannel {
+  return Object.values(ChromeReleaseChannel).includes(value as any);
+}

--- a/packages/browsers/test/src/CLI.test.ts
+++ b/packages/browsers/test/src/CLI.test.ts
@@ -64,12 +64,7 @@ describe('CLI', function () {
       process.exit = originalExit;
     }
     assert.ok(error, 'Expected an error to be thrown');
-    assert.ok(
-      error.message.includes(
-        'Cannot launch a system browser for the provided release channel: invalid-channel',
-      ) || error.message.includes('process.exit'),
-      'Expected error message to contain validation output',
-    );
+    assert.ok(error.message.includes('Invalid Chrome channel'));
   });
 
   it('should pass argument to binary', async () => {

--- a/packages/browsers/test/src/CLI.test.ts
+++ b/packages/browsers/test/src/CLI.test.ts
@@ -38,6 +38,40 @@ describe('CLI', function () {
     ]);
   });
 
+  it('should throw an error if an invalid system browser channel is provided', async () => {
+    let error: Error | undefined;
+
+    // Yargs may log the error and we want to capture it through thrown errors
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    const originalExit = process.exit;
+    try {
+      (process as any).exit = (code: number) => {
+        throw new Error(`process.exit called with ${code}`);
+      };
+      await new CLI(tmpDir).run([
+        'npx',
+        '@puppeteer/browsers',
+        'launch',
+        'chrome@invalid-channel',
+        `--path=${tmpDir}`,
+        '--system',
+      ]);
+    } catch (err) {
+      error = err as Error;
+    } finally {
+      console.error = originalConsoleError;
+      process.exit = originalExit;
+    }
+    assert.ok(error, 'Expected an error to be thrown');
+    assert.ok(
+      error.message.includes(
+        'Cannot launch a system browser for the provided release channel: invalid-channel',
+      ) || error.message.includes('process.exit'),
+      'Expected error message to contain validation output',
+    );
+  });
+
   it('should pass argument to binary', async () => {
     if (os.platform() === 'win32') {
       // Windows executable behaves differently


### PR DESCRIPTION
Fixes an issue where providing an invalid release channel to the `@puppeteer/browsers` CLI during a `--system` launch would result in opaque system errors or unintended behavior.

### 💡 What
Added a check to validate that the provided buildId (used as the `channel` parameter) is a valid `ChromeReleaseChannel` when `--system` is used. Throws an explicit `Error` if invalid. Also added test coverage.

### 🎯 Why
This resolves a `TODO` left in the codebase to make error handling more robust and informative for users invoking the CLI manually.

### 📊 Measured Improvement
N/A (Error handling improvement, no performance benchmark relevant).

---
*PR created automatically by Jules for task [7971239580070121402](https://jules.google.com/task/7971239580070121402) started by @Lightning00Blade*