### PR TITLE
feat: expose high-level PWA APIs

### DIFF
--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -335,6 +335,111 @@ export interface ExtensionInstallOptions {
 }
 
 /**
+ * @public
+ */
+export type PWADisplayMode = 'standalone' | 'browser';
+
+/**
+ * @public
+ */
+export interface PWAInstallOptions {
+  /**
+   * The ID from the web app's manifest.
+   */
+  manifestId: string;
+
+  /**
+   * The app or bundle location to use instead of the one derived from the
+   * manifest ID.
+   */
+  installUrlOrBundleUrl?: string;
+
+  /**
+   * Whether to open the installed app in a browser tab or standalone window.
+   *
+   * @remarks
+   * Chrome applies this setting after installing the app. If applying the
+   * setting fails, the method rejects but the app remains installed.
+   */
+  displayMode?: PWADisplayMode;
+}
+
+/**
+ * @public
+ */
+export interface PWAUninstallOptions {
+  /**
+   * The ID from the web app's manifest.
+   */
+  manifestId: string;
+}
+
+/**
+ * @public
+ */
+export interface PWALaunchOptions {
+  /**
+   * The ID from the web app's manifest.
+   */
+  manifestId: string;
+
+  /**
+   * The URL to open in the launched app.
+   */
+  url?: string;
+}
+
+/**
+ * @public
+ */
+export interface PWAFileHandlerAccept {
+  /**
+   * The MIME type accepted by the file handler.
+   */
+  mediaType: string;
+
+  /**
+   * The file extensions accepted for the MIME type.
+   */
+  fileExtensions: string[];
+}
+
+/**
+ * @public
+ */
+export interface PWAFileHandler {
+  /**
+   * The URL handling the files.
+   */
+  action: string;
+
+  /**
+   * The MIME types and file extensions accepted by the handler.
+   */
+  accepts: PWAFileHandlerAccept[];
+
+  /**
+   * The handler name displayed to the user.
+   */
+  displayName: string;
+}
+
+/**
+ * @public
+ */
+export interface PWAState {
+  /**
+   * The app's current badge count.
+   */
+  badgeCount: number;
+
+  /**
+   * The app's registered file handlers.
+   */
+  fileHandlers: PWAFileHandler[];
+}
+
+/**
  * {@link Browser} represents a browser instance that is either:
  *
  * - connected to via {@link Puppeteer.connect} or
@@ -661,6 +766,46 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * Uninstalls an extension.
    */
   abstract uninstallExtension(id: string): Promise<void>;
+
+  /**
+   * Installs a progressive web app and returns its manifest ID.
+   *
+   * @remarks
+   * This Chrome-only API requires a pipe connection.
+   *
+   * @experimental
+   */
+  abstract installPWA(options: PWAInstallOptions): Promise<string>;
+
+  /**
+   * Uninstalls a progressive web app.
+   *
+   * @remarks
+   * This Chrome-only API requires a pipe connection.
+   *
+   * @experimental
+   */
+  abstract uninstallPWA(options: PWAUninstallOptions): Promise<void>;
+
+  /**
+   * Launches a progressive web app and returns its page.
+   *
+   * @remarks
+   * This Chrome-only API requires a pipe connection.
+   *
+   * @experimental
+   */
+  abstract launchPWA(options: PWALaunchOptions): Promise<Page>;
+
+  /**
+   * Returns the operating system state for a progressive web app.
+   *
+   * @remarks
+   * This Chrome-only API requires a pipe connection.
+   *
+   * @experimental
+   */
+  abstract getPWAState(options: {manifestId: string}): Promise<PWAState>;
 
   /**
    * Gets a list of {@link ScreenInfo | screen information objects}.

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -83,7 +83,7 @@ import {
 import {stringToTypedArray} from '../util/encoding.js';
 
 import type {BluetoothEmulation} from './BluetoothEmulation.js';
-import type {Browser, WindowId} from './Browser.js';
+import type {Browser, PWADisplayMode, WindowId} from './Browser.js';
 import type {BrowserContext} from './BrowserContext.js';
 import type {CDPSession} from './CDPSession.js';
 import type {DeviceRequestPrompt} from './DeviceRequestPrompt.js';
@@ -3254,6 +3254,31 @@ export abstract class Page extends EventEmitter<PageEvents> {
    * @experimental
    */
   abstract hasDevTools(): Promise<boolean>;
+
+  /**
+   * Installs the current page as a progressive web app and returns its
+   * manifest ID.
+   *
+   * @remarks
+   * This Chrome-only API requires a pipe connection.
+   *
+   * @experimental
+   */
+  abstract installAsPWA(options?: {
+    displayMode?: PWADisplayMode;
+  }): Promise<string>;
+
+  /**
+   * Opens the current page in its installed progressive web app.
+   *
+   * @remarks
+   * This Chrome-only API requires a pipe connection.
+   * The method returns when Chrome accepts the command, without waiting for the
+   * app page to finish loading.
+   *
+   * @experimental
+   */
+  abstract openInPWA(): Promise<void>;
 
   /**
    * {@inheritDoc BluetoothEmulation}

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -19,6 +19,10 @@ import {
   type WindowBounds,
   type WindowId,
   type DebugInfo,
+  type PWAInstallOptions,
+  type PWALaunchOptions,
+  type PWAState,
+  type PWAUninstallOptions,
 } from '../api/Browser.js';
 import {BrowserContextEvent} from '../api/BrowserContext.js';
 import type {Extension} from '../api/Extension.js';
@@ -295,6 +299,22 @@ export class BidiBrowser extends Browser {
 
   override async uninstallExtension(id: string): Promise<void> {
     await this.#browserCore.uninstallExtension(id);
+  }
+
+  override installPWA(_options: PWAInstallOptions): Promise<string> {
+    throw new UnsupportedOperation();
+  }
+
+  override uninstallPWA(_options: PWAUninstallOptions): Promise<void> {
+    throw new UnsupportedOperation();
+  }
+
+  override launchPWA(_options: PWALaunchOptions): Promise<Page> {
+    throw new UnsupportedOperation();
+  }
+
+  override getPWAState(_options: {manifestId: string}): Promise<PWAState> {
+    throw new UnsupportedOperation();
   }
 
   override screens(): Promise<ScreenInfo[]> {

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -9,7 +9,7 @@ import * as Bidi from 'webdriver-bidi-protocol';
 
 import {firstValueFrom, from, raceWith} from '../../third_party/rxjs/rxjs.js';
 import type {BluetoothEmulation} from '../api/BluetoothEmulation.js';
-import type {WindowId} from '../api/Browser.js';
+import type {PWADisplayMode, WindowId} from '../api/Browser.js';
 import type {CDPSession} from '../api/CDPSession.js';
 import type {DeviceRequestPrompt} from '../api/DeviceRequestPrompt.js';
 import type {BoundingBox} from '../api/ElementHandle.js';
@@ -248,6 +248,16 @@ export class BidiPage extends Page {
   }
 
   override hasDevTools(): Promise<boolean> {
+    throw new UnsupportedOperation();
+  }
+
+  override installAsPWA(_options?: {
+    displayMode?: PWADisplayMode;
+  }): Promise<string> {
+    throw new UnsupportedOperation();
+  }
+
+  override openInPWA(): Promise<void> {
     throw new UnsupportedOperation();
   }
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -12,6 +12,10 @@ import type {
   CreatePageOptions,
   DebugInfo,
   ExtensionInstallOptions,
+  PWAInstallOptions,
+  PWALaunchOptions,
+  PWAState,
+  PWAUninstallOptions,
 } from '../api/Browser.js';
 import {
   Browser as BrowserBase,
@@ -521,6 +525,58 @@ export class CdpBrowser extends BrowserBase {
     await Promise.all(targetDestroyedPromises);
 
     this.#extensions.delete(id);
+  }
+
+  async _installPWA(
+    options: PWAInstallOptions,
+    session?: CdpCDPSession,
+  ): Promise<string> {
+    const {displayMode, ...installOptions} = options;
+    const client = session ?? this.#connection;
+    await client.send('PWA.install', installOptions);
+    if (displayMode) {
+      await client.send('PWA.changeAppUserSettings', {
+        manifestId: options.manifestId,
+        displayMode,
+      });
+    }
+    return options.manifestId;
+  }
+
+  override async installPWA(options: PWAInstallOptions): Promise<string> {
+    return await this._installPWA(options);
+  }
+
+  override async uninstallPWA(options: PWAUninstallOptions): Promise<void> {
+    await this.#connection.send('PWA.uninstall', options);
+  }
+
+  override async launchPWA(options: PWALaunchOptions): Promise<Page> {
+    const {targetId: launchedTargetId} = await this.#connection.send(
+      'PWA.launch',
+      options,
+    );
+    const target = (await this.waitForTarget(candidate => {
+      // PWA.launch returns the tab target, while Puppeteer exposes its page child.
+      const launchedTarget = this.#targetManager
+        .getAvailableTargets()
+        .get(launchedTargetId);
+      return (
+        candidate.type() === 'page' &&
+        launchedTarget?._childTargets().has(candidate as CdpTarget) === true
+      );
+    })) as CdpTarget;
+    const page = await target.page();
+    if (!page) {
+      throw new Error(
+        `Failed to create a page for PWA target (id = ${launchedTargetId})`,
+      );
+    }
+    return page;
+  }
+
+  override async getPWAState(options: {manifestId: string}): Promise<PWAState> {
+    return await this.#connection.send('PWA.getOsAppState', options);
   }
 
   override async screens(): Promise<ScreenInfo[]> {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -8,7 +8,7 @@ import type {Protocol} from 'devtools-protocol';
 
 import {firstValueFrom, from, raceWith} from '../../third_party/rxjs/rxjs.js';
 import type {BluetoothEmulation} from '../api/BluetoothEmulation.js';
-import type {Browser, WindowId} from '../api/Browser.js';
+import type {Browser, PWADisplayMode, WindowId} from '../api/Browser.js';
 import type {BrowserContext} from '../api/BrowserContext.js';
 import {CDPSessionEvent, type CDPSession} from '../api/CDPSession.js';
 import type {DeviceRequestPrompt} from '../api/DeviceRequestPrompt.js';
@@ -494,6 +494,30 @@ export class CdpPage extends Page {
     const browser = this.browser() as CdpBrowser;
     const targetId = await browser._hasDevToolsTarget(this.target()._targetId);
     return Boolean(targetId);
+  }
+
+  async #getPWAAppId(): Promise<string> {
+    const {appId} = await this.#primaryTargetClient.send('Page.getAppId');
+    assert(appId, 'Page is not associated with a PWA');
+    return appId;
+  }
+
+  override async installAsPWA(options?: {
+    displayMode?: PWADisplayMode;
+  }): Promise<string> {
+    const manifestId = await this.#getPWAAppId();
+    const browser = this.browser() as CdpBrowser;
+    return await browser._installPWA(
+      {manifestId, ...options},
+      this.#primaryTargetClient,
+    );
+  }
+
+  override async openInPWA(): Promise<void> {
+    const manifestId = await this.#getPWAAppId();
+    await this.#primaryTargetClient.send('PWA.openCurrentPageInApp', {
+      manifestId,
+    });
   }
 
   override async waitForFileChooser(

--- a/test/src/cdp/pwa.test.ts
+++ b/test/src/cdp/pwa.test.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {setTimeout} from 'node:timers/promises';
+
+import expect from 'expect';
+import type {Browser} from 'puppeteer-core/internal/api/Browser.js';
+import type {Page} from 'puppeteer-core/internal/api/Page.js';
+import {UnsupportedOperation} from 'puppeteer-core/internal/common/Errors.js';
+
+import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
+
+async function waitForStandalonePage(browser: Browser): Promise<Page> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    for (const candidate of await browser.pages()) {
+      const isStandalone = await candidate
+        .evaluate(() => {
+          return matchMedia('(display-mode: standalone)').matches;
+        })
+        .catch(() => {
+          return false;
+        });
+      if (isStandalone) {
+        return candidate;
+      }
+    }
+    await setTimeout(50);
+  }
+  throw new Error('Timed out waiting for the standalone PWA page');
+}
+
+describe('PWA', function () {
+  this.timeout(30000);
+
+  const state = setupSeparateTestBrowserHooks(
+    {headless: false, pipe: true},
+    {createContext: false},
+  );
+  let page: Page;
+
+  beforeEach(async () => {
+    const {browser, server} = state;
+    page = await browser.newPage();
+    server.setRoute('/pwa.html', (_req, res) => {
+      res.end(`<!doctype html>
+        <html>
+          <head>
+            <title>PWA test</title>
+            <link rel="manifest" href="/pwa.webmanifest">
+          </head>
+          <body>
+            <script>navigator.serviceWorker.register('/pwa-sw.js')</script>
+          </body>
+        </html>`);
+    });
+    server.setRoute('/pwa.webmanifest', (_req, res) => {
+      res.setHeader('Content-Type', 'application/manifest+json');
+      res.end(
+        JSON.stringify({
+          id: '/pwa',
+          name: 'PWA test',
+          short_name: 'PWA test',
+          start_url: '/pwa.html',
+          scope: '/',
+          display: 'standalone',
+          icons: [
+            {
+              src: '/pwa-icon.svg',
+              sizes: 'any',
+              type: 'image/svg+xml',
+            },
+          ],
+        }),
+      );
+    });
+    server.setRoute('/pwa-sw.js', (_req, res) => {
+      res.setHeader('Content-Type', 'text/javascript');
+      res.end('self.addEventListener("fetch", () => {});');
+    });
+    server.setRoute('/pwa-icon.svg', (_req, res) => {
+      res.setHeader('Content-Type', 'image/svg+xml');
+      res.end(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">' +
+          '<rect width="512" height="512" fill="black"/>' +
+          '</svg>',
+      );
+    });
+
+    await page.goto(server.PREFIX + '/pwa.html');
+    await page.evaluate(() => {
+      return navigator.serviceWorker.ready;
+    });
+  });
+
+  afterEach(async () => {
+    const {browser, server} = state;
+    await browser
+      .uninstallPWA({manifestId: server.PREFIX + '/pwa'})
+      .catch(() => {});
+    if (!page.isClosed()) {
+      await page.close();
+    }
+  });
+
+  it('should install, inspect, and uninstall a PWA', async () => {
+    const {browser, server} = state;
+    const manifestId = server.PREFIX + '/pwa';
+
+    expect(
+      await browser.installPWA({
+        manifestId,
+        installUrlOrBundleUrl: server.PREFIX + '/pwa.html',
+        displayMode: 'browser',
+      }),
+    ).toBe(manifestId);
+
+    const appPage = await browser.launchPWA({manifestId});
+    expect(
+      await appPage.evaluate(() => {
+        return matchMedia('(display-mode: standalone)').matches;
+      }),
+    ).toBe(false);
+
+    expect(await browser.getPWAState({manifestId})).toEqual({
+      badgeCount: 0,
+      fileHandlers: [],
+    });
+
+    await browser.uninstallPWA({manifestId});
+    await expect(browser.getPWAState({manifestId})).rejects.toThrow();
+  });
+
+  it('should launch an installed PWA as a page', async () => {
+    const {browser, server} = state;
+    const manifestId = server.PREFIX + '/pwa';
+    await browser.installPWA({
+      manifestId,
+      installUrlOrBundleUrl: server.PREFIX + '/pwa.html',
+    });
+
+    const appPage = await browser.launchPWA({manifestId});
+    expect(await appPage.title()).toBe('PWA test');
+
+    await browser.uninstallPWA({manifestId});
+  });
+
+  it('should install the current page with a display mode', async () => {
+    const {browser, server} = state;
+    const manifestId = server.PREFIX + '/pwa';
+
+    expect(await page.installAsPWA({displayMode: 'browser'})).toBe(manifestId);
+
+    const appPage = await browser.launchPWA({manifestId});
+    expect(
+      await appPage.evaluate(() => {
+        return matchMedia('(display-mode: standalone)').matches;
+      }),
+    ).toBe(false);
+
+    await browser.uninstallPWA({manifestId});
+  });
+
+  it('should open the current page as a PWA', async () => {
+    const {browser, server} = state;
+    const manifestId = server.PREFIX + '/pwa';
+
+    await page.installAsPWA({displayMode: 'standalone'});
+
+    await page.openInPWA();
+    const appPage = await waitForStandalonePage(browser);
+    expect(await appPage.title()).toBe('PWA test');
+
+    await browser.uninstallPWA({manifestId});
+  });
+
+  it('should reject page PWA operations without an app id', async () => {
+    const {server} = state;
+    await page.goto(server.EMPTY_PAGE);
+
+    await expect(page.installAsPWA()).rejects.toThrow(
+      'Page is not associated with a PWA',
+    );
+    await expect(page.openInPWA()).rejects.toThrow(
+      'Page is not associated with a PWA',
+    );
+  });
+});
+
+describe('PWA (WebDriver BiDi)', function () {
+  const state = setupSeparateTestBrowserHooks(
+    {protocol: 'webDriverBiDi'},
+    {createContext: false},
+  );
+  let page: Page;
+
+  beforeEach(async () => {
+    page = await state.browser.newPage();
+  });
+
+  afterEach(async () => {
+    await page.close();
+  });
+
+  it('should reject browser PWA operations', async () => {
+    const {browser} = state;
+    const manifestId = 'https://example.com/app';
+
+    expect(() => {
+      return browser.installPWA({manifestId});
+    }).toThrow(UnsupportedOperation);
+    expect(() => {
+      return browser.uninstallPWA({manifestId});
+    }).toThrow(UnsupportedOperation);
+    expect(() => {
+      return browser.launchPWA({manifestId});
+    }).toThrow(UnsupportedOperation);
+    expect(() => {
+      return browser.getPWAState({manifestId});
+    }).toThrow(UnsupportedOperation);
+  });
+
+  it('should reject page PWA operations', async () => {
+    expect(() => {
+      return page.installAsPWA();
+    }).toThrow(UnsupportedOperation);
+    expect(() => {
+      return page.openInPWA();
+    }).toThrow(UnsupportedOperation);
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add tests for your changes?**

Yes. The new Chrome pipe integration tests cover all six APIs, including PWA
installation, launch, opening the current page as an app, OS state inspection,
uninstallation, display mode changes, invalid page state, and the WebDriver
BiDi unsupported paths.

**If relevant, did you update the documentation?**

Yes. The public API TSDoc marks the methods experimental and documents that the
PWA domain is currently available only for Chrome pipe connections.

## Summary

Fixes #15202.

Chromium exposes PWA lifecycle operations through CDP, but Puppeteer callers
currently need to create raw sessions and manually map launched app targets back
to pages.

This adds high-level `Browser` APIs for installing, uninstalling, launching,
and inspecting PWAs, plus `Page` APIs for installing or opening the current
page as a PWA. The CDP implementation uses the required browser or page session
scope and maps a launched app to the correct driveable `Page`. WebDriver BiDi
reports these operations as unsupported for now.

## Changes

- Add typed Browser APIs for PWA installation, uninstallation, launch, and OS
  state inspection.
- Add Page APIs that derive the manifest ID and install or open the current PWA.
- Apply optional display mode changes after installation.
- Resolve Chromium's launched app-tab target to the corresponding Puppeteer
  page.
- Add real-browser CDP coverage and explicit WebDriver BiDi unsupported paths.

**Does this PR introduce a breaking change?**

No. It adds experimental APIs without changing existing behavior.

**Other information**

`launchFilesInApp` is intentionally outside this change, as discussed in the
issue.

## Verification

```bash
npm run build --workspace @puppeteer-test/test
npm test -- --test-suite chrome-pipe --grep '^PWA '
npm run test-types
npm run unit --workspace puppeteer-core
npm run lint
```
