### PR TITLE
fix: await for Worker script exection

### DIFF
--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -16,6 +16,8 @@ import {
 import {EventEmitter} from '../common/EventEmitter.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError, debugCatchError} from '../common/util.js';
+import type {EvaluateFunc, HandleFor} from '../index-browser.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {ExecutionContext} from './ExecutionContext.js';
 import {IsolatedWorld} from './IsolatedWorld.js';
@@ -39,6 +41,7 @@ export class CdpWebWorker extends WebWorker {
   readonly #id: string;
   readonly #targetType: TargetType;
   readonly #emitter: EventEmitter<WebWorkerEvents>;
+  #workerLoaded = new Deferred<void>();
 
   get internalEmitter(): EventEmitter<WebWorkerEvents> {
     return this.#emitter;
@@ -64,6 +67,10 @@ export class CdpWebWorker extends WebWorker {
         new ExecutionContext(client, event.context, this.#world),
       );
     });
+    this.#client.once('Inspector.workerScriptLoaded', () => {
+      this.#workerLoaded.resolve();
+    });
+
     this.#world.emitter.on('consoleapicalled', async event => {
       try {
         const values = event.args.map(arg => {
@@ -137,5 +144,24 @@ export class CdpWebWorker extends WebWorker {
           self.close();
         });
     }
+  }
+
+  override async evaluate<
+    Params extends unknown[],
+    Func extends EvaluateFunc<Params> = EvaluateFunc<Params>,
+  >(func: Func | string, ...args: Params): Promise<Awaited<ReturnType<Func>>> {
+    await this.#workerLoaded.valueOrThrow();
+    return await super.evaluate(func, ...args);
+  }
+
+  override async evaluateHandle<
+    Params extends unknown[],
+    Func extends EvaluateFunc<Params> = EvaluateFunc<Params>,
+  >(
+    func: Func | string,
+    ...args: Params
+  ): Promise<HandleFor<Awaited<ReturnType<Func>>>> {
+    await this.#workerLoaded.valueOrThrow();
+    return await super.evaluateHandle(func, ...args);
   }
 }

--- a/test/src/cdp/extensions.test.ts
+++ b/test/src/cdp/extensions.test.ts
@@ -49,36 +49,24 @@ describe('extensions', function () {
     assertNoServiceWorkerReported(targets, extensionId);
   });
 
-  it('can evaluate in the service worker', async function () {
-    const {browser} = state;
-    const extensionId = await browser.installExtension(extensionPath);
-    const serviceWorkerTarget = await browser.waitForTarget(target => {
-      return target.type() === 'service_worker';
-    });
-    const worker = await serviceWorkerTarget.worker()!;
-
-    let result = '';
-    // TODO: Chrome is flaky and MAGIC is sometimes not yet
-    // defined. Generally, it should not be the case but it look like
-    // there is a race condition between Runtime.evaluate and the
-    // worker's main script execution.
-    for (let i = 0; i < 5; i++) {
-      try {
-        result = await worker!.evaluate(() => {
-          // @ts-expect-error different context.
-          return globalThis.MAGIC;
-        });
-        break;
-      } catch {}
-      await new Promise(resolve => {
-        return setTimeout(resolve, 200);
+  for (let index = 0; index < 100; index++) {
+    it.only('can evaluate in the service worker', async function () {
+      const {browser} = state;
+      const extensionId = await browser.installExtension(extensionPath);
+      const serviceWorkerTarget = await browser.waitForTarget(target => {
+        return target.type() === 'service_worker';
       });
-    }
-    expect(result).toBe(42);
-    await browser.uninstallExtension(extensionId);
-    const targets = browser.targets();
-    assertNoServiceWorkerReported(targets, extensionId);
-  });
+      const worker = await serviceWorkerTarget.worker();
+      const result = await worker!.evaluate(() => {
+        // @ts-expect-error different context.
+        return globalThis.MAGIC;
+      });
+      expect(result).toBe(42);
+      await browser.uninstallExtension(extensionId);
+      const targets = browser.targets();
+      assertNoServiceWorkerReported(targets, extensionId);
+    });
+  }
 
   it('should list extensions and their properties', async () => {
     const {browser} = state;

--- a/test/src/cdp/extensions.test.ts
+++ b/test/src/cdp/extensions.test.ts
@@ -49,24 +49,22 @@ describe('extensions', function () {
     assertNoServiceWorkerReported(targets, extensionId);
   });
 
-  for (let index = 0; index < 100; index++) {
-    it.only('can evaluate in the service worker', async function () {
-      const {browser} = state;
-      const extensionId = await browser.installExtension(extensionPath);
-      const serviceWorkerTarget = await browser.waitForTarget(target => {
-        return target.type() === 'service_worker';
-      });
-      const worker = await serviceWorkerTarget.worker();
-      const result = await worker!.evaluate(() => {
-        // @ts-expect-error different context.
-        return globalThis.MAGIC;
-      });
-      expect(result).toBe(42);
-      await browser.uninstallExtension(extensionId);
-      const targets = browser.targets();
-      assertNoServiceWorkerReported(targets, extensionId);
+  it('can evaluate in the service worker', async function () {
+    const {browser} = state;
+    const extensionId = await browser.installExtension(extensionPath);
+    const serviceWorkerTarget = await browser.waitForTarget(target => {
+      return target.type() === 'service_worker';
     });
-  }
+    const worker = await serviceWorkerTarget.worker();
+    const result = await worker!.evaluate(() => {
+      // @ts-expect-error different context.
+      return globalThis.MAGIC;
+    });
+    expect(result).toBe(42);
+    await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    assertNoServiceWorkerReported(targets, extensionId);
+  });
 
   it('should list extensions and their properties', async () => {
     const {browser} = state;

--- a/test/src/worker.test.ts
+++ b/test/src/worker.test.ts
@@ -15,37 +15,26 @@ import {waitEvent} from './utils.js';
 describe('Workers', function () {
   setupTestBrowserHooks();
 
-  it('Page.workers', async () => {
-    const {page, server} = await getTestState();
+  for (let index = 0; index < 100; index++) {
+    it.only('Page.workers', async () => {
+      const {page, server} = await getTestState();
 
-    await Promise.all([
-      waitEvent(page, 'workercreated'),
-      page.goto(server.PREFIX + '/worker/worker.html'),
-    ]);
-    const worker = page.workers()[0]!;
-    expect(worker.url()).toContain('worker.js');
+      await Promise.all([
+        waitEvent(page, 'workercreated'),
+        page.goto(server.PREFIX + '/worker/worker.html'),
+      ]);
+      const worker = page.workers()[0]!;
+      expect(worker.url()).toContain('worker.js');
 
-    let result = '';
-    // TODO: Chrome is flaky and workerFunction is sometimes not yet
-    // defined. Generally, it should not be the case but it look like
-    // there is a race condition between Runtime.evaluate and the
-    // worker's main script execution.
-    for (let i = 0; i < 5; i++) {
-      try {
-        result = await worker.evaluate(() => {
-          return (globalThis as any).workerFunction();
-        });
-        break;
-      } catch {}
-      await new Promise(resolve => {
-        return setTimeout(resolve, 200);
+      const result = await worker.evaluate(() => {
+        return (globalThis as any).workerFunction();
       });
-    }
-    expect(result).toBe('worker function result');
+      expect(result).toBe('worker function result');
 
-    await page.goto(server.EMPTY_PAGE);
-    expect(page.workers()).toHaveLength(0);
-  });
+      await page.goto(server.EMPTY_PAGE);
+      expect(page.workers()).toHaveLength(0);
+    });
+  }
   it('should emit created and destroyed events', async () => {
     const {page} = await getTestState();
 

--- a/test/src/worker.test.ts
+++ b/test/src/worker.test.ts
@@ -15,26 +15,25 @@ import {waitEvent} from './utils.js';
 describe('Workers', function () {
   setupTestBrowserHooks();
 
-  for (let index = 0; index < 100; index++) {
-    it.only('Page.workers', async () => {
-      const {page, server} = await getTestState();
+  it('Page.workers', async () => {
+    const {page, server} = await getTestState();
 
-      await Promise.all([
-        waitEvent(page, 'workercreated'),
-        page.goto(server.PREFIX + '/worker/worker.html'),
-      ]);
-      const worker = page.workers()[0]!;
-      expect(worker.url()).toContain('worker.js');
+    await Promise.all([
+      waitEvent(page, 'workercreated'),
+      page.goto(server.PREFIX + '/worker/worker.html'),
+    ]);
+    const worker = page.workers()[0]!;
+    expect(worker.url()).toContain('worker.js');
 
-      const result = await worker.evaluate(() => {
-        return (globalThis as any).workerFunction();
-      });
-      expect(result).toBe('worker function result');
-
-      await page.goto(server.EMPTY_PAGE);
-      expect(page.workers()).toHaveLength(0);
+    const result = await worker.evaluate(() => {
+      return (globalThis as any).workerFunction();
     });
-  }
+    expect(result).toBe('worker function result');
+
+    await page.goto(server.EMPTY_PAGE);
+    expect(page.workers()).toHaveLength(0);
+  });
+
   it('should emit created and destroyed events', async () => {
     const {page} = await getTestState();
 


### PR DESCRIPTION
This PR make it so that we wait for the Worker script to be executed before we allow execution on it's Realm.
This means that user don't need to implement awaiting logic or check something to make sure the code is ran.