### PR TITLE
test: fix flaky empty-body navigation tests under WebDriverBidi MacOs

### DIFF
--- a/test/src/navigation.test.ts
+++ b/test/src/navigation.test.ts
@@ -372,7 +372,9 @@ describe('navigation', function () {
 
       server.setRoute('/404-error', (_, res) => {
         res.statusCode = 404;
-        res.end();
+        setTimeout(() => {
+          res.end();
+        }, 50);
       });
 
       const response = (await page.goto(server.PREFIX + '/404-error'))!;
@@ -384,7 +386,9 @@ describe('navigation', function () {
 
       server.setRoute('/500-error', (_, res) => {
         res.statusCode = 500;
-        res.end();
+        setTimeout(() => {
+          res.end();
+        }, 50);
       });
 
       const response = (await page.goto(server.PREFIX + '/500-error'))!;


### PR DESCRIPTION
Introduced a 50ms delay before closing the connection (`res.end()`) for the empty-body 404 and 500 tests in `navigation.test.ts`.

Without this delay, macOS's aggressive TCP loopback socket teardown caused a race condition where Chrome aborted the connection with `net::ERR_HTTP_RESPONSE_CODE_FAILURE` before it could finish parsing the headers. This caused `page.goto` to return `null` under the WebDriverBiDi protocol. The delay ensures the browser has enough time to read the response headers before the socket is closed.
