### PR TITLE
fix: tell the user how to recover a partial browser folder

### DIFF
--- a/packages/browsers/src/CLI.ts
+++ b/packages/browsers/src/CLI.ts
@@ -21,7 +21,7 @@ import {
 } from './browser-data/browser-data.js';
 import {Cache} from './Cache.js';
 import {detectBrowserPlatform} from './detectPlatform.js';
-import {install} from './install.js';
+import {IncompleteInstallationError, install} from './install.js';
 import {
   computeExecutablePath,
   computeSystemExecutablePath,
@@ -635,17 +635,32 @@ export class CLI {
       args.platform,
       args.browser.buildId,
     );
-    await install({
-      browser: args.browser.name,
-      buildId: args.browser.buildId,
-      platform: args.platform,
-      cacheDir: args.path ?? this.#cachePath,
-      downloadProgressCallback: 'default',
-      baseUrl: args.baseUrl,
-      buildIdAlias:
-        originalBuildId !== args.browser.buildId ? originalBuildId : undefined,
-      installDeps: args.installDeps,
-    });
+    try {
+      await install({
+        browser: args.browser.name,
+        buildId: args.browser.buildId,
+        platform: args.platform,
+        cacheDir: args.path ?? this.#cachePath,
+        downloadProgressCallback: 'default',
+        baseUrl: args.baseUrl,
+        buildIdAlias:
+          originalBuildId !== args.browser.buildId
+            ? originalBuildId
+            : undefined,
+        installDeps: args.installDeps,
+      });
+    } catch (error) {
+      if (!(error instanceof IncompleteInstallationError)) {
+        throw error;
+      }
+      const command = this.#prefixCommand
+        ? `${this.#scriptName} ${this.#prefixCommand.cmd}`
+        : this.#scriptName;
+      throw new Error(
+        `${error.message}\nYou can also empty the whole browser cache with \`npx ${command} clear\` and then run \`npx ${command} install\` again.`,
+        {cause: error},
+      );
+    }
     const executablePath = computeExecutablePath({
       browser: args.browser.name,
       buildId: args.browser.buildId,

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -158,6 +158,14 @@ export interface InstallOptions {
 }
 
 /**
+ * Thrown when an installation folder is present but does not hold a browser
+ * that can be launched.
+ *
+ * @internal
+ */
+export class IncompleteInstallationError extends Error {}
+
+/**
  * Install using custom provider plugins.
  * Tries each provider in order until one succeeds.
  * Falls back to default provider if all custom providers fail.
@@ -270,9 +278,16 @@ async function installWithProviders(
       return `  - ${e.providerName}: ${e.error.message}`;
     })
     .join('\n');
-  throw new Error(
-    `All providers failed for ${options.browser} ${options.buildId}:\n${errorDetails}`,
-  );
+  const message = `All providers failed for ${options.browser} ${options.buildId}:\n${errorDetails}`;
+  if (
+    errors.length > 0 &&
+    errors.every(e => {
+      return e.error instanceof IncompleteInstallationError;
+    })
+  ) {
+    throw new IncompleteInstallationError(message);
+  }
+  throw new Error(message);
 }
 
 /**
@@ -449,7 +464,7 @@ async function installUrl(
   try {
     if (existsSync(outputPath)) {
       if (!existsSync(installedBrowser.executablePath)) {
-        throw new Error(
+        throw new IncompleteInstallationError(
           `The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing. ` +
             `An earlier install of this build probably did not finish. ` +
             `Delete ${outputPath} and install the browser again.`,

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -7,7 +7,7 @@
 import assert from 'node:assert';
 import {spawnSync} from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
-import {mkdir, rm, unlink} from 'node:fs/promises';
+import {mkdir, unlink} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -448,22 +448,18 @@ async function installUrl(
 
   try {
     if (existsSync(outputPath)) {
-      if (existsSync(installedBrowser.executablePath)) {
-        await runSetup(installedBrowser, logger);
-        if (options.installDeps) {
-          await installDeps(installedBrowser, logger);
-        }
-        return installedBrowser;
+      if (!existsSync(installedBrowser.executablePath)) {
+        throw new Error(
+          `The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing. ` +
+            `An earlier install of this build probably did not finish. ` +
+            `Run \`npx puppeteer browsers clear\` to empty the browser cache, then install again.`,
+        );
       }
-      logger?.(DEBUG_PREFIXES.install)?.(
-        `Reinstalling ${outputPath}: the executable ${installedBrowser.executablePath} is missing`,
-      );
-      await rm(outputPath, {
-        force: true,
-        recursive: true,
-        maxRetries: 10,
-        retryDelay: 500,
-      });
+      await runSetup(installedBrowser, logger);
+      if (options.installDeps) {
+        await installDeps(installedBrowser, logger);
+      }
+      return installedBrowser;
     }
 
     // Check if archive already exists (e.g., from a custom provider)

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -452,7 +452,7 @@ async function installUrl(
         throw new Error(
           `The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing. ` +
             `An earlier install of this build probably did not finish. ` +
-            `Run \`npx puppeteer browsers clear\` to empty the browser cache, then install again.`,
+            `Delete ${outputPath} and install the browser again.`,
         );
       }
       await runSetup(installedBrowser, logger);

--- a/packages/browsers/src/install.ts
+++ b/packages/browsers/src/install.ts
@@ -7,7 +7,7 @@
 import assert from 'node:assert';
 import {spawnSync} from 'node:child_process';
 import {existsSync, readFileSync} from 'node:fs';
-import {mkdir, unlink} from 'node:fs/promises';
+import {mkdir, rm, unlink} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -448,16 +448,22 @@ async function installUrl(
 
   try {
     if (existsSync(outputPath)) {
-      if (!existsSync(installedBrowser.executablePath)) {
-        throw new Error(
-          `The browser folder (${outputPath}) exists but the executable (${installedBrowser.executablePath}) is missing`,
-        );
+      if (existsSync(installedBrowser.executablePath)) {
+        await runSetup(installedBrowser, logger);
+        if (options.installDeps) {
+          await installDeps(installedBrowser, logger);
+        }
+        return installedBrowser;
       }
-      await runSetup(installedBrowser, logger);
-      if (options.installDeps) {
-        await installDeps(installedBrowser, logger);
-      }
-      return installedBrowser;
+      logger?.(DEBUG_PREFIXES.install)?.(
+        `Reinstalling ${outputPath}: the executable ${installedBrowser.executablePath} is missing`,
+      );
+      await rm(outputPath, {
+        force: true,
+        recursive: true,
+        maxRetries: 10,
+        retryDelay: 500,
+      });
     }
 
     // Check if archive already exists (e.g., from a custom provider)

--- a/packages/browsers/test/src/CLI.test.ts
+++ b/packages/browsers/test/src/CLI.test.ts
@@ -159,4 +159,72 @@ describe('CLI', function () {
     );
     assert.strictEqual(found[2], 'chrome', 'Expected browser to match');
   });
+
+  it('should name its own clear command when an installation is incomplete', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'chrome', `linux-${testChromeBuildId}`), {
+      recursive: true,
+    });
+
+    const output = await runAndCaptureFailure(
+      new CLI({
+        cachePath: tmpDir,
+        scriptName: 'puppeteer',
+        prefixCommand: {cmd: 'browsers', description: 'Manage browsers'},
+      }),
+      [
+        'npx',
+        'puppeteer',
+        'browsers',
+        'install',
+        `chrome@${testChromeBuildId}`,
+        `--path=${tmpDir}`,
+        '--platform=linux',
+        `--base-url=${getServerUrl()}`,
+      ],
+    );
+
+    assert.ok(
+      output.includes('npx puppeteer browsers clear'),
+      `Expected the output to contain "npx puppeteer browsers clear" but got "${output}"`,
+    );
+  });
+
+  it('should not name its clear command for other install failures', async () => {
+    const output = await runAndCaptureFailure(new CLI(tmpDir), [
+      'npx',
+      '@puppeteer/browsers',
+      'install',
+      `chrome@${testChromeBuildId}`,
+      `--path=${tmpDir}`,
+      '--platform=linux',
+      '--base-url=http://localhost:1',
+    ]);
+
+    assert.ok(
+      !output.includes('empty the whole browser cache'),
+      `Expected the output to not mention the clear command but got "${output}"`,
+    );
+  });
 });
+
+// Yargs logs the error and exits the process, so both have to be captured.
+async function runAndCaptureFailure(cli: CLI, argv: string[]): Promise<string> {
+  const logs: string[] = [];
+  const originalConsoleError = console.error;
+  const originalExit = process.exit;
+  console.error = (message: unknown) => {
+    logs.push(String(message));
+  };
+  try {
+    (process as any).exit = (code: number) => {
+      throw new Error(`process.exit called with ${code}`);
+    };
+    await cli.run(argv);
+  } catch (err) {
+    logs.push((err as Error).message);
+  } finally {
+    console.error = originalConsoleError;
+    process.exit = originalExit;
+  }
+  return logs.join('\n');
+}

--- a/packages/browsers/test/src/chrome/install.test.ts
+++ b/packages/browsers/test/src/chrome/install.test.ts
@@ -64,7 +64,7 @@ describe('Chrome install', () => {
     );
   });
 
-  it('can detect missing executables', async function () {
+  it('should re-install a build with a missing executable', async function () {
     this.timeout(60000);
     const expectedOutputPath = path.join(
       tmpDir,
@@ -72,34 +72,29 @@ describe('Chrome install', () => {
       `${BrowserPlatform.LINUX}-${testChromeBuildId}`,
     );
     fs.mkdirSync(expectedOutputPath, {recursive: true});
-    assert.strictEqual(fs.existsSync(expectedOutputPath), true);
-    async function installThatThrows(): Promise<Error | undefined> {
-      try {
-        await install({
-          cacheDir: tmpDir,
-          browser: Browser.CHROME,
-          platform: BrowserPlatform.LINUX,
-          buildId: testChromeBuildId,
-        });
-        return undefined;
-      } catch (err) {
-        return err as Error;
-      }
-    }
-    const error = await installThatThrows();
-    const expectedMessage = `The browser folder (${expectedOutputPath}) exists but the executable (${computeExecutablePath(
-      {
+    fs.writeFileSync(path.join(expectedOutputPath, 'partial'), '');
+    const browser = await install({
+      cacheDir: tmpDir,
+      browser: Browser.CHROME,
+      platform: BrowserPlatform.LINUX,
+      buildId: testChromeBuildId,
+      baseUrl: getServerUrl(),
+    });
+    assert.strictEqual(browser.path, expectedOutputPath);
+    assert.strictEqual(
+      browser.executablePath,
+      computeExecutablePath({
         cacheDir: tmpDir,
         browser: Browser.CHROME,
         platform: BrowserPlatform.LINUX,
         buildId: testChromeBuildId,
-      },
-    )}) is missing`;
-    assert.ok(
-      error?.message.includes(expectedMessage),
-      `Expected error message to contain "${expectedMessage}" but got "${error?.message}"`,
+      }),
     );
-    assert.strictEqual(fs.existsSync(expectedOutputPath), true);
+    assert.ok(fs.existsSync(browser.executablePath));
+    assert.strictEqual(
+      fs.existsSync(path.join(expectedOutputPath, 'partial')),
+      false,
+    );
   });
 
   it('should download a buildId that is a zip archive', async function () {

--- a/packages/browsers/test/src/chrome/install.test.ts
+++ b/packages/browsers/test/src/chrome/install.test.ts
@@ -100,8 +100,8 @@ describe('Chrome install', () => {
       `Expected error message to contain "${expectedMessage}" but got "${error?.message}"`,
     );
     assert.ok(
-      error?.message.includes('npx puppeteer browsers clear'),
-      `Expected error message to tell the user how to recover but got "${error?.message}"`,
+      error?.message.includes(`Delete ${expectedOutputPath}`),
+      `Expected error message to contain "Delete ${expectedOutputPath}" but got "${error?.message}"`,
     );
     assert.strictEqual(fs.existsSync(expectedOutputPath), true);
   });

--- a/packages/browsers/test/src/chrome/install.test.ts
+++ b/packages/browsers/test/src/chrome/install.test.ts
@@ -64,7 +64,7 @@ describe('Chrome install', () => {
     );
   });
 
-  it('should re-install a build with a missing executable', async function () {
+  it('can detect missing executables', async function () {
     this.timeout(60000);
     const expectedOutputPath = path.join(
       tmpDir,
@@ -72,29 +72,38 @@ describe('Chrome install', () => {
       `${BrowserPlatform.LINUX}-${testChromeBuildId}`,
     );
     fs.mkdirSync(expectedOutputPath, {recursive: true});
-    fs.writeFileSync(path.join(expectedOutputPath, 'partial'), '');
-    const browser = await install({
-      cacheDir: tmpDir,
-      browser: Browser.CHROME,
-      platform: BrowserPlatform.LINUX,
-      buildId: testChromeBuildId,
-      baseUrl: getServerUrl(),
-    });
-    assert.strictEqual(browser.path, expectedOutputPath);
-    assert.strictEqual(
-      browser.executablePath,
-      computeExecutablePath({
+    assert.strictEqual(fs.existsSync(expectedOutputPath), true);
+    async function installThatThrows(): Promise<Error | undefined> {
+      try {
+        await install({
+          cacheDir: tmpDir,
+          browser: Browser.CHROME,
+          platform: BrowserPlatform.LINUX,
+          buildId: testChromeBuildId,
+        });
+        return undefined;
+      } catch (err) {
+        return err as Error;
+      }
+    }
+    const error = await installThatThrows();
+    const expectedMessage = `The browser folder (${expectedOutputPath}) exists but the executable (${computeExecutablePath(
+      {
         cacheDir: tmpDir,
         browser: Browser.CHROME,
         platform: BrowserPlatform.LINUX,
         buildId: testChromeBuildId,
-      }),
+      },
+    )}) is missing`;
+    assert.ok(
+      error?.message.includes(expectedMessage),
+      `Expected error message to contain "${expectedMessage}" but got "${error?.message}"`,
     );
-    assert.ok(fs.existsSync(browser.executablePath));
-    assert.strictEqual(
-      fs.existsSync(path.join(expectedOutputPath, 'partial')),
-      false,
+    assert.ok(
+      error?.message.includes('npx puppeteer browsers clear'),
+      `Expected error message to tell the user how to recover but got "${error?.message}"`,
     );
+    assert.strictEqual(fs.existsSync(expectedOutputPath), true);
   });
 
   it('should download a buildId that is a zip archive', async function () {

--- a/packages/browsers/test/src/chrome/install.test.ts
+++ b/packages/browsers/test/src/chrome/install.test.ts
@@ -11,6 +11,7 @@ import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
 
+import {IncompleteInstallationError} from '../../../lib/install.js';
 import {
   install,
   canDownload,
@@ -102,6 +103,10 @@ describe('Chrome install', () => {
     assert.ok(
       error?.message.includes(`Delete ${expectedOutputPath}`),
       `Expected error message to contain "Delete ${expectedOutputPath}" but got "${error?.message}"`,
+    );
+    assert.ok(
+      error instanceof IncompleteInstallationError,
+      `Expected an IncompleteInstallationError but got "${error?.name}"`,
     );
     assert.strictEqual(fs.existsSync(expectedOutputPath), true);
   });

--- a/packages/puppeteer/install.mjs
+++ b/packages/puppeteer/install.mjs
@@ -37,7 +37,7 @@ async function importInstaller() {
 
 try {
   const {downloadBrowsers} = await importInstaller();
-  downloadBrowsers();
+  await downloadBrowsers();
 } catch (error) {
   console.warn('Browser download failed', error);
 }

--- a/packages/puppeteer/src/node/install.ts
+++ b/packages/puppeteer/src/node/install.ts
@@ -141,7 +141,9 @@ export async function downloadBrowsers(): Promise<void> {
     for (const failure of failures) {
       console.error(failure.reason);
     }
-    process.exit(1);
+    throw new Error(
+      'Failed to download one or more browsers. Run `npx puppeteer browsers install` to try again, or `npx puppeteer browsers clear` first if the cache holds an unfinished install.',
+    );
   }
 }
 


### PR DESCRIPTION
An install that gets interrupted while extracting leaves behind a browser folder with no executable in it. `install()` reads that folder as a finished installation and throws, and the message says what is wrong but not what to do about it.

`@puppeteer/browsers` now names the folder to delete, which holds for anyone using the package, and throws an `IncompleteInstallationError` for that case. The CLI catches that error and adds the clear command built from its own `scriptName` and `prefixCommand`, so `npx puppeteer browsers install` and `npx @puppeteer/browsers install` each name the command they actually have.

The install script also stopped calling `process.exit(1)` on a failed download. `downloadBrowsers()` throws instead, `install.mjs` awaits it, and the existing catch reports it. The postinstall exit code goes from 1 to 0 on a download failure, so `npm install` no longer fails with nothing on screen and the missing browser is reported at `launch()`.

Fixes #15318
