### PR TITLE
chore: add on exception event to receive thrown exceptions in service workers 

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -228,6 +228,19 @@ The constructor for this class is marked as internal. Third-party code should no
 </td></tr>
 <tr><td>
 
+<span id="exceptionmessage">[ExceptionMessage](./puppeteer.exceptionmessage.md)</span>
+
+</td><td>
+
+ExceptionMessage objects are dispatched by page via the 'exception' event.
+
+**Remarks:**
+
+The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `ExceptionMessage` class.
+
+</td></tr>
+<tr><td>
+
 <span id="extension">[Extension](./puppeteer.extension.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.exceptionmessage.exception.md
+++ b/docs/api/puppeteer.exceptionmessage.exception.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ExceptionMessage.exception
+---
+
+# ExceptionMessage.exception() method
+
+The exception object as a JSHandle.
+
+### Signature
+
+```typescript
+class ExceptionMessage {
+  exception(): JSHandle | undefined;
+}
+```
+
+**Returns:**
+
+[JSHandle](./puppeteer.jshandle.md) \| undefined

--- a/docs/api/puppeteer.exceptionmessage.exceptionid.md
+++ b/docs/api/puppeteer.exceptionmessage.exceptionid.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ExceptionMessage.exceptionId
+---
+
+# ExceptionMessage.exceptionId() method
+
+The exception ID.
+
+### Signature
+
+```typescript
+class ExceptionMessage {
+  exceptionId(): number | undefined;
+}
+```
+
+**Returns:**
+
+number \| undefined

--- a/docs/api/puppeteer.exceptionmessage.location.md
+++ b/docs/api/puppeteer.exceptionmessage.location.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ExceptionMessage.location
+---
+
+# ExceptionMessage.location() method
+
+The location of the exception message.
+
+### Signature
+
+```typescript
+class ExceptionMessage {
+  location(): ConsoleMessageLocation;
+}
+```
+
+**Returns:**
+
+[ConsoleMessageLocation](./puppeteer.consolemessagelocation.md)

--- a/docs/api/puppeteer.exceptionmessage.md
+++ b/docs/api/puppeteer.exceptionmessage.md
@@ -1,0 +1,89 @@
+---
+sidebar_label: ExceptionMessage
+---
+
+# ExceptionMessage class
+
+ExceptionMessage objects are dispatched by page via the 'exception' event.
+
+### Signature
+
+```typescript
+export declare class ExceptionMessage
+```
+
+## Remarks
+
+The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `ExceptionMessage` class.
+
+## Methods
+
+<table><thead><tr><th>
+
+Method
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="exception">[exception()](./puppeteer.exceptionmessage.exception.md)</span>
+
+</td><td>
+
+</td><td>
+
+The exception object as a JSHandle.
+
+</td></tr>
+<tr><td>
+
+<span id="exceptionid">[exceptionId()](./puppeteer.exceptionmessage.exceptionid.md)</span>
+
+</td><td>
+
+</td><td>
+
+The exception ID.
+
+</td></tr>
+<tr><td>
+
+<span id="location">[location()](./puppeteer.exceptionmessage.location.md)</span>
+
+</td><td>
+
+</td><td>
+
+The location of the exception message.
+
+</td></tr>
+<tr><td>
+
+<span id="stacktrace">[stackTrace()](./puppeteer.exceptionmessage.stacktrace.md)</span>
+
+</td><td>
+
+</td><td>
+
+The array of locations on the stack of the exception message.
+
+</td></tr>
+<tr><td>
+
+<span id="text">[text()](./puppeteer.exceptionmessage.text.md)</span>
+
+</td><td>
+
+</td><td>
+
+The text of the exception message.
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.exceptionmessage.stacktrace.md
+++ b/docs/api/puppeteer.exceptionmessage.stacktrace.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ExceptionMessage.stackTrace
+---
+
+# ExceptionMessage.stackTrace() method
+
+The array of locations on the stack of the exception message.
+
+### Signature
+
+```typescript
+class ExceptionMessage {
+  stackTrace(): ConsoleMessageLocation[];
+}
+```
+
+**Returns:**
+
+[ConsoleMessageLocation](./puppeteer.consolemessagelocation.md)\[\]

--- a/docs/api/puppeteer.exceptionmessage.text.md
+++ b/docs/api/puppeteer.exceptionmessage.text.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ExceptionMessage.text
+---
+
+# ExceptionMessage.text() method
+
+The text of the exception message.
+
+### Signature
+
+```typescript
+class ExceptionMessage {
+  text(): string;
+}
+```
+
+**Returns:**
+
+string

--- a/docs/api/puppeteer.pageevent.md
+++ b/docs/api/puppeteer.pageevent.md
@@ -98,6 +98,19 @@ Emitted when the page crashes. Will contain an `Error`.
 </td></tr>
 <tr><td>
 
+Exception
+
+</td><td>
+
+`"exception"`
+
+</td><td>
+
+Emitted when an uncaught exception happens within the page. Contains the exception details.
+
+</td></tr>
+<tr><td>
+
 FrameAttached
 
 </td><td>

--- a/docs/api/puppeteer.pageevents.md
+++ b/docs/api/puppeteer.pageevents.md
@@ -122,7 +122,7 @@ Error
 
 </td><td>
 
-Protocol.Runtime.ExceptionDetails
+[ExceptionMessage](./puppeteer.exceptionmessage.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.pageevents.md
+++ b/docs/api/puppeteer.pageevents.md
@@ -116,6 +116,21 @@ Error
 </td></tr>
 <tr><td>
 
+<span id="exception">exception</span>
+
+</td><td>
+
+</td><td>
+
+Protocol.Runtime.ExceptionDetails
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="frameattached">frameattached</span>
 
 </td><td>

--- a/docs/api/puppeteer.webworkerevent.md
+++ b/docs/api/puppeteer.webworkerevent.md
@@ -51,4 +51,21 @@ Error
 Emitted when the worker throws an exception.
 
 </td></tr>
+<tr><td>
+
+Exception
+
+</td><td>
+
+`"exception"`
+
+</td><td>
+
+Emitted when the worker throws an exception.
+
+**Remarks:**
+
+Contains the exception details.
+
+</td></tr>
 </tbody></table>

--- a/docs/api/puppeteer.webworkerevents.md
+++ b/docs/api/puppeteer.webworkerevents.md
@@ -65,4 +65,19 @@ Error
 </td><td>
 
 </td></tr>
+<tr><td>
+
+<span id="exception">exception</span>
+
+</td><td>
+
+</td><td>
+
+Protocol.Runtime.ExceptionDetails
+
+</td><td>
+
+</td><td>
+
+</td></tr>
 </tbody></table>

--- a/docs/api/puppeteer.webworkerevents.md
+++ b/docs/api/puppeteer.webworkerevents.md
@@ -73,7 +73,7 @@ Error
 
 </td><td>
 
-Protocol.Runtime.ExceptionDetails
+[ExceptionMessage](./puppeteer.exceptionmessage.md)
 
 </td><td>
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -49,6 +49,7 @@ import {
   type EventType,
   type Handler,
 } from '../common/EventEmitter.js';
+import type {ExceptionMessage} from '../common/ExceptionMessage.js';
 import type {FileChooser} from '../common/FileChooser.js';
 import type {PDFOptions} from '../common/PDFOptions.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
@@ -620,7 +621,7 @@ export interface PageEvents extends Record<EventType, unknown> {
   [PageEvent.Load]: undefined;
   [PageEvent.Metrics]: {title: string; metrics: Metrics};
   [PageEvent.PageError]: Error | unknown;
-  [PageEvent.Exception]: Protocol.Runtime.ExceptionDetails;
+  [PageEvent.Exception]: ExceptionMessage;
   [PageEvent.Popup]: Page | null;
   [PageEvent.Request]: HTTPRequest;
   [PageEvent.Response]: HTTPResponse;

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -522,6 +522,11 @@ export const enum PageEvent {
    */
   PageError = 'pageerror',
   /**
+   * Emitted when an uncaught exception happens within the page. Contains the
+   * exception details.
+   */
+  Exception = 'exception',
+  /**
    * Emitted when the page opens a new tab or window.
    *
    * Contains a {@link Page} corresponding to the popup window.
@@ -615,6 +620,7 @@ export interface PageEvents extends Record<EventType, unknown> {
   [PageEvent.Load]: undefined;
   [PageEvent.Metrics]: {title: string; metrics: Metrics};
   [PageEvent.PageError]: Error | unknown;
+  [PageEvent.Exception]: Protocol.Runtime.ExceptionDetails;
   [PageEvent.Popup]: Page | null;
   [PageEvent.Request]: HTTPRequest;
   [PageEvent.Response]: HTTPResponse;

--- a/packages/puppeteer-core/src/api/WebWorker.ts
+++ b/packages/puppeteer-core/src/api/WebWorker.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {Protocol} from 'devtools-protocol';
+
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
 import {UnsupportedOperation} from '../common/Errors.js';
 import type {EventType} from '../common/EventEmitter.js';
@@ -27,6 +29,13 @@ export enum WebWorkerEvent {
    * Emitted when the worker throws an exception.
    */
   Error = 'error',
+  /**
+   * Emitted when the worker throws an exception.
+   *
+   * @remarks
+   * Contains the exception details.
+   */
+  Exception = 'exception',
 }
 
 /**
@@ -35,6 +44,7 @@ export enum WebWorkerEvent {
 export interface WebWorkerEvents extends Record<EventType, unknown> {
   [WebWorkerEvent.Console]: ConsoleMessage;
   [WebWorkerEvent.Error]: Error;
+  [WebWorkerEvent.Exception]: Protocol.Runtime.ExceptionDetails;
 }
 
 /**

--- a/packages/puppeteer-core/src/api/WebWorker.ts
+++ b/packages/puppeteer-core/src/api/WebWorker.ts
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {Protocol} from 'devtools-protocol';
-
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
 import {UnsupportedOperation} from '../common/Errors.js';
 import type {EventType} from '../common/EventEmitter.js';
 import {EventEmitter} from '../common/EventEmitter.js';
+import type {ExceptionMessage} from '../common/ExceptionMessage.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import type {EvaluateFunc, HandleFor} from '../common/types.js';
 import {withSourcePuppeteerURLIfNone} from '../common/util.js';
@@ -44,7 +43,7 @@ export enum WebWorkerEvent {
 export interface WebWorkerEvents extends Record<EventType, unknown> {
   [WebWorkerEvent.Console]: ConsoleMessage;
   [WebWorkerEvent.Error]: Error;
-  [WebWorkerEvent.Exception]: Protocol.Runtime.ExceptionDetails;
+  [WebWorkerEvent.Exception]: ExceptionMessage;
 }
 
 /**

--- a/packages/puppeteer-core/src/bidi/Frame.ts
+++ b/packages/puppeteer-core/src/bidi/Frame.ts
@@ -33,6 +33,7 @@ import {PageEvent, type WaitTimeoutOptions} from '../api/Page.js';
 import type {Realm} from '../api/Realm.js';
 import {Accessibility} from '../cdp/Accessibility.js';
 import {TargetCloseError, UnsupportedOperation} from '../common/Errors.js';
+import {ExceptionMessage} from '../common/ExceptionMessage.js';
 import type {TimeoutSettings} from '../common/TimeoutSettings.js';
 import type {Awaitable, HandleFor} from '../common/types.js';
 import {
@@ -181,8 +182,14 @@ export class BidiFrame extends Frame {
         const messageLines = error.stack!.split('\n').splice(0, messageHeight);
 
         const stackLines = [];
+        const locations = [];
         if (entry.stackTrace) {
           for (const frame of entry.stackTrace.callFrames) {
+            locations.push({
+              url: frame.url,
+              lineNumber: frame.lineNumber + 1,
+              columnNumber: frame.columnNumber + 1,
+            });
             // Note we need to add `1` because the values are 0-indexed.
             stackLines.push(
               `    at ${frame.functionName || '<anonymous>'} (${frame.url}:${
@@ -193,7 +200,23 @@ export class BidiFrame extends Frame {
               break;
             }
           }
+        } else {
+          locations.push({
+            url: entry.source.realm,
+            lineNumber: 0,
+            columnNumber: 0,
+          });
         }
+
+        const exceptionMessage = new ExceptionMessage(
+          entry.text ?? '',
+          locations,
+          undefined,
+          undefined,
+          undefined,
+          entry.stackTrace,
+        );
+        this.page().trustedEmitter.emit(PageEvent.Exception, exceptionMessage);
 
         error.stack = [...messageLines, ...stackLines].join('\n');
         this.page().trustedEmitter.emit(PageEvent.PageError, error);

--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -10,6 +10,7 @@ import type {JSHandle} from '../api/JSHandle.js';
 import {Realm} from '../api/Realm.js';
 import {WebWorkerEvent} from '../api/WebWorker.js';
 import {ARIAQueryHandler} from '../common/AriaQueryHandler.js';
+import {ExceptionMessage} from '../common/ExceptionMessage.js';
 import {LazyArg} from '../common/LazyArg.js';
 import {scriptInjector} from '../common/ScriptInjector.js';
 import type {TimeoutSettings} from '../common/TimeoutSettings.js';
@@ -39,6 +40,7 @@ import {ExposableFunction} from './ExposedFunction.js';
 import type {BidiFrame} from './Frame.js';
 import {BidiJSHandle} from './JSHandle.js';
 import {BidiSerializer} from './Serializer.js';
+import {isJavaScriptLogEntry} from './util.js';
 import {
   createEvaluationError,
   getConsoleMessage,
@@ -434,6 +436,51 @@ export class BidiWorkerRealm extends BidiRealm {
           this.realm.id,
         );
         this.#worker.emit(WebWorkerEvent.Console, message);
+      } else if (isJavaScriptLogEntry(entry)) {
+        const error = new Error(entry.text ?? '');
+
+        const messageHeight = error.message.split('\n').length;
+        const messageLines = error.stack!.split('\n').splice(0, messageHeight);
+
+        const stackLines = [];
+        const locations = [];
+        if (entry.stackTrace) {
+          for (const frame of entry.stackTrace.callFrames) {
+            locations.push({
+              url: frame.url,
+              lineNumber: frame.lineNumber,
+              columnNumber: frame.columnNumber,
+            });
+            // Note we need to add `1` because the values are 0-indexed.
+            stackLines.push(
+              `    at ${frame.functionName || '<anonymous>'} (${frame.url}:${
+                frame.lineNumber + 1
+              }:${frame.columnNumber + 1})`,
+            );
+            if (stackLines.length >= Error.stackTraceLimit) {
+              break;
+            }
+          }
+        } else {
+          locations.push({
+            url: entry.source.realm,
+            lineNumber: 0,
+            columnNumber: 0,
+          });
+        }
+
+        const exceptionMessage = new ExceptionMessage(
+          entry.text ?? '',
+          locations,
+          undefined,
+          undefined,
+          undefined,
+          entry.stackTrace,
+        );
+        this.#worker.emit(WebWorkerEvent.Exception, exceptionMessage);
+
+        error.stack = [...messageLines, ...stackLines].join('\n');
+        this.#worker.emit(WebWorkerEvent.Error, error);
       }
     });
   }

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -44,6 +44,7 @@ import type {
 } from '../common/Cookie.js';
 import {TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
+import {ExceptionMessage} from '../common/ExceptionMessage.js';
 import {FileChooser} from '../common/FileChooser.js';
 import {NetworkManagerEvent} from '../common/NetworkManagerEvents.js';
 import type {PDFOptions} from '../common/PDFOptions.js';
@@ -939,7 +940,41 @@ export class CdpPage extends Page {
   }
 
   #handleException(exception: Protocol.Runtime.ExceptionThrownEvent): void {
-    this.emit(PageEvent.Exception, exception.exceptionDetails);
+    const {exceptionDetails} = exception;
+
+    // eslint-disable-next-line max-len -- The comment is long.
+    // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
+    let exceptionHandle: JSHandle | undefined;
+    if (exceptionDetails.exception) {
+      exceptionHandle = this.mainFrame()
+        .mainRealm()
+        .createCdpHandle(exceptionDetails.exception);
+    }
+
+    const locations = exceptionDetails.stackTrace?.callFrames.map(frame => {
+      return {
+        url: frame.url,
+        lineNumber: frame.lineNumber,
+        columnNumber: frame.columnNumber,
+      };
+    }) || [
+      {
+        url: exceptionDetails.url,
+        lineNumber: exceptionDetails.lineNumber,
+        columnNumber: exceptionDetails.columnNumber,
+      },
+    ];
+
+    const exceptionMessage = new ExceptionMessage(
+      exceptionDetails.text,
+      locations,
+      exceptionHandle,
+      exceptionDetails.exceptionId,
+      exceptionDetails.stackTrace,
+      undefined,
+    );
+
+    this.emit(PageEvent.Exception, exceptionMessage);
     this.emit(
       PageEvent.PageError,
       createClientError(exception.exceptionDetails),

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -939,6 +939,7 @@ export class CdpPage extends Page {
   }
 
   #handleException(exception: Protocol.Runtime.ExceptionThrownEvent): void {
+    this.emit(PageEvent.Exception, exception.exceptionDetails);
     this.emit(
       PageEvent.PageError,
       createClientError(exception.exceptionDetails),

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -14,6 +14,7 @@ import {
   type WebWorkerEvents,
 } from '../api/WebWorker.js';
 import {EventEmitter} from '../common/EventEmitter.js';
+import {ExceptionMessage} from '../common/ExceptionMessage.js';
 import {TimeoutSettings} from '../common/TimeoutSettings.js';
 import {debugError, debugCatchError} from '../common/util.js';
 import type {EvaluateFunc, HandleFor} from '../index-browser.js';
@@ -101,8 +102,42 @@ export class CdpWebWorker extends WebWorker {
       }
     });
     this.#client.on('Runtime.exceptionThrown', event => {
-      this.#emitter.emit(WebWorkerEvent.Exception, event.exceptionDetails);
-      this.emit(WebWorkerEvent.Exception, event.exceptionDetails);
+      const {exceptionDetails} = event;
+
+      // eslint-disable-next-line max-len -- The comment is long.
+      // eslint-disable-next-line @puppeteer/use-using -- These are not owned by this function.
+      let exceptionHandle: HandleFor<unknown> | undefined;
+      if (exceptionDetails.exception) {
+        exceptionHandle = this.#world.createCdpHandle(
+          exceptionDetails.exception,
+        );
+      }
+
+      const locations = exceptionDetails.stackTrace?.callFrames.map(frame => {
+        return {
+          url: frame.url,
+          lineNumber: frame.lineNumber,
+          columnNumber: frame.columnNumber,
+        };
+      }) || [
+        {
+          url: exceptionDetails.url,
+          lineNumber: exceptionDetails.lineNumber,
+          columnNumber: exceptionDetails.columnNumber,
+        },
+      ];
+
+      const exceptionMessage = new ExceptionMessage(
+        exceptionDetails.text,
+        locations,
+        exceptionHandle,
+        exceptionDetails.exceptionId,
+        exceptionDetails.stackTrace,
+        undefined,
+      );
+
+      this.#emitter.emit(WebWorkerEvent.Exception, exceptionMessage);
+      this.emit(WebWorkerEvent.Exception, exceptionMessage);
       if (exceptionThrown) {
         exceptionThrown(event);
       }

--- a/packages/puppeteer-core/src/cdp/WebWorker.ts
+++ b/packages/puppeteer-core/src/cdp/WebWorker.ts
@@ -100,7 +100,13 @@ export class CdpWebWorker extends WebWorker {
         debugError?.(err);
       }
     });
-    this.#client.on('Runtime.exceptionThrown', exceptionThrown);
+    this.#client.on('Runtime.exceptionThrown', event => {
+      this.#emitter.emit(WebWorkerEvent.Exception, event.exceptionDetails);
+      this.emit(WebWorkerEvent.Exception, event.exceptionDetails);
+      if (exceptionThrown) {
+        exceptionThrown(event);
+      }
+    });
     this.#client.once(CDPSessionEvent.Disconnected, () => {
       this.#world.dispose();
     });

--- a/packages/puppeteer-core/src/common/ExceptionMessage.ts
+++ b/packages/puppeteer-core/src/common/ExceptionMessage.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as Bidi from 'chromium-bidi/lib/protocol/protocol.js';
+import type {Protocol} from 'devtools-protocol';
+
+import type {JSHandle} from '../api/JSHandle.js';
+
+import type {ConsoleMessageLocation} from './ConsoleMessage.js';
+
+/**
+ * ExceptionMessage objects are dispatched by page via the 'exception' event.
+ * @public
+ */
+export class ExceptionMessage {
+  #text: string;
+  #stackTraceLocations: ConsoleMessageLocation[];
+  #exception?: JSHandle;
+  #exceptionId?: number;
+  #rawCdpStackTrace?: Protocol.Runtime.StackTrace;
+  #rawBidiStackTrace?: Bidi.Script.StackTrace;
+
+  /**
+   * @internal
+   */
+  constructor(
+    text: string,
+    stackTraceLocations: ConsoleMessageLocation[],
+    exception?: JSHandle,
+    exceptionId?: number,
+    rawCdpStackTrace?: Protocol.Runtime.StackTrace,
+    rawBidiStackTrace?: Bidi.Script.StackTrace,
+  ) {
+    this.#text = text;
+    this.#stackTraceLocations = stackTraceLocations;
+    this.#exception = exception;
+    this.#exceptionId = exceptionId;
+    this.#rawCdpStackTrace = rawCdpStackTrace;
+    this.#rawBidiStackTrace = rawBidiStackTrace;
+  }
+
+  /**
+   * The text of the exception message.
+   */
+  text(): string {
+    return this.#text;
+  }
+
+  /**
+   * The array of locations on the stack of the exception message.
+   */
+  stackTrace(): ConsoleMessageLocation[] {
+    return this.#stackTraceLocations;
+  }
+
+  /**
+   * The location of the exception message.
+   */
+  location(): ConsoleMessageLocation {
+    return this.#stackTraceLocations[0] ?? {};
+  }
+
+  /**
+   * The exception object as a JSHandle.
+   */
+  exception(): JSHandle | undefined {
+    return this.#exception;
+  }
+
+  /**
+   * The exception ID.
+   */
+  exceptionId(): number | undefined {
+    return this.#exceptionId;
+  }
+
+  /**
+   * The underlying CDP protocol stack trace if available.
+   *
+   * @internal
+   */
+  _rawCdpStackTrace(): Protocol.Runtime.StackTrace | undefined {
+    return this.#rawCdpStackTrace;
+  }
+
+  /**
+   * The underlying BiDi protocol stack trace if available.
+   *
+   * @internal
+   */
+  _rawBidiStackTrace(): Bidi.Script.StackTrace | undefined {
+    return this.#rawBidiStackTrace;
+  }
+}

--- a/packages/puppeteer-core/src/common/common.ts
+++ b/packages/puppeteer-core/src/common/common.ts
@@ -16,6 +16,7 @@ export * from './CustomQueryHandler.js';
 export * from './Debug.js';
 export * from './Device.js';
 export * from './Errors.js';
+export * from './ExceptionMessage.js';
 export * from './EventEmitter.js';
 export * from './FileChooser.js';
 export * from './GetQueryHandler.js';

--- a/test/src/cdp/extensions.test.ts
+++ b/test/src/cdp/extensions.test.ts
@@ -10,8 +10,10 @@ import path from 'node:path';
 import expect from 'expect';
 import type {Target} from 'puppeteer-core/internal/api/Target.js';
 import type {ConsoleMessage} from 'puppeteer-core/internal/common/ConsoleMessage.js';
+import type {ExceptionMessage} from 'puppeteer-core/internal/common/ExceptionMessage.js';
 
 import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
+import {waitEvent} from '../utils.js';
 
 const extensionWithPagePath = path.join(
   import.meta.dirname,
@@ -266,27 +268,20 @@ describe('extensions', function () {
     const worker = await serviceWorkerTarget.worker();
     const errorMessage = 'error from extension worker';
 
-    let capturedDetails: any;
-    worker!.on('exception', details => {
-      capturedDetails = details;
-    });
+    const exceptionMessagePromise = waitEvent(worker!, 'exception');
 
     await worker!.evaluate(msg => {
       setTimeout(() => {
-        // @ts-expect-error global variable for test
-        globalThis.didThrow = true;
         throw new Error(msg);
       }, 0);
     }, errorMessage);
 
-    await worker!.waitForFunction(() => {
-      // @ts-expect-error global variable for test
-      return globalThis.didThrow;
-    });
+    const exceptionMessage = await exceptionMessagePromise as ExceptionMessage;
 
-    expect(capturedDetails).toBeDefined();
-    const errorText =
-      capturedDetails.exception?.description || capturedDetails.text;
+    expect(exceptionMessage).toBeDefined();
+    
+    const handle = exceptionMessage.exception();
+    const errorText = handle ? handle.remoteObject().description : exceptionMessage.text();
     expect(errorText).toContain(errorMessage);
 
     await browser.uninstallExtension(extensionId);

--- a/test/src/cdp/extensions.test.ts
+++ b/test/src/cdp/extensions.test.ts
@@ -254,6 +254,46 @@ describe('extensions', function () {
     assertNoServiceWorkerReported(targets, extensionId);
   });
 
+  it('should capture exceptions from extension workers', async () => {
+    const {browser} = state;
+    const extensionId = await browser.installExtension(extensionPath);
+    const serviceWorkerTarget = await browser.waitForTarget(target => {
+      return (
+        target.url().includes(extensionId) && target.type() === 'service_worker'
+      );
+    });
+
+    const worker = await serviceWorkerTarget.worker();
+    const errorMessage = 'error from extension worker';
+
+    let capturedDetails: any;
+    worker!.on('exception', details => {
+      capturedDetails = details;
+    });
+
+    await worker!.evaluate(msg => {
+      setTimeout(() => {
+        // @ts-expect-error global variable for test
+        globalThis.didThrow = true;
+        throw new Error(msg);
+      }, 0);
+    }, errorMessage);
+
+    await worker!.waitForFunction(() => {
+      // @ts-expect-error global variable for test
+      return globalThis.didThrow;
+    });
+
+    expect(capturedDetails).toBeDefined();
+    const errorText =
+      capturedDetails.exception?.description || capturedDetails.text;
+    expect(errorText).toContain(errorMessage);
+
+    await browser.uninstallExtension(extensionId);
+    const targets = browser.targets();
+    assertNoServiceWorkerReported(targets, extensionId);
+  });
+
   it('should remove extension from list after uninstall', async () => {
     const {browser} = state;
     const id = await browser.installExtension(extensionPath);

--- a/test/src/page.test.ts
+++ b/test/src/page.test.ts
@@ -1246,6 +1246,20 @@ describe('Page', function () {
     });
   });
 
+  describe('Page.Events.Exception', function () {
+    it('should fire', async () => {
+      const {page, server} = await getTestState();
+
+      const [exceptionDetails] = await Promise.all([
+        waitEvent(page, 'exception'),
+        page.goto(server.PREFIX + '/error.html'),
+      ]);
+      expect(exceptionDetails.exception?.description).toContain('Fancy');
+      expect(exceptionDetails.lineNumber).toBe(13);
+      expect(exceptionDetails.columnNumber).toBe(10);
+    });
+  });
+
   describe('Page.setUserAgent', function () {
     it('should work', async () => {
       const {page, server} = await getTestState();

--- a/test/src/page.test.ts
+++ b/test/src/page.test.ts
@@ -1247,16 +1247,68 @@ describe('Page', function () {
   });
 
   describe('Page.Events.Exception', function () {
-    it('should fire', async () => {
-      const {page, server} = await getTestState();
+    it('should fire and map properties correctly', async () => {
+      const {page, server, defaultBrowserOptions} = await getTestState();
 
-      const [exceptionDetails] = await Promise.all([
+      const [exceptionMessage] = await Promise.all([
         waitEvent(page, 'exception'),
         page.goto(server.PREFIX + '/error.html'),
       ]);
-      expect(exceptionDetails.exception?.description).toContain('Fancy');
-      expect(exceptionDetails.lineNumber).toBe(13);
-      expect(exceptionDetails.columnNumber).toBe(10);
+
+      const isBidi = defaultBrowserOptions.protocol === 'webDriverBiDi';
+
+      if (isBidi) {
+        expect(exceptionMessage.text()).toContain('Error: Fancy error!');
+      } else {
+        expect(exceptionMessage.text()).toContain('Uncaught');
+      }
+
+      const location = exceptionMessage.location();
+      expect(location.url).toContain('error.html');
+
+      const stackTrace = exceptionMessage.stackTrace();
+      expect(stackTrace.length).toBeGreaterThan(0);
+      expect(stackTrace[0]!.url).toContain('error.html');
+
+      if (!isBidi) {
+        expect(exceptionMessage.exception()).toBeDefined();
+        expect(exceptionMessage.exceptionId()).toBeDefined();
+        expect(exceptionMessage._rawCdpStackTrace()).toBeDefined();
+        expect(exceptionMessage._rawBidiStackTrace()).toBeUndefined();
+      } else {
+        expect(exceptionMessage.exception()).toBeUndefined();
+        expect(exceptionMessage.exceptionId()).toBeUndefined();
+        expect(exceptionMessage._rawCdpStackTrace()).toBeUndefined();
+        expect(exceptionMessage._rawBidiStackTrace()).toBeDefined();
+      }
+    });
+
+    it('should provide the remote exception object in CDP', async () => {
+      const {page, server, defaultBrowserOptions} = await getTestState();
+
+      const isBidi = defaultBrowserOptions.protocol === 'webDriverBiDi';
+      if (isBidi) {
+        // BiDi does not supply the remote object for exceptions currently.
+        return;
+      }
+
+      const [exceptionMessage] = await Promise.all([
+        waitEvent(page, 'exception'),
+        page.goto(server.PREFIX + '/error.html'),
+      ]);
+
+      const handle = exceptionMessage.exception()!;
+      expect(handle).toBeDefined();
+
+      const errorName = await handle.evaluate((err: unknown) => {
+        return (err as Error).name;
+      });
+      expect(errorName).toBe('Error');
+
+      const errorMessage = await handle.evaluate((err: unknown) => {
+        return (err as Error).message;
+      });
+      expect(errorMessage).toBe('Fancy error!');
     });
   });
 

--- a/test/src/worker.test.ts
+++ b/test/src/worker.test.ts
@@ -116,7 +116,7 @@ describe('Workers', function () {
   });
 
   it('should report exceptions', async () => {
-    const {page} = await getTestState();
+    const {page, defaultBrowserOptions} = await getTestState();
 
     const workerCreatedPromise = waitEvent(page, 'workercreated');
     await page.evaluate(() => {
@@ -125,10 +125,17 @@ describe('Workers', function () {
       );
     });
     const worker = await workerCreatedPromise;
-    const exceptionDetails = await waitEvent(worker, 'exception');
-    expect(exceptionDetails.exception?.description).toContain(
-      'this is my error',
-    );
+    const exceptionMessage = await waitEvent(worker, 'exception');
+
+    const isBidi = defaultBrowserOptions.protocol === 'webDriverBiDi';
+    if (isBidi) {
+      expect(exceptionMessage.text()).toContain('this is my error');
+    } else {
+      expect(exceptionMessage.text()).toContain('Uncaught');
+      const handle = exceptionMessage.exception()!;
+      expect(handle).toBeDefined();
+      expect(handle.remoteObject().description).toContain('this is my error');
+    }
   });
 
   it('can be closed', async () => {

--- a/test/src/worker.test.ts
+++ b/test/src/worker.test.ts
@@ -115,6 +115,22 @@ describe('Workers', function () {
     expect(errorLog.message).toContain('this is my error');
   });
 
+  it('should report exceptions', async () => {
+    const {page} = await getTestState();
+
+    const workerCreatedPromise = waitEvent(page, 'workercreated');
+    await page.evaluate(() => {
+      return new Worker(
+        `data:text/javascript, throw new Error('this is my error');`,
+      );
+    });
+    const worker = await workerCreatedPromise;
+    const exceptionDetails = await waitEvent(worker, 'exception');
+    expect(exceptionDetails.exception?.description).toContain(
+      'this is my error',
+    );
+  });
+
   it('can be closed', async () => {
     const {page, server} = await getTestState();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
This PR allows to receive service worker exceptions by catching them into an `on("exception")` event. 
Additionally it also allow page to register the same event.

The `page.on("pageerror")` is preserved as it was to receive errors from both the page and the workers and avoid breaking current behaviours. This avoid using the `Runtime.exceptionThrown` directly to catch these events.

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
Yes
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Currently listening to exceptions originating from service workers/web workers required developers to manually create a CDP session, enable the Runtime domain, and listen to the `Runtime.exceptionThrown`.

This PR allows the user to be able to listen to the exception event on both `Page` and `WebWorker` instances.

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
