### PR TITLE
fix: use Page.setDocumentContent for CDP setContent

### DIFF
--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -286,8 +286,9 @@ export class CdpFrame extends Frame {
       timeout = this._frameManager.timeoutSettings.navigationTimeout(),
     } = options;
 
-    // We rely upon the fact that document.open() will reset frame lifecycle with "init"
-    // lifecycle event. @see https://crrev.com/608658
+    // Page.setDocumentContent resets frame lifecycle (same role document.open
+    // played) without using document.write, which triggers Chromium's
+    // parser-blocking cross-site script console error (#12476).
     await this.setFrameContent(html);
 
     const watcher = new LifecycleWatcher(
@@ -304,6 +305,16 @@ export class CdpFrame extends Frame {
     if (error) {
       throw error;
     }
+  }
+
+  /**
+   * @internal
+   */
+  override async setFrameContent(content: string): Promise<void> {
+    await this.#client.send('Page.setDocumentContent', {
+      frameId: this._id,
+      html: content,
+    });
   }
 
   override url(): string {


### PR DESCRIPTION
## Summary

Fixes #12476.

`page.setContent()` / `Frame.setFrameContent()` used:

```js
document.open();
document.write(html);
document.close();
```

When `html` includes a cross-site `<script src=...>`, Chromium emits:

> A parser-blocking, cross site script … is invoked via document.write …

`setContent` should not depend on a deprecated / warned path for everyday HTML assignment.

### Change

For **CDP** frames, implement `setFrameContent` via [`Page.setDocumentContent`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDocumentContent). That command still resets frame lifecycle (so `waitUntil` continues to work) without going through `document.write`.

BiDi continues to use the existing evaluate-based `setFrameContent` for now (no equivalent CDP command on that path).

### Test plan

- [ ] Existing `page.setContent` suite (Chrome headless / shell)
- [ ] Repro from #12476: `setContent` with a CDN script and assert no `document.write` console warning