### PR TITLE
fix: correct screencast frame timing so playback matches real time

### DIFF
--- a/packages/puppeteer-core/src/node/ScreenRecorder.test.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {countFrames} from './ScreenRecorder.js';
+
+describe('ScreenRecorder', () => {
+  describe('countFrames', () => {
+    const FPS = 30;
+
+    // Total frames emitted for a stream captured at `captureFps` for `seconds`,
+    // anchored at t=0 — i.e. summing countFrames over each captured interval.
+    function totalFrames(
+      captureFps: number,
+      seconds: number,
+      fps = FPS,
+    ): number {
+      const frames = Math.round(captureFps * seconds);
+      let total = 0;
+      let previous = 0;
+      for (let i = 1; i <= frames; i++) {
+        const timestamp = i / captureFps;
+        total += countFrames(0, previous, timestamp, fps);
+        previous = timestamp;
+      }
+      return total;
+    }
+
+    it('keeps the total close to fps * duration for any capture rate', () => {
+      for (const captureFps of [24, 30, 31, 48, 53, 60, 90, 120]) {
+        const total = totalFrames(captureFps, 1);
+        // Always ~30 frames for 1s at 30fps, within one frame of rounding.
+        expect(total).toBeGreaterThanOrEqual(FPS - 1);
+        expect(total).toBeLessThanOrEqual(FPS + 1);
+      }
+    });
+
+    it('does not inflate the count when captured faster than fps', () => {
+      // The old per-interval rounding wrote ~1 frame per captured frame, i.e.
+      // ~60 frames for 1s captured at 60fps (a 2x timeline stretch).
+      expect(totalFrames(60, 1)).toBeLessThanOrEqual(FPS + 1);
+    });
+
+    it('does not drop all frames when captured much faster than fps', () => {
+      // The old per-interval rounding computed round(30/120) = 0 per interval,
+      // dropping every frame. The corrected accounting keeps ~30.
+      expect(totalFrames(120, 1)).toBeGreaterThanOrEqual(FPS - 1);
+    });
+
+    it('scales with the requested fps', () => {
+      expect(totalFrames(60, 1, 60)).toBeGreaterThanOrEqual(59);
+      expect(totalFrames(60, 1, 60)).toBeLessThanOrEqual(61);
+    });
+
+    it('returns zero for non-increasing timestamps', () => {
+      expect(countFrames(0, 1, 1, FPS)).toBe(0);
+      expect(countFrames(0, 1, 0.5, FPS)).toBe(0);
+    });
+  });
+});

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -37,6 +37,36 @@ const DEFAULT_FPS = 30;
 const debugFfmpeg = debug('puppeteer:ffmpeg');
 
 /**
+ * Computes how many encoder frames to emit for a captured frame that spans
+ * `[previousTimestamp, timestamp]`, so that the cumulative number of emitted
+ * frames tracks a constant-`fps` grid anchored at `startTimestamp`.
+ *
+ * Counting each interval independently with
+ * `Math.round(fps * (timestamp - previousTimestamp))` is wrong when frames are
+ * captured faster than `fps`: every sub-`1/fps` interval still rounds up to a
+ * whole frame, so the emitted frame count grows with the capture rate instead
+ * of staying at `fps * duration`, which stretches playback (and, for very high
+ * capture rates, the per-interval value rounds down to 0 and frames are
+ * dropped). Differencing the rounded cumulative position keeps the total at
+ * `Math.round(fps * (lastTimestamp - startTimestamp))`, independent of the
+ * capture rate.
+ *
+ * Timestamps are in seconds (CDP `Page.screencastFrame` metadata timestamps).
+ *
+ * @internal
+ */
+export function countFrames(
+  startTimestamp: number,
+  previousTimestamp: number,
+  timestamp: number,
+  fps: number,
+): number {
+  const end = Math.round((timestamp - startTimestamp) * fps);
+  const start = Math.round((previousTimestamp - startTimestamp) * fps);
+  return Math.max(0, end - start);
+}
+
+/**
  * @internal
  */
 export interface ScreenRecorderOptions {
@@ -160,15 +190,17 @@ export class ScreenRecorder extends PassThrough {
           'nobuffer',
         ],
         // Forces input to be read from standard input, and forces png input
-        // image format.
-        ['-f', 'image2pipe', '-vcodec', 'png', '-i', 'pipe:0'],
+        // image format. `-framerate` is an input option and must appear before
+        // `-i`; otherwise ffmpeg ignores it and the image2pipe demuxer falls
+        // back to its default 25fps, stretching the output timeline relative to
+        // the frames we feed it at `fps`.
+        // prettier-ignore
+        ['-framerate', `${fps}`, '-f', 'image2pipe', '-vcodec', 'png', '-i', 'pipe:0'],
         // No audio
         ['-an'],
         // This drastically reduces stalling when cpu is overbooked. By default
         // VP9 tries to use all available threads?
         ['-threads', '1'],
-        // Specifies the frame rate we are giving ffmpeg.
-        ['-framerate', `${fps}`],
         // Disable bitrate.
         ['-b:v', '0'],
         // Specifies the encoding and format we are using.
@@ -194,6 +226,8 @@ export class ScreenRecorder extends PassThrough {
       void this.stop().catch(debugCatchError);
     });
 
+    // Anchor for the constant-fps grid; set to the first frame's timestamp.
+    let startTimestamp: number | undefined;
     this.#lastFrame = lastValueFrom(
       fromEmitterEvent(client, 'Page.screencastFrame').pipe(
         tap(event => {
@@ -218,9 +252,10 @@ export class ScreenRecorder extends PassThrough {
           ]
         >,
         concatMap(([{timestamp: previousTimestamp, buffer}, {timestamp}]) => {
+          startTimestamp ??= previousTimestamp;
           return from(
             Array<Buffer>(
-              Math.round(fps * Math.max(timestamp - previousTimestamp, 0)),
+              countFrames(startTimestamp, previousTimestamp, timestamp, fps),
             ).fill(buffer),
           );
         }),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

Yes — a browser-free unit test (`ScreenRecorder.test.ts`, placed next to the class per `contributing.md`). `countFrames` keeps the total ≈ `fps × duration` for capture rates 24→120fps, doesn't inflate at 60fps, and doesn't drop everything at 120fps. Reverting to the old per-interval formula fails these (verified fails-before / passes-after). `npm run unit --workspace puppeteer-core` → 154/154 pass; `eslint` + `prettier` clean.

I did **not** run the full browser `screencast.test.ts` suite locally (test harness + pinned browser) — leaving that to CI. The size-ratio assertion in `should work concurrently` should still hold (frames stay ∝ duration). Real end-to-end was checked manually instead (macOS: a ~12s window went 14.60s/1.19×/25fps → 12.03s/~0.99×/30fps), plus the cross-environment table below.

**If relevant, did you update the documentation?**

Not applicable. The change is internal to `ScreenRecorder`'s ffmpeg muxing — no public API, option, type, or documented-behavior signature changes. `countFrames` is exported `@internal` only so the unit test can import it (same pattern as `referrerPolicyToProtocol`).

**Summary**

Fixes #15111.

`page.screencast()` produces videos whose playback timeline is stretched — the recording plays in slow motion, and the stretch factor grows with how fast the page is captured. Two independent bugs in `ScreenRecorder` combine:

1. **`-framerate` is in the wrong position.** It's an input option but is placed **after** `-i pipe:0`, so ffmpeg ignores it and the `image2pipe` demuxer falls back to its default **25fps**, while frames are duplicated for a **30fps** (`DEFAULT_FPS`) timeline → a constant **30/25 = 1.2×** stretch. Fixed by moving `-framerate` before `-i`.

2. **Per-interval rounding in the frame duplication.** `Math.round(fps * (timestamp - previousTimestamp))` is applied per captured interval; when the page is captured faster than `fps`, every sub-`1/fps` interval still rounds up to one frame, so the written frame count tracks the **capture rate** instead of `fps` (and above ~2×`fps` it rounds to 0 and drops frames). Replaced with a cumulative constant-`fps` grid (`countFrames`) anchored at the first frame, so the total is always `round(fps × duration)`.

Net effect: **playback stretch ≈ capture_fps / 25** before the fix, **≈ 1.0× at any capture rate** after — one relationship that explains the widely varying reported factor.

![Screencast timeline — before: a 5s clock plays back over ~12s (≈2.4x slow-motion); after: plays in 5s (1.0x)](https://raw.githubusercontent.com/nebrass/puppeteer/pr-assets/screencast-fix-before-after.gif)

> **Controlled reconstruction**, not a live capture: deterministic 60fps frames (the original report's capture rate) muxed through the **actual** before/after `ScreenRecorder` logic. A live 60fps capture couldn't be produced on the test hardware (capture caps ~30fps — see table), so this isolates the muxing behaviour deterministically; the fix itself is proven by the unit test above.

| Environment | capture rate | **unfixed** (output fps · stretch) | **fixed** (output fps · stretch) |
|---|---|---|---|
| macOS · Chrome-for-Testing 149 · headless · ffmpeg 8.1 | ~30 fps | 25 fps · **1.19×** | 30 fps · **0.99×** |
| macOS · CfT 149 · headful · ffmpeg 8.1 | ~31 fps | 25 fps · **1.22×** | 30 fps · ~1.0× |
| WSL2 → Chrome on Windows host (CDP over the WSL↔host socket) · ffmpeg 4.4 | ~25 fps | 25 fps · **1.02×** | 30 fps · **0.94×** |
| WSL2 · local Chrome (WSLg) · ffmpeg 4.4 | ~31 fps | 25 fps · **1.24×** | 30 fps · ~1.0× |
| **Original report (chrome-devtools-mcp, WSL2)** — [ref](https://github.com/ChromeDevTools/chrome-devtools-mcp/issues/2204) | **~53–65 fps** | 25 fps · **2.1× – 2.6×** | — |

The output fps reported by ffprobe is **25 before the fix and 30 after** in every environment (Bug 1, visible in container metadata); the stretch tracks the capture rate (`≈ capture_fps / 25`). Capture rate is bounded by Puppeteer ack-ing every frame (`Page.screencastFrameAck`) — ~25–31fps across four setups, ~53–65fps in the original report.

<details>
<summary>Raw per-run measurements (frames · video · real)</summary>

| Environment | variant | frames | output fps | video | real (page clock) | stretch |
|---|---|---|---|---|---|---|
| macOS · CfT 149 · headless | unfixed | 365 | 25 | 14.60s | 12.24s | 1.19× |
| macOS · CfT 149 · headless | fixed (moving content) | — | 30 | 12.03s | 12.18s (wall) | 0.99× |
| macOS · CfT 149 · headful (60fps synthetic anim) | unfixed | 188 | 25 | 7.52s | 6.14s | 1.22× |
| WSL2 → Windows-host Chrome | unfixed | 272 | 25 | 10.88s | 10.67s | 1.02× |
| WSL2 → Windows-host Chrome | fixed | 293 | 30 | 9.77s | 10.42s | 0.94× |
| WSL2 · local Chrome (WSLg), 10s window | unfixed | 311 | 25 | 12.44s | ~10.0s | ~1.24× |
| WSL2 · local Chrome (WSLg), 10s window | fixed | 299 | 30 | 9.77s | ~10.0s | ~1.0× |
| Original report (cdmcp) | unfixed | 810 | 25 | 32.40s | 15.38s | 2.11× |
| Original report (cdmcp) | unfixed | 578 | 25 | 23.12s | 8.91s | 2.60× |

Reproduction confounds worth flagging: (a) headless Chrome that only changes a text node may not composite at all (0 captured frames) — drive a transform animation; (b) a backgrounded/occluded window throttles rAF and freezes the clock mid-recording — launch with `--disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling` and keep it foreground.

</details>

**Does this PR introduce a breaking change?**

No public API/type/option change. It does change `page.screencast()` **output**: videos are now muxed at the intended `fps` (30 by default) and at real-time duration, where before they were tagged 25fps and stretched. Anyone who manually compensated for the old stretch (e.g. re-timing with `setpts`) would no longer need to — output is now correct.

**Other information**

- The `stop()` tail-padding uses a separate `performance.now()` time base and is left unchanged.
- Originally surfaced via chrome-devtools-mcp, which wraps `page.screencast()` unchanged: ChromeDevTools/chrome-devtools-mcp#2204.
