### PR TITLE
fix: reject PWA access if network conditions are configured

### DIFF
--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -132,6 +132,7 @@ export class CdpBrowser extends BrowserBase {
   #handleDevToolsAsPage = false;
   #extensions = new Map<string, Extension>();
   #version?: Deferred<Protocol.Browser.GetVersionResponse>;
+  #hasNetworkRestrictions = false;
 
   constructor(
     connection: Connection,
@@ -162,10 +163,12 @@ export class CdpBrowser extends BrowserBase {
       });
     this.#handleDevToolsAsPage = handleDevToolsAsPage;
     this.#setIsPageTargetCallback(isPageTargetCallback);
-    connection.rejectEmulateNetworkConditionsCalls = Boolean(
+    this.#hasNetworkRestrictions = Boolean(
       (blocklist && blocklist.length > 0) ||
       (allowlist && allowlist.length > 0),
     );
+    connection.rejectEmulateNetworkConditionsCalls =
+      this.#hasNetworkRestrictions;
     this.#targetManager = new TargetManager(
       connection,
       this.#createTarget,
@@ -529,6 +532,11 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async installPWA(options: InstallPWAOptions): Promise<string> {
+    if (this.#hasNetworkRestrictions) {
+      throw new Error(
+        'PWA APIs are not supported when network restrictions are configured.',
+      );
+    }
     await this.#connection.send('PWA.install', {
       manifestId: options.manifestId,
       installUrlOrBundleUrl: options.installUrlOrBundleUrl,
@@ -543,12 +551,22 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async uninstallPWA(options: UninstallPWAOptions): Promise<void> {
+    if (this.#hasNetworkRestrictions) {
+      throw new Error(
+        'PWA APIs are not supported when network restrictions are configured.',
+      );
+    }
     await this.#connection.send('PWA.uninstall', {
       manifestId: options.manifestId,
     });
   }
 
   override async launchPWA(options: LaunchPWAOptions): Promise<Page> {
+    if (this.#hasNetworkRestrictions) {
+      throw new Error(
+        'PWA APIs are not supported when network restrictions are configured.',
+      );
+    }
     // `PWA.launch` resolves with the id of the launched *tab* target (see the
     // CDP `PWA.LaunchResponse` docs). Tab targets sit above page targets in the
     // target hierarchy and are not exposed through `browser.targets()`, so the
@@ -582,6 +600,11 @@ export class CdpBrowser extends BrowserBase {
   }
 
   override async getPWAState(options: GetPWAStateOptions): Promise<PWAState> {
+    if (this.#hasNetworkRestrictions) {
+      throw new Error(
+        'PWA APIs are not supported when network restrictions are configured.',
+      );
+    }
     const {badgeCount, fileHandlers} = await this.#connection.send(
       'PWA.getOsAppState',
       {manifestId: options.manifestId},

--- a/test/src/cdp/network_restrictions.test.ts
+++ b/test/src/cdp/network_restrictions.test.ts
@@ -514,6 +514,74 @@ describe('Network Restrictions', function () {
     });
   });
 
+  describe('PWA validation', () => {
+    describe('blocklist', () => {
+      const state = setupSeparateTestBrowserHooks({
+        blocklist: ['*://*:*/empty.html'],
+        pipe: true,
+      });
+
+      it('should throw when calling PWA APIs', async () => {
+        const {browser, server} = state;
+        const manifestId = `${server.PREFIX}/pwa/`;
+
+        await expect(
+          browser.installPWA({
+            manifestId,
+            installUrlOrBundleUrl: `${server.PREFIX}/pwa/index.html`,
+          }),
+        ).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+
+        await expect(browser.launchPWA({manifestId})).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+
+        await expect(browser.uninstallPWA({manifestId})).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+
+        await expect(browser.getPWAState({manifestId})).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+      });
+    });
+
+    describe('allowlist', () => {
+      const state = setupSeparateTestBrowserHooks({
+        allowlist: ['*://*:*/empty.html'],
+        pipe: true,
+      });
+
+      it('should throw when calling PWA APIs', async () => {
+        const {browser, server} = state;
+        const manifestId = `${server.PREFIX}/pwa/`;
+
+        await expect(
+          browser.installPWA({
+            manifestId,
+            installUrlOrBundleUrl: `${server.PREFIX}/pwa/index.html`,
+          }),
+        ).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+
+        await expect(browser.launchPWA({manifestId})).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+
+        await expect(browser.uninstallPWA({manifestId})).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+
+        await expect(browser.getPWAState({manifestId})).rejects.toThrow(
+          'PWA APIs are not supported when network restrictions are configured.',
+        );
+      });
+    });
+  });
+
   it('should detach from targets violating blocklist when connecting to a running browser', async () => {
     const {browser: originalBrowser, server} = await getTestState({
       skipContextCreation: true,


### PR DESCRIPTION
Turns out network conditions CDP command is not available for PWA targets.

Refs: https://github.com/ChromeDevTools/chrome-devtools-mcp/pull/2430