### PR TITLE
chore: fix logger docs and force logger usege via type

### DIFF
--- a/docs/api/puppeteer.browser.md
+++ b/docs/api/puppeteer.browser.md
@@ -111,21 +111,6 @@ Whether Puppeteer is connected to this [browser](./puppeteer.browser.md).
 Currently, includes pending protocol calls. In the future, we might add more info.
 
 </td></tr>
-<tr><td>
-
-<span id="logger">logger</span>
-
-</td><td>
-
-`protected, readonly`
-
-</td><td>
-
-[Logger](./puppeteer.logger.md)
-
-</td><td>
-
-</td></tr>
 </tbody></table>
 
 ## Methods

--- a/docs/api/puppeteer.browsercontext.md
+++ b/docs/api/puppeteer.browsercontext.md
@@ -94,21 +94,6 @@ string \| undefined
 Identifier for this [browser context](./puppeteer.browsercontext.md).
 
 </td></tr>
-<tr><td>
-
-<span id="logger">logger</span>
-
-</td><td>
-
-`protected, readonly`
-
-</td><td>
-
-[Logger](./puppeteer.logger.md)
-
-</td><td>
-
-</td></tr>
 </tbody></table>
 
 ## Methods

--- a/docs/api/puppeteer.browserlauncher.md
+++ b/docs/api/puppeteer.browserlauncher.md
@@ -50,21 +50,6 @@ Description
 </td><td>
 
 </td></tr>
-<tr><td>
-
-<span id="logger">logger</span>
-
-</td><td>
-
-`protected, readonly`
-
-</td><td>
-
-[Logger](./puppeteer.logger.md)
-
-</td><td>
-
-</td></tr>
 </tbody></table>
 
 ## Methods

--- a/docs/api/puppeteer.jshandle.md
+++ b/docs/api/puppeteer.jshandle.md
@@ -64,21 +64,6 @@ Used for nominally typing [JSHandle](./puppeteer.jshandle.md).
 </td></tr>
 <tr><td>
 
-<span id="logger">logger</span>
-
-</td><td>
-
-`protected, readonly`
-
-</td><td>
-
-[Logger](./puppeteer.logger.md)
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
 <span id="move">move</span>
 
 </td><td>

--- a/docs/api/puppeteer.locator.md
+++ b/docs/api/puppeteer.locator.md
@@ -58,21 +58,6 @@ Used for nominally typing [Locator](./puppeteer.locator.md).
 </td></tr>
 <tr><td>
 
-<span id="logger">logger</span>
-
-</td><td>
-
-`protected, readonly`
-
-</td><td>
-
-[Logger](./puppeteer.logger.md)
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
 <span id="timeout">timeout</span>
 
 </td><td>

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -486,6 +486,9 @@ export abstract class Browser extends EventEmitter<BrowserEvents> {
     this.#logger = logger;
   }
 
+  /**
+   * @internal
+   */
   protected get logger(): Logger {
     return this.#logger;
   }

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -117,6 +117,9 @@ export abstract class BrowserContext extends EventEmitter<BrowserContextEvents> 
     this.#logger = logger;
   }
 
+  /**
+   * @internal
+   */
   protected get logger(): Logger {
     return this.#logger;
   }

--- a/packages/puppeteer-core/src/api/JSHandle.ts
+++ b/packages/puppeteer-core/src/api/JSHandle.ts
@@ -54,6 +54,9 @@ export abstract class JSHandle<T = unknown> {
     this.#logger = logger;
   }
 
+  /**
+   * @internal
+   */
   protected get logger(): Logger {
     return this.#logger;
   }

--- a/packages/puppeteer-core/src/api/locators/locators.ts
+++ b/packages/puppeteer-core/src/api/locators/locators.ts
@@ -125,6 +125,9 @@ export abstract class Locator<T> extends EventEmitter<LocatorEvents> {
     this.#logger = logger;
   }
 
+  /**
+   * @internal
+   */
   protected get logger(): Logger {
     return this.#logger;
   }

--- a/packages/puppeteer-core/src/bidi/Realm.ts
+++ b/packages/puppeteer-core/src/bidi/Realm.ts
@@ -64,6 +64,9 @@ export abstract class BidiRealm extends Realm {
     this.#logger = logger;
   }
 
+  /**
+   * @internal
+   */
   protected get logger(): Logger {
     return this.#logger;
   }

--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -38,6 +38,9 @@ describe('BrowserConnector', () => {
       await _connectToBrowser({
         browserURL: 'http://localhost:1234',
         headers: {Authorization: 'Bearer test-token'},
+        logger: () => {
+          return undefined;
+        },
       }).catch(() => {});
 
       expect(capturedRequests).toHaveLength(1);
@@ -57,6 +60,9 @@ describe('BrowserConnector', () => {
           browserWSEndpoint: 'ws://localhost:1234',
           blocklist: ['test'],
           allowlist: ['test'],
+          logger: () => {
+            return undefined;
+          },
         }),
       ).rejects.toThrow('Cannot specify both blocklist and allowlist');
     });
@@ -67,6 +73,9 @@ describe('BrowserConnector', () => {
           browserWSEndpoint: 'ws://localhost:1234',
           protocol: 'webDriverBiDi',
           blocklist: ['https://example.com/*'],
+          logger: () => {
+            return undefined;
+          },
         }),
       ).rejects.toThrow(
         'blocklist and allowlist are only supported with the CDP protocol',
@@ -79,6 +88,9 @@ describe('BrowserConnector', () => {
           browserWSEndpoint: 'ws://localhost:1234',
           protocol: 'webDriverBiDi',
           allowlist: ['https://example.com/*'],
+          logger: () => {
+            return undefined;
+          },
         }),
       ).rejects.toThrow(
         'blocklist and allowlist are only supported with the CDP protocol',

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -14,7 +14,7 @@ import {isErrorLike} from '../util/ErrorLike.js';
 
 import type {ConnectionTransport} from './ConnectionTransport.js';
 import type {ConnectOptions} from './ConnectOptions.js';
-import {debug} from './Debug.js';
+import type {Logger} from './Debug.js';
 
 const getWebSocketTransportClass = async () => {
   return isNode
@@ -57,10 +57,12 @@ export function assertSupportedUrlRestrictions(options: {
   }
 }
 
+/**
+ * @internal
+ */
 export async function _connectToBrowser(
-  options: ConnectOptions,
+  options: ConnectOptions & {logger: Logger},
 ): Promise<Browser> {
-  options.logger ??= debug;
   assertSupportedUrlRestrictions(options);
   const {connectionTransport, endpointUrl} =
     await getConnectionTransport(options);
@@ -87,9 +89,10 @@ export async function _connectToBrowser(
 /**
  * Establishes a websocket connection by given options and returns both transport and
  * endpoint url the transport is connected to.
+ * @internal
  */
 async function getConnectionTransport(
-  options: ConnectOptions,
+  options: ConnectOptions & {logger: Logger},
 ): Promise<{connectionTransport: ConnectionTransport; endpointUrl: string}> {
   const {
     browserWSEndpoint,
@@ -113,11 +116,7 @@ async function getConnectionTransport(
   } else if (browserWSEndpoint) {
     const WebSocketClass = await getWebSocketTransportClass();
     const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(
-        browserWSEndpoint,
-        headers,
-        options.logger ?? debug,
-      );
+      await WebSocketClass.create(browserWSEndpoint, headers, options.logger);
     return {
       connectionTransport: connectionTransport,
       endpointUrl: browserWSEndpoint,
@@ -126,11 +125,7 @@ async function getConnectionTransport(
     const connectionURL = await getWSEndpoint(browserURL, headers);
     const WebSocketClass = await getWebSocketTransportClass();
     const connectionTransport: ConnectionTransport =
-      await WebSocketClass.create(
-        connectionURL,
-        headers,
-        options.logger ?? debug,
-      );
+      await WebSocketClass.create(connectionURL, headers, options.logger);
     return {
       connectionTransport: connectionTransport,
       endpointUrl: connectionURL,
@@ -176,7 +171,7 @@ async function getConnectionTransport(
       const connectionTransport = await WebSocketClass.create(
         browserWSEndpoint,
         headers,
-        options.logger ?? debug,
+        options.logger,
       );
       return {
         connectionTransport: connectionTransport,

--- a/packages/puppeteer-core/src/common/Puppeteer.ts
+++ b/packages/puppeteer-core/src/common/Puppeteer.ts
@@ -12,6 +12,7 @@ import {
   type CustomQueryHandler,
   customQueryHandlers,
 } from './CustomQueryHandler.js';
+import {debug} from './Debug.js';
 
 /**
  * Settings that are common to the Puppeteer class, regardless of environment.
@@ -120,6 +121,10 @@ export class Puppeteer {
    * @returns Promise which resolves to browser instance.
    */
   connect(options: ConnectOptions): Promise<Browser> {
-    return _connectToBrowser(options);
+    const withLogger = {
+      logger: debug,
+      ...options,
+    };
+    return _connectToBrowser(withLogger);
   }
 }

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -97,6 +97,9 @@ export abstract class BrowserLauncher {
     this.#logger = logger;
   }
 
+  /**
+   * @internal
+   */
   protected get logger(): Logger {
     return this.#logger;
   }


### PR DESCRIPTION
This should make the logger story complete as all the internal loggers are always there and we only need to expose this to the Public API, which I will do in a separate PR marked as `feat`