### PR TITLE
fix: preserve browserURL path prefix when resolving /json/version

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -48,6 +48,33 @@ describe('BrowserConnector', () => {
         ],
       ).toBe('Bearer test-token');
     });
+
+    it('should preserve browserURL path prefix when resolving /json/version', async () => {
+      const capturedRequests: Array<{url: string}> = [];
+
+      mock.method(
+        globalThis,
+        'fetch',
+        async (url: string | URL | Request) => {
+          capturedRequests.push({url: String(url)});
+          return new Response(
+            JSON.stringify({
+              webSocketDebuggerUrl: 'ws://localhost:1234/t/abc/devtools/browser/1',
+            }),
+            {status: 200, headers: {'Content-Type': 'application/json'}},
+          );
+        },
+      );
+
+      await _connectToBrowser({
+        browserURL: 'http://localhost:1234/t/abc123',
+      }).catch(() => {});
+
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0]!.url).toBe(
+        'http://localhost:1234/t/abc123/json/version',
+      );
+    });
   });
 
   describe('_connectToBrowser', () => {

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -185,7 +185,12 @@ async function getWSEndpoint(
   browserURL: string,
   headers?: Record<string, string>,
 ): Promise<string> {
-  const endpointURL = new URL('/json/version', browserURL);
+  // Append json/version to any path prefix on browserURL. Using
+  // `new URL('/json/version', browserURL)` would replace the pathname and
+  // drop reverse-proxy / tunnel prefixes (see #15250).
+  const endpointURL = new URL(browserURL);
+  endpointURL.pathname =
+    endpointURL.pathname.replace(/\/?$/, '/') + 'json/version';
 
   try {
     const result = await globalThis.fetch(endpointURL.toString(), {


### PR DESCRIPTION
## Summary

Fixes #15250.

`getWSEndpoint()` discovered the WebSocket debugger URL with:

```ts
new URL('/json/version', browserURL)
```

Per the WHATWG URL Standard, an absolute path replaces the base pathname. So a `browserURL` like `http://host:9222/t/abc123` requested `http://host:9222/json/version` and dropped the `/t/abc123` prefix used by reverse proxies, API gateways, and CDP tunnels.

### Change

Build the discovery URL by appending `json/version` to the existing pathname (normalizing a trailing slash), preserving any path prefix.

| `browserURL` | Before | After |
|---|---|---|
| `http://host:9222` | `/json/version` | `/json/version` |
| `http://host:9222/t/token` | `/json/version` | `/t/token/json/version` |

### Test plan

- [x] Unit test covering path-prefixed `browserURL` discovery
- [ ] Manual: `puppeteer.connect({ browserURL: 'http://127.0.0.1:PORT/prefix' })` against a proxied DevTools endpoint