### PR TITLE
fix(browser): preserve browserURL path prefixes

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -41,12 +41,37 @@ describe('BrowserConnector', () => {
       }).catch(() => {});
 
       expect(capturedRequests).toHaveLength(1);
-      expect(capturedRequests[0]!.url).toContain('/json/version');
+      expect(capturedRequests[0]!.url).toBe(
+        'http://localhost:1234/json/version',
+      );
       expect(
         (capturedRequests[0]!.init?.headers as Record<string, string>)?.[
           'Authorization'
         ],
       ).toBe('Bearer test-token');
+    });
+
+    it('should preserve path prefixes in the /json/version request', async () => {
+      const capturedUrls: string[] = [];
+
+      mock.method(globalThis, 'fetch', async (url: string | URL | Request) => {
+        capturedUrls.push(String(url));
+        return new Response(
+          JSON.stringify({
+            webSocketDebuggerUrl: 'ws://localhost:1234/devtools/browser/1',
+          }),
+          {status: 200, headers: {'Content-Type': 'application/json'}},
+        );
+      });
+
+      await _connectToBrowser({
+        browserURL:
+          'http://localhost:1234/gateway/session?token=secret#fragment',
+      }).catch(() => {});
+
+      expect(capturedUrls).toEqual([
+        'http://localhost:1234/gateway/session/json/version',
+      ]);
     });
   });
 

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -185,7 +185,11 @@ async function getWSEndpoint(
   browserURL: string,
   headers?: Record<string, string>,
 ): Promise<string> {
-  const endpointURL = new URL('/json/version', browserURL);
+  const endpointURL = new URL(browserURL);
+  endpointURL.pathname =
+    endpointURL.pathname.replace(/\/+$/, '') + '/json/version';
+  endpointURL.search = '';
+  endpointURL.hash = '';
 
   try {
     const result = await globalThis.fetch(endpointURL.toString(), {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**Did you add tests for your changes?**

Yes. The `BrowserConnector` unit coverage now checks both origin-only and path-prefixed discovery URLs while retaining the existing header-forwarding assertion.

**If relevant, did you update the documentation?**

No public API or option changes.

**Summary**

`puppeteer.connect({browserURL})` built `/json/version` with an absolute pathname, which discarded reverse-proxy and gateway path prefixes. This keeps the configured pathname, appends the discovery suffix, and preserves the existing origin-only, query/fragment, header, and WebSocket behavior.

Testing:

- `node --test --test-reporter=spec packages/puppeteer-core/lib/puppeteer/common/BrowserConnector.test.js` — 5 passed
- `npm run unit --workspace puppeteer-core` — 162 passed; one environment-dependent `PuppeteerNode` test requires a locally installed stable Chrome and fails identically on the base revision
- targeted ESLint and Prettier checks — passed
- `git diff --check` — passed

Fixes #15275

**Does this PR introduce a breaking change?**

No. Origin-only `browserURL` values still request `/json/version`.

**Other information**

The downstream Chrome DevTools MCP workaround was declined in favor of fixing the shared discovery behavior in Puppeteer.