### PR TITLE
chore: upgrade webmcp-types to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40085,7 +40085,7 @@
       },
       "devDependencies": {
         "@types/pngjs": "6.0.5",
-        "webmcp-types": "0.1.2"
+        "webmcp-types": "0.1.3"
       }
     },
     "test/installation": {
@@ -40161,9 +40161,9 @@
       }
     },
     "test/node_modules/webmcp-types": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.2.tgz",
-      "integrity": "sha512-weWM+Iyj7rITLBoANf3GjxOD25MgriZnKUafJOXErmOnTbbHp5kr7hcPl+UlfeSlwtvE8+55HozF6jxtv0j17g==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/webmcp-types/-/webmcp-types-0.1.3.tgz",
+      "integrity": "sha512-73B1NGAO6ulK8tKq5bGk/AjPwYpIG7WYr7x18WLEkSOi7cU9ECdquiXIX0HbauDgp+jIk+Wm4/KdVnTJzRts5w==",
       "dev": true,
       "license": "MIT"
     },

--- a/test/package.json
+++ b/test/package.json
@@ -33,6 +33,6 @@
   },
   "devDependencies": {
     "@types/pngjs": "6.0.5",
-    "webmcp-types": "0.1.2"
+    "webmcp-types": "0.1.3"
   }
 }

--- a/test/src/cdp/webmcp.test.ts
+++ b/test/src/cdp/webmcp.test.ts
@@ -426,7 +426,7 @@ describe('Page.webmcp', function () {
 
     // Execute WebMCP tool.
     await page.evaluate(async () => {
-      const [tool] = await (window as any).navigator.modelContext.getTools();
+      const [tool] = await document.modelContext!.getTools();
       (window as any).navigator.modelContext.executeTool(
         tool,
         JSON.stringify({text: 'test'}),
@@ -493,7 +493,7 @@ describe('Page.webmcp', function () {
 
     // Execute WebMCP tool.
     await page.evaluate(async () => {
-      const [tool] = await (window as any).navigator.modelContext.getTools();
+      const [tool] = await document.modelContext!.getTools();
       (window as any).navigator.modelContext.executeTool(
         tool,
         JSON.stringify({text: 'world'}),
@@ -538,7 +538,7 @@ describe('Page.webmcp', function () {
 
     // Execute WebMCP tool.
     await page.evaluate(async () => {
-      const [tool] = await (window as any).navigator.modelContext.getTools();
+      const [tool] = await document.modelContext!.getTools();
       (window as any).navigator.modelContext.executeTool(tool, '{}');
     });
 
@@ -586,7 +586,7 @@ describe('Page.webmcp', function () {
 
     // Execute unknown WebMCP tool.
     await page.evaluate(async () => {
-      const [tool] = await (window as any).navigator.modelContext.getTools();
+      const [tool] = await document.modelContext!.getTools();
       (window as any).navigator.modelContext.executeTool(tool, 'invalid json');
     });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Upgrade webmcp-types to 0.1.3 to use `getTools()` proper signature 

**Did you add tests for your changes?**

N/A

**If relevant, did you update the documentation?**

Yes.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

N/A

**Other information**

FYI @OrKoN 