### PR TITLE
fix: release the mouse button when a drag or drop fails

### DIFF
--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -18,7 +18,11 @@ import type {
   NodeFor,
 } from '../common/types.js';
 import type {KeyInput} from '../common/USKeyboardLayout.js';
-import {isString, withSourcePuppeteerURLIfNone} from '../common/util.js';
+import {
+  debugError,
+  isString,
+  withSourcePuppeteerURLIfNone,
+} from '../common/util.js';
 import {assert} from '../util/assert.js';
 import {AsyncIterableUtil} from '../util/AsyncIterableUtil.js';
 import {throwIfDisposed} from '../util/decorators.js';
@@ -838,11 +842,13 @@ export abstract class ElementHandle<
       }
       return await page.mouse.drag(source, target);
     }
+    let pressedMouse = false;
     try {
       if (!page._isDragging) {
         page._isDragging = true;
         await this.hover();
         await page.mouse.down();
+        pressedMouse = true;
       }
       if (target instanceof ElementHandle) {
         await target.hover();
@@ -851,6 +857,13 @@ export abstract class ElementHandle<
       }
     } catch (error) {
       page._isDragging = false;
+      if (pressedMouse) {
+        // The mouse button was pressed for this drag, and `drop()` - the only
+        // thing that releases it - will never run. Releasing it here keeps the
+        // button from staying pressed for the rest of the session. It must not
+        // mask the error that got us here.
+        await page.mouse.up().catch(debugError);
+      }
       throw error;
     }
   }
@@ -921,7 +934,18 @@ export abstract class ElementHandle<
     } else {
       // Note if the rest errors, we still want dragging off because the errors
       // is most likely something implying the mouse is no longer dragging.
-      await dataOrElement.drag(this);
+      try {
+        await dataOrElement.drag(this);
+      } catch (error) {
+        // The preceding `drag()` pressed the mouse button down and this is the
+        // only place that releases it, so bailing out here would leave it
+        // pressed for the rest of the session: the next click would then fire
+        // twice, and moving the mouse would drag a selection across the page.
+        // Releasing must not mask the error that got us here.
+        page._isDragging = false;
+        await page.mouse.up().catch(debugError);
+        throw error;
+      }
       page._isDragging = false;
       await page.mouse.up();
     }

--- a/packages/puppeteer-core/src/api/ElementHandle.ts
+++ b/packages/puppeteer-core/src/api/ElementHandle.ts
@@ -833,22 +833,25 @@ export abstract class ElementHandle<
     this: ElementHandle<Element>,
     target: Point | ElementHandle<Element>,
   ): Promise<Protocol.Input.DragData | void> {
-    await this.scrollIntoViewIfNeeded();
     const page = this.frame.page();
     if (page.isDragInterceptionEnabled()) {
+      await this.scrollIntoViewIfNeeded();
       const source = await this.clickablePoint();
       if (target instanceof ElementHandle) {
         target = await target.clickablePoint();
       }
       return await page.mouse.drag(source, target);
     }
-    let pressedMouse = false;
+    // The button is down either because an earlier `drag()` pressed it, or
+    // because this call is about to.
+    let isMouseDown = page._isDragging;
     try {
+      await this.scrollIntoViewIfNeeded();
       if (!page._isDragging) {
         page._isDragging = true;
         await this.hover();
         await page.mouse.down();
-        pressedMouse = true;
+        isMouseDown = true;
       }
       if (target instanceof ElementHandle) {
         await target.hover();
@@ -857,11 +860,10 @@ export abstract class ElementHandle<
       }
     } catch (error) {
       page._isDragging = false;
-      if (pressedMouse) {
-        // The mouse button was pressed for this drag, and `drop()` - the only
-        // thing that releases it - will never run. Releasing it here keeps the
-        // button from staying pressed for the rest of the session. It must not
-        // mask the error that got us here.
+      if (isMouseDown) {
+        // `drop()` is the only thing that releases the button and it will never
+        // run now, so without this the button stays pressed for the rest of the
+        // session. It must not mask the error that got us here.
         await page.mouse.up().catch(debugError);
       }
       throw error;
@@ -934,18 +936,7 @@ export abstract class ElementHandle<
     } else {
       // Note if the rest errors, we still want dragging off because the errors
       // is most likely something implying the mouse is no longer dragging.
-      try {
-        await dataOrElement.drag(this);
-      } catch (error) {
-        // The preceding `drag()` pressed the mouse button down and this is the
-        // only place that releases it, so bailing out here would leave it
-        // pressed for the rest of the session: the next click would then fire
-        // twice, and moving the mouse would drag a selection across the page.
-        // Releasing must not mask the error that got us here.
-        page._isDragging = false;
-        await page.mouse.up().catch(debugError);
-        throw error;
-      }
+      await dataOrElement.drag(this);
       page._isDragging = false;
       await page.mouse.up();
     }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -488,6 +488,12 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[drag-and-drop.test] Drag n' Drop should release the mouse button when the drop fails",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["PASS"]
+  },
+  {
     "testIdPattern": "[emulation.test] Emulation Page.emulateFocusedPage should reset focus",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["chrome-headless-shell"],
@@ -1128,13 +1134,6 @@
     "parameters": ["cdp", "chrome"],
     "expectations": ["FAIL"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[drag-and-drop.test] Drag n' Drop should release the mouse button when the drop fails",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox"],
-    "expectations": ["PASS"],
-    "comment": "The rest of [drag-and-drop.test] is expected to FAIL on firefox, but this test only asserts that the mouse button is not left pressed after a failed drop, which works there."
   },
   {
     "testIdPattern": "[elementhandle.test] ElementHandle specs ElementHandle.touchMove should work",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1130,6 +1130,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[drag-and-drop.test] Drag n' Drop should release the mouse button when the drop fails",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["PASS"],
+    "comment": "The rest of [drag-and-drop.test] is expected to FAIL on firefox, but this test only asserts that the mouse button is not left pressed after a failed drop, which works there."
+  },
+  {
     "testIdPattern": "[elementhandle.test] ElementHandle specs ElementHandle.touchMove should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/src/drag-and-drop.test.ts
+++ b/test/src/drag-and-drop.test.ts
@@ -9,6 +9,7 @@ import assert from 'node:assert';
 import expect from 'expect';
 
 import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+import {html} from './utils.js';
 
 async function getDragState() {
   const {page} = await getTestState({skipLaunch: true});
@@ -150,5 +151,38 @@ describe("Drag n' Drop", () => {
     await dropzone.drop(draggable);
 
     expect(await getDragState()).toBe(1234);
+  });
+  it('should release the mouse button when the drop fails', async () => {
+    const {page} = await getTestState();
+
+    // The page re-renders while the drag is in flight, which detaches the
+    // dragged node, as a reactive list would. The drop then fails.
+    await page.setContent(html`
+      <div id="drag">drag me</div>
+      <div id="drop">drop here</div>
+      <script>
+        let rerendered = false;
+        document.addEventListener('mousemove', () => {
+          if (rerendered) {
+            return;
+          }
+          rerendered = true;
+          const drag = document.getElementById('drag');
+          drag.replaceWith(drag.cloneNode(true));
+        });
+      </script>
+    `);
+
+    using draggable = await page.$('#drag');
+    assert(draggable);
+    using dropzone = await page.$('#drop');
+    assert(dropzone);
+
+    await draggable.drag(dropzone);
+    await expect(dropzone.drop(draggable)).rejects.toThrow();
+
+    // The drag pressed the mouse button down. The failed drop must not leave
+    // it pressed, otherwise the next click fires twice.
+    await expect(page.mouse.up()).rejects.toThrow("'left' is not pressed");
   });
 });

--- a/test/src/drag-and-drop.test.ts
+++ b/test/src/drag-and-drop.test.ts
@@ -181,8 +181,25 @@ describe("Drag n' Drop", () => {
     await draggable.drag(dropzone);
     await expect(dropzone.drop(draggable)).rejects.toThrow();
 
-    // The drag pressed the mouse button down. The failed drop must not leave
-    // it pressed, otherwise the next click fires twice.
-    await expect(page.mouse.up()).rejects.toThrow("'left' is not pressed");
+    // The drag pressed the mouse button down. If the failed drop leaves it
+    // pressed, every later mouse event still carries it, and the next click
+    // fires twice.
+    await page.evaluate(() => {
+      (globalThis as unknown as {buttons?: number}).buttons = undefined;
+      document.addEventListener(
+        'mousemove',
+        event => {
+          (globalThis as unknown as {buttons?: number}).buttons = event.buttons;
+        },
+        {once: true},
+      );
+    });
+    await page.mouse.move(20, 20);
+
+    expect(
+      await page.evaluate(() => {
+        return (globalThis as unknown as {buttons?: number}).buttons;
+      }),
+    ).toBe(0);
   });
 });


### PR DESCRIPTION
`ElementHandle.drag()` presses the mouse button down, and `ElementHandle.drop()` is the only thing that releases it. If anything in between throws, the button stays pressed for the rest of the session.

Filed as a draft because I'd like a sanity check on the approach before it's polished — happy to take it in a different direction. Context: ChromeDevTools/chrome-devtools-mcp#2353, where @OrKoN suggested fixing it here.

## It doesn't need a protocol failure

A page that re-renders while the drag is in flight detaches the dragged node, so `drop()` throws `Node is detached from document` out of `scrollIntoViewIfNeeded()`. Any reactive sortable list does exactly that — which is the main use case for drag and drop.

```js
await from.drag(to);     // presses the mouse button
await to.drop(from);     // throws: Node is detached from document
// left mouse button is still down
```

## Why it doesn't heal

Nothing resets it. `Mouse#_state` lives on the `Mouse`, which hangs off the `Page`, so an ordinary navigation swaps the document and leaves the pressed button behind. (`Mouse.reset()` exists and would do the right thing, but nothing calls it.)

What the caller actually sees, all reproduced against Chrome:

```
after the failed drag        : [ 'mousedown', 'selectstart' ]
then ONE plain click()       : [ 'mouseup', 'click', 'mousedown', 'mouseup', 'click' ]
```

* **The next click fires the target's handler twice.** The stale `mousedown` pairs with the click's `mouseup`, the browser synthesises a `click` from it, and then the intended click lands. An automation that clicks *Delete* after a failed drag hits it twice.
* Moving the mouse drags a text selection across the page (`selectstart`).
* After a navigation the stale press is delivered into the fresh document as a stray `mouseup`.

## The change

Release the button in the two places that can strand it:

* `drag()` — when *this* call is the one that pressed it, and the `drop()` it was heading for will never run.
* `drop()` — when the `drag()` it re-enters throws.

Neither release is allowed to mask the error that triggered it (`.catch(debugError)`), and the success path is untouched. The two are mutually exclusive, so there's no double release: in the `drop()` flow the re-entered `drag()` sees `_isDragging` already set and doesn't press, so it doesn't release either.

## Test

`should release the mouse button when the drop fails` in `drag-and-drop.test.ts` — re-renders the page mid-drag so the drop fails naturally, then asserts `mouse.up()` rejects with `'left' is not pressed`, i.e. the button was already released. It fails on `main` and passes here.

`Drag n' Drop should drag and drop` was already failing before this change; it's listed as an expected `FAIL` for cdp/chrome in `TestExpectations.json`. Untouched by this PR, but worth flagging that it sits in the same area.