### PR TITLE
fix: preserve browserURL path prefixes

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -4,13 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {describe, it} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 
 import expect from 'expect';
 
-import {_connectToBrowser} from './BrowserConnector.js';
+import {_connectToBrowser, getWSEndpoint} from './BrowserConnector.js';
 
 describe('BrowserConnector', () => {
+  describe('getWSEndpoint', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('preserves path prefixes when fetching the JSON version endpoint', async () => {
+      let requestedURL = '';
+      globalThis.fetch = async (url: string | URL | Request) => {
+        requestedURL = url.toString();
+
+        return new Response(
+          JSON.stringify({
+            webSocketDebuggerUrl: 'ws://example.com/devtools/browser/id',
+          }),
+        );
+      };
+
+      await expect(
+        getWSEndpoint('http://example.com/t/session?token=secret'),
+      ).resolves.toBe('ws://example.com/devtools/browser/id');
+
+      expect(requestedURL).toBe(
+        'http://example.com/t/session/json/version?token=secret',
+      );
+    });
+  });
+
   describe('_connectToBrowser', () => {
     it('should throw an error when both blocklist and allowlist are specified', async () => {
       await expect(

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -181,8 +181,9 @@ async function getConnectionTransport(
   throw new Error('Invalid connection options');
 }
 
-async function getWSEndpoint(browserURL: string): Promise<string> {
-  const endpointURL = new URL('/json/version', browserURL);
+export async function getWSEndpoint(browserURL: string): Promise<string> {
+  const endpointURL = new URL(browserURL);
+  endpointURL.pathname = `${endpointURL.pathname.replace(/\/$/, '')}/json/version`;
 
   try {
     const result = await globalThis.fetch(endpointURL.toString(), {


### PR DESCRIPTION
Fixes #15250

This preserves any path prefix from `browserURL` when Puppeteer fetches `/json/version`, so reverse-proxied DevTools URLs like `/t/session` resolve under that prefix instead of dropping it.

Tests:
- `npm run build --workspace puppeteer-core`
- `node --test --test-reporter=spec packages/puppeteer-core/lib/puppeteer/common/BrowserConnector.test.js`
- `npx eslint packages/puppeteer-core/src/common/BrowserConnector.ts packages/puppeteer-core/src/common/BrowserConnector.test.ts`
- `git diff --check`
