### PR TITLE
fix: close connection on transport errors

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/common/BrowserWebSocketTransport.ts
@@ -25,6 +25,8 @@ export class BrowserWebSocketTransport implements ConnectionTransport {
   onmessage?: (message: string) => void;
   onclose?: () => void;
 
+  #closed = false;
+
   constructor(ws: WebSocket) {
     this.#ws = ws;
     this.#ws.addEventListener('message', event => {
@@ -33,16 +35,34 @@ export class BrowserWebSocketTransport implements ConnectionTransport {
       }
     });
     this.#ws.addEventListener('close', () => {
-      if (this.onclose) {
-        this.onclose.call(null);
-      }
+      this.#handleClose();
     });
-    // Silently log all errors - we don't know what to do with them.
-    this.#ws.addEventListener('error', debugCatchError);
+    // Transport errors leave CDP callbacks hanging unless we close the
+    // connection (see #13054). Log then tear down like a normal close.
+    this.#ws.addEventListener('error', event => {
+      debugCatchError(event);
+      this.#handleClose();
+    });
+  }
+
+  #handleClose(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    if (this.onclose) {
+      this.onclose.call(null);
+    }
   }
 
   send(message: string): void {
-    this.#ws.send(message);
+    try {
+      this.#ws.send(message);
+    } catch (error) {
+      debugCatchError(error);
+      this.#handleClose();
+      throw error;
+    }
   }
 
   close(): void {

--- a/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/node/NodeWebSocketTransport.ts
@@ -37,6 +37,7 @@ export class NodeWebSocketTransport implements ConnectionTransport {
   }
 
   #ws: NodeWebSocket;
+  #closed = false;
   onmessage?: (message: NodeWebSocket.Data) => void;
   onclose?: () => void;
 
@@ -48,16 +49,34 @@ export class NodeWebSocketTransport implements ConnectionTransport {
       }
     });
     this.#ws.addEventListener('close', () => {
-      if (this.onclose) {
-        this.onclose.call(null);
-      }
+      this.#handleClose();
     });
-    // Silently log all errors - we don't know what to do with them.
-    this.#ws.addEventListener('error', debugCatchError);
+    // Transport errors leave CDP callbacks hanging unless we close the
+    // connection (see #13054). Log then tear down like a normal close.
+    this.#ws.addEventListener('error', event => {
+      debugCatchError(event);
+      this.#handleClose();
+    });
+  }
+
+  #handleClose(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    if (this.onclose) {
+      this.onclose.call(null);
+    }
   }
 
   send(message: string): void {
-    this.#ws.send(message);
+    try {
+      this.#ws.send(message);
+    } catch (error) {
+      debugCatchError(error);
+      this.#handleClose();
+      throw error;
+    }
   }
 
   close(): void {

--- a/packages/puppeteer-core/src/node/PipeTransport.test.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.test.ts
@@ -124,5 +124,15 @@ describe('PipeTransport', () => {
       expect(messages[1]).toBe('Second');
       expect(messages[2]).toBe('Third');
     });
+
+    it('should invoke onclose when the pipe emits an error', async () => {
+      const closed = new Promise<void>(resolve => {
+        transport.onclose = () => {
+          resolve();
+        };
+      });
+      myReadable.emit('error', new Error('boom'));
+      await closed;
+    });
   });
 });

--- a/packages/puppeteer-core/src/node/PipeTransport.ts
+++ b/packages/puppeteer-core/src/node/PipeTransport.ts
@@ -38,11 +38,14 @@ export class PipeTransport implements ConnectionTransport {
       return this.#dispatch(buffer);
     });
     pipeReadEmitter.on('close', () => {
-      if (this.onclose) {
-        this.onclose.call(null);
-      }
+      this.#handleClose();
     });
-    pipeReadEmitter.on('error', debugCatchError);
+    // Transport errors leave CDP callbacks hanging unless we close the
+    // connection (see #13054).
+    pipeReadEmitter.on('error', error => {
+      debugCatchError(error);
+      this.#handleClose();
+    });
     const pipeWriteEmitter = this.#subscriptions.use(
       // NodeJS event emitters don't support `*` so we need to typecast
       // As long as we don't use it we should be OK.
@@ -50,7 +53,20 @@ export class PipeTransport implements ConnectionTransport {
         pipeWrite as unknown as EventEmitter<Record<string, any>>,
       ),
     );
-    pipeWriteEmitter.on('error', debugCatchError);
+    pipeWriteEmitter.on('error', error => {
+      debugCatchError(error);
+      this.#handleClose();
+    });
+  }
+
+  #handleClose(): void {
+    if (this.#isClosed) {
+      return;
+    }
+    this.#isClosed = true;
+    if (this.onclose) {
+      this.onclose.call(null);
+    }
   }
 
   send(message: string): void {
@@ -89,7 +105,7 @@ export class PipeTransport implements ConnectionTransport {
   }
 
   close(): void {
-    this.#isClosed = true;
+    this.#handleClose();
     this.#subscriptions.dispose();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #13054.

WebSocket and pipe transports previously treated post-connect `error` events as log-only (`debugCatchError`). When the underlying transport failed — for example a message larger than the runtime WebSocket limit — Puppeteer left CDP `CallbackRegistry` entries unresolved. Call sites such as `page.screenshot()` never settled, so automation could not recover or clean up.

### Change

For `BrowserWebSocketTransport`, `NodeWebSocketTransport`, and `PipeTransport`:

1. On transport `error`, log and invoke the same `onclose` path used for a normal disconnect (idempotent).
2. For WebSocket `send()` failures, close the transport the same way and rethrow.
3. `Connection` already clears pending callbacks with `TargetCloseError` when `onclose` fires, so callers get a rejected promise instead of a hang.

### Test plan

- [x] Unit test: `PipeTransport` invokes `onclose` when the readable pipe emits `error`
- [ ] Manual / integration: provoke a transport failure and confirm pending protocol calls reject rather than hang