### PR TITLE
refactor: use a enum to manage the prefixes

### DIFF
--- a/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
+++ b/packages/puppeteer-core/src/bidi/BidiOverCdp.ts
@@ -9,7 +9,7 @@ import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js'
 
 import type {CDPEvents, CDPSession} from '../api/CDPSession.js';
 import type {Connection as CdpConnection} from '../cdp/Connection.js';
-import {debug} from '../common/Debug.js';
+import {debug, type DebugPrefix} from '../common/Debug.js';
 import {TargetCloseError} from '../common/Errors.js';
 import type {Handler} from '../common/EventEmitter.js';
 
@@ -18,7 +18,7 @@ import {BidiConnection} from './Connection.js';
 const bidiServerLogger = (
   prefix: string,
 ): ((...args: unknown[]) => void) | undefined => {
-  return debug(`bidi:${prefix}`);
+  return debug(`bidi:${prefix}` as DebugPrefix);
 };
 
 /**

--- a/packages/puppeteer-core/src/bidi/Connection.ts
+++ b/packages/puppeteer-core/src/bidi/Connection.ts
@@ -9,7 +9,7 @@ import type * as Bidi from 'webdriver-bidi-protocol';
 
 import {CallbackRegistry} from '../common/CallbackRegistry.js';
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
-import {debug} from '../common/Debug.js';
+import {debug, DEBUG_PREFIXES} from '../common/Debug.js';
 import {ConnectionClosedError} from '../common/Errors.js';
 import type {EventsWithWildcard} from '../common/EventEmitter.js';
 import {EventEmitter} from '../common/EventEmitter.js';
@@ -23,8 +23,8 @@ import type {
   Connection,
 } from './core/Connection.js';
 
-const debugProtocolSend = debug('puppeteer:webDriverBiDi:SEND ►');
-const debugProtocolReceive = debug('puppeteer:webDriverBiDi:RECV ◀');
+const debugProtocolSend = debug(DEBUG_PREFIXES.bidiSend);
+const debugProtocolReceive = debug(DEBUG_PREFIXES.bidiReceive);
 
 export type CdpEvent = ChromiumBidi.Cdp.Event;
 

--- a/packages/puppeteer-core/src/cdp/Connection.ts
+++ b/packages/puppeteer-core/src/cdp/Connection.ts
@@ -15,7 +15,7 @@ import {
 } from '../api/CDPSession.js';
 import {CallbackRegistry} from '../common/CallbackRegistry.js';
 import type {ConnectionTransport} from '../common/ConnectionTransport.js';
-import {debug} from '../common/Debug.js';
+import {debug, DEBUG_PREFIXES} from '../common/Debug.js';
 import {ConnectionClosedError, TargetCloseError} from '../common/Errors.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import {createProtocolErrorMessage} from '../util/ErrorLike.js';
@@ -26,8 +26,8 @@ import {
 
 import {CdpCDPSession} from './CdpSession.js';
 
-const debugProtocolSend = debug('puppeteer:protocol:SEND ►');
-const debugProtocolReceive = debug('puppeteer:protocol:RECV ◀');
+const debugProtocolSend = debug(DEBUG_PREFIXES.cdpSend);
+const debugProtocolReceive = debug(DEBUG_PREFIXES.cdpReceive);
 
 /**
  * @public

--- a/packages/puppeteer-core/src/common/Debug.ts
+++ b/packages/puppeteer-core/src/common/Debug.ts
@@ -10,6 +10,23 @@ declare global {
   const __PUPPETEER_DEBUG: string;
 }
 /**
+ * @internal
+ */
+export const DEBUG_PREFIXES = {
+  cdpSend: 'puppeteer:protocol:SEND ►',
+  cdpReceive: 'puppeteer:protocol:RECV ◀',
+  bidiSend: 'puppeteer:webDriverBiDi:SEND ►',
+  bidiReceive: 'puppeteer:webDriverBiDi:RECV ◀',
+  error: 'puppeteer:error',
+  ffmpeg: 'puppeteer:ffmpeg',
+} as const;
+
+/**
+ * @internal
+ */
+export type DebugPrefix = (typeof DEBUG_PREFIXES)[keyof typeof DEBUG_PREFIXES];
+
+/**
  * A debug function that can be used in any environment.
  *
  * @remarks
@@ -36,7 +53,7 @@ declare global {
  * @example
  *
  * ```
- * const log = debug('Page');
+ * const log = debug(DEBUG_PREFIXES.error);
  *
  * log('new page created')
  * // logs "Page: new page created"
@@ -48,7 +65,7 @@ declare global {
  * @internal
  */
 export const debug = (
-  prefix: string,
+  prefix: DebugPrefix,
 ): ((...args: unknown[]) => void) | undefined => {
   if (isNode) {
     const nodeDebug = environment.value.debuglog?.(prefix);

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -21,7 +21,7 @@ import {assert} from '../util/assert.js';
 import {mergeUint8Arrays, stringToTypedArray} from '../util/encoding.js';
 import {packageVersion} from '../util/version.js';
 
-import {debug} from './Debug.js';
+import {debug, DEBUG_PREFIXES} from './Debug.js';
 import {TimeoutError} from './Errors.js';
 import type {EventEmitter, EventType} from './EventEmitter.js';
 import type {
@@ -34,7 +34,7 @@ import {paperFormats} from './PDFOptions.js';
 /**
  * @internal
  */
-export const debugError = debug('puppeteer:error');
+export const debugError = debug(DEBUG_PREFIXES.error);
 
 /**
  * @internal

--- a/packages/puppeteer-core/src/node/ScreenRecorder.ts
+++ b/packages/puppeteer-core/src/node/ScreenRecorder.ts
@@ -26,7 +26,7 @@ import {
 import {CDPSessionEvent} from '../api/CDPSession.js';
 import type {BoundingBox} from '../api/ElementHandle.js';
 import type {Page, VideoFormat} from '../api/Page.js';
-import {debug} from '../common/Debug.js';
+import {debug, DEBUG_PREFIXES} from '../common/Debug.js';
 import {fromEmitterEvent, debugCatchError} from '../common/util.js';
 import {guarded} from '../util/decorators.js';
 import {asyncDisposeSymbol} from '../util/disposable.js';
@@ -34,7 +34,7 @@ import {asyncDisposeSymbol} from '../util/disposable.js';
 const CRF_VALUE = 30;
 const DEFAULT_FPS = 30;
 
-const debugFfmpeg = debug('puppeteer:ffmpeg');
+const debugFfmpeg = debug(DEBUG_PREFIXES.ffmpeg);
 
 /**
  * Computes how many encoder frames to emit for a captured frame that spans


### PR DESCRIPTION
A pre-factoring to extract the prefixes similar to the @puppteer/browser package.