### PR TITLE
test(webmcp): Support official WebMCP types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40032,7 +40032,7 @@
       },
       "devDependencies": {
         "@types/pngjs": "6.0.5",
-        "webmcp-types": "0.1.1"
+        "webmcp-types": "0.1.2"
       }
     },
     "test/installation": {
@@ -40108,9 +40108,9 @@
       }
     },
     "test/node_modules/webmcp-types": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.1.tgz",
-      "integrity": "sha512-EsC8PLjUxAR58Nhf57W1iQO8IPKLa7F2yBG3SzxX1WDgGPWystUoXVorkabPBIDYg3oTGwhcFU+Tt5G8MfXRHQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.2.tgz",
+      "integrity": "sha512-weWM+Iyj7rITLBoANf3GjxOD25MgriZnKUafJOXErmOnTbbHp5kr7hcPl+UlfeSlwtvE8+55HozF6jxtv0j17g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40031,7 +40031,8 @@
         "pngjs": "7.0.0"
       },
       "devDependencies": {
-        "@types/pngjs": "6.0.5"
+        "@types/pngjs": "6.0.5",
+        "webmcp-types": "0.1.1"
       }
     },
     "test/installation": {
@@ -40105,6 +40106,13 @@
       "engines": {
         "node": ">=14.19.0"
       }
+    },
+    "test/node_modules/webmcp-types": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.1.tgz",
+      "integrity": "sha512-EsC8PLjUxAR58Nhf57W1iQO8IPKLa7F2yBG3SzxX1WDgGPWystUoXVorkabPBIDYg3oTGwhcFU+Tt5G8MfXRHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "tools/docgen": {
       "name": "@puppeteer/docgen",

--- a/test/package.json
+++ b/test/package.json
@@ -33,6 +33,6 @@
   },
   "devDependencies": {
     "@types/pngjs": "6.0.5",
-    "webmcp-types": "0.1.1"
+    "webmcp-types": "0.1.2"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -32,6 +32,7 @@
     "pngjs": "7.0.0"
   },
   "devDependencies": {
-    "@types/pngjs": "6.0.5"
+    "@types/pngjs": "6.0.5",
+    "webmcp-types": "0.1.1"
   }
 }

--- a/test/src/cdp/webmcp.test.ts
+++ b/test/src/cdp/webmcp.test.ts
@@ -51,9 +51,8 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: (params: any) => {
-          const {text} = params as {text: string};
-          return text;
+        execute: (params: {text: string}) => {
+          return params.text;
         },
         annotations: {readOnlyHint: true, untrustedContentHint: true},
       });
@@ -478,9 +477,8 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: (params: any) => {
-          const {text} = params as {text: string};
-          return `hello ${text}`;
+        execute: (params: {text: string}) => {
+          return `hello ${params.text}`;
         },
       });
     });
@@ -625,9 +623,8 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: (params: any) => {
-          const {text} = params as {text: string};
-          return `hello ${text}`;
+        execute: (params: {text: string}) => {
+          return `hello ${params.text}`;
         },
       });
     });

--- a/test/src/cdp/webmcp.test.ts
+++ b/test/src/cdp/webmcp.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import 'webmcp-types';
+/// <reference types="webmcp-types" />
 
 import expect from 'expect';
 import type {Issue} from 'puppeteer';

--- a/test/src/cdp/webmcp.test.ts
+++ b/test/src/cdp/webmcp.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import 'webmcp-types';
+
 import expect from 'expect';
 import type {Issue} from 'puppeteer';
 import type {
@@ -39,7 +41,7 @@ describe('Page.webmcp', function () {
 
     // Register an imperative WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'test-tool-1',
         description: 'A test tool 1',
         inputSchema: {
@@ -49,8 +51,9 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: (params: {text: string}) => {
-          return params.text;
+        execute: (params: any) => {
+          const {text} = params as {text: string};
+          return text;
         },
         annotations: {readOnlyHint: true, untrustedContentHint: true},
       });
@@ -113,7 +116,7 @@ describe('Page.webmcp', function () {
 
     // Register an imperative WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'test-tool-1',
         description: 'A test tool 1',
         inputSchema: {
@@ -181,7 +184,7 @@ describe('Page.webmcp', function () {
     // Register an imperative WebMCP tool.
     using controllerHandle = await page.evaluateHandle(() => {
       const controller = new AbortController();
-      (document as any).modelContext.registerTool(
+      void document.modelContext?.registerTool(
         {
           name: 'test-tool-1',
           description: 'A test tool 1',
@@ -398,7 +401,7 @@ describe('Page.webmcp', function () {
 
     // Register a WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'test-tool-1',
         description: 'A test tool 1',
         inputSchema: {
@@ -465,7 +468,7 @@ describe('Page.webmcp', function () {
 
     // Register a WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'test-tool-1',
         description: 'A test tool 1',
         inputSchema: {
@@ -475,8 +478,9 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: (params: {text: string}) => {
-          return `hello ${params.text}`;
+        execute: (params: any) => {
+          const {text} = params as {text: string};
+          return `hello ${text}`;
         },
       });
     });
@@ -517,7 +521,7 @@ describe('Page.webmcp', function () {
 
     // Register a WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'raise-exception-tool',
         description: 'A tool that raises JS exception',
         execute: () => {
@@ -560,7 +564,7 @@ describe('Page.webmcp', function () {
 
     // Register a WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'test-tool-1',
         description: 'A test tool 1',
         inputSchema: {
@@ -611,7 +615,7 @@ describe('Page.webmcp', function () {
 
     // Register an imperative WebMCP tool.
     await page.evaluate(() => {
-      (document as any).modelContext.registerTool({
+      void document.modelContext?.registerTool({
         name: 'test-tool-1',
         description: 'A test tool 1',
         inputSchema: {
@@ -621,8 +625,9 @@ describe('Page.webmcp', function () {
           },
           required: ['text'],
         },
-        execute: (params: {text: string}) => {
-          return `hello ${params.text}`;
+        execute: (params: any) => {
+          const {text} = params as {text: string};
+          return `hello ${text}`;
         },
       });
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR simply adds support for official WebMCP types.

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

Nope

**Summary**

Instead of using `document as any` for WebMCP stuff, we can now use official WebMCP types that were just published with https://github.com/webmachinelearning/webmcp/issues/190#issuecomment-4893522032

**Does this PR introduce a breaking change?**

None

**Other information**
