### PR TITLE
feat: track dialog status

### DIFF
--- a/packages/puppeteer-core/src/bidi/Dialog.ts
+++ b/packages/puppeteer-core/src/bidi/Dialog.ts
@@ -18,6 +18,10 @@ export class BidiDialog extends Dialog {
     super(prompt.info.type, prompt.info.message, prompt.info.defaultValue);
     this.#prompt = prompt;
     this.handled = prompt.handled;
+
+    prompt.once('handled', () => {
+      this.handled = true;
+    });
   }
 
   override async handle(options: {

--- a/packages/puppeteer-core/src/cdp/Dialog.ts
+++ b/packages/puppeteer-core/src/cdp/Dialog.ts
@@ -23,6 +23,8 @@ export class CdpDialog extends Dialog {
   ) {
     super(type, message, defaultValue);
     this.#client = client;
+
+    client.once('Page.javascriptDialogClosed', this.#onDialogClosed);
   }
 
   override async handle(options: {
@@ -33,5 +35,10 @@ export class CdpDialog extends Dialog {
       accept: options.accept,
       promptText: options.text,
     });
+    this.#client.off('Page.javascriptDialogClosed', this.#onDialogClosed);
   }
+
+  #onDialogClosed = () => {
+    this.handled = true;
+  };
 }

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1109,6 +1109,13 @@
     "comment": "We can't connect to a browser started with pipe:true"
   },
   {
+    "testIdPattern": "[dialog.test] Page.Events.Dialog should see dialogs handled by other connections",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "pipe"],
+    "expectations": ["FAIL"],
+    "comment": "Chrome can't connect when run with pipe"
+  },
+  {
     "testIdPattern": "[download.test] Download Browser.createBrowserContext should download to configured location",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1116,6 +1116,13 @@
     "comment": "Chrome can't connect when run with pipe"
   },
   {
+    "testIdPattern": "[dialog.test] Page.Events.Dialog should see dialogs handled by other connections",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox does not support multiple active BiDi sessions."
+  },
+  {
     "testIdPattern": "[download.test] Download Browser.createBrowserContext should download to configured location",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -1958,13 +1965,6 @@
     "parameters": ["cdp", "chrome", "headless"],
     "expectations": ["FAIL", "PASS"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
-  },
-  {
-    "testIdPattern": "[dialog.test] Page.Events.Dialog should see dialogs handled by other connections",
-    "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "webDriverBiDi"],
-    "expectations": ["FAIL"],
-    "comment": "Firefox does not support multiple active BiDi sessions."
   },
   {
     "testIdPattern": "[mouse.test] Mouse should select the text with mouse",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1953,6 +1953,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[dialog.test] Page.Events.Dialog should see dialogs handled by other connections",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "headless", "webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Firefox does not support multiple active BiDi sessions."
+  },
+  {
     "testIdPattern": "[mouse.test] Mouse should select the text with mouse",
     "platforms": ["win32"],
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1962,7 +1962,7 @@
   {
     "testIdPattern": "[dialog.test] Page.Events.Dialog should see dialogs handled by other connections",
     "platforms": ["darwin", "linux", "win32"],
-    "parameters": ["firefox", "headless", "webDriverBiDi"],
+    "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL"],
     "comment": "Firefox does not support multiple active BiDi sessions."
   },

--- a/test/src/dialog.test.ts
+++ b/test/src/dialog.test.ts
@@ -61,4 +61,50 @@ describe('Page.Events.Dialog', function () {
     });
     expect(result).toBe(null);
   });
+  it('should see dialogs handled by other connections', async () => {
+    const {page, server, browser, puppeteer, defaultBrowserOptions} =
+      await getTestState();
+
+    await page.goto(server.EMPTY_PAGE);
+
+    using browser2 = await puppeteer.connect({
+      browserWSEndpoint: browser.wsEndpoint(),
+      protocol: defaultBrowserOptions.protocol,
+    });
+    const page2 = await browser2.pages().then(pages => {
+      return pages.find(p => {
+        return p.url() === server.EMPTY_PAGE;
+      });
+    });
+    if (!page2) {
+      throw new Error('Could not find page2');
+    }
+
+    const dialog1Promise = new Promise<any>(resolve => {
+      page.once('dialog', resolve);
+    });
+    const dialog2Promise = new Promise<any>(resolve => {
+      page2.once('dialog', resolve);
+    });
+
+    const evaluatePromise = page2.evaluate(() => {
+      return prompt('question?', 'yes.');
+    });
+
+    const dialog1 = await dialog1Promise;
+    const dialog2 = await dialog2Promise;
+
+    await dialog2.accept('answer!');
+
+    const result = await evaluatePromise;
+    expect(result).toBe('answer!');
+
+    // Wait for the event to be processed by the first connection.
+    await page.evaluate(() => {
+      return 1;
+    });
+
+    expect(dialog1.handled).toBe(true);
+    expect(dialog2.handled).toBe(true);
+  });
 });


### PR DESCRIPTION
If I recall correctly we always fire the events even if the user manually closes this. So we can allow automation to know this happened. 