### PR TITLE
fix: don't throw in checkVisibility for a detached text node

### DIFF
--- a/packages/puppeteer-core/src/injected/util.ts
+++ b/packages/puppeteer-core/src/injected/util.ts
@@ -20,7 +20,10 @@ export const checkVisibility = (
   }
   const element = (
     node.nodeType === Node.TEXT_NODE ? node.parentElement : node
-  ) as Element;
+  ) as Element | null;
+  if (!element) {
+    return visible === false;
+  }
 
   const style = window.getComputedStyle(element);
   const isVisible =

--- a/test/src/elementhandle.test.ts
+++ b/test/src/elementhandle.test.ts
@@ -271,6 +271,17 @@ describe('ElementHandle specs', function () {
       await expect(element.isVisible()).resolves.toBeTruthy();
       await expect(element.isHidden()).resolves.toBeFalsy();
     });
+
+    it('should not throw for a detached text node with no parent element', async () => {
+      const {page} = await getTestState();
+      await page.setContent(html`<div>x</div>`);
+      using handle = await page.evaluateHandle(() => {
+        return document.createTextNode('orphan');
+      });
+      using textHandle = handle.asElement()!;
+      await expect(textHandle.isHidden()).resolves.toBeTruthy();
+      await expect(textHandle.isVisible()).resolves.toBeFalsy();
+    });
   });
 
   describe('ElementHandle.click', function () {


### PR DESCRIPTION
isHidden()/isVisible() resolve a text node to its parent element before calling getComputedStyle, but a text node that was never attached to the DOM has parentElement === null, so getComputedStyle(null) throws a TypeError instead of resolving. e.g. calling isHidden() on an ElementHandle wrapping document.createTextNode('x') (never appended anywhere) blows up rather than returning true per the "no computed styles → hidden" doc.

#14159 fixed the exact same TEXT_NODE → parentElement pattern in Accessibility.ts, this one in util.ts's checkVisibility just got missed. Fix mirrors the existing `if (!node) return visible === false;` guard right above it, just one level down after the parent lookup. Added a test using page.evaluateHandle to create the orphan text node.