### PR TITLE
fix: upgrade serialize-javascript to 7.0.3 (GHSA-5c6j-r48x-rmvq)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -23,7 +23,8 @@
         "react": "19.2.7",
         "react-cookie-consent": "10.0.1",
         "react-dom": "19.2.7",
-        "semver": "7.8.5"
+        "semver": "7.8.5",
+        "serialize-javascript": "^7.0.3"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.2",
@@ -16414,9 +16415,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -16434,9 +16432,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -16454,9 +16449,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -16474,9 +16466,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -16494,9 +16483,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -16514,9 +16500,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -23560,6 +23543,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,8 @@
     "react": "19.2.7",
     "react-cookie-consent": "10.0.1",
     "react-dom": "19.2.7",
-    "semver": "7.8.5"
+    "semver": "7.8.5",
+    "serialize-javascript": "^7.0.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.2",


### PR DESCRIPTION
## Summary
Upgrade serialize-javascript from 6.0.2 to 7.0.3 to fix GHSA-5c6j-r48x-rmvq.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-5c6j-r48x-rmvq |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-5c6j-r48x-rmvq` |
| **File** | `website/package-lock.json` |
| **Assessment** | Pattern match — needs manual review |

**Description**: Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()

## Evidence

**Scanner confirmation**: trivy rule `GHSA-5c6j-r48x-rmvq` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `website/package.json`
- `website/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
