### PR TITLE
fix: combine duplicate BiDi response headers instead of overwriting

### DIFF
--- a/packages/puppeteer-core/src/bidi/HTTPResponse.test.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+import type * as Bidi from 'webdriver-bidi-protocol';
+
+import type {BidiHTTPRequest} from './HTTPRequest.js';
+import {BidiHTTPResponse} from './HTTPResponse.js';
+
+function stringHeader(name: string, value: string): Bidi.Network.Header {
+  return {name, value: {type: 'string', value}};
+}
+
+describe('BidiHTTPResponse', () => {
+  it('should combine duplicate set-cookie headers using \\n', () => {
+    const request = {
+      response() {
+        return undefined;
+      },
+      frame() {
+        return undefined;
+      },
+    } as unknown as BidiHTTPRequest;
+    const data = {
+      url: 'http://localhost/',
+      protocol: 'http/1.1',
+      status: 200,
+      statusText: 'OK',
+      fromCache: false,
+      headers: [
+        stringHeader('set-cookie', 'a=b'),
+        stringHeader('set-cookie', 'c=d'),
+      ],
+    } as unknown as Bidi.Network.ResponseData;
+
+    const response = BidiHTTPResponse.from(data, request, false);
+    expect(response.headers()['set-cookie']).toBe('a=b\n c=d');
+  });
+
+  it('should combine other duplicate headers using ,', () => {
+    const request = {
+      response() {
+        return undefined;
+      },
+      frame() {
+        return undefined;
+      },
+    } as unknown as BidiHTTPRequest;
+    const data = {
+      url: 'http://localhost/',
+      protocol: 'http/1.1',
+      status: 200,
+      statusText: 'OK',
+      fromCache: false,
+      headers: [
+        stringHeader('cache-control', 'no-cache'),
+        stringHeader('cache-control', 'no-store'),
+      ],
+    } as unknown as Bidi.Network.ResponseData;
+
+    const response = BidiHTTPResponse.from(data, request, false);
+    expect(response.headers()['cache-control']).toBe('no-cache, no-store');
+  });
+});

--- a/packages/puppeteer-core/src/bidi/HTTPResponse.ts
+++ b/packages/puppeteer-core/src/bidi/HTTPResponse.ts
@@ -102,10 +102,11 @@ export class BidiHTTPResponse extends HTTPResponse {
       // https://w3c.github.io/webdriver-bidi/#type-network-Header
       if (header.value.type === 'string') {
         const headerName = header.name.toLowerCase();
-        headers[headerName] = normalizeHeaderValue(
-          headerName,
-          header.value.value,
-        );
+        const value =
+          headerName in headers
+            ? `${headers[headerName]}\n${header.value.value}`
+            : header.value.value;
+        headers[headerName] = normalizeHeaderValue(headerName, value);
       }
     }
     return headers;


### PR DESCRIPTION
## Description

With the WebDriver BiDi backend, `HTTPResponse.headers()` keeps only the last of any duplicate response header, silently dropping the rest. The most impactful case is `Set-Cookie`: a server that sends several cookies (the norm) loses all but the last when user code reads `response.headers()['set-cookie']`.

BiDi delivers headers as a list where duplicate names are separate `{ name, value }` entries. The loop in `src/bidi/HTTPResponse.ts` did `headers[headerName] = normalizeHeaderValue(...)`, overwriting on each duplicate. CDP is unaffected only because Chrome pre-merges duplicates into one newline-joined string before puppeteer sees it; BiDi values arrive standalone, so the per-entry normalize is a no-op and earlier values are lost.

This violates the documented contract added in #15173: duplicate header values are combined into a single comma-separated list, except `Set-Cookie` which is separated by a newline. The closed #14627 tried to fix both backends and was closed as a duplicate of #14492, but #14492 only added the CDP path, leaving BiDi unaddressed.

## Fix

Accumulate duplicate values with a newline before normalizing, reusing the existing `normalizeHeaderValue` combining logic so BiDi output matches CDP (`, ` for normal headers, `\n ` for `Set-Cookie`).

## Test

Added `src/bidi/HTTPResponse.test.ts` with two cases: duplicate `Set-Cookie` combine with a newline, and other duplicate headers combine with a comma. Both fail before the change (`c=d` instead of `a=b\n c=d`; `no-store` instead of `no-cache, no-store`) and pass after.
