### PR TITLE
fix: apply allowlist to non-auto-attach sessions

### DIFF
--- a/packages/puppeteer-core/src/cdp/TargetManager.ts
+++ b/packages/puppeteer-core/src/cdp/TargetManager.ts
@@ -344,6 +344,7 @@ export class TargetManager
     }
 
     if (!this.#connection.isAutoAttached(targetInfo.targetId)) {
+      await this.#maybeSetupNetworkConditions(session, targetInfo);
       return;
     }
 
@@ -364,7 +365,7 @@ export class TargetManager
     if (targetInfo.type === 'service_worker') {
       if (!this.isUrlAllowed(targetInfo.url)) {
         await Promise.all([
-          this.#maybeSetupNetworkConditions(session),
+          this.#maybeSetupNetworkConditions(session, targetInfo),
           session.send('Runtime.runIfWaitingForDebugger'),
         ]).catch(debugCatchError);
         return;
@@ -436,8 +437,8 @@ export class TargetManager
       this.#finishInitializationIfReady(parentTarget._targetId);
     }
 
-    // TODO: the browser might be shutting down here. What do we do with the
-    // error?
+    // The browser might be shutting down here, so we
+    // ignore potential errors.
     await Promise.all([
       session.send('Target.setAutoAttach', {
         waitForDebuggerOnStart: true,
@@ -445,7 +446,7 @@ export class TargetManager
         autoAttach: true,
         filter: this.#discoveryFilter,
       }),
-      this.#maybeSetupNetworkConditions(session),
+      this.#maybeSetupNetworkConditions(session, targetInfo),
       session.send('Runtime.runIfWaitingForDebugger'),
     ]).catch(debugCatchError);
   };
@@ -521,7 +522,10 @@ export class TargetManager
     return result;
   }
 
-  #maybeSetupNetworkConditions = async (session: CDPSession): Promise<void> => {
+  #maybeSetupNetworkConditions = async (
+    session: CDPSession,
+    targetInfo: Protocol.Target.TargetInfo,
+  ): Promise<void> => {
     if (this.#blocklist.length === 0 && this.#allowlist.length === 0) {
       return;
     }
@@ -556,9 +560,21 @@ export class TargetManager
       });
     }
 
-    await session.send('Network.emulateNetworkConditionsByRule', {
-      offline: this.#blocklist.length > 0 ? true : undefined,
-      matchedNetworkConditions,
-    });
+    const needsNetwork =
+      targetInfo.type === 'worker' ||
+      targetInfo.type === 'service_worker' ||
+      targetInfo.type === 'shared_worker';
+
+    const promises = [];
+    if (needsNetwork) {
+      promises.push(session.send('Network.enable'));
+    }
+    promises.push(
+      session.send('Network.emulateNetworkConditionsByRule', {
+        offline: this.#blocklist.length > 0 ? true : undefined,
+        matchedNetworkConditions,
+      }),
+    );
+    await Promise.all(promises).catch(debugCatchError);
   };
 }

--- a/test/src/cdp/network_restrictions.test.ts
+++ b/test/src/cdp/network_restrictions.test.ts
@@ -24,6 +24,7 @@ describe('Network Restrictions', function () {
         '*://*:*/empty.html',
         '*://*:*/pptr.png',
         '*://*:*/serviceworkers/empty/sw.js',
+        '*://*:*/serviceworkers/fetch/style.css',
       ],
     });
 
@@ -97,6 +98,34 @@ describe('Network Restrictions', function () {
 
       expect(swError).toBeTruthy();
       expect(swError).toContain('Failed to register a ServiceWorker');
+    });
+
+    it('should fail fetch requests from within a service worker to URLs in the blocklist', async () => {
+      const {page, server, context} = state;
+      const allowedUrl = server.PREFIX + '/serviceworkers/fetch/sw.html';
+      const blockedUrl = server.PREFIX + '/serviceworkers/fetch/style.css';
+
+      await page.goto(allowedUrl);
+
+      const target = await context.waitForTarget(
+        target => {
+          return target.type() === 'service_worker';
+        },
+        {timeout: 3000},
+      );
+      const worker = (await target.worker())!;
+
+      const fetchError = await worker.evaluate(async url => {
+        try {
+          await fetch(url);
+          return null;
+        } catch (e) {
+          return (e as Error).message;
+        }
+      }, blockedUrl);
+
+      expect(fetchError).toBeTruthy();
+      expect(fetchError).toContain('Failed to fetch');
     });
 
     it('should prevent loading of blocklisted subresources (e.g., images)', async () => {


### PR DESCRIPTION
the non-auto-attach sessions include the custom CDP sessions created by the user but also the lazily created sessions such as worker sessions. Additionally, the Network needs to be enabled for workers because Puppeteer does not do it by default. It is not enabled for other targets to avoid double Network.enable and potential negative effects of that.