### PR TITLE
fix: remove global skipDownload early return to include other configs

### DIFF
--- a/docs/api/puppeteer.configuration.md
+++ b/docs/api/puppeteer.configuration.md
@@ -211,9 +211,9 @@ boolean
 
 </td><td>
 
-Tells Puppeteer to not download during installation.
+Tells Puppeteer to not download any of the browsers during installation.
 
-Can be overridden by `PUPPETEER_SKIP_DOWNLOAD`.
+Can be overridden by `PUPPETEER_SKIP_DOWNLOAD` or by specifying either `skipDownload` property in each browser specific config or by providing `PUPPETEER_FIREFOX_SKIP_DOWNLOAD` and `PUPPETEER_CHROME_SKIP_DOWNLOAD`.
 
 </td><td>
 

--- a/packages/puppeteer-core/src/common/Configuration.ts
+++ b/packages/puppeteer-core/src/common/Configuration.ts
@@ -58,9 +58,11 @@ export interface Configuration {
    */
   temporaryDirectory?: string;
   /**
-   * Tells Puppeteer to not download during installation.
+   * Tells Puppeteer to not download any of the browsers during installation.
    *
-   * Can be overridden by `PUPPETEER_SKIP_DOWNLOAD`.
+   * Can be overridden by `PUPPETEER_SKIP_DOWNLOAD` or by specifying either
+   * `skipDownload` property in each browser specific config or by providing
+   * `PUPPETEER_FIREFOX_SKIP_DOWNLOAD` and `PUPPETEER_CHROME_SKIP_DOWNLOAD`.
    */
   skipDownload?: boolean;
   /**

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -40,7 +40,9 @@
     "build": "wireit",
     "clean": "../../tools/clean.mjs",
     "postinstall": "node install.mjs",
-    "prepack": "wireit"
+    "prepack": "wireit",
+    "unit": "wireit",
+    "unit:only": "wireit"
   },
   "wireit": {
     "prepack": {
@@ -96,6 +98,18 @@
       ],
       "dependencies": [
         "build:tsc"
+      ]
+    },
+    "unit": {
+      "command": "node --test --test-reporter=spec \"lib/**/*.test.js\"",
+      "dependencies": [
+        "build"
+      ]
+    },
+    "unit:only": {
+      "command": "node --test --test-only --test-reporter=spec \"lib/**/*.test.js\"",
+      "dependencies": [
+        "build"
       ]
     }
   },

--- a/packages/puppeteer/src/getConfiguration.test.ts
+++ b/packages/puppeteer/src/getConfiguration.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {describe, it} from 'node:test';
+
+import {getBrowserSetting} from './getConfiguration.js';
+
+void describe('getConfiguration', () => {
+  void describe('getBrowserSetting', () => {
+    void it('picks the correct browser config when local skipDownload is true', () => {
+      const result = getBrowserSetting('chrome', {
+        chrome: {
+          skipDownload: true,
+          version: 'latest',
+        },
+      });
+
+      assert.notStrictEqual(result, {skipDownload: true, version: 'latest'});
+    });
+
+    void it('picks the correct browser config when global skipDownload is true', () => {
+      const result = getBrowserSetting('chrome', {
+        skipDownload: true,
+        chrome: {
+          version: 'latest',
+        },
+      });
+
+      assert.notStrictEqual(result, {skipDownload: true, version: 'latest'});
+    });
+  });
+});

--- a/packages/puppeteer/src/getConfiguration.test.ts
+++ b/packages/puppeteer/src/getConfiguration.test.ts
@@ -19,7 +19,25 @@ void describe('getConfiguration', () => {
         },
       });
 
-      assert.notStrictEqual(result, {skipDownload: true, version: 'latest'});
+      assert.partialDeepStrictEqual(result, {
+        skipDownload: true,
+        version: 'latest',
+      });
+    });
+
+    void it('picks the correct skipDownload when both global and local properies are used', () => {
+      const result = getBrowserSetting('chrome', {
+        skipDownload: true,
+        chrome: {
+          skipDownload: false,
+          version: 'latest',
+        },
+        firefox: {
+          version: 'stable',
+        },
+      });
+
+      assert.equal(result.skipDownload, false);
     });
 
     void it('picks the correct browser config when global skipDownload is true', () => {
@@ -30,7 +48,10 @@ void describe('getConfiguration', () => {
         },
       });
 
-      assert.notStrictEqual(result, {skipDownload: true, version: 'latest'});
+      assert.partialDeepStrictEqual(result, {
+        skipDownload: true,
+        version: 'latest',
+      });
     });
   });
 });

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -72,6 +72,9 @@ function getLogLevel(logLevel: unknown): 'silent' | 'error' | 'warn' {
   }
 }
 
+/**
+ * @internal
+ */
 export function getBrowserSetting(
   browser: 'chrome' | 'chrome-headless-shell' | 'firefox',
   configuration: Configuration,

--- a/packages/puppeteer/src/getConfiguration.ts
+++ b/packages/puppeteer/src/getConfiguration.ts
@@ -72,7 +72,7 @@ function getLogLevel(logLevel: unknown): 'silent' | 'error' | 'warn' {
   }
 }
 
-function getBrowserSetting(
+export function getBrowserSetting(
   browser: 'chrome' | 'chrome-headless-shell' | 'firefox',
   configuration: Configuration,
   defaultConfig:
@@ -80,11 +80,6 @@ function getBrowserSetting(
     | ChromeHeadlessShellSettings
     | FirefoxSettings = {},
 ): ChromeSettings | ChromeHeadlessShellSettings | FirefoxSettings {
-  if (configuration.skipDownload) {
-    return {
-      skipDownload: true,
-    };
-  }
   const browserSetting:
     | ChromeSettings
     | ChromeHeadlessShellSettings
@@ -95,6 +90,7 @@ function getBrowserSetting(
     process.env[`PUPPETEER_${browserEnvName}_VERSION`] ??
     configuration[browser]?.version ??
     defaultConfig.version;
+
   browserSetting.downloadBaseUrl =
     process.env[`PUPPETEER_${browserEnvName}_DOWNLOAD_BASE_URL`] ??
     configuration[browser]?.downloadBaseUrl ??
@@ -104,6 +100,7 @@ function getBrowserSetting(
     getBooleanEnvVar(`PUPPETEER_${browserEnvName}_SKIP_DOWNLOAD`) ??
     getBooleanEnvVar(`PUPPETEER_SKIP_${browserEnvName}_DOWNLOAD`) ??
     configuration[browser]?.skipDownload ??
+    configuration.skipDownload ??
     defaultConfig.skipDownload;
 
   return browserSetting;


### PR DESCRIPTION
By avoiding the early return and append the global `skipDownload` to the other chain of checks we are keeping the same behavior while also returning other config values that could be useful later on. (like version, in this case).   

closes: #15116 
