### PR TITLE
feat: add browser-level PWA install/launch/uninstall APIs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1089,6 +1089,15 @@ Device in a request prompt.
 </td></tr>
 <tr><td>
 
+<span id="getpwastateoptions">[GetPWAStateOptions](./puppeteer.getpwastateoptions.md)</span>
+
+</td><td>
+
+Options for [Browser.getPWAState()](./puppeteer.browser.getpwastate.md).
+
+</td></tr>
+<tr><td>
+
 <span id="gotooptions">[GoToOptions](./puppeteer.gotooptions.md)</span>
 
 </td><td>
@@ -1101,6 +1110,15 @@ Device in a request prompt.
 </td><td>
 
 Options for [Page.captureHeapSnapshot()](./puppeteer.page.captureheapsnapshot.md).
+
+</td></tr>
+<tr><td>
+
+<span id="installpwaoptions">[InstallPWAOptions](./puppeteer.installpwaoptions.md)</span>
+
+</td><td>
+
+Options for [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
 </td></tr>
 <tr><td>
@@ -1165,6 +1183,15 @@ Set of configurable options for JS coverage.
 </td><td>
 
 Generic launch options that can be passed when launching any browser.
+
+</td></tr>
+<tr><td>
+
+<span id="launchpwaoptions">[LaunchPWAOptions](./puppeteer.launchpwaoptions.md)</span>
+
+</td><td>
+
+Options for [Browser.launchPWA()](./puppeteer.browser.launchpwa.md).
 
 </td></tr>
 <tr><td>
@@ -1312,6 +1339,15 @@ A bluetooth peripheral to be simulated.
 </td></tr>
 <tr><td>
 
+<span id="pwastate">[PWAState](./puppeteer.pwastate.md)</span>
+
+</td><td>
+
+The OS-integration state of an installed web app, returned by [Browser.getPWAState()](./puppeteer.browser.getpwastate.md).
+
+</td></tr>
+<tr><td>
+
 <span id="queryoptions">[QueryOptions](./puppeteer.queryoptions.md)</span>
 
 </td><td>
@@ -1423,6 +1459,15 @@ The TouchHandle interface exposes methods to manipulate touches that have been s
 <span id="tracingoptions">[TracingOptions](./puppeteer.tracingoptions.md)</span>
 
 </td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="uninstallpwaoptions">[UninstallPWAOptions](./puppeteer.uninstallpwaoptions.md)</span>
+
+</td><td>
+
+Options for [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
 
 </td></tr>
 <tr><td>
@@ -1947,6 +1992,15 @@ in favor of .
 <span id="puppeteerlifecycleevent">[PuppeteerLifeCycleEvent](./puppeteer.puppeteerlifecycleevent.md)</span>
 
 </td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="pwadisplaymode">[PWADisplayMode](./puppeteer.pwadisplaymode.md)</span>
+
+</td><td>
+
+If the user prefers opening an installed web app in a standalone window or in a browser tab.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.getpwastate.md
+++ b/docs/api/puppeteer.browser.getpwastate.md
@@ -1,0 +1,51 @@
+---
+sidebar_label: Browser.getPWAState
+---
+
+# Browser.getPWAState() method
+
+Returns the OS-integration state of an installed Progressive Web App (PWA), such as its badge count and registered file handlers.
+
+### Signature
+
+```typescript
+class Browser {
+  abstract getPWAState(options: GetPWAStateOptions): Promise<PWAState>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+[GetPWAStateOptions](./puppeteer.getpwastateoptions.md)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;[PWAState](./puppeteer.pwastate.md)&gt;
+
+## Remarks
+
+Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md). Meaningful only for an app that is currently installed; querying an unknown manifest id rejects.

--- a/docs/api/puppeteer.browser.installpwa.md
+++ b/docs/api/puppeteer.browser.installpwa.md
@@ -48,6 +48,6 @@ Promise&lt;string&gt;
 
 ## Remarks
 
-Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection, and additionally requires launching the browser with the `--enable-devtools-pwa-handler` argument.
+Only available when connected to the browser over a pipe connection. Set `pipe: true` in [puppeteer.launch](./puppeteer.puppeteernode.launch.md); the launch option defaults to `false`. The underlying `PWA` CDP domain is not exposed over a WebSocket connection.
 
 The returned manifest id echoes [InstallPWAOptions.manifestId](./puppeteer.installpwaoptions.md#manifestid), so it can be passed directly to [Browser.launchPWA()](./puppeteer.browser.launchpwa.md), [Browser.getPWAState()](./puppeteer.browser.getpwastate.md), or [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).

--- a/docs/api/puppeteer.browser.installpwa.md
+++ b/docs/api/puppeteer.browser.installpwa.md
@@ -1,0 +1,53 @@
+---
+sidebar_label: Browser.installPWA
+---
+
+# Browser.installPWA() method
+
+Installs a Progressive Web App (PWA) and returns its manifest id.
+
+### Signature
+
+```typescript
+class Browser {
+  abstract installPWA(options: InstallPWAOptions): Promise<string>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+[InstallPWAOptions](./puppeteer.installpwaoptions.md)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;string&gt;
+
+## Remarks
+
+Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection.
+
+The returned manifest id echoes [InstallPWAOptions.manifestId](./puppeteer.installpwaoptions.md#manifestid), so it can be passed directly to [Browser.launchPWA()](./puppeteer.browser.launchpwa.md), [Browser.getPWAState()](./puppeteer.browser.getpwastate.md), or [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).

--- a/docs/api/puppeteer.browser.installpwa.md
+++ b/docs/api/puppeteer.browser.installpwa.md
@@ -48,6 +48,6 @@ Promise&lt;string&gt;
 
 ## Remarks
 
-Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection.
+Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection, and additionally requires launching the browser with the `--enable-devtools-pwa-handler` argument.
 
 The returned manifest id echoes [InstallPWAOptions.manifestId](./puppeteer.installpwaoptions.md#manifestid), so it can be passed directly to [Browser.launchPWA()](./puppeteer.browser.launchpwa.md), [Browser.getPWAState()](./puppeteer.browser.getpwastate.md), or [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).

--- a/docs/api/puppeteer.browser.launchpwa.md
+++ b/docs/api/puppeteer.browser.launchpwa.md
@@ -1,0 +1,51 @@
+---
+sidebar_label: Browser.launchPWA
+---
+
+# Browser.launchPWA() method
+
+Launches an installed Progressive Web App (PWA) and resolves with the [page](./puppeteer.page.md) backing the app window.
+
+### Signature
+
+```typescript
+class Browser {
+  abstract launchPWA(options: LaunchPWAOptions): Promise<Page>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+[LaunchPWAOptions](./puppeteer.launchpwaoptions.md)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;[Page](./puppeteer.page.md)&gt;
+
+## Remarks
+
+Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).

--- a/docs/api/puppeteer.browser.launchpwa.md
+++ b/docs/api/puppeteer.browser.launchpwa.md
@@ -49,3 +49,5 @@ Promise&lt;[Page](./puppeteer.page.md)&gt;
 ## Remarks
 
 Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
+
+Resolves with the newly opened app-window page. Because the launched app-window target is not surfaced through the CDP `Target` domain, the page is matched by origin; launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.

--- a/docs/api/puppeteer.browser.launchpwa.md
+++ b/docs/api/puppeteer.browser.launchpwa.md
@@ -50,4 +50,4 @@ Promise&lt;[Page](./puppeteer.page.md)&gt;
 
 Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
-Resolves with the newly opened app-window page. Because the launched app-window target is not surfaced through the CDP `Target` domain, the page is matched by origin; launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.
+`PWA.launch` resolves with the id of the launched \_tab\_ target, which is not exposed through the CDP `Target` domain; this method resolves with the tab's child page target (the app's web contents). Launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.

--- a/docs/api/puppeteer.browser.launchpwa.md
+++ b/docs/api/puppeteer.browser.launchpwa.md
@@ -50,4 +50,4 @@ Promise&lt;[Page](./puppeteer.page.md)&gt;
 
 Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
-`PWA.launch` resolves with the id of the launched \_tab\_ target, which is not exposed through the CDP `Target` domain; this method resolves with the tab's child page target (the app's web contents). Launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.
+`PWA.launch` resolves with the id of the launched \_tab\_ target. Puppeteer does not expose tab targets through [Browser.targets()](./puppeteer.browser.targets.md); this method instead resolves with the tab's child page target (the app's web contents). If Chromium focuses an existing app window, this returns that window's existing page.

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -311,7 +311,7 @@ Installs a Progressive Web App (PWA) and returns its manifest id.
 
 **Remarks:**
 
-Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection.
+Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection, and additionally requires launching the browser with the `--enable-devtools-pwa-handler` argument.
 
 The returned manifest id echoes [InstallPWAOptions.manifestId](./puppeteer.installpwaoptions.md#manifestid), so it can be passed directly to [Browser.launchPWA()](./puppeteer.browser.launchpwa.md), [Browser.getPWAState()](./puppeteer.browser.getpwastate.md), or [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
 
@@ -329,6 +329,8 @@ Launches an installed Progressive Web App (PWA) and resolves with the [page](./p
 **Remarks:**
 
 Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
+
+Resolves with the newly opened app-window page. Because the launched app-window target is not surfaced through the CDP `Target` domain, the page is matched by origin; launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -264,6 +264,21 @@ Retrieves a map of all extensions installed in the browser, where the keys are e
 </td></tr>
 <tr><td>
 
+<span id="getpwastate">[getPWAState(options)](./puppeteer.browser.getpwastate.md)</span>
+
+</td><td>
+
+</td><td>
+
+Returns the OS-integration state of an installed Progressive Web App (PWA), such as its badge count and registered file handlers.
+
+**Remarks:**
+
+Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md). Meaningful only for an app that is currently installed; querying an unknown manifest id rejects.
+
+</td></tr>
+<tr><td>
+
 <span id="getwindowbounds">[getWindowBounds(windowId)](./puppeteer.browser.getwindowbounds.md)</span>
 
 </td><td>
@@ -282,6 +297,38 @@ Gets the specified window [bounds](./puppeteer.windowbounds.md).
 </td><td>
 
 Installs an extension and returns the ID.
+
+</td></tr>
+<tr><td>
+
+<span id="installpwa">[installPWA(options)](./puppeteer.browser.installpwa.md)</span>
+
+</td><td>
+
+</td><td>
+
+Installs a Progressive Web App (PWA) and returns its manifest id.
+
+**Remarks:**
+
+Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection.
+
+The returned manifest id echoes [InstallPWAOptions.manifestId](./puppeteer.installpwaoptions.md#manifestid), so it can be passed directly to [Browser.launchPWA()](./puppeteer.browser.launchpwa.md), [Browser.getPWAState()](./puppeteer.browser.getpwastate.md), or [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
+
+</td></tr>
+<tr><td>
+
+<span id="launchpwa">[launchPWA(options)](./puppeteer.browser.launchpwa.md)</span>
+
+</td><td>
+
+</td><td>
+
+Launches an installed Progressive Web App (PWA) and resolves with the [page](./puppeteer.page.md) backing the app window.
+
+**Remarks:**
+
+Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
 </td></tr>
 <tr><td>
@@ -423,6 +470,21 @@ In case of multiple [browser contexts](./puppeteer.browsercontext.md), this retu
 </td><td>
 
 Uninstalls an extension.
+
+</td></tr>
+<tr><td>
+
+<span id="uninstallpwa">[uninstallPWA(options)](./puppeteer.browser.uninstallpwa.md)</span>
+
+</td><td>
+
+</td><td>
+
+Uninstalls a previously installed Progressive Web App (PWA).
+
+**Remarks:**
+
+Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -330,7 +330,7 @@ Launches an installed Progressive Web App (PWA) and resolves with the [page](./p
 
 Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
-Resolves with the newly opened app-window page. Because the launched app-window target is not surfaced through the CDP `Target` domain, the page is matched by origin; launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.
+`PWA.launch` resolves with the id of the launched \_tab\_ target, which is not exposed through the CDP `Target` domain; this method resolves with the tab's child page target (the app's web contents). Launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -311,7 +311,7 @@ Installs a Progressive Web App (PWA) and returns its manifest id.
 
 **Remarks:**
 
-Only available when connected to the browser over a pipe connection (the default when Puppeteer launches the browser). The underlying `PWA` CDP domain is not exposed over a WebSocket connection, and additionally requires launching the browser with the `--enable-devtools-pwa-handler` argument.
+Only available when connected to the browser over a pipe connection. Set `pipe: true` in [puppeteer.launch](./puppeteer.puppeteernode.launch.md); the launch option defaults to `false`. The underlying `PWA` CDP domain is not exposed over a WebSocket connection.
 
 The returned manifest id echoes [InstallPWAOptions.manifestId](./puppeteer.installpwaoptions.md#manifestid), so it can be passed directly to [Browser.launchPWA()](./puppeteer.browser.launchpwa.md), [Browser.getPWAState()](./puppeteer.browser.getpwastate.md), or [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
 
@@ -330,7 +330,7 @@ Launches an installed Progressive Web App (PWA) and resolves with the [page](./p
 
 Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).
 
-`PWA.launch` resolves with the id of the launched \_tab\_ target, which is not exposed through the CDP `Target` domain; this method resolves with the tab's child page target (the app's web contents). Launching an app that already has an open window (which the browser may focus instead of opening a new one) rejects once [LaunchPWAOptions.timeout](./puppeteer.launchpwaoptions.md#timeout) elapses.
+`PWA.launch` resolves with the id of the launched \_tab\_ target. Puppeteer does not expose tab targets through [Browser.targets()](./puppeteer.browser.targets.md); this method instead resolves with the tab's child page target (the app's web contents). If Chromium focuses an existing app window, this returns that window's existing page.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.browser.uninstallpwa.md
+++ b/docs/api/puppeteer.browser.uninstallpwa.md
@@ -1,0 +1,51 @@
+---
+sidebar_label: Browser.uninstallPWA
+---
+
+# Browser.uninstallPWA() method
+
+Uninstalls a previously installed Progressive Web App (PWA).
+
+### Signature
+
+```typescript
+class Browser {
+  abstract uninstallPWA(options: UninstallPWAOptions): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+[UninstallPWAOptions](./puppeteer.uninstallpwaoptions.md)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;
+
+## Remarks
+
+Only available over a pipe connection. See [Browser.installPWA()](./puppeteer.browser.installpwa.md).

--- a/docs/api/puppeteer.getpwastateoptions.md
+++ b/docs/api/puppeteer.getpwastateoptions.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: GetPWAStateOptions
+---
+
+# GetPWAStateOptions interface
+
+Options for [Browser.getPWAState()](./puppeteer.browser.getpwastate.md).
+
+### Signature
+
+```typescript
+export interface GetPWAStateOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="manifestid">manifestId</span>
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+The id from the web app's manifest file.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.installpwaoptions.md
+++ b/docs/api/puppeteer.installpwaoptions.md
@@ -64,15 +64,15 @@ Whether the app should open in a standalone window or a browser tab.
 
 </td><td>
 
-`optional`
-
 </td><td>
 
 string
 
 </td><td>
 
-The location of the app or bundle overriding the one derived from the `manifestId`.
+The URL used to install the app, or the URL of its signed web bundle.
+
+This is required because the browser-scoped CDP session has no associated page from which Chromium could derive an install URL.
 
 </td><td>
 

--- a/docs/api/puppeteer.installpwaoptions.md
+++ b/docs/api/puppeteer.installpwaoptions.md
@@ -1,0 +1,97 @@
+---
+sidebar_label: InstallPWAOptions
+---
+
+# InstallPWAOptions interface
+
+Options for [Browser.installPWA()](./puppeteer.browser.installpwa.md).
+
+### Signature
+
+```typescript
+export interface InstallPWAOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="displaymode">displayMode</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+[PWADisplayMode](./puppeteer.pwadisplaymode.md)
+
+</td><td>
+
+Whether the app should open in a standalone window or a browser tab.
+
+**Remarks:**
+
+`PWA.install` alone leaves the app at Chromium's default display mode (`browser`); setting this chains a `PWA.changeAppUserSettings` call to apply the preference.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="installurlorbundleurl">installUrlOrBundleUrl</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+The location of the app or bundle overriding the one derived from the `manifestId`.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="manifestid">manifestId</span>
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+The id from the web app's manifest file, commonly the URL of the site installing the web app. See [Web app manifest](https://web.dev/learn/pwa/web-app-manifest).
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.launchpwaoptions.md
+++ b/docs/api/puppeteer.launchpwaoptions.md
@@ -66,7 +66,7 @@ number
 
 </td><td>
 
-Maximum wait time in milliseconds for the app window to open. Defaults to 30 seconds.
+Maximum time in milliseconds for launching the app and resolving its page. Defaults to 30 seconds. Pass `0` to disable the timeout.
 
 </td><td>
 

--- a/docs/api/puppeteer.launchpwaoptions.md
+++ b/docs/api/puppeteer.launchpwaoptions.md
@@ -54,6 +54,25 @@ The id from the web app's manifest file.
 </td></tr>
 <tr><td>
 
+<span id="timeout">timeout</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Maximum wait time in milliseconds for the app window to open. Defaults to 30 seconds.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="url">url</span>
 
 </td><td>

--- a/docs/api/puppeteer.launchpwaoptions.md
+++ b/docs/api/puppeteer.launchpwaoptions.md
@@ -1,0 +1,74 @@
+---
+sidebar_label: LaunchPWAOptions
+---
+
+# LaunchPWAOptions interface
+
+Options for [Browser.launchPWA()](./puppeteer.browser.launchpwa.md).
+
+### Signature
+
+```typescript
+export interface LaunchPWAOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="manifestid">manifestId</span>
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+The id from the web app's manifest file.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="url">url</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+An optional URL within the app's scope to launch. Defaults to the app's start URL.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.launchpwaoptions.md
+++ b/docs/api/puppeteer.launchpwaoptions.md
@@ -66,7 +66,7 @@ number
 
 </td><td>
 
-Maximum time in milliseconds for launching the app and resolving its page. Defaults to 30 seconds. Pass `0` to disable the timeout.
+Maximum time in milliseconds to wait for the app's page target to appear. Defaults to 30 seconds. Pass `0` to disable the timeout.
 
 </td><td>
 

--- a/docs/api/puppeteer.pwadisplaymode.md
+++ b/docs/api/puppeteer.pwadisplaymode.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: PWADisplayMode
+---
+
+# PWADisplayMode type
+
+If the user prefers opening an installed web app in a standalone window or in a browser tab.
+
+### Signature
+
+```typescript
+export type PWADisplayMode = 'standalone' | 'browser';
+```

--- a/docs/api/puppeteer.pwastate.md
+++ b/docs/api/puppeteer.pwastate.md
@@ -1,0 +1,72 @@
+---
+sidebar_label: PWAState
+---
+
+# PWAState interface
+
+The OS-integration state of an installed web app, returned by [Browser.getPWAState()](./puppeteer.browser.getpwastate.md).
+
+### Signature
+
+```typescript
+export interface PWAState
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="badgecount">badgeCount</span>
+
+</td><td>
+
+</td><td>
+
+number
+
+</td><td>
+
+The current badge count shown on the app icon.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="filehandlers">fileHandlers</span>
+
+</td><td>
+
+</td><td>
+
+Protocol.PWA.FileHandler\[\]
+
+</td><td>
+
+The file handlers registered by the app with the OS.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.uninstallpwaoptions.md
+++ b/docs/api/puppeteer.uninstallpwaoptions.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: UninstallPWAOptions
+---
+
+# UninstallPWAOptions interface
+
+Options for [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
+
+### Signature
+
+```typescript
+export interface UninstallPWAOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="manifestid">manifestId</span>
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+The id from the web app's manifest file.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -796,11 +796,11 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    *
    * Only available over a pipe connection. See {@link Browser.installPWA}.
    *
-   * Resolves with the newly opened app-window page. Because the launched
-   * app-window target is not surfaced through the CDP `Target` domain, the
-   * page is matched by origin; launching an app that already has an open
-   * window (which the browser may focus instead of opening a new one) rejects
-   * once {@link LaunchPWAOptions.timeout} elapses.
+   * `PWA.launch` resolves with the id of the launched _tab_ target, which is
+   * not exposed through the CDP `Target` domain; this method resolves with the
+   * tab's child page target (the app's web contents). Launching an app that
+   * already has an open window (which the browser may focus instead of opening
+   * a new one) rejects once {@link LaunchPWAOptions.timeout} elapses.
    */
   abstract launchPWA(options: LaunchPWAOptions): Promise<Page>;
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -335,6 +335,101 @@ export interface ExtensionInstallOptions {
 }
 
 /**
+ * If the user prefers opening an installed web app in a standalone window or in
+ * a browser tab.
+ *
+ * @public
+ */
+export type PWADisplayMode = 'standalone' | 'browser';
+
+/**
+ * Options for {@link Browser.installPWA}.
+ *
+ * @public
+ */
+export interface InstallPWAOptions {
+  /**
+   * The id from the web app's manifest file, commonly the URL of the site
+   * installing the web app. See
+   * {@link https://web.dev/learn/pwa/web-app-manifest | Web app manifest}.
+   */
+  manifestId: string;
+  /**
+   * The location of the app or bundle overriding the one derived from the
+   * `manifestId`.
+   */
+  installUrlOrBundleUrl?: string;
+  /**
+   * Whether the app should open in a standalone window or a browser tab.
+   *
+   * @remarks
+   *
+   * `PWA.install` alone leaves the app at Chromium's default display mode
+   * (`browser`); setting this chains a `PWA.changeAppUserSettings` call to apply
+   * the preference.
+   */
+  displayMode?: PWADisplayMode;
+}
+
+/**
+ * Options for {@link Browser.uninstallPWA}.
+ *
+ * @public
+ */
+export interface UninstallPWAOptions {
+  /**
+   * The id from the web app's manifest file.
+   */
+  manifestId: string;
+}
+
+/**
+ * Options for {@link Browser.launchPWA}.
+ *
+ * @public
+ */
+export interface LaunchPWAOptions {
+  /**
+   * The id from the web app's manifest file.
+   */
+  manifestId: string;
+  /**
+   * An optional URL within the app's scope to launch. Defaults to the app's
+   * start URL.
+   */
+  url?: string;
+}
+
+/**
+ * Options for {@link Browser.getPWAState}.
+ *
+ * @public
+ */
+export interface GetPWAStateOptions {
+  /**
+   * The id from the web app's manifest file.
+   */
+  manifestId: string;
+}
+
+/**
+ * The OS-integration state of an installed web app, returned by
+ * {@link Browser.getPWAState}.
+ *
+ * @public
+ */
+export interface PWAState {
+  /**
+   * The current badge count shown on the app icon.
+   */
+  badgeCount: number;
+  /**
+   * The file handlers registered by the app with the OS.
+   */
+  fileHandlers: Protocol.PWA.FileHandler[];
+}
+
+/**
  * {@link Browser} represents a browser instance that is either:
  *
  * - connected to via {@link Puppeteer.connect} or
@@ -661,6 +756,52 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * Uninstalls an extension.
    */
   abstract uninstallExtension(id: string): Promise<void>;
+
+  /**
+   * Installs a Progressive Web App (PWA) and returns its manifest id.
+   *
+   * @remarks
+   *
+   * Only available when connected to the browser over a pipe connection (the
+   * default when Puppeteer launches the browser). The underlying `PWA` CDP
+   * domain is not exposed over a WebSocket connection.
+   *
+   * The returned manifest id echoes {@link InstallPWAOptions.manifestId}, so it
+   * can be passed directly to {@link Browser.launchPWA},
+   * {@link Browser.getPWAState}, or {@link Browser.uninstallPWA}.
+   */
+  abstract installPWA(options: InstallPWAOptions): Promise<string>;
+
+  /**
+   * Uninstalls a previously installed Progressive Web App (PWA).
+   *
+   * @remarks
+   *
+   * Only available over a pipe connection. See {@link Browser.installPWA}.
+   */
+  abstract uninstallPWA(options: UninstallPWAOptions): Promise<void>;
+
+  /**
+   * Launches an installed Progressive Web App (PWA) and resolves with the
+   * {@link Page | page} backing the app window.
+   *
+   * @remarks
+   *
+   * Only available over a pipe connection. See {@link Browser.installPWA}.
+   */
+  abstract launchPWA(options: LaunchPWAOptions): Promise<Page>;
+
+  /**
+   * Returns the OS-integration state of an installed Progressive Web App (PWA),
+   * such as its badge count and registered file handlers.
+   *
+   * @remarks
+   *
+   * Only available over a pipe connection. See {@link Browser.installPWA}.
+   * Meaningful only for an app that is currently installed; querying an
+   * unknown manifest id rejects.
+   */
+  abstract getPWAState(options: GetPWAStateOptions): Promise<PWAState>;
 
   /**
    * Gets a list of {@link ScreenInfo | screen information objects}.

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -355,10 +355,12 @@ export interface InstallPWAOptions {
    */
   manifestId: string;
   /**
-   * The location of the app or bundle overriding the one derived from the
-   * `manifestId`.
+   * The URL used to install the app, or the URL of its signed web bundle.
+   *
+   * This is required because the browser-scoped CDP session has no associated
+   * page from which Chromium could derive an install URL.
    */
-  installUrlOrBundleUrl?: string;
+  installUrlOrBundleUrl: string;
   /**
    * Whether the app should open in a standalone window or a browser tab.
    *
@@ -399,8 +401,8 @@ export interface LaunchPWAOptions {
    */
   url?: string;
   /**
-   * Maximum wait time in milliseconds for the app window to open. Defaults to
-   * 30 seconds.
+   * Maximum time in milliseconds for launching the app and resolving its page.
+   * Defaults to 30 seconds. Pass `0` to disable the timeout.
    */
   timeout?: number;
 }
@@ -767,11 +769,10 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    *
    * @remarks
    *
-   * Only available when connected to the browser over a pipe connection (the
-   * default when Puppeteer launches the browser). The underlying `PWA` CDP
-   * domain is not exposed over a WebSocket connection, and additionally
-   * requires launching the browser with the `--enable-devtools-pwa-handler`
-   * argument.
+   * Only available when connected to the browser over a pipe connection. Set
+   * `pipe: true` in {@link PuppeteerNode.launch | puppeteer.launch}; the launch
+   * option defaults to `false`. The underlying `PWA` CDP domain is not exposed
+   * over a WebSocket connection.
    *
    * The returned manifest id echoes {@link InstallPWAOptions.manifestId}, so it
    * can be passed directly to {@link Browser.launchPWA},
@@ -796,11 +797,11 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    *
    * Only available over a pipe connection. See {@link Browser.installPWA}.
    *
-   * `PWA.launch` resolves with the id of the launched _tab_ target, which is
-   * not exposed through the CDP `Target` domain; this method resolves with the
-   * tab's child page target (the app's web contents). Launching an app that
-   * already has an open window (which the browser may focus instead of opening
-   * a new one) rejects once {@link LaunchPWAOptions.timeout} elapses.
+   * `PWA.launch` resolves with the id of the launched _tab_ target. Puppeteer
+   * does not expose tab targets through {@link Browser.targets}; this method
+   * instead resolves with the tab's child page target (the app's web contents).
+   * If Chromium focuses an existing app window, this returns that window's
+   * existing page.
    */
   abstract launchPWA(options: LaunchPWAOptions): Promise<Page>;
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -398,6 +398,11 @@ export interface LaunchPWAOptions {
    * start URL.
    */
   url?: string;
+  /**
+   * Maximum wait time in milliseconds for the app window to open. Defaults to
+   * 30 seconds.
+   */
+  timeout?: number;
 }
 
 /**
@@ -764,7 +769,9 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    *
    * Only available when connected to the browser over a pipe connection (the
    * default when Puppeteer launches the browser). The underlying `PWA` CDP
-   * domain is not exposed over a WebSocket connection.
+   * domain is not exposed over a WebSocket connection, and additionally
+   * requires launching the browser with the `--enable-devtools-pwa-handler`
+   * argument.
    *
    * The returned manifest id echoes {@link InstallPWAOptions.manifestId}, so it
    * can be passed directly to {@link Browser.launchPWA},
@@ -788,6 +795,12 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
    * @remarks
    *
    * Only available over a pipe connection. See {@link Browser.installPWA}.
+   *
+   * Resolves with the newly opened app-window page. Because the launched
+   * app-window target is not surfaced through the CDP `Target` domain, the
+   * page is matched by origin; launching an app that already has an open
+   * window (which the browser may focus instead of opening a new one) rejects
+   * once {@link LaunchPWAOptions.timeout} elapses.
    */
   abstract launchPWA(options: LaunchPWAOptions): Promise<Page>;
 

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -401,7 +401,7 @@ export interface LaunchPWAOptions {
    */
   url?: string;
   /**
-   * Maximum time in milliseconds for launching the app and resolving its page.
+   * Maximum time in milliseconds to wait for the app's page target to appear.
    * Defaults to 30 seconds. Pass `0` to disable the timeout.
    */
   timeout?: number;

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -19,6 +19,7 @@ import {
   type WindowBounds,
   type WindowId,
   type DebugInfo,
+  type PWAState,
 } from '../api/Browser.js';
 import {BrowserContextEvent} from '../api/BrowserContext.js';
 import type {Extension} from '../api/Extension.js';
@@ -295,6 +296,22 @@ export class BidiBrowser extends Browser {
 
   override async uninstallExtension(id: string): Promise<void> {
     await this.#browserCore.uninstallExtension(id);
+  }
+
+  override installPWA(): Promise<string> {
+    throw new UnsupportedOperation();
+  }
+
+  override uninstallPWA(): Promise<void> {
+    throw new UnsupportedOperation();
+  }
+
+  override launchPWA(): Promise<Page> {
+    throw new UnsupportedOperation();
+  }
+
+  override getPWAState(): Promise<PWAState> {
+    throw new UnsupportedOperation();
   }
 
   override screens(): Promise<ScreenInfo[]> {

--- a/packages/puppeteer-core/src/cdp/Browser.test.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {BrowserEvent} from '../api/Browser.js';
+import type {CDPSessionEvents, CommandOptions} from '../api/CDPSession.js';
+import {TimeoutError} from '../common/Errors.js';
+import {EventEmitter} from '../common/EventEmitter.js';
+import {Deferred} from '../util/Deferred.js';
+
+import {CdpBrowser} from './Browser.js';
+import type {Connection} from './Connection.js';
+
+class MockConnection extends EventEmitter<CDPSessionEvents> {
+  rejectEmulateNetworkConditionsCalls = false;
+  readonly command = Deferred.create<{targetId: string}>();
+  commandTimeout?: number;
+
+  send(
+    _method: string,
+    _params: unknown,
+    options?: CommandOptions,
+  ): Promise<{targetId: string}> {
+    this.commandTimeout = options?.timeout;
+    return this.command.valueOrThrow();
+  }
+}
+
+describe('CdpBrowser', function () {
+  describe('launchPWA', function () {
+    it('should apply the timeout while the protocol command is pending', async () => {
+      const connection = new MockConnection();
+      const browser = new CdpBrowser(connection as unknown as Connection, []);
+
+      const launchPromise = browser.launchPWA({
+        manifestId: 'https://example.com/',
+        timeout: 1,
+      });
+      await expect(launchPromise).rejects.toBeInstanceOf(TimeoutError);
+      expect(connection.commandTimeout).toBe(1);
+
+      connection.command.resolve({targetId: 'tab'});
+      await new Promise(resolve => {
+        setImmediate(resolve);
+      });
+      expect(browser.listenerCount(BrowserEvent.TargetCreated)).toBe(0);
+      expect(browser.listenerCount(BrowserEvent.TargetChanged)).toBe(0);
+    });
+  });
+});

--- a/packages/puppeteer-core/src/cdp/Browser.test.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.test.ts
@@ -4,18 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {describe, it} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 
 import expect from 'expect';
+import sinon from 'sinon';
 
 import {BrowserEvent} from '../api/Browser.js';
 import type {CDPSessionEvents, CommandOptions} from '../api/CDPSession.js';
-import {TimeoutError} from '../common/Errors.js';
+import type {Page} from '../api/Page.js';
+import {TargetCloseError, TimeoutError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {Deferred} from '../util/Deferred.js';
 
 import {CdpBrowser} from './Browser.js';
 import type {Connection} from './Connection.js';
+import type {CdpTarget} from './Target.js';
 
 class MockConnection extends EventEmitter<CDPSessionEvents> {
   rejectEmulateNetworkConditionsCalls = false;
@@ -33,6 +36,10 @@ class MockConnection extends EventEmitter<CDPSessionEvents> {
 }
 
 describe('CdpBrowser', function () {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('launchPWA', function () {
     it('should apply the timeout while the protocol command is pending', async () => {
       const connection = new MockConnection();
@@ -49,8 +56,58 @@ describe('CdpBrowser', function () {
       await new Promise(resolve => {
         setImmediate(resolve);
       });
+      expect(browser.listenerCount(BrowserEvent.Disconnected)).toBe(0);
       expect(browser.listenerCount(BrowserEvent.TargetCreated)).toBe(0);
       expect(browser.listenerCount(BrowserEvent.TargetChanged)).toBe(0);
+    });
+
+    it('should stop waiting when the browser disconnects', async () => {
+      const connection = new MockConnection();
+      const browser = new CdpBrowser(connection as unknown as Connection, []);
+      connection.command.resolve({targetId: 'tab'});
+
+      const launchPromise = browser.launchPWA({
+        manifestId: 'https://example.com/',
+        timeout: 0,
+      });
+      await new Promise(resolve => {
+        setImmediate(resolve);
+      });
+      browser.emit(BrowserEvent.Disconnected, undefined);
+
+      await expect(launchPromise).rejects.toBeInstanceOf(TargetCloseError);
+      expect(browser.listenerCount(BrowserEvent.Disconnected)).toBe(0);
+      expect(browser.listenerCount(BrowserEvent.TargetCreated)).toBe(0);
+      expect(browser.listenerCount(BrowserEvent.TargetChanged)).toBe(0);
+    });
+
+    it('should stop while the page is being created', async () => {
+      const connection = new MockConnection();
+      const browser = new CdpBrowser(connection as unknown as Connection, []);
+      const pageDeferred = Deferred.create<Page>();
+      const target = {
+        page: () => {
+          return pageDeferred.valueOrThrow();
+        },
+      } as unknown as CdpTarget;
+      sinon.stub(browser, 'waitForTarget').resolves(target);
+      connection.command.resolve({targetId: 'tab'});
+
+      const launchPromise = browser.launchPWA({
+        manifestId: 'https://example.com/',
+        timeout: 0,
+      });
+      await new Promise(resolve => {
+        setImmediate(resolve);
+      });
+      browser.emit(BrowserEvent.Disconnected, undefined);
+
+      await expect(launchPromise).rejects.toBeInstanceOf(TargetCloseError);
+      pageDeferred.resolve({} as Page);
+      await new Promise(resolve => {
+        setImmediate(resolve);
+      });
+      expect(browser.listenerCount(BrowserEvent.Disconnected)).toBe(0);
     });
   });
 });

--- a/packages/puppeteer-core/src/cdp/Browser.test.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.test.ts
@@ -9,10 +9,8 @@ import {afterEach, describe, it} from 'node:test';
 import expect from 'expect';
 import sinon from 'sinon';
 
-import {BrowserEvent} from '../api/Browser.js';
 import type {CDPSessionEvents, CommandOptions} from '../api/CDPSession.js';
 import type {Page} from '../api/Page.js';
-import {TargetCloseError, TimeoutError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {Deferred} from '../util/Deferred.js';
 
@@ -41,73 +39,29 @@ describe('CdpBrowser', function () {
   });
 
   describe('launchPWA', function () {
-    it('should apply the timeout while the protocol command is pending', async () => {
+    it('should apply the timeout while waiting for the page target', async () => {
       const connection = new MockConnection();
       const browser = new CdpBrowser(connection as unknown as Connection, []);
-
-      const launchPromise = browser.launchPWA({
-        manifestId: 'https://example.com/',
-        timeout: 1,
-      });
-      await expect(launchPromise).rejects.toBeInstanceOf(TimeoutError);
-      expect(connection.commandTimeout).toBe(1);
-
-      connection.command.resolve({targetId: 'tab'});
-      await new Promise(resolve => {
-        setImmediate(resolve);
-      });
-      expect(browser.listenerCount(BrowserEvent.Disconnected)).toBe(0);
-      expect(browser.listenerCount(BrowserEvent.TargetCreated)).toBe(0);
-      expect(browser.listenerCount(BrowserEvent.TargetChanged)).toBe(0);
-    });
-
-    it('should stop waiting when the browser disconnects', async () => {
-      const connection = new MockConnection();
-      const browser = new CdpBrowser(connection as unknown as Connection, []);
-      connection.command.resolve({targetId: 'tab'});
-
-      const launchPromise = browser.launchPWA({
-        manifestId: 'https://example.com/',
-        timeout: 0,
-      });
-      await new Promise(resolve => {
-        setImmediate(resolve);
-      });
-      browser.emit(BrowserEvent.Disconnected, undefined);
-
-      await expect(launchPromise).rejects.toBeInstanceOf(TargetCloseError);
-      expect(browser.listenerCount(BrowserEvent.Disconnected)).toBe(0);
-      expect(browser.listenerCount(BrowserEvent.TargetCreated)).toBe(0);
-      expect(browser.listenerCount(BrowserEvent.TargetChanged)).toBe(0);
-    });
-
-    it('should stop while the page is being created', async () => {
-      const connection = new MockConnection();
-      const browser = new CdpBrowser(connection as unknown as Connection, []);
-      const pageDeferred = Deferred.create<Page>();
+      const page = {} as Page;
       const target = {
-        page: () => {
-          return pageDeferred.valueOrThrow();
+        page: async () => {
+          return page;
         },
       } as unknown as CdpTarget;
-      sinon.stub(browser, 'waitForTarget').resolves(target);
+      const waitForTarget = sinon
+        .stub(browser, 'waitForTarget')
+        .resolves(target);
       connection.command.resolve({targetId: 'tab'});
 
-      const launchPromise = browser.launchPWA({
+      const result = await browser.launchPWA({
         manifestId: 'https://example.com/',
-        timeout: 0,
+        timeout: 123,
       });
-      await new Promise(resolve => {
-        setImmediate(resolve);
-      });
-      browser.emit(BrowserEvent.Disconnected, undefined);
 
-      await expect(launchPromise).rejects.toBeInstanceOf(TargetCloseError);
-      pageDeferred.resolve({} as Page);
-      await new Promise(resolve => {
-        setImmediate(resolve);
-      });
-      expect(browser.listenerCount(BrowserEvent.Disconnected)).toBe(0);
+      expect(result).toBe(page);
+      expect(connection.commandTimeout).toBeUndefined();
+      expect(waitForTarget.calledOnce).toBe(true);
+      expect(waitForTarget.firstCall.args[1]).toEqual({timeout: 123});
     });
   });
 });

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -549,25 +549,70 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async launchPWA(options: LaunchPWAOptions): Promise<Page> {
-    const {targetId} = await this.#connection.send('PWA.launch', {
+    // `PWA.launch` returns the id of the launched app-window target, which is
+    // not surfaced through the `Target` domain and therefore never appears in
+    // `browser.targets()`. The app's actual page (web contents) is a separate
+    // target with its own id. So instead of matching the returned id, we wait
+    // for the new page target that the launch creates, scoped to the app's
+    // origin (a PWA's launch URL is same-origin as its manifest id).
+    const appOrigin = (() => {
+      try {
+        return new URL(options.url ?? options.manifestId).origin;
+      } catch {
+        return undefined;
+      }
+    })();
+    const knownPageTargetIds = new Set(
+      this.targets()
+        .filter(target => {
+          return target.type() === 'page';
+        })
+        .map(target => {
+          return (target as CdpTarget)._targetId;
+        }),
+    );
+    await this.#connection.send('PWA.launch', {
       manifestId: options.manifestId,
       url: options.url,
     });
-    const target = (await this.waitForTarget(t => {
-      return (t as CdpTarget)._targetId === targetId;
-    })) as CdpTarget;
+    const target = (await this.waitForTarget(
+      candidate => {
+        if (candidate.type() !== 'page') {
+          return false;
+        }
+        const targetId = (candidate as CdpTarget)._targetId;
+        if (knownPageTargetIds.has(targetId)) {
+          return false;
+        }
+        if (appOrigin === undefined) {
+          return true;
+        }
+        try {
+          return new URL(candidate.url()).origin === appOrigin;
+        } catch {
+          return false;
+        }
+      },
+      {timeout: options.timeout},
+    )) as CdpTarget;
     if (!target) {
-      throw new Error(`Missing target for launched PWA (id = ${targetId})`);
+      throw new Error(
+        `Missing target for launched PWA (manifestId = ${options.manifestId})`,
+      );
     }
     const initialized =
       (await target._initializedDeferred.valueOrThrow()) ===
       InitializationStatus.SUCCESS;
     if (!initialized) {
-      throw new Error(`Failed to create target for PWA (id = ${targetId})`);
+      throw new Error(
+        `Failed to create target for PWA (manifestId = ${options.manifestId})`,
+      );
     }
     const page = await target.page();
     if (!page) {
-      throw new Error(`Failed to create a page for PWA (id = ${targetId})`);
+      throw new Error(
+        `Failed to create a page for PWA (manifestId = ${options.manifestId})`,
+      );
     }
     return page;
   }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -36,6 +36,7 @@ import type {Extension} from '../api/Extension.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
+import {TargetCloseError} from '../common/Errors.js';
 import type {Viewport} from '../common/Viewport.js';
 import {Deferred} from '../util/Deferred.js';
 
@@ -555,6 +556,13 @@ export class CdpBrowser extends BrowserBase {
       timeout,
       message: `Timed out after waiting ${timeout}ms`,
     });
+    const disconnectedDeferred = Deferred.create<Page, TargetCloseError>();
+    const onDisconnected = () => {
+      const error = new TargetCloseError('Browser disconnected');
+      controller.abort(error);
+      disconnectedDeferred.reject(error);
+    };
+    this.on(BrowserEvent.Disconnected, onDisconnected);
 
     try {
       return await Deferred.race([
@@ -598,8 +606,10 @@ export class CdpBrowser extends BrowserBase {
           return page;
         })(),
         timeoutDeferred,
+        disconnectedDeferred,
       ]);
     } finally {
+      this.off(BrowserEvent.Disconnected, onDisconnected);
       controller.abort();
     }
   }

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -24,6 +24,11 @@ import {
   type AddScreenParams,
   type WindowBounds,
   type WindowId,
+  type InstallPWAOptions,
+  type UninstallPWAOptions,
+  type LaunchPWAOptions,
+  type GetPWAStateOptions,
+  type PWAState,
 } from '../api/Browser.js';
 import {BrowserContextEvent} from '../api/BrowserContext.js';
 import {CDPSessionEvent} from '../api/CDPSession.js';
@@ -521,6 +526,58 @@ export class CdpBrowser extends BrowserBase {
     await Promise.all(targetDestroyedPromises);
 
     this.#extensions.delete(id);
+  }
+
+  override async installPWA(options: InstallPWAOptions): Promise<string> {
+    await this.#connection.send('PWA.install', {
+      manifestId: options.manifestId,
+      installUrlOrBundleUrl: options.installUrlOrBundleUrl,
+    });
+    if (options.displayMode) {
+      await this.#connection.send('PWA.changeAppUserSettings', {
+        manifestId: options.manifestId,
+        displayMode: options.displayMode,
+      });
+    }
+    return options.manifestId;
+  }
+
+  override async uninstallPWA(options: UninstallPWAOptions): Promise<void> {
+    await this.#connection.send('PWA.uninstall', {
+      manifestId: options.manifestId,
+    });
+  }
+
+  override async launchPWA(options: LaunchPWAOptions): Promise<Page> {
+    const {targetId} = await this.#connection.send('PWA.launch', {
+      manifestId: options.manifestId,
+      url: options.url,
+    });
+    const target = (await this.waitForTarget(t => {
+      return (t as CdpTarget)._targetId === targetId;
+    })) as CdpTarget;
+    if (!target) {
+      throw new Error(`Missing target for launched PWA (id = ${targetId})`);
+    }
+    const initialized =
+      (await target._initializedDeferred.valueOrThrow()) ===
+      InitializationStatus.SUCCESS;
+    if (!initialized) {
+      throw new Error(`Failed to create target for PWA (id = ${targetId})`);
+    }
+    const page = await target.page();
+    if (!page) {
+      throw new Error(`Failed to create a page for PWA (id = ${targetId})`);
+    }
+    return page;
+  }
+
+  override async getPWAState(options: GetPWAStateOptions): Promise<PWAState> {
+    const {badgeCount, fileHandlers} = await this.#connection.send(
+      'PWA.getOsAppState',
+      {manifestId: options.manifestId},
+    );
+    return {badgeCount, fileHandlers};
   }
 
   override async screens(): Promise<ScreenInfo[]> {

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -549,38 +549,59 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async launchPWA(options: LaunchPWAOptions): Promise<Page> {
-    // `PWA.launch` resolves with the id of the launched *tab* target (see the
-    // CDP `PWA.LaunchResponse` docs). Tab targets sit above page targets in the
-    // target hierarchy and are not exposed through `browser.targets()`, so the
-    // returned id can't be awaited directly. Instead we wait for the tab's
-    // child page target (the web contents), which the target manager links to
-    // its parent tab as a child target before exposing it.
-    const {targetId: tabTargetId} = await this.#connection.send('PWA.launch', {
-      manifestId: options.manifestId,
-      url: options.url,
+    const timeout = options.timeout ?? 30_000;
+    const controller = new AbortController();
+    const timeoutDeferred = Deferred.create<Page>({
+      timeout,
+      message: `Timed out after waiting ${timeout}ms`,
     });
-    const target = (await this.waitForTarget(
-      candidate => {
-        const tab = this.#targetManager.getAvailableTargets().get(tabTargetId);
-        if (tab?.type() !== 'tab') {
-          return false;
-        }
-        for (const child of tab._childTargets()) {
-          if (child === candidate) {
-            return true;
+
+    try {
+      return await Deferred.race([
+        (async () => {
+          // `PWA.launch` resolves with the id of the launched *tab* target (see
+          // the CDP `PWA.LaunchResponse` docs). Tab targets sit above page
+          // targets in the target hierarchy and are not exposed through
+          // `browser.targets()`, so the returned id can't be awaited directly.
+          const {targetId: tabTargetId} = await this.#connection.send(
+            'PWA.launch',
+            {
+              manifestId: options.manifestId,
+              url: options.url,
+            },
+            {timeout},
+          );
+          controller.signal.throwIfAborted();
+          const target = (await this.waitForTarget(
+            candidate => {
+              const tab = this.#targetManager
+                .getAvailableTargets()
+                .get(tabTargetId);
+              if (tab?.type() !== 'tab') {
+                return false;
+              }
+              for (const child of tab._childTargets()) {
+                if (child === candidate) {
+                  return true;
+                }
+              }
+              return false;
+            },
+            {timeout: 0, signal: controller.signal},
+          )) as CdpTarget;
+          const page = await target.page();
+          if (!page) {
+            throw new Error(
+              `Failed to create a page for the launched PWA (manifestId = ${options.manifestId})`,
+            );
           }
-        }
-        return false;
-      },
-      {timeout: options.timeout},
-    )) as CdpTarget;
-    const page = await target.page();
-    if (!page) {
-      throw new Error(
-        `Failed to create a page for the launched PWA (manifestId = ${options.manifestId})`,
-      );
+          return page;
+        })(),
+        timeoutDeferred,
+      ]);
+    } finally {
+      controller.abort();
     }
-    return page;
   }
 
   override async getPWAState(options: GetPWAStateOptions): Promise<PWAState> {

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -549,69 +549,35 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async launchPWA(options: LaunchPWAOptions): Promise<Page> {
-    // `PWA.launch` returns the id of the launched app-window target, which is
-    // not surfaced through the `Target` domain and therefore never appears in
-    // `browser.targets()`. The app's actual page (web contents) is a separate
-    // target with its own id. So instead of matching the returned id, we wait
-    // for the new page target that the launch creates, scoped to the app's
-    // origin (a PWA's launch URL is same-origin as its manifest id).
-    const appOrigin = (() => {
-      try {
-        return new URL(options.url ?? options.manifestId).origin;
-      } catch {
-        return undefined;
-      }
-    })();
-    const knownPageTargetIds = new Set(
-      this.targets()
-        .filter(target => {
-          return target.type() === 'page';
-        })
-        .map(target => {
-          return (target as CdpTarget)._targetId;
-        }),
-    );
-    await this.#connection.send('PWA.launch', {
+    // `PWA.launch` resolves with the id of the launched *tab* target (see the
+    // CDP `PWA.LaunchResponse` docs). Tab targets sit above page targets in the
+    // target hierarchy and are not exposed through `browser.targets()`, so the
+    // returned id can't be awaited directly. Instead we wait for the tab's
+    // child page target (the web contents), which the target manager links to
+    // its parent tab as a child target before exposing it.
+    const {targetId: tabTargetId} = await this.#connection.send('PWA.launch', {
       manifestId: options.manifestId,
       url: options.url,
     });
     const target = (await this.waitForTarget(
       candidate => {
-        if (candidate.type() !== 'page') {
+        const tab = this.#targetManager.getAvailableTargets().get(tabTargetId);
+        if (tab?.type() !== 'tab') {
           return false;
         }
-        const targetId = (candidate as CdpTarget)._targetId;
-        if (knownPageTargetIds.has(targetId)) {
-          return false;
+        for (const child of tab._childTargets()) {
+          if (child === candidate) {
+            return true;
+          }
         }
-        if (appOrigin === undefined) {
-          return true;
-        }
-        try {
-          return new URL(candidate.url()).origin === appOrigin;
-        } catch {
-          return false;
-        }
+        return false;
       },
       {timeout: options.timeout},
     )) as CdpTarget;
-    if (!target) {
-      throw new Error(
-        `Missing target for launched PWA (manifestId = ${options.manifestId})`,
-      );
-    }
-    const initialized =
-      (await target._initializedDeferred.valueOrThrow()) ===
-      InitializationStatus.SUCCESS;
-    if (!initialized) {
-      throw new Error(
-        `Failed to create target for PWA (manifestId = ${options.manifestId})`,
-      );
-    }
     const page = await target.page();
     if (!page) {
       throw new Error(
-        `Failed to create a page for PWA (manifestId = ${options.manifestId})`,
+        `Failed to create a page for the launched PWA (manifestId = ${options.manifestId})`,
       );
     }
     return page;

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -36,7 +36,6 @@ import type {Extension} from '../api/Extension.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
-import {TargetCloseError} from '../common/Errors.js';
 import type {Viewport} from '../common/Viewport.js';
 import {Deferred} from '../util/Deferred.js';
 
@@ -550,68 +549,36 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async launchPWA(options: LaunchPWAOptions): Promise<Page> {
-    const timeout = options.timeout ?? 30_000;
-    const controller = new AbortController();
-    const timeoutDeferred = Deferred.create<Page>({
-      timeout,
-      message: `Timed out after waiting ${timeout}ms`,
+    // `PWA.launch` resolves with the id of the launched *tab* target (see the
+    // CDP `PWA.LaunchResponse` docs). Tab targets sit above page targets in the
+    // target hierarchy and are not exposed through `browser.targets()`, so the
+    // returned id can't be awaited directly.
+    const {targetId: tabTargetId} = await this.#connection.send('PWA.launch', {
+      manifestId: options.manifestId,
+      url: options.url,
     });
-    const disconnectedDeferred = Deferred.create<Page, TargetCloseError>();
-    const onDisconnected = () => {
-      const error = new TargetCloseError('Browser disconnected');
-      controller.abort(error);
-      disconnectedDeferred.reject(error);
-    };
-    this.on(BrowserEvent.Disconnected, onDisconnected);
-
-    try {
-      return await Deferred.race([
-        (async () => {
-          // `PWA.launch` resolves with the id of the launched *tab* target (see
-          // the CDP `PWA.LaunchResponse` docs). Tab targets sit above page
-          // targets in the target hierarchy and are not exposed through
-          // `browser.targets()`, so the returned id can't be awaited directly.
-          const {targetId: tabTargetId} = await this.#connection.send(
-            'PWA.launch',
-            {
-              manifestId: options.manifestId,
-              url: options.url,
-            },
-            {timeout},
-          );
-          controller.signal.throwIfAborted();
-          const target = (await this.waitForTarget(
-            candidate => {
-              const tab = this.#targetManager
-                .getAvailableTargets()
-                .get(tabTargetId);
-              if (tab?.type() !== 'tab') {
-                return false;
-              }
-              for (const child of tab._childTargets()) {
-                if (child === candidate) {
-                  return true;
-                }
-              }
-              return false;
-            },
-            {timeout: 0, signal: controller.signal},
-          )) as CdpTarget;
-          const page = await target.page();
-          if (!page) {
-            throw new Error(
-              `Failed to create a page for the launched PWA (manifestId = ${options.manifestId})`,
-            );
+    const target = (await this.waitForTarget(
+      candidate => {
+        const tab = this.#targetManager.getAvailableTargets().get(tabTargetId);
+        if (tab?.type() !== 'tab') {
+          return false;
+        }
+        for (const child of tab._childTargets()) {
+          if (child === candidate) {
+            return true;
           }
-          return page;
-        })(),
-        timeoutDeferred,
-        disconnectedDeferred,
-      ]);
-    } finally {
-      this.off(BrowserEvent.Disconnected, onDisconnected);
-      controller.abort();
+        }
+        return false;
+      },
+      {timeout: options.timeout},
+    )) as CdpTarget;
+    const page = await target.page();
+    if (!page) {
+      throw new Error(
+        `Failed to create a page for the launched PWA (manifestId = ${options.manifestId})`,
+      );
     }
+    return page;
   }
 
   override async getPWAState(options: GetPWAStateOptions): Promise<PWAState> {

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -217,6 +217,13 @@
     "comment": "No PWA domain in WebDriver BiDi"
   },
   {
+    "testIdPattern": "[pwa.test] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDiOnly"],
+    "expectations": ["SKIP"],
+    "comment": "No PWA domain in WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[realms.test] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -203,6 +203,20 @@
     "comment": "Chrome-specific test"
   },
   {
+    "testIdPattern": "[pwa.test] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"],
+    "comment": "Chrome-specific test (PWA CDP domain is Chromium-only)"
+  },
+  {
+    "testIdPattern": "[pwa.test] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["SKIP"],
+    "comment": "No PWA domain in WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[realms.test] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["webDriverBiDi"],
@@ -835,6 +849,13 @@
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[pwa.test] *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "chrome-headless-shell"],
+    "expectations": ["SKIP"],
+    "comment": "No PWA support in chrome-headless-shell"
   },
   {
     "testIdPattern": "[queryObjects.test] *",

--- a/test/assets/pwa/index.html
+++ b/test/assets/pwa/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <title>Puppeteer Test PWA</title>
+  </head>
+  <body>
+    <h1>Puppeteer Test PWA</h1>
+  </body>
+</html>

--- a/test/assets/pwa/manifest.webmanifest
+++ b/test/assets/pwa/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "id": "/pwa/",
+  "name": "Puppeteer Test PWA",
+  "short_name": "PptrPWA",
+  "start_url": "index.html",
+  "scope": "/pwa/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/pptr.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/pptr.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/test/src/cdp/pwa.test.ts
+++ b/test/src/cdp/pwa.test.ts
@@ -19,7 +19,9 @@ describe('PWA', function () {
     {createContext: false},
   );
 
-  async function installTestPWA(): Promise<{
+  async function installTestPWA(
+    displayMode?: 'standalone' | 'browser',
+  ): Promise<{
     manifestId: string;
     startUrl: string;
   }> {
@@ -29,6 +31,7 @@ describe('PWA', function () {
     const returnedId = await browser.installPWA({
       manifestId,
       installUrlOrBundleUrl: startUrl,
+      displayMode,
     });
     expect(returnedId).toBe(manifestId);
     return {manifestId, startUrl};
@@ -51,7 +54,7 @@ describe('PWA', function () {
 
   it('launches an installed PWA and returns its Page', async () => {
     const {browser} = state;
-    const {manifestId, startUrl} = await installTestPWA();
+    const {manifestId, startUrl} = await installTestPWA('standalone');
 
     const page = await browser.launchPWA({manifestId});
     try {
@@ -60,6 +63,19 @@ describe('PWA', function () {
         return matchMedia('(display-mode: standalone)').matches;
       });
       expect(isStandalone).toBe(true);
+    } finally {
+      await page.close().catch(() => {});
+      await browser.uninstallPWA({manifestId}).catch(() => {});
+    }
+  });
+
+  it('launches an installed PWA at an explicit url', async () => {
+    const {browser} = state;
+    const {manifestId, startUrl} = await installTestPWA('standalone');
+
+    const page = await browser.launchPWA({manifestId, url: startUrl});
+    try {
+      expect(page.url()).toBe(startUrl);
     } finally {
       await page.close().catch(() => {});
       await browser.uninstallPWA({manifestId}).catch(() => {});

--- a/test/src/cdp/pwa.test.ts
+++ b/test/src/cdp/pwa.test.ts
@@ -9,12 +9,10 @@ import expect from 'expect';
 import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
 
 describe('PWA', function () {
-  // The `PWA` CDP domain is only available over a pipe connection and requires
-  // the `--enable-devtools-pwa-handler` flag.
+  // The `PWA` CDP domain is only available over a pipe connection.
   const state = setupSeparateTestBrowserHooks(
     {
       pipe: true,
-      args: ['--enable-devtools-pwa-handler'],
     },
     {createContext: false},
   );

--- a/test/src/cdp/pwa.test.ts
+++ b/test/src/cdp/pwa.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import expect from 'expect';
+
+import {setupSeparateTestBrowserHooks} from '../mocha-utils.js';
+
+describe('PWA', function () {
+  // The `PWA` CDP domain is only available over a pipe connection and requires
+  // the `--enable-devtools-pwa-handler` flag.
+  const state = setupSeparateTestBrowserHooks(
+    {
+      pipe: true,
+      args: ['--enable-devtools-pwa-handler'],
+    },
+    {createContext: false},
+  );
+
+  async function installTestPWA(): Promise<{
+    manifestId: string;
+    startUrl: string;
+  }> {
+    const {browser, server} = state;
+    const manifestId = `${server.PREFIX}/pwa/`;
+    const startUrl = `${server.PREFIX}/pwa/index.html`;
+    const returnedId = await browser.installPWA({
+      manifestId,
+      installUrlOrBundleUrl: startUrl,
+    });
+    expect(returnedId).toBe(manifestId);
+    return {manifestId, startUrl};
+  }
+
+  it('installs and uninstalls a PWA', async () => {
+    const {browser} = state;
+    const {manifestId} = await installTestPWA();
+
+    // getPWAState resolves for an installed app.
+    const installedState = await browser.getPWAState({manifestId});
+    expect(installedState.badgeCount).toBe(0);
+    expect(Array.isArray(installedState.fileHandlers)).toBe(true);
+
+    await browser.uninstallPWA({manifestId});
+
+    // After uninstall, querying the app state should reject.
+    await expect(browser.getPWAState({manifestId})).rejects.toThrow();
+  });
+
+  it('launches an installed PWA and returns its Page', async () => {
+    const {browser} = state;
+    const {manifestId, startUrl} = await installTestPWA();
+
+    const page = await browser.launchPWA({manifestId});
+    try {
+      expect(page.url()).toBe(startUrl);
+      const isStandalone = await page.evaluate(() => {
+        return matchMedia('(display-mode: standalone)').matches;
+      });
+      expect(isStandalone).toBe(true);
+    } finally {
+      await page.close().catch(() => {});
+      await browser.uninstallPWA({manifestId}).catch(() => {});
+    }
+  });
+
+  it('installs a PWA with a standalone display mode', async () => {
+    const {browser, server} = state;
+    const manifestId = `${server.PREFIX}/pwa/`;
+    const startUrl = `${server.PREFIX}/pwa/index.html`;
+
+    await browser.installPWA({
+      manifestId,
+      installUrlOrBundleUrl: startUrl,
+      displayMode: 'standalone',
+    });
+
+    const page = await browser.launchPWA({manifestId});
+    try {
+      const isStandalone = await page.evaluate(() => {
+        return matchMedia('(display-mode: standalone)').matches;
+      });
+      expect(isStandalone).toBe(true);
+    } finally {
+      await page.close().catch(() => {});
+      await browser.uninstallPWA({manifestId}).catch(() => {});
+    }
+  });
+});

--- a/test/src/cdp/pwa.test.ts
+++ b/test/src/cdp/pwa.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google Inc.
+ * Copyright 2026 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
## What / Why

Adds first-class **Progressive Web App (PWA) automation** to the `Browser` API, wrapping Chromium's browser-scoped `PWA.*` CDP domain so callers can install, launch, inspect, and uninstall PWAs without managing raw sessions.

Implements the API agreed on in #15202.

## API

```ts
browser.installPWA({manifestId, installUrlOrBundleUrl, displayMode?}) // => manifestId
browser.uninstallPWA({manifestId})                                    // => void
browser.launchPWA({manifestId, url?, timeout?})                       // => Page
browser.getPWAState({manifestId})                                     // => {badgeCount, fileHandlers}
```

## Behavior and compatibility

- Chromium/CDP only; WebDriver BiDi implementations throw `UnsupportedOperation`.
- The `PWA` domain requires an opt-in pipe connection (`puppeteer.launch({pipe: true})`) and is unavailable over WebSocket.
- `installUrlOrBundleUrl` is required because the browser-scoped session has no associated page from which Chromium could derive the install URL.
- `launchPWA` uses the tab target id returned by `PWA.launch` to resolve its child page target. Existing app windows that Chromium focuses resolve to their existing `Page`.
- `timeout` controls how long `launchPWA` waits for the app's page target. The protocol command uses the configured `protocolTimeout`; `0` disables the target-wait timeout.

## Testing

The PWA integration suite covers lifecycle/state, default and explicit-URL launch, and standalone display mode. Unsupported Firefox, BiDi, BiDi-only, and headless-shell configurations are expected-skipped. Focused unit coverage verifies that the launch timeout is applied to target waiting without overriding the protocol timeout.

Validated with Chrome for Testing 150 and a Chromium/Edge build in headless and headful modes. The exact PR build was also consumed by a local `chrome-devtools-mcp` PWA category and passed a real stdio MCP lifecycle: install, inspect OS state, launch/select the returned `Page`, execute a page script in standalone mode, uninstall, and verify state rejection. Generated docs, API extraction, formatting, and lint checks pass.

Refs #15202
