### PR TITLE
docs: include units in page metrics

### DIFF
--- a/docs/api/puppeteer.metrics.md
+++ b/docs/api/puppeteer.metrics.md
@@ -47,6 +47,8 @@ number
 
 </td><td>
 
+Number of documents in the page.
+
 </td><td>
 
 </td></tr>
@@ -63,6 +65,8 @@ number
 number
 
 </td><td>
+
+Number of frames in the page.
 
 </td><td>
 
@@ -81,6 +85,8 @@ number
 
 </td><td>
 
+Number of event listeners in the page.
+
 </td><td>
 
 </td></tr>
@@ -97,6 +103,8 @@ number
 number
 
 </td><td>
+
+Total JavaScript heap size, in bytes.
 
 </td><td>
 
@@ -115,6 +123,8 @@ number
 
 </td><td>
 
+Used JavaScript heap size, in bytes.
+
 </td><td>
 
 </td></tr>
@@ -131,6 +141,8 @@ number
 number
 
 </td><td>
+
+Total number of full or partial page layouts.
 
 </td><td>
 
@@ -149,6 +161,8 @@ number
 
 </td><td>
 
+Combined duration of all page layouts, in seconds.
+
 </td><td>
 
 </td></tr>
@@ -165,6 +179,8 @@ number
 number
 
 </td><td>
+
+Number of DOM nodes in the page.
 
 </td><td>
 
@@ -183,6 +199,8 @@ number
 
 </td><td>
 
+Total number of page style recalculations.
+
 </td><td>
 
 </td></tr>
@@ -199,6 +217,8 @@ number
 number
 
 </td><td>
+
+Combined duration of all page style recalculations, in seconds.
 
 </td><td>
 
@@ -217,6 +237,8 @@ number
 
 </td><td>
 
+Combined duration of JavaScript execution, in seconds.
+
 </td><td>
 
 </td></tr>
@@ -234,6 +256,8 @@ number
 
 </td><td>
 
+Combined duration of all tasks performed by the browser, in seconds.
+
 </td><td>
 
 </td></tr>
@@ -250,6 +274,8 @@ number
 number
 
 </td><td>
+
+Monotonic timestamp in seconds when the metrics sample was taken.
 
 </td><td>
 

--- a/docs/api/puppeteer.page.metrics.md
+++ b/docs/api/puppeteer.page.metrics.md
@@ -18,13 +18,13 @@ class Page {
 
 Promise&lt;[Metrics](./puppeteer.metrics.md)&gt;
 
-- `Timestamp` : The timestamp when the metrics sample was taken.
+- `Timestamp` : The monotonic timestamp, in seconds, when the metrics sample was taken.
 
 - `Documents` : Number of documents in the page.
 
 - `Frames` : Number of frames in the page.
 
-- `JSEventListeners` : Number of events in the page.
+- `JSEventListeners` : Number of event listeners in the page.
 
 - `Nodes` : Number of DOM nodes in the page.
 
@@ -32,17 +32,17 @@ Promise&lt;[Metrics](./puppeteer.metrics.md)&gt;
 
 - `RecalcStyleCount` : Total number of page style recalculations.
 
-- `LayoutDuration` : Combined durations of all page layouts.
+- `LayoutDuration` : Combined duration of all page layouts, in seconds.
 
-- `RecalcStyleDuration` : Combined duration of all page style recalculations.
+- `RecalcStyleDuration` : Combined duration of all page style recalculations, in seconds.
 
-- `ScriptDuration` : Combined duration of JavaScript execution.
+- `ScriptDuration` : Combined duration of JavaScript execution, in seconds.
 
-- `TaskDuration` : Combined duration of all tasks performed by the browser.
+- `TaskDuration` : Combined duration of all tasks performed by the browser, in seconds.
 
-- `JSHeapUsedSize` : Used JavaScript heap size.
+- `JSHeapUsedSize` : Used JavaScript heap size, in bytes.
 
-- `JSHeapTotalSize` : Total JavaScript heap size.
+- `JSHeapTotalSize` : Total JavaScript heap size, in bytes.
 
 ## Remarks
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -125,18 +125,57 @@ import type {WebWorker} from './WebWorker.js';
  * @public
  */
 export interface Metrics {
+  /**
+   * Monotonic timestamp in seconds when the metrics sample was taken.
+   */
   Timestamp?: number;
+  /**
+   * Number of documents in the page.
+   */
   Documents?: number;
+  /**
+   * Number of frames in the page.
+   */
   Frames?: number;
+  /**
+   * Number of event listeners in the page.
+   */
   JSEventListeners?: number;
+  /**
+   * Number of DOM nodes in the page.
+   */
   Nodes?: number;
+  /**
+   * Total number of full or partial page layouts.
+   */
   LayoutCount?: number;
+  /**
+   * Total number of page style recalculations.
+   */
   RecalcStyleCount?: number;
+  /**
+   * Combined duration of all page layouts, in seconds.
+   */
   LayoutDuration?: number;
+  /**
+   * Combined duration of all page style recalculations, in seconds.
+   */
   RecalcStyleDuration?: number;
+  /**
+   * Combined duration of JavaScript execution, in seconds.
+   */
   ScriptDuration?: number;
+  /**
+   * Combined duration of all tasks performed by the browser, in seconds.
+   */
   TaskDuration?: number;
+  /**
+   * Used JavaScript heap size, in bytes.
+   */
   JSHeapUsedSize?: number;
+  /**
+   * Total JavaScript heap size, in bytes.
+   */
   JSHeapTotalSize?: number;
 }
 
@@ -1720,13 +1759,14 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *
    * @returns
    *
-   * - `Timestamp` : The timestamp when the metrics sample was taken.
+   * - `Timestamp` : The monotonic timestamp, in seconds, when the metrics
+   *   sample was taken.
    *
    * - `Documents` : Number of documents in the page.
    *
    * - `Frames` : Number of frames in the page.
    *
-   * - `JSEventListeners` : Number of events in the page.
+   * - `JSEventListeners` : Number of event listeners in the page.
    *
    * - `Nodes` : Number of DOM nodes in the page.
    *
@@ -1734,18 +1774,20 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *
    * - `RecalcStyleCount` : Total number of page style recalculations.
    *
-   * - `LayoutDuration` : Combined durations of all page layouts.
+   * - `LayoutDuration` : Combined duration of all page layouts, in seconds.
    *
    * - `RecalcStyleDuration` : Combined duration of all page style
-   *   recalculations.
+   *   recalculations, in seconds.
    *
-   * - `ScriptDuration` : Combined duration of JavaScript execution.
+   * - `ScriptDuration` : Combined duration of JavaScript execution, in
+   *   seconds.
    *
-   * - `TaskDuration` : Combined duration of all tasks performed by the browser.
+   * - `TaskDuration` : Combined duration of all tasks performed by the browser,
+   *   in seconds.
    *
-   * - `JSHeapUsedSize` : Used JavaScript heap size.
+   * - `JSHeapUsedSize` : Used JavaScript heap size, in bytes.
    *
-   * - `JSHeapTotalSize` : Total JavaScript heap size.
+   * - `JSHeapTotalSize` : Total JavaScript heap size, in bytes.
    *
    * @remarks
    * All timestamps are in monotonic time: monotonically increasing time


### PR DESCRIPTION
Fixes #13082

## Summary
- Add descriptions to each `Metrics` field in the API source docs.
- Clarify seconds vs bytes for `Page.metrics()` duration, timestamp, and heap-size values.
- Update the generated API markdown for the touched metrics pages.

## Verification
- `npx --yes prettier@3.8.3 --check packages/puppeteer-core/src/api/Page.ts docs/api/puppeteer.page.metrics.md docs/api/puppeteer.metrics.md`
- `git diff --check`