### PR TITLE
feat: expose handled getter on Dialog

### DIFF
--- a/docs/api/puppeteer.dialog.md
+++ b/docs/api/puppeteer.dialog.md
@@ -31,6 +31,42 @@ page.on('dialog', async dialog => {
 await page.evaluate(() => alert('1'));
 ```
 
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="handled">handled</span>
+
+</td><td>
+
+</td><td>
+
+boolean
+
+</td><td>
+
+A boolean value indicating whether the dialog has been handled.
+
+</td></tr>
+</tbody></table>
+
 ## Methods
 
 <table><thead><tr><th>

--- a/packages/puppeteer-core/src/api/Dialog.ts
+++ b/packages/puppeteer-core/src/api/Dialog.ts
@@ -34,10 +34,18 @@ export abstract class Dialog {
   #type: Protocol.Page.DialogType;
   #message: string;
   #defaultValue: string;
+  #handled = false;
+
   /**
-   * @internal
+   * A boolean value indicating whether the dialog has been handled.
    */
-  protected handled = false;
+  public get handled(): boolean {
+    return this.#handled;
+  }
+
+  protected set handled(handled: boolean) {
+    this.#handled = handled;
+  }
 
   /**
    * @internal


### PR DESCRIPTION
If multiple listeners are added to the Dialog event one may handle before the other, in such case this can't be handled gracefully if the Dialog object was saved as reference, without having a try/catch around access/decline.