### PR TITLE
fix: add timer waiting for browser.closeBrowser()

### DIFF
--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -326,8 +326,21 @@ export abstract class BrowserLauncher {
     if (cdpConnection) {
       // Attempt to close the browser gracefully
       try {
-        await cdpConnection.closeBrowser();
-        await browserProcess.hasClosed();
+        await firstValueFrom(
+          race(
+            from(
+              (async () => {
+                await cdpConnection.closeBrowser();
+                await browserProcess.hasClosed();
+              })(),
+            ),
+            timer(5000).pipe(
+              map(() => {
+                throw new Error('Timeout waiting for browser to close');
+              }),
+            ),
+          ),
+        );
       } catch (error) {
         debugError?.(error);
         await browserProcess.close();


### PR DESCRIPTION
Some timeouts in tests in chrome-devtools-mcp are supposedly caused by the cdpConnection.closeBrowser() timing out. I was not able to reproduce this in a standalone scenario.