### PR TITLE
fix(cdp): do not fail a per-frame fan-out when an OOP iframe goes away

### DIFF
--- a/packages/puppeteer-core/src/cdp/FrameManager.ts
+++ b/packages/puppeteer-core/src/cdp/FrameManager.ts
@@ -282,22 +282,39 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
     return this._frameTree.getById(frameId) || null;
   }
 
-  async addExposedFunctionBinding(binding: Binding): Promise<void> {
-    this.#bindings.add(binding);
+  async #forEachFrame(
+    action: (frame: CdpFrame) => Promise<unknown>,
+  ): Promise<void> {
     await Promise.all(
       this.frames().map(async frame => {
-        return await frame.addExposedFunctionBinding(binding);
+        try {
+          await action(frame);
+        } catch (error) {
+          // Only an out-of-process frame has a session of its own to lose.
+          if (
+            frame._client() === this.#client ||
+            !isErrorLike(error) ||
+            !isTargetClosedError(error)
+          ) {
+            throw error;
+          }
+        }
       }),
     );
   }
 
+  async addExposedFunctionBinding(binding: Binding): Promise<void> {
+    this.#bindings.add(binding);
+    await this.#forEachFrame(frame => {
+      return frame.addExposedFunctionBinding(binding);
+    });
+  }
+
   async removeExposedFunctionBinding(binding: Binding): Promise<void> {
     this.#bindings.delete(binding);
-    await Promise.all(
-      this.frames().map(async frame => {
-        return await frame.removeExposedFunctionBinding(binding);
-      }),
-    );
+    await this.#forEachFrame(frame => {
+      return frame.removeExposedFunctionBinding(binding);
+    });
   }
 
   async evaluateOnNewDocument(
@@ -317,11 +334,9 @@ export class FrameManager extends EventEmitter<FrameManagerEvents> {
 
     this.#scriptsToEvaluateOnNewDocument.set(identifier, preloadScript);
 
-    await Promise.all(
-      this.frames().map(async frame => {
-        return await frame.addPreloadScript(preloadScript);
-      }),
-    );
+    await this.#forEachFrame(frame => {
+      return frame.addPreloadScript(preloadScript);
+    });
 
     return {identifier};
   }

--- a/test/src/oopif.test.ts
+++ b/test/src/oopif.test.ts
@@ -433,6 +433,39 @@ describe('OOPIF', function () {
     });
   });
 
+  it('should exposeFunction when an OOP iframe goes away mid-call', async () => {
+    const {page, server} = state;
+    const frameCount = 8;
+
+    await page.goto(server.EMPTY_PAGE);
+    for (let i = 0; i < frameCount; i++) {
+      await attachFrame(
+        page,
+        `oopif${i}`,
+        server.CROSS_PROCESS_PREFIX + '/empty.html',
+      );
+    }
+    expect(page.frames()).toHaveLength(frameCount + 1);
+
+    // Start the teardown first so it lands while the per-frame calls run.
+    const detached = page.evaluate(() => {
+      for (const frame of document.querySelectorAll('iframe')) {
+        frame.remove();
+      }
+    });
+    const exposed = page.exposeFunction('doubleIt', (value: number) => {
+      return value * 2;
+    });
+    await exposed;
+    await detached;
+
+    expect(
+      await page.evaluate(() => {
+        return (window as any).doubleIt(21);
+      }),
+    ).toBe(42);
+  });
+
   it('should evaluate on a page with a PDF viewer', async () => {
     const {page, server} = state;
 


### PR DESCRIPTION
Fixes #15299

## Summary

`page.exposeFunction()` and `page.evaluateOnNewDocument()` fan out over every frame and send on that frame's own CDP session. If an out-of-process iframe is torn down while those calls are in flight, its session is detached and the whole page level call rejects, even though the page and the main frame are fine.

## Problem

`FrameManager` sends `Runtime.addBinding` and `Page.addScriptToEvaluateOnNewDocument` per frame over `frame._client()`, which an OOPIF owns. When the frame goes away, `Connection.onMessage` closes that session and `CallbackRegistry.clear` rejects whatever was pending:

```
TargetCloseError: Protocol error (Runtime.addBinding): Target closed
```

The rejection is misleading. In every failure I looked at, `window.<name>` was already installed on the main frame and calling it from the page reached the Node callback.

This came in with b6b536bb (#12722), which moved both commands off `#primaryTargetClient` onto per frame sessions. With the repro from #15299, `22.12.1` resolves in 3 of 3 runs and `22.13.0` throws in 3 of 3. The three tests that PR added are all happy path, so nothing covered a frame disappearing mid call.

## Fix

The three fan outs in `FrameManager` were the same five lines three times. They now go through one `#forEachFrame` helper that tolerates a frame losing a session that was its own, so each call site is shorter than before:

```diff
-    await Promise.all(
-      this.frames().map(async frame => {
-        return await frame.addExposedFunctionBinding(binding);
-      }),
-    );
+    await this.#forEachFrame(frame => {
+      return frame.addExposedFunctionBinding(binding);
+    });
```

A frame sharing the manager's client is not excused, because there `TargetCloseError` means the page itself is gone and the caller has to hear about it. `#initialize` already swallows the same error for the same reason when it seeds a newly attached frame, and `Input#withTransaction` is the same helper shape. `CdpFrame` is untouched.

## Test

`should exposeFunction when an OOP iframe goes away mid-call` attaches 8 cross-process frames, starts tearing them down, then calls `exposeFunction` while that is in flight. It fails on `main` in 8 of 8 runs and passes in 8 of 8 with the fix.

On the pinned Chrome 151 the OOPIF suite stays at 28 passing, and `evaluation`, `page`, `waittask`, `elementhandle` and `ariaqueryhandler` keep the same 7 pre-existing failures. Killing the browser mid call still rejects with and without subframes, so the helper is not hiding real page loss.
