### PR TITLE
fix(leftover files): Clean up temp userDataDir when the process exits unexpectedly

### DIFF
--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -6,7 +6,7 @@
 
 import childProcess from 'node:child_process';
 import {EventEmitter} from 'node:events';
-import {accessSync} from 'node:fs';
+import {accessSync, rmSync} from 'node:fs';
 import os from 'node:os';
 import readline from 'node:readline';
 import type Stream from 'node:stream';
@@ -195,6 +195,17 @@ export interface LaunchOptions {
    * If provided, the process will be killed when the signal is aborted.
    */
   signal?: AbortSignal;
+  /**
+   * If provided, this directory is forcefully removed when the Node.js
+   * process exits, even if the browser process crashes or the Node.js
+   * process itself terminates unexpectedly (e.g. an uncaught exception or
+   * `process.exit()`) before the normal {@link LaunchOptions.onExit} cleanup
+   * can run.
+   *
+   * This should only be set to a directory Puppeteer itself created (e.g. a
+   * temporary `userDataDir`), never a user-supplied directory.
+   */
+  tempDirectory?: string;
 }
 
 /**
@@ -220,26 +231,30 @@ export const WEBDRIVER_BIDI_WEBSOCKET_ENDPOINT_REGEX =
 
 type EventHandler = (...args: any[]) => void;
 const processListeners = new Map<string, EventHandler[]>();
+// Dispatchers iterate over a snapshot copy of the listeners array: some
+// listeners (e.g. Process#onDriverProcessExit) synchronously unsubscribe
+// themselves while being invoked here, which would otherwise mutate the
+// array mid-iteration and cause later listeners to be skipped.
 const dispatchers = {
   exit: (...args: any[]) => {
-    processListeners.get('exit')?.forEach(handler => {
-      return handler(...args);
-    });
+    for (const handler of [...(processListeners.get('exit') ?? [])]) {
+      handler(...args);
+    }
   },
   SIGINT: (...args: any[]) => {
-    processListeners.get('SIGINT')?.forEach(handler => {
-      return handler(...args);
-    });
+    for (const handler of [...(processListeners.get('SIGINT') ?? [])]) {
+      handler(...args);
+    }
   },
   SIGHUP: (...args: any[]) => {
-    processListeners.get('SIGHUP')?.forEach(handler => {
-      return handler(...args);
-    });
+    for (const handler of [...(processListeners.get('SIGHUP') ?? [])]) {
+      handler(...args);
+    }
   },
   SIGTERM: (...args: any[]) => {
-    processListeners.get('SIGTERM')?.forEach(handler => {
-      return handler(...args);
-    });
+    for (const handler of [...(processListeners.get('SIGTERM') ?? [])]) {
+      handler(...args);
+    }
   },
 };
 
@@ -271,6 +286,42 @@ function unsubscribeFromProcessEvent(
   }
 }
 
+// Temp directories (e.g. a temp `userDataDir`) that must be forcefully
+// removed if the Node.js process exits before the normal async cleanup
+// (triggered by the browser's own 'exit' event) has a chance to run, e.g.
+// on an uncaught exception. Node's 'exit' event handler must be fully
+// synchronous, so this uses `rmSync` instead of the regular async cleanup.
+const tempDirectoriesToDelete = new Set<string>();
+
+function cleanUpTempDirectories(): void {
+  for (const dir of tempDirectoriesToDelete) {
+    try {
+      rmSync(dir, {
+        force: true,
+        recursive: true,
+        maxRetries: 10,
+        retryDelay: 500,
+      });
+    } catch (error) {
+      debugLaunch?.(`Failed to remove temp directory ${dir} on exit`, error);
+    }
+  }
+}
+
+function trackTempDirectory(dir: string): void {
+  if (tempDirectoriesToDelete.size === 0) {
+    subscribeToProcessEvent('exit', cleanUpTempDirectories);
+  }
+  tempDirectoriesToDelete.add(dir);
+}
+
+function untrackTempDirectory(dir: string): void {
+  tempDirectoriesToDelete.delete(dir);
+  if (tempDirectoriesToDelete.size === 0) {
+    unsubscribeFromProcessEvent('exit', cleanUpTempDirectories);
+  }
+}
+
 /**
  * @public
  */
@@ -292,6 +343,7 @@ export class Process {
     this.kill();
   };
   #signal?: AbortSignal;
+  #tempDirectory?: string;
 
   constructor(opts: LaunchOptions) {
     this.#executablePath = opts.executablePath;
@@ -365,6 +417,10 @@ export class Process {
     if (opts.onExit) {
       this.#onExitHook = opts.onExit;
     }
+    if (opts.tempDirectory) {
+      this.#tempDirectory = opts.tempDirectory;
+      trackTempDirectory(this.#tempDirectory);
+    }
     this.#browserProcessExiting = new Promise((resolve, reject) => {
       this.#browserProcess.once('exit', async () => {
         debugLaunch?.(`Browser process ${this.#browserProcess.pid} onExit`);
@@ -387,6 +443,12 @@ export class Process {
     }
     this.#hooksRan = true;
     await this.#onExitHook();
+    // The async cleanup above succeeded, so the synchronous exit-time
+    // fallback is no longer needed for this directory.
+    if (this.#tempDirectory) {
+      untrackTempDirectory(this.#tempDirectory);
+      this.#tempDirectory = undefined;
+    }
   }
 
   get nodeProcess(): childProcess.ChildProcess {

--- a/packages/browsers/test/src/chrome/launch.test.ts
+++ b/packages/browsers/test/src/chrome/launch.test.ts
@@ -175,5 +175,26 @@ describe('Chrome', () => {
       controller.abort();
       await process.hasClosed();
     });
+
+    it('should clean up the temp userDataDir if the host process exits without closing the browser', async () => {
+      const executablePath = computeExecutablePath({
+        cacheDir: tmpDir,
+        browser: Browser.CHROME,
+        buildId: testChromeBuildId,
+      });
+      const profileDir = path.join(tmpDir, 'profile');
+      const browserProcess = launch({
+        executablePath,
+        args: getArgs(),
+        tempDirectory: profileDir,
+      });
+      await browserProcess.waitForLineOutput(CDP_WEBSOCKET_ENDPOINT_REGEX);
+
+      // Simulate the Node.js host process exiting abnormally (e.g. an
+      // uncaught exception) without ever calling close()/browser.close().
+      process.emit('exit', 1);
+
+      assert.ok(!fs.existsSync(profileDir));
+    });
   });
 });

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -171,6 +171,9 @@ export abstract class BrowserLauncher {
       env,
       pipe: usePipe,
       onExit: onProcessExit,
+      tempDirectory: launchArgs.isTempUserDataDir
+        ? launchArgs.userDataDir
+        : undefined,
       signal: options.signal,
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: Clean up temp userDataDir when the process exits unexpectedly

**Did you add tests for your changes?**

Added `packages/browsers/test/src/chrome/launch.test.ts` > `'should clean up the temp userDataDir if the host process exits without closing the browser'`, which launches Chrome with a temp `userDataDir`, simulates an abnormal Node.js process exit via `process.emit('exit', 1)` (without calling `close()`), and asserts the temp directory was removed. Also manually verified against the reporter's exact repro script (`throw new Error('crash')` with no try/catch) end-to-end through `puppeteer` → `BrowserLauncher` → `@puppeteer/browsers`, and confirmed the bug reproduces when the fix is reverted.

**Summary**

Puppeteer creates a temporary `userDataDir` for each launch and only removes it asynchronously, triggered by the browser child process's own `'exit'` event. If the Node.js host process itself terminates abnormally (an uncaught exception, `process.exit()`, etc.), Node's own `'exit'` handler runs synchronously while the event loop is already shutting down, so that async cleanup never gets a chance to run — the temp directory is left behind permanently.

On macOS/APFS, accumulating many such leftover `puppeteer_dev_chrome_profile-*` directories can trigger an APFS directory-hash-collision kernel bug, making `ls`/`find`/`rm -rf` on the parent temp dir hang for hours, in one case freezing the reporter's Mac at boot.

This PR tracks temp directories created for a launch and force-removes them synchronously (`rmSync`) on the Node process's real `'exit'` event, as a fallback for when the normal async cleanup doesn't get to run. It also fixes a related latent bug in the process-event dispatchers (`exit`/`SIGINT`/`SIGHUP`/`SIGTERM`) where they iterated the live listeners array with `.forEach` while a listener (`Process#onDriverProcessExit` calling `kill()`) synchronously unsubscribes itself during that same iteration, which could cause a listener registered after it (including the new cleanup listener) to be silently skipped. Dispatchers now iterate over a snapshot copy instead.

Fix #15156 

**Other information**

The directory naming scheme (`puppeteer_dev_chrome_profile-*`) is intentionally left unchanged, per the issue reporter's request, this PR only addresses the leftover-on-crash cleanup.
