### PR TITLE
fix: forward headers to browserURL HTTP discovery and WebSocket connection

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {describe, it, mock, beforeEach, afterEach} from 'node:test';
+import {describe, it, mock, afterEach} from 'node:test';
 
 import expect from 'expect';
 
@@ -12,27 +12,26 @@ import {_connectToBrowser} from './BrowserConnector.js';
 
 describe('BrowserConnector', () => {
   describe('getWSEndpoint via browserURL', () => {
-    let originalFetch: typeof globalThis.fetch;
-
-    beforeEach(() => {
-      originalFetch = globalThis.fetch;
-    });
-
     afterEach(() => {
-      globalThis.fetch = originalFetch;
       mock.restoreAll();
     });
 
     it('should forward headers to the /json/version HTTP request', async () => {
       const capturedRequests: {url: string; init?: RequestInit}[] = [];
 
-      globalThis.fetch = async (url, init) => {
-        capturedRequests.push({url: String(url), init});
-        return new Response(
-          JSON.stringify({webSocketDebuggerUrl: 'ws://localhost:1234/devtools/browser/1'}),
-          {status: 200, headers: {'Content-Type': 'application/json'}},
-        );
-      };
+      mock.method(
+        globalThis,
+        'fetch',
+        async (url: string | URL | Request, init?: RequestInit) => {
+          capturedRequests.push({url: String(url), init});
+          return new Response(
+            JSON.stringify({
+              webSocketDebuggerUrl: 'ws://localhost:1234/devtools/browser/1',
+            }),
+            {status: 200, headers: {'Content-Type': 'application/json'}},
+          );
+        },
+      );
 
       // We expect this to fail when trying to open the WebSocket, which is fine —
       // we only care that fetch was called with the right headers.

--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -4,13 +4,49 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {describe, it} from 'node:test';
+import {describe, it, mock, beforeEach, afterEach} from 'node:test';
 
 import expect from 'expect';
 
 import {_connectToBrowser} from './BrowserConnector.js';
 
 describe('BrowserConnector', () => {
+  describe('getWSEndpoint via browserURL', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+      mock.restoreAll();
+    });
+
+    it('should forward headers to the /json/version HTTP request', async () => {
+      const capturedRequests: {url: string; init?: RequestInit}[] = [];
+
+      globalThis.fetch = async (url, init) => {
+        capturedRequests.push({url: String(url), init});
+        return new Response(
+          JSON.stringify({webSocketDebuggerUrl: 'ws://localhost:1234/devtools/browser/1'}),
+          {status: 200, headers: {'Content-Type': 'application/json'}},
+        );
+      };
+
+      // We expect this to fail when trying to open the WebSocket, which is fine —
+      // we only care that fetch was called with the right headers.
+      await _connectToBrowser({
+        browserURL: 'http://localhost:1234',
+        headers: {Authorization: 'Bearer test-token'},
+      }).catch(() => {});
+
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0]!.url).toContain('/json/version');
+      expect((capturedRequests[0]!.init?.headers as Record<string, string>)?.['Authorization']).toBe('Bearer test-token');
+    });
+  });
+
   describe('_connectToBrowser', () => {
     it('should throw an error when both blocklist and allowlist are specified', async () => {
       await expect(

--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -17,7 +17,7 @@ describe('BrowserConnector', () => {
     });
 
     it('should forward headers to the /json/version HTTP request', async () => {
-      const capturedRequests: {url: string; init?: RequestInit}[] = [];
+      const capturedRequests: Array<{url: string; init?: RequestInit}> = [];
 
       mock.method(
         globalThis,
@@ -42,7 +42,11 @@ describe('BrowserConnector', () => {
 
       expect(capturedRequests).toHaveLength(1);
       expect(capturedRequests[0]!.url).toContain('/json/version');
-      expect((capturedRequests[0]!.init?.headers as Record<string, string>)?.['Authorization']).toBe('Bearer test-token');
+      expect(
+        (capturedRequests[0]!.init?.headers as Record<string, string>)?.[
+          'Authorization'
+        ],
+      ).toBe('Bearer test-token');
     });
   });
 

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -115,10 +115,10 @@ async function getConnectionTransport(
       endpointUrl: browserWSEndpoint,
     };
   } else if (browserURL) {
-    const connectionURL = await getWSEndpoint(browserURL);
+    const connectionURL = await getWSEndpoint(browserURL, headers);
     const WebSocketClass = await getWebSocketTransportClass();
     const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(connectionURL);
+      await WebSocketClass.create(connectionURL, headers);
     return {
       connectionTransport: connectionTransport,
       endpointUrl: connectionURL,
@@ -181,12 +181,16 @@ async function getConnectionTransport(
   throw new Error('Invalid connection options');
 }
 
-async function getWSEndpoint(browserURL: string): Promise<string> {
+async function getWSEndpoint(
+  browserURL: string,
+  headers?: Record<string, string>,
+): Promise<string> {
   const endpointURL = new URL('/json/version', browserURL);
 
   try {
     const result = await globalThis.fetch(endpointURL.toString(), {
       method: 'GET',
+      headers,
     });
     if (!result.ok) {
       throw new Error(`HTTP ${result.statusText}`);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix. The headers option passed to `puppeteer.connect()` was silently dropped when using browserURL (an `http://` or `https://` URL). The option was destructured from `ConnectOptions` but never forwarded — neither to the HTTP request that discovers the WebSocket endpoint (`/json/version`), nor to the resulting WebSocket connection itself.

**Did you add tests for your changes?**
Yes. A unit test was added to `packages/puppeteer-core/src/common/BrowserConnector.test.ts` that stubs `globalThis.fetch` and verifies the headers option is forwarded to the `/json/version` discovery request when connecting via `browserURL`.

**If relevant, did you update the documentation?**
No documentation changes are needed. The headers option is already documented in `ConnectOptions` as "Headers to use for the web socket connection." This fix makes the `browserURL` path behave consistently with that documented contract.

**Summary**
When connecting via `browserURL`, the `headers` option was silently dropped — it was never passed to the `/json/version` fetch or to the resulting WebSocket connection. This brings the `browserURL` path into parity with the `browserWSEndpoint` and `channel` paths, both of which already forwarded headers correctly.

**Does this PR introduce a breaking change?**
No. Headers that were previously silently dropped are now forwarded as expected. Existing callers not using headers are unaffected.

**Other information**
The root cause was a missing argument in two call sites inside `getConnectionTransport()` in `packages/puppeteer-core/src/common/BrowserConnector.ts`. The `headers` default was already `{}`, so the only change is that they now reach their destinations.
