### PR TITLE
feat: support installing extensions for browser contexts

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1040,6 +1040,13 @@ Device in a request prompt.
 </td></tr>
 <tr><td>
 
+<span id="extensioninstalloptions">[ExtensionInstallOptions](./puppeteer.extensioninstalloptions.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="firefoxsettings">[FirefoxSettings](./puppeteer.firefoxsettings.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.browser.installextension.md
+++ b/docs/api/puppeteer.browser.installextension.md
@@ -10,7 +10,10 @@ Installs an extension and returns the ID.
 
 ```typescript
 class Browser {
-  abstract installExtension(path: string): Promise<string>;
+  abstract installExtension(
+    path: string,
+    options?: ExtensionInstallOptions,
+  ): Promise<string>;
 }
 ```
 
@@ -38,6 +41,19 @@ path
 string
 
 </td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[ExtensionInstallOptions](./puppeteer.extensioninstalloptions.md)
+
+</td><td>
+
+_(Optional)_
 
 </td></tr>
 </tbody></table>

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -275,7 +275,7 @@ Gets the specified window [bounds](./puppeteer.windowbounds.md).
 </td></tr>
 <tr><td>
 
-<span id="installextension">[installExtension(path)](./puppeteer.browser.installextension.md)</span>
+<span id="installextension">[installExtension(path, options)](./puppeteer.browser.installextension.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.extensioninstalloptions.md
+++ b/docs/api/puppeteer.extensioninstalloptions.md
@@ -1,0 +1,53 @@
+---
+sidebar_label: ExtensionInstallOptions
+---
+
+# ExtensionInstallOptions interface
+
+### Signature
+
+```typescript
+export interface ExtensionInstallOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="enabledinincognito">enabledInIncognito</span>
+
+</td><td>
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether to enable the extension in Incognito or OTR profiles in Chrome.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.launchoptions.md
+++ b/docs/api/puppeteer.launchoptions.md
@@ -222,6 +222,25 @@ When using this is recommended to set the `browser` property as well as Puppetee
 </td></tr>
 <tr><td>
 
+<span id="extensionsenabledinincognito">extensionsEnabledInIncognito</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string\[\]
+
+</td><td>
+
+List of extensions that will be enable in Incognito and off-the-record profiles.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="extraprefsfirefox">extraPrefsFirefox</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -324,6 +324,15 @@ export interface AddScreenParams {
   label?: string;
   isInternal?: boolean;
 }
+/**
+ * @public
+ */
+export interface ExtensionInstallOptions {
+  /**
+   * Whether to enable the extension in Incognito or OTR profiles in Chrome.
+   */
+  enabledInIncognito: boolean;
+}
 
 /**
  * {@link Browser} represents a browser instance that is either:
@@ -643,7 +652,10 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
   /**
    * Installs an extension and returns the ID.
    */
-  abstract installExtension(path: string): Promise<string>;
+  abstract installExtension(
+    path: string,
+    options?: ExtensionInstallOptions,
+  ): Promise<string>;
 
   /**
    * Uninstalls an extension.

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -8,7 +8,11 @@ import type {ChildProcess} from 'node:child_process';
 
 import type {Protocol} from 'devtools-protocol';
 
-import type {CreatePageOptions, DebugInfo} from '../api/Browser.js';
+import type {
+  CreatePageOptions,
+  DebugInfo,
+  ExtensionInstallOptions,
+} from '../api/Browser.js';
 import {
   Browser as BrowserBase,
   BrowserEvent,
@@ -477,8 +481,14 @@ export class CdpBrowser extends BrowserBase {
     return response.targetId;
   }
 
-  override async installExtension(path: string): Promise<string> {
-    const {id} = await this.#connection.send('Extensions.loadUnpacked', {path});
+  override async installExtension(
+    path: string,
+    options?: ExtensionInstallOptions,
+  ): Promise<string> {
+    const {id} = await this.#connection.send('Extensions.loadUnpacked', {
+      path,
+      enableInIncognito: options?.enabledInIncognito ?? false,
+    });
     this.#extensions.delete(id);
     return id;
   }

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -95,6 +95,7 @@ export abstract class BrowserLauncher {
     const {
       dumpio = false,
       enableExtensions = false,
+      extensionsEnabledInIncognito = [],
       env = process.env,
       handleSIGINT = true,
       handleSIGTERM = true,
@@ -279,7 +280,9 @@ export abstract class BrowserLauncher {
     if (Array.isArray(enableExtensions)) {
       await Promise.all([
         enableExtensions.map(path => {
-          return browser.installExtension(path);
+          return browser.installExtension(path, {
+            enabledInIncognito: extensionsEnabledInIncognito.includes(path),
+          });
         }),
       ]);
     }

--- a/packages/puppeteer-core/src/node/LaunchOptions.ts
+++ b/packages/puppeteer-core/src/node/LaunchOptions.ts
@@ -66,6 +66,11 @@ export interface LaunchOptions extends ConnectOptions {
    */
   enableExtensions?: boolean | string[];
   /**
+   * List of extensions that will be enable in Incognito and off-the-record
+   * profiles.
+   */
+  extensionsEnabledInIncognito?: string[];
+  /**
    * Close the browser process on `Ctrl+C`.
    * @defaultValue `true`
    */

--- a/test/src/cdp/extensions.test.ts
+++ b/test/src/cdp/extensions.test.ts
@@ -273,6 +273,46 @@ describe('extensions', function () {
     extensions = await browser.extensions();
     expect(extensions.has(id)).toBe(false);
   });
+
+  it('should be available in Incognito profiles if enabledInIncognito is true', async () => {
+    const {browser, server} = state;
+    const extensionId = await browser.installExtension(extensionPath, {
+      enabledInIncognito: true,
+    });
+
+    const context = await browser.createBrowserContext();
+    const page = await context.newPage();
+    await page.goto(server.EMPTY_PAGE);
+
+    const target = await browser.waitForTarget(target => {
+      return (
+        target.url().includes(extensionId) && target.type() === 'service_worker'
+      );
+    });
+    expect(target).toBeTruthy();
+
+    const realms = page.extensionRealms();
+
+    let contentScriptRealm;
+    for (const realm of realms) {
+      const extension = await realm.extension();
+      if (extension && extension.id === extensionId) {
+        contentScriptRealm = realm;
+        break;
+      }
+    }
+    assert(contentScriptRealm, 'realm should be defined');
+
+    const isContentScript = await contentScriptRealm.evaluate(() => {
+      return (globalThis as any).thisIsTheContentScript;
+    });
+    expect(isContentScript).toBe(true);
+
+    await browser.uninstallExtension(extensionId);
+    await context.close();
+    const targets = browser.targets();
+    assertNoServiceWorkerReported(targets, extensionId);
+  });
 });
 
 function assertNoServiceWorkerReported(targets: Target[], id: string) {


### PR DESCRIPTION
previously extensions would only apply to the default browser context. With enabledInIncognito flag, it is possible to allow extensions to run on Puppeteer's browser contexts.