### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: npm
-          node-version: '22.12'
+          node-version: '24.0'
       - name: Test install
         env:
           PKG_MANAGER: ${{ matrix.pkg_manager }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: npm
-          node-version: '24.0'
+          node-version-file: '.nvmrc'
       - name: Test install
         env:
           PKG_MANAGER: ${{ matrix.pkg_manager }}


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Use `.nvmrc` as the source of truth for the Node.js version in CI (instead of a hard-coded pin).

- `.github/workflows/ci.yml`
  - `node-version: '22.12'` → `node-version-file: '.nvmrc'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [ ] Updated workflow now follows `.nvmrc` via `node-version-file`
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.