### PR TITLE
fix: do not clear UA Client Hints on connect

### DIFF
--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -1628,5 +1628,32 @@ describe('NetworkManager', () => {
       });
       await manager.addClient(mockCDPSession);
     });
+
+    it('should not send Network.setUserAgentOverride unless an override is set', async () => {
+      const sent: string[] = [];
+      class TrackingSession extends EventEmitter<CDPSessionEvents> {
+        async send(method: string): Promise<any> {
+          sent.push(method);
+        }
+        connection() {
+          return undefined;
+        }
+        readonly detached = false;
+        async detach() {}
+        id() {
+          return '1';
+        }
+        parentSession() {
+          return undefined;
+        }
+      }
+      const mockCDPSession = new TrackingSession();
+      const manager = createNetworkManager();
+      await manager.addClient(mockCDPSession);
+      expect(sent).not.toContain('Network.setUserAgentOverride');
+
+      await manager.setUserAgent('custom-agent');
+      expect(sent).toContain('Network.setUserAgentOverride');
+    });
   });
 });

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -285,6 +285,18 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
   }
 
   async #applyUserAgent(client: CDPSession) {
+    // Do not call Network.setUserAgentOverride unless the user asked for an
+    // override. Sending only `userAgent` (with userAgentMetadata omitted)
+    // clears User-Agent Client Hints from Chrome 114+; see
+    // https://github.com/puppeteer/puppeteer/issues/15273 and crbug 40270800.
+    if (
+      this.#userAgent === undefined &&
+      this.#userAgentMetadata === undefined &&
+      this.#acceptLanguage === undefined &&
+      this.#platform === undefined
+    ) {
+      return;
+    }
     const userAgent =
       this.#userAgent ??
       (await this.#frameManager.page().browser().userAgent());


### PR DESCRIPTION
## Summary

Fixes #15273.

`NetworkManager.#applyUserAgent` currently runs for every CDP session that joins the network manager (including on `connect()` / `newPage()`). When the caller never asked for an override, it still sends:

```json
{"method":"Network.setUserAgentOverride","params":{"userAgent":"<browser UA>"}}
```

From Chrome 114 onward, a `setUserAgentOverride` **without** `userAgentMetadata` clears User-Agent Client Hints (`Sec-CH-UA*`, `navigator.userAgentData.brands`). The UA string stays intact, so the regression is easy to miss — but anti-bot and fingerprinting layers treat “Chrome UA + empty Client Hints” as spoofed. On a shared browser (`connect({browserURL})`), this also affects tabs Puppeteer did not create.

### Change

Skip `Network.setUserAgentOverride` unless at least one of `#userAgent`, `#userAgentMetadata`, `#acceptLanguage`, or `#platform` was set via `setUserAgent` / `setAcceptLanguage` / related APIs. Explicit overrides continue to work as before.

### Test plan

- [x] Unit test: `addClient` does not send `Network.setUserAgentOverride` until `setUserAgent` is called
- [ ] Manual: connect to a Chrome with remote debugging, open a secure page, confirm `navigator.userAgentData.brands` is non-empty and `Sec-CH-UA` is present without calling `setUserAgent`