### PR TITLE
fix: do not override the user agent when nothing is emulated

### DIFF
--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -1542,6 +1542,21 @@ describe('NetworkManager', () => {
     ).toEqual([200, 302, 200]);
   });
 
+  it('should not override the user agent when nothing is emulated', async () => {
+    const commands: string[] = [];
+    const mockCDPSession = new MockCDPSession();
+    mockCDPSession.send = (async (method: string) => {
+      commands.push(method);
+    }) as any;
+    const manager = createNetworkManager();
+
+    await manager.addClient(mockCDPSession);
+    expect(commands).not.toContain('Network.setUserAgentOverride');
+
+    await manager.setUserAgent('custom-user-agent');
+    expect(commands).toContain('Network.setUserAgentOverride');
+  });
+
   describe('error handling', () => {
     function createMockSession<E extends ErrorConstructor>(
       ErrorCls: E,

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -1557,6 +1557,34 @@ describe('NetworkManager', () => {
     expect(commands).toContain('Network.setUserAgentOverride');
   });
 
+  it('should reset the override when the emulated accept-language is cleared', async () => {
+    const commands: string[] = [];
+    const mockCDPSession = new MockCDPSession();
+    mockCDPSession.send = (async (method: string) => {
+      commands.push(method);
+    }) as any;
+    const manager = createNetworkManager();
+
+    await manager.addClient(mockCDPSession);
+    expect(commands).not.toContain('Network.setUserAgentOverride');
+
+    await manager.setAcceptLanguage('fr-FR');
+    expect(
+      commands.filter(command => {
+        return command === 'Network.setUserAgentOverride';
+      }),
+    ).toHaveLength(1);
+
+    // Clearing the emulated accept-language must still send an override so the
+    // browser is reset back to its defaults instead of keeping the stale value.
+    await manager.setAcceptLanguage(undefined);
+    expect(
+      commands.filter(command => {
+        return command === 'Network.setUserAgentOverride';
+      }),
+    ).toHaveLength(2);
+  });
+
   describe('error handling', () => {
     function createMockSession<E extends ErrorConstructor>(
       ErrorCls: E,

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -291,10 +291,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
       this.#userAgentMetadata === undefined &&
       this.#acceptLanguage === undefined &&
       this.#platform === undefined;
-    // Skip only when nothing is emulated and no override has ever been applied.
-    // If an override was applied earlier (e.g. an emulated locale that is now
-    // being cleared), we still need to send the command once to reset the
-    // browser back to its defaults.
+    // Still need to send once to reset a previously-applied override.
     if (nothingToEmulate && !this.#userAgentOverrideApplied) {
       return;
     }

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -285,6 +285,14 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   async #applyUserAgent(client: CDPSession) {
+    if (
+      this.#userAgent === undefined &&
+      this.#userAgentMetadata === undefined &&
+      this.#acceptLanguage === undefined &&
+      this.#platform === undefined
+    ) {
+      return;
+    }
     const userAgent =
       this.#userAgent ??
       (await this.#frameManager.page().browser().userAgent());

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -85,6 +85,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   #userAgentMetadata?: Protocol.Emulation.UserAgentMetadata;
   #platform?: string;
   #acceptLanguage?: string;
+  #userAgentOverrideApplied = false;
 
   readonly #handlers = [
     ['Fetch.requestPaused', this.#onRequestPaused],
@@ -285,12 +286,16 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   async #applyUserAgent(client: CDPSession) {
-    if (
+    const nothingToEmulate =
       this.#userAgent === undefined &&
       this.#userAgentMetadata === undefined &&
       this.#acceptLanguage === undefined &&
-      this.#platform === undefined
-    ) {
+      this.#platform === undefined;
+    // Skip only when nothing is emulated and no override has ever been applied.
+    // If an override was applied earlier (e.g. an emulated locale that is now
+    // being cleared), we still need to send the command once to reset the
+    // browser back to its defaults.
+    if (nothingToEmulate && !this.#userAgentOverrideApplied) {
       return;
     }
     const userAgent =
@@ -306,6 +311,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
         userAgentMetadata: this.#userAgentMetadata,
         platform: this.#platform,
       });
+      this.#userAgentOverrideApplied = !nothingToEmulate;
     } catch (error) {
       if (this.#canIgnoreError(error)) {
         return;


### PR DESCRIPTION
Attaching to a browser sends `Network.setUserAgentOverride` for every client, even when no user agent was set. That override carries no `userAgentMetadata`, so Chrome blanks the User-Agent Client Hints: `navigator.userAgentData.brands` empties and the `Sec-CH-UA` headers stop being sent, which anti-bot layers read as a spoofed client. Skipping the override when nothing was emulated keeps the browser's native hints, while `setUserAgent` and `emulate` still take effect.

Fixes #15273
