### PR TITLE
fix: serialize concurrent browser installs with a lock

### DIFF
--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -22,6 +22,7 @@ import {DefaultProvider} from './DefaultProvider.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
 import {unpackArchive} from './fileUtil.js';
 import {downloadFile, headHttpRequest} from './httpUtil.js';
+import {withInstallLock} from './installLock.js';
 import {ProgressBar} from './ProgressBar.js';
 import type {BrowserProvider} from './provider.js';
 
@@ -446,66 +447,71 @@ async function installUrl(
     );
   }
 
-  try {
-    if (existsSync(outputPath)) {
-      if (!existsSync(installedBrowser.executablePath)) {
-        throw new Error(
-          `The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing`,
+  // Serialize concurrent installs of the same browser/buildId so parallel
+  // `npm install` / install.js runs cannot corrupt the shared cache (#14417).
+  const lockPath = `${outputPath}.install-lock`;
+  return await withInstallLock(lockPath, async () => {
+    try {
+      if (existsSync(outputPath)) {
+        if (!existsSync(installedBrowser.executablePath)) {
+          throw new Error(
+            `The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing`,
+          );
+        }
+        await runSetup(installedBrowser, logger);
+        if (options.installDeps) {
+          await installDeps(installedBrowser, logger);
+        }
+        return installedBrowser;
+      }
+
+      // Check if archive already exists (e.g., from a custom provider)
+      if (!existsSync(archivePath)) {
+        logger?.(DEBUG_PREFIXES.install)?.(`Downloading binary from ${url}`);
+        try {
+          debugTime('download');
+          await downloadFile(
+            url,
+            archivePath,
+            downloadProgressCallback,
+            options.expectedHash,
+          );
+        } finally {
+          debugTimeEnd('download', logger);
+        }
+      } else {
+        logger?.(DEBUG_PREFIXES.install)?.(
+          `Using existing archive at ${archivePath}`,
         );
       }
+
+      logger?.(DEBUG_PREFIXES.install)?.(
+        `Installing ${archivePath} to ${outputPath}`,
+      );
+      try {
+        debugTime('extract');
+        await unpackArchive(archivePath, outputPath, options.logger);
+      } finally {
+        debugTimeEnd('extract', logger);
+      }
+
+      if (options.buildIdAlias) {
+        const metadata = installedBrowser.readMetadata();
+        metadata.aliases[options.buildIdAlias] = options.buildId;
+        installedBrowser.writeMetadata(metadata);
+      }
+
       await runSetup(installedBrowser, logger);
       if (options.installDeps) {
         await installDeps(installedBrowser, logger);
       }
       return installedBrowser;
-    }
-
-    // Check if archive already exists (e.g., from a custom provider)
-    if (!existsSync(archivePath)) {
-      logger?.(DEBUG_PREFIXES.install)?.(`Downloading binary from ${url}`);
-      try {
-        debugTime('download');
-        await downloadFile(
-          url,
-          archivePath,
-          downloadProgressCallback,
-          options.expectedHash,
-        );
-      } finally {
-        debugTimeEnd('download', logger);
-      }
-    } else {
-      logger?.(DEBUG_PREFIXES.install)?.(
-        `Using existing archive at ${archivePath}`,
-      );
-    }
-
-    logger?.(DEBUG_PREFIXES.install)?.(
-      `Installing ${archivePath} to ${outputPath}`,
-    );
-    try {
-      debugTime('extract');
-      await unpackArchive(archivePath, outputPath, options.logger);
     } finally {
-      debugTimeEnd('extract', logger);
+      if (existsSync(archivePath)) {
+        await unlink(archivePath);
+      }
     }
-
-    if (options.buildIdAlias) {
-      const metadata = installedBrowser.readMetadata();
-      metadata.aliases[options.buildIdAlias] = options.buildId;
-      installedBrowser.writeMetadata(metadata);
-    }
-
-    await runSetup(installedBrowser, logger);
-    if (options.installDeps) {
-      await installDeps(installedBrowser, logger);
-    }
-    return installedBrowser;
-  } finally {
-    if (existsSync(archivePath)) {
-      await unlink(archivePath);
-    }
-  }
+  });
 }
 
 async function runSetup(

--- a/packages/browsers/src/installLock.ts
+++ b/packages/browsers/src/installLock.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {mkdir, rm} from 'node:fs/promises';
+import {setTimeout as delay} from 'node:timers/promises';
+
+/**
+ * Cross-platform install lock with no extra dependencies.
+ * Uses exclusive directory creation (`mkdir` without recursive) as the lock.
+ *
+ * @internal
+ */
+export async function withInstallLock<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+  options: {timeoutMs?: number; pollMs?: number} = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 10 * 60 * 1000;
+  const pollMs = options.pollMs ?? 100;
+  const release = await acquireInstallLock(lockPath, timeoutMs, pollMs);
+  try {
+    return await fn();
+  } finally {
+    await release();
+  }
+}
+
+async function acquireInstallLock(
+  lockPath: string,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<() => Promise<void>> {
+  const start = Date.now();
+  const pidPath = `${lockPath}.pid`;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await mkdir(lockPath);
+      try {
+        writeFileSync(pidPath, String(process.pid), {flag: 'w'});
+      } catch {
+        // Best-effort pid recording for stale-lock recovery.
+      }
+      return async () => {
+        try {
+          await rm(pidPath, {force: true});
+        } catch {
+          // ignore
+        }
+        try {
+          await rm(lockPath, {recursive: true, force: true});
+        } catch {
+          // ignore
+        }
+      };
+    } catch {
+      // Lock held by another process — clear if clearly stale.
+      if (isStaleLock(pidPath)) {
+        try {
+          await rm(pidPath, {force: true});
+          await rm(lockPath, {recursive: true, force: true});
+          continue;
+        } catch {
+          // Another process may have won the race to clear; retry.
+        }
+      }
+      await delay(pollMs);
+    }
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for browser install lock at ${lockPath}`,
+  );
+}
+
+function isStaleLock(pidPath: string): boolean {
+  if (!existsSync(pidPath)) {
+    return false;
+  }
+  try {
+    const pid = Number(readFileSync(pidPath, 'utf8').trim());
+    if (!Number.isFinite(pid) || pid <= 0) {
+      return true;
+    }
+    // signal 0 throws if the process does not exist (or we cannot signal it).
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    // EPERM means the process exists but we cannot signal it — lock is live.
+    if (err?.code === 'EPERM') {
+      return false;
+    }
+    return true;
+  }
+}

--- a/packages/browsers/test/src/installLock.test.ts
+++ b/packages/browsers/test/src/installLock.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {withInstallLock} from '../../lib/installLock.js';
+
+describe('withInstallLock', function () {
+  let tmpDir = '';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'puppeteer-install-lock-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, {
+        force: true,
+        recursive: true,
+        maxRetries: 10,
+        retryDelay: 100,
+      });
+    } catch {}
+  });
+
+  it('serializes concurrent critical sections for the same lock path', async () => {
+    const lockPath = path.join(tmpDir, 'chrome.install-lock');
+    const order: string[] = [];
+
+    const first = withInstallLock(lockPath, async () => {
+      order.push('first-enter');
+      await new Promise(resolve => {
+        return setTimeout(resolve, 50);
+      });
+      order.push('first-exit');
+      return 1;
+    });
+
+    await new Promise(resolve => {
+      return setTimeout(resolve, 10);
+    });
+
+    const second = withInstallLock(lockPath, async () => {
+      order.push('second-enter');
+      order.push('second-exit');
+      return 2;
+    });
+
+    assert.deepStrictEqual(await Promise.all([first, second]), [1, 2]);
+    assert.deepStrictEqual(order, [
+      'first-enter',
+      'first-exit',
+      'second-enter',
+      'second-exit',
+    ]);
+    assert.strictEqual(fs.existsSync(lockPath), false);
+  });
+
+  it('recovers from a stale lock left by a dead process', async () => {
+    const lockPath = path.join(tmpDir, 'chrome.install-lock');
+    fs.mkdirSync(lockPath);
+    // Use a PID that should not exist on this host.
+    fs.writeFileSync(`${lockPath}.pid`, '2147483646');
+
+    const result = await withInstallLock(
+      lockPath,
+      async () => {
+        return 'ok';
+      },
+      {timeoutMs: 2000, pollMs: 20},
+    );
+    assert.strictEqual(result, 'ok');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #14417.

`@puppeteer/browsers` install was not atomic. Two processes installing the same `browser`/`buildId` into the shared cache could interleave download, extract, and archive `unlink`, producing:

- a browser folder without an executable
- a missing zip mid-extract
- other corrupt cache states

Maintainers noted they would review a PR that implements locking in a cross-platform way **without additional dependencies**.

### Change

1. Add `withInstallLock()` using exclusive `mkdir` as the lock primitive (no new deps).
2. Record a PID file for stale-lock recovery (`process.kill(pid, 0)`).
3. Wrap the unpack/install critical section for a given `outputPath` so concurrent installers of that build serialize; the second waiter reuses the completed install when it acquires the lock.

### Test plan

- [x] Unit tests for serialization and stale-lock recovery (`packages/browsers/test/src/installLock.test.ts`)
- [ ] Optional stress: two parallel `install.js` runs against a cleared cache for the same Chrome buildId