### PR TITLE
fix: regression when using Puppeteer with untrusted sessions

### DIFF
--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -28,6 +28,7 @@ import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
 import type {Viewport} from '../common/Viewport.js';
+import {Deferred} from '../util/Deferred.js';
 
 import {CdpBrowserContext} from './BrowserContext.js';
 import type {CdpCDPSession} from './CdpSession.js';
@@ -121,6 +122,7 @@ export class CdpBrowser extends BrowserBase {
   #targetManager: TargetManager;
   #handleDevToolsAsPage = false;
   #extensions = new Map<string, Extension>();
+  #version?: Deferred<Protocol.Browser.GetVersionResponse>;
 
   constructor(
     connection: Connection,
@@ -601,8 +603,18 @@ export class CdpBrowser extends BrowserBase {
     return !this.#connection._closed;
   }
 
-  #getVersion(): Promise<Protocol.Browser.GetVersionResponse> {
-    return this.#connection.send('Browser.getVersion');
+  async #getVersion(): Promise<Protocol.Browser.GetVersionResponse> {
+    if (!this.#version) {
+      this.#version = Deferred.create<Protocol.Browser.GetVersionResponse>();
+      try {
+        this.#version.resolve(
+          await this.#connection.send('Browser.getVersion'),
+        );
+      } catch (error) {
+        this.#version.reject(error as Error);
+      }
+    }
+    return await this.#version.valueOrThrow();
   }
 
   override get debugInfo(): DebugInfo {

--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -87,7 +87,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     client: CdpCDPSession,
     page: CdpPage,
     timeoutSettings: TimeoutSettings,
-    defaultUserAgent?: string,
   ) {
     super();
     this.#client = client;
@@ -95,7 +94,6 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     this.#networkManager = new NetworkManager(
       this,
       page.browser().isNetworkEnabled(),
-      defaultUserAgent,
     );
     this.#timeoutSettings = timeoutSettings;
     this.setupEventListeners(this.#client);

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -27,7 +27,15 @@ function createNetworkManager() {
       return null;
     },
     page() {
-      return {} as any;
+      return {
+        browser() {
+          return {
+            userAgent() {
+              return 'user-agent';
+            },
+          };
+        },
+      } as any;
     },
   });
 }
@@ -1598,6 +1606,27 @@ describe('NetworkManager', () => {
       expect(async () => {
         await manager.setUserAgent('test');
       }).rejects.toThrow();
+    });
+
+    it('should not throw if page().browser().userAgent() throws', async () => {
+      const mockCDPSession = new MockCDPSession();
+      const manager = new NetworkManager({
+        frame(): CdpFrame | null {
+          return null;
+        },
+        page() {
+          return {
+            browser() {
+              return {
+                userAgent() {
+                  throw new TargetCloseError('Target closed');
+                },
+              };
+            },
+          } as any;
+        },
+      });
+      await manager.addClient(mockCDPSession);
     });
   });
 });

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -21,6 +21,17 @@ import {NetworkManager} from './NetworkManager.js';
 // TODO: develop a helper to generate fake network events for attributes that
 // are not relevant for the network manager to make tests shorter.
 
+function createNetworkManager() {
+  return new NetworkManager({
+    frame(): CdpFrame | null {
+      return null;
+    },
+    page() {
+      return {} as any;
+    },
+  });
+}
+
 class MockCDPSession extends EventEmitter<CDPSessionEvents> {
   async send(): Promise<any> {}
   connection() {
@@ -39,11 +50,7 @@ class MockCDPSession extends EventEmitter<CDPSessionEvents> {
 describe('NetworkManager', () => {
   it('should process extra info on multiple redirects', async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
     mockCDPSession.emit('Network.requestWillBeSent', {
       requestId: '7760711DEFCFA23132D98ABA6B4E175C',
@@ -479,11 +486,7 @@ describe('NetworkManager', () => {
   });
   it(`should handle "double pause" (crbug.com/1196004) Fetch.requestPaused events for the same Network.requestWillBeSent event`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
     await manager.setRequestInterception(true);
 
@@ -563,11 +566,7 @@ describe('NetworkManager', () => {
   });
   it(`should handle Network.responseReceivedExtraInfo event after Network.responseReceived event (github.com/puppeteer/puppeteer/issues/8234)`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
 
     const requests: HTTPRequest[] = [];
@@ -680,11 +679,7 @@ describe('NetworkManager', () => {
 
   it(`should resolve the response once the late responseReceivedExtraInfo event arrives`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
 
     const finishedRequests: HTTPRequest[] = [];
@@ -831,11 +826,7 @@ describe('NetworkManager', () => {
 
   it(`should send responses for iframe that don't receive loadingFinished event`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
 
     const responses: HTTPResponse[] = [];
@@ -994,11 +985,7 @@ describe('NetworkManager', () => {
 
   it(`should send responses for iframe that don't receive loadingFinished event`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
 
     const responses: HTTPResponse[] = [];
@@ -1139,11 +1126,7 @@ describe('NetworkManager', () => {
 
   it(`should handle cached redirects`, async () => {
     const mockCDPSession = new MockCDPSession();
-    const manager = new NetworkManager({
-      frame(): CdpFrame | null {
-        return null;
-      },
-    });
+    const manager = createNetworkManager();
     await manager.addClient(mockCDPSession);
 
     const responses: HTTPResponse[] = [];
@@ -1579,11 +1562,7 @@ describe('NetworkManager', () => {
       const mockCDPSession = createMockSession(
         TargetCloseError as unknown as ErrorConstructor,
       );
-      const manager = new NetworkManager({
-        frame(): CdpFrame | null {
-          return null;
-        },
-      });
+      const manager = createNetworkManager();
       await manager.addClient(mockCDPSession);
       await manager.setCacheEnabled(true);
       await manager.setExtraHTTPHeaders({});
@@ -1593,11 +1572,7 @@ describe('NetworkManager', () => {
 
     it('should not throw on unsupported errors', async () => {
       const mockCDPSession = createMockSession(Error, 'Not supported');
-      const manager = new NetworkManager({
-        frame(): CdpFrame | null {
-          return null;
-        },
-      });
+      const manager = createNetworkManager();
       await manager.addClient(mockCDPSession);
       await manager.setCacheEnabled(true);
       await manager.setExtraHTTPHeaders({});
@@ -1607,11 +1582,7 @@ describe('NetworkManager', () => {
 
     it('should throw on non-TargetClose errors', async () => {
       const mockCDPSession = createMockSession(Error);
-      const manager = new NetworkManager({
-        frame(): CdpFrame | null {
-          return null;
-        },
-      });
+      const manager = createNetworkManager();
       expect(async () => {
         await manager.addClient(mockCDPSession);
       }).rejects.toThrow();

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -8,7 +8,7 @@ import type {Protocol} from 'devtools-protocol';
 
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
 import type {Frame} from '../api/Frame.js';
-import type {Credentials} from '../api/Page.js';
+import type {Credentials, Page} from '../api/Page.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {
   NetworkManagerEvent,
@@ -65,6 +65,7 @@ export interface InternalNetworkConditions extends NetworkConditions {
  */
 export interface FrameProvider {
   frame(id: string): Frame | null;
+  page(): Page;
 }
 
 /**
@@ -81,7 +82,6 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #userCacheDisabled?: boolean;
   #emulatedNetworkConditions?: InternalNetworkConditions;
   #userAgent?: string;
-  #defaultUserAgent?: string;
   #userAgentMetadata?: Protocol.Emulation.UserAgentMetadata;
   #platform?: string;
   #acceptLanguage?: string;
@@ -100,17 +100,12 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   ] as const;
 
   #clients = new Map<CDPSession, DisposableStack>();
-  #networkEnabled = true;
+  #networkEnabled: boolean;
 
-  constructor(
-    frameManager: FrameProvider,
-    networkEnabled?: boolean,
-    defaultUserAgent?: string,
-  ) {
+  constructor(frameManager: FrameProvider, networkEnabled?: boolean) {
     super();
     this.#frameManager = frameManager;
     this.#networkEnabled = networkEnabled ?? true;
-    this.#defaultUserAgent = defaultUserAgent;
   }
 
   #canIgnoreError(error: unknown) {
@@ -290,7 +285,9 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   async #applyUserAgent(client: CDPSession) {
-    const userAgent = this.#userAgent ?? this.#defaultUserAgent;
+    const userAgent =
+      this.#userAgent ??
+      (await this.#frameManager.page().browser().userAgent());
     if (userAgent === undefined) {
       return;
     }

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -120,11 +120,7 @@ export class CdpPage extends Page {
     target: CdpTarget,
     defaultViewport: Viewport | null,
   ): Promise<CdpPage> {
-    const page = new CdpPage(
-      client,
-      target,
-      await target.browser().userAgent(),
-    );
+    const page = new CdpPage(client, target);
     await page.#initialize();
     if (defaultViewport) {
       try {
@@ -165,11 +161,7 @@ export class CdpPage extends Page {
   #serviceWorkerBypassed = false;
   #userDragInterceptionEnabled = false;
 
-  constructor(
-    client: CdpCDPSession,
-    target: CdpTarget,
-    defaultUserAgent?: string,
-  ) {
+  constructor(client: CdpCDPSession, target: CdpTarget) {
     super();
     this.#primaryTargetClient = client;
     this.#tabTargetClient = client.parentSession()!;
@@ -182,12 +174,7 @@ export class CdpPage extends Page {
     this.#keyboard = new CdpKeyboard(client);
     this.#mouse = new CdpMouse(client, this.#keyboard);
     this.#touchscreen = new CdpTouchscreen(client, this.#keyboard);
-    this.#frameManager = new FrameManager(
-      client,
-      this,
-      this._timeoutSettings,
-      defaultUserAgent,
-    );
+    this.#frameManager = new FrameManager(client, this, this._timeoutSettings);
     this.#emulationManager = new EmulationManager(client);
     this.#tracing = new Tracing(client);
     this.#webmcp = new WebMCP(client, this.#frameManager);


### PR DESCRIPTION
I also used the opportunity to make sure the version is only called once as we don't expect it to change.

