### PR TITLE
fix: run hooks even if we try to kill the process

### DIFF
--- a/docs/browsers-api/browsers.process.kill.md
+++ b/docs/browsers-api/browsers.process.kill.md
@@ -4,6 +4,8 @@ sidebar_label: Process.kill
 
 # Process.kill() method
 
+Kills the browser process. Without running any hooks.
+
 ### Signature
 
 ```typescript

--- a/docs/browsers-api/browsers.process.kill.md
+++ b/docs/browsers-api/browsers.process.kill.md
@@ -4,7 +4,7 @@ sidebar_label: Process.kill
 
 # Process.kill() method
 
-Kills the browser process. Without running any hooks.
+Kills the browser process without running any hooks.
 
 ### Signature
 

--- a/docs/browsers-api/browsers.process.md
+++ b/docs/browsers-api/browsers.process.md
@@ -126,7 +126,7 @@ Get recent logs (stderr + stdout) emitted by the browser.
 
 </td><td>
 
-Kills the browser process. Without running any hooks.
+Kills the browser process without running any hooks.
 
 </td></tr>
 <tr><td>

--- a/docs/browsers-api/browsers.process.md
+++ b/docs/browsers-api/browsers.process.md
@@ -126,6 +126,8 @@ Get recent logs (stderr + stdout) emitted by the browser.
 
 </td><td>
 
+Kills the browser process. Without running any hooks.
+
 </td></tr>
 <tr><td>
 

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -427,6 +427,7 @@ export class Process {
   };
 
   async close(): Promise<void> {
+    await this.#runHooks();
     if (!this.#exited) {
       this.kill();
     }

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -416,8 +416,12 @@ export class Process {
   #onDriverProcessSignal = (signal: string): void => {
     switch (signal) {
       case 'SIGINT':
-        this.kill();
-        process.exit(130);
+        this.close()
+          .catch(() => {})
+          .finally(() => {
+            process.exit(130);
+          });
+        break;
       case 'SIGTERM':
       case 'SIGHUP':
         void this.close();
@@ -426,7 +430,6 @@ export class Process {
   };
 
   async close(): Promise<void> {
-    await this.#runHooks();
     if (!this.#exited) {
       this.kill();
     }

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -416,11 +416,8 @@ export class Process {
   #onDriverProcessSignal = (signal: string): void => {
     switch (signal) {
       case 'SIGINT':
-        this.close()
-          .catch(() => {})
-          .finally(() => {
-            process.exit(130);
-          });
+        this.kill();
+        process.exitCode = 130;
         break;
       case 'SIGTERM':
       case 'SIGHUP':

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -442,6 +442,9 @@ export class Process {
     return this.#browserProcessExiting;
   }
 
+  /**
+   * Kills the browser process. Without running any hooks.
+   */
   kill(): void {
     debugLaunch?.(`Trying to kill ${this.#browserProcess.pid}`);
     // If the process failed to launch (for example if the browser executable path

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -443,7 +443,7 @@ export class Process {
   }
 
   /**
-   * Kills the browser process. Without running any hooks.
+   * Kills the browser process without running any hooks.
    */
   kill(): void {
     debugLaunch?.(`Trying to kill ${this.#browserProcess.pid}`);

--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -289,7 +289,7 @@ export class Process {
   #maxLogLinesSize = 1000;
   #lineEmitter = new EventEmitter();
   #onAbort = (): void => {
-    this.kill();
+    void this.#killWithHooks();
   };
   #signal?: AbortSignal;
 
@@ -410,13 +410,13 @@ export class Process {
   }
 
   #onDriverProcessExit = (_code: number) => {
-    this.kill();
+    void this.#killWithHooks();
   };
 
   #onDriverProcessSignal = (signal: string): void => {
     switch (signal) {
       case 'SIGINT':
-        this.kill();
+        void this.#killWithHooks();
         process.exitCode = 130;
         break;
       case 'SIGTERM':
@@ -426,12 +426,16 @@ export class Process {
     }
   };
 
-  async close(): Promise<void> {
+  async #killWithHooks(): Promise<void> {
     await this.#runHooks();
+    this.kill();
+  }
+
+  async close(): Promise<void> {
     if (!this.#exited) {
-      this.kill();
+      await this.#killWithHooks();
     }
-    return await this.#browserProcessExiting;
+    await this.#browserProcessExiting;
   }
 
   hasClosed(): Promise<void> {

--- a/packages/browsers/test/src/chrome/launch.test.ts
+++ b/packages/browsers/test/src/chrome/launch.test.ts
@@ -175,5 +175,41 @@ describe('Chrome', () => {
       controller.abort();
       await process.hasClosed();
     });
+
+    afterEach(() => {
+      // Reset exitCode so mocha doesn't fail the whole test run
+      process.exitCode = 0;
+    });
+
+    it('should run onExit hook if the host process receives SIGINT', async () => {
+      const executablePath = computeExecutablePath({
+        cacheDir: tmpDir,
+        browser: Browser.CHROME,
+        buildId: testChromeBuildId,
+      });
+      const profileDir = path.join(tmpDir, 'profile');
+      let hookRan = false;
+      const browserProcess = launch({
+        executablePath,
+        args: getArgs(),
+        onExit: async () => {
+          hookRan = true;
+          if (fs.existsSync(profileDir)) {
+            fs.rmSync(profileDir, {recursive: true, force: true});
+          }
+        },
+      });
+      await browserProcess.waitForLineOutput(CDP_WEBSOCKET_ENDPOINT_REGEX);
+
+      // Simulate the Node.js host process receiving SIGINT
+      process.emit('SIGINT');
+
+      // Wait for it to close!
+      await browserProcess.hasClosed();
+
+      assert.ok(hookRan);
+      assert.ok(!fs.existsSync(profileDir));
+      assert.strictEqual(process.exitCode, 130);
+    });
   });
 });

--- a/packages/browsers/test/src/chrome/launch.test.ts
+++ b/packages/browsers/test/src/chrome/launch.test.ts
@@ -187,28 +187,21 @@ describe('Chrome', () => {
         browser: Browser.CHROME,
         buildId: testChromeBuildId,
       });
-      const profileDir = path.join(tmpDir, 'profile');
       let hookRan = false;
       const browserProcess = launch({
         executablePath,
         args: getArgs(),
         onExit: async () => {
           hookRan = true;
-          if (fs.existsSync(profileDir)) {
-            fs.rmSync(profileDir, {recursive: true, force: true});
-          }
         },
       });
       await browserProcess.waitForLineOutput(CDP_WEBSOCKET_ENDPOINT_REGEX);
 
-      // Simulate the Node.js host process receiving SIGINT
-      process.emit('SIGINT');
+      process.emit('SIGINT', 'SIGINT');
 
-      // Wait for it to close!
       await browserProcess.hasClosed();
 
       assert.ok(hookRan);
-      assert.ok(!fs.existsSync(profileDir));
       assert.strictEqual(process.exitCode, 130);
     });
   });

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -669,6 +669,9 @@ export interface PageEvents extends Record<EventType, unknown> {
  * @public
  */
 export interface NewDocumentScriptEvaluation {
+  /**
+   * REVERT, here to test Puppteer
+   */
   identifier: string;
 }
 

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -669,9 +669,6 @@ export interface PageEvents extends Record<EventType, unknown> {
  * @public
  */
 export interface NewDocumentScriptEvaluation {
-  /**
-   * REVERT, here to test Puppteer
-   */
   identifier: string;
 }
 


### PR DESCRIPTION
Issue - #15156

This means that now the Hooks will run correctly and the the folder will be clean after.