### PR TITLE
docs: Update Page.target deprecation message to cover broader usage.

### DIFF
--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -1347,7 +1347,7 @@ A target this page was created from.
 
 **Deprecated:**
 
-Use [Page.createCDPSession()](./puppeteer.page.createcdpsession.md) directly.
+To create CDP session use [Page.createCDPSession()](./puppeteer.page.createcdpsession.md) directly. To identify pages spawned by this one, use [PageEvent.Popup](./puppeteer.pageevent.md) event instead.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.page.target.md
+++ b/docs/api/puppeteer.page.target.md
@@ -6,7 +6,7 @@ sidebar_label: Page.target
 
 > Warning: This API is now obsolete.
 >
-> Use [Page.createCDPSession()](./puppeteer.page.createcdpsession.md) directly.
+> To create CDP session use [Page.createCDPSession()](./puppeteer.page.createcdpsession.md) directly. To identify pages spawned by this one, use [PageEvent.Popup](./puppeteer.pageevent.md) event instead.
 
 A target this page was created from.
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -910,7 +910,8 @@ export abstract class Page extends EventEmitter<PageEvents> {
   /**
    * A target this page was created from.
    *
-   * @deprecated Use {@link Page.createCDPSession} directly.
+   * @deprecated To create CDP session use {@link Page.createCDPSession} directly. To
+   * identify pages spawned by this one, use {@link PageEvent.Popup} event instead.
    */
   abstract target(): Target;
 


### PR DESCRIPTION
Improve Page.target deprecation message to instruct users how to transition code identifying popups spawned from a page.

Fixes: #15092 
Closes: #15103 