### PR TITLE
feat: expose custom Logger to launch/connect

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1606,6 +1606,15 @@ Description
 </td></tr>
 <tr><td>
 
+<span id="debug_prefixes">[DEBUG\_PREFIXES](./puppeteer.debug_prefixes.md)</span>
+
+</td><td>
+
+**_(Experimental)_**
+
+</td></tr>
+<tr><td>
+
 <span id="default_intercept_resolution_priority">[DEFAULT\_INTERCEPT\_RESOLUTION\_PRIORITY](./puppeteer.default_intercept_resolution_priority.md)</span>
 
 </td><td>
@@ -1784,6 +1793,15 @@ Represents the source scheme of the origin that originally set the cookie. A val
 </td></tr>
 <tr><td>
 
+<span id="debugprefix">[DebugPrefix](./puppeteer.debugprefix.md)</span>
+
+</td><td>
+
+**_(Experimental)_**
+
+</td></tr>
+<tr><td>
+
 <span id="downloadpolicy">[DownloadPolicy](./puppeteer.downloadpolicy.md)</span>
 
 </td><td>
@@ -1913,7 +1931,7 @@ All the valid keys that can be passed to functions that take user input, such as
 
 </td><td>
 
-**_(Experimental)_**
+**_(Experimental)_** A logger factory function that receives a debug channel prefix and returns a [LoggerFunction](./puppeteer.loggerfunction.md) to emit logs for that channel, or `undefined` if logging is disabled for that channel.
 
 </td></tr>
 <tr><td>
@@ -1922,7 +1940,7 @@ All the valid keys that can be passed to functions that take user input, such as
 
 </td><td>
 
-**_(Experimental)_**
+**_(Experimental)_** A function called by Puppeteer to output debug messages.
 
 </td></tr>
 <tr><td>

--- a/docs/api/puppeteer.connectoptions.md
+++ b/docs/api/puppeteer.connectoptions.md
@@ -309,6 +309,25 @@ boolean
 </td></tr>
 <tr><td>
 
+<span id="logger">logger</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+[Logger](./puppeteer.logger.md)
+
+</td><td>
+
+**_(Experimental)_** When provided, Puppeteer calls the logger with a debug channel prefix [DebugPrefix](./puppeteer.debugprefix.md). If the logger returns a [LoggerFunction](./puppeteer.loggerfunction.md), Puppeteer uses it to log details for that channel.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="networkenabled">networkEnabled</span>
 
 </td><td>

--- a/docs/api/puppeteer.debug_prefixes.md
+++ b/docs/api/puppeteer.debug_prefixes.md
@@ -1,0 +1,18 @@
+---
+sidebar_label: DEBUG_PREFIXES
+---
+
+# DEBUG\_PREFIXES variable
+
+### Signature
+
+```typescript
+DEBUG_PREFIXES: {
+    readonly cdpSend: "puppeteer:protocol:SEND ►";
+    readonly cdpReceive: "puppeteer:protocol:RECV ◀";
+    readonly bidiSend: "puppeteer:webDriverBiDi:SEND ►";
+    readonly bidiReceive: "puppeteer:webDriverBiDi:RECV ◀";
+    readonly error: "puppeteer:error";
+    readonly ffmpeg: "puppeteer:ffmpeg";
+}
+```

--- a/docs/api/puppeteer.debugprefix.md
+++ b/docs/api/puppeteer.debugprefix.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: DebugPrefix
+---
+
+# DebugPrefix type
+
+### Signature
+
+```typescript
+export type DebugPrefix = (typeof DEBUG_PREFIXES)[keyof typeof DEBUG_PREFIXES];
+```
+
+**References:** [DEBUG\_PREFIXES](./puppeteer.debug_prefixes.md)

--- a/docs/api/puppeteer.logger.md
+++ b/docs/api/puppeteer.logger.md
@@ -4,6 +4,8 @@ sidebar_label: Logger
 
 # Logger type
 
+A logger factory function that receives a debug channel prefix and returns a [LoggerFunction](./puppeteer.loggerfunction.md) to emit logs for that channel, or `undefined` if logging is disabled for that channel.
+
 ### Signature
 
 ```typescript
@@ -11,3 +13,14 @@ export type Logger = (prefix: string) => LoggerFunction | undefined;
 ```
 
 **References:** [LoggerFunction](./puppeteer.loggerfunction.md)
+
+## Example
+
+```ts
+const customLogger: Logger = (prefix: string) => {
+  if (prefix.includes('protocol')) {
+    return (...args: unknown[]) => console.log(`[DEBUG: ${prefix}]`, ...args);
+  }
+  return undefined;
+};
+```

--- a/docs/api/puppeteer.loggerfunction.md
+++ b/docs/api/puppeteer.loggerfunction.md
@@ -4,6 +4,8 @@ sidebar_label: LoggerFunction
 
 # LoggerFunction type
 
+A function called by Puppeteer to output debug messages.
+
 ### Signature
 
 ```typescript

--- a/packages/puppeteer-core/src/common/ConnectOptions.ts
+++ b/packages/puppeteer-core/src/common/ConnectOptions.ts
@@ -235,7 +235,22 @@ export interface ConnectOptions {
    */
   allowlist?: string[];
   /**
-   * @internal
+   * When provided, Puppeteer calls the logger with a debug channel prefix
+   * {@link DebugPrefix}. If the logger returns a
+   * {@link LoggerFunction}, Puppeteer uses it to log details for that channel.
+   *
+   * @example
+   *
+   * ```ts
+   * const browser = await puppeteer.connect({
+   *   browserWSEndpoint,
+   *   logger: prefix => {
+   *     return (...args) => console.log(`[${prefix}]`, ...args);
+   *   },
+   * });
+   * ```
+   *
+   * @experimental The API may change in future releases.
    */
   logger?: Logger;
 }

--- a/packages/puppeteer-core/src/common/Debug.ts
+++ b/packages/puppeteer-core/src/common/Debug.ts
@@ -10,7 +10,8 @@ declare global {
   const __PUPPETEER_DEBUG: string;
 }
 /**
- * @internal
+ * @public
+ * @experimental
  */
 export const DEBUG_PREFIXES = {
   cdpSend: 'puppeteer:protocol:SEND ►',
@@ -22,16 +23,42 @@ export const DEBUG_PREFIXES = {
 } as const;
 
 /**
- * @internal
+ * @public
+ * @experimental
  */
 export type DebugPrefix = (typeof DEBUG_PREFIXES)[keyof typeof DEBUG_PREFIXES];
 
 /**
+ * A function called by Puppeteer to output debug messages.
+ *
+ * @param args - Arbitrary values to log for a debug event.
+ *
  * @public
  * @experimental
  */
 export type LoggerFunction = (...args: unknown[]) => void;
+
 /**
+ * A logger factory function that receives a debug channel prefix and returns
+ * a {@link LoggerFunction} to emit logs for that channel, or `undefined` if
+ * logging is disabled for that channel.
+ *
+ * @example
+ *
+ * ```ts
+ * const customLogger: Logger = (prefix: string) => {
+ *   if (prefix.includes('protocol')) {
+ *     return (...args: unknown[]) =>
+ *       console.log(`[DEBUG: ${prefix}]`, ...args);
+ *   }
+ *   return undefined;
+ * };
+ * ```
+ *
+ * @param prefix - A debug channel prefix, one of {@link DebugPrefix}.
+ * @returns A {@link LoggerFunction} to log messages for the channel,
+ * or `undefined` if logging is disabled.
+ *
  * @public
  * @experimental
  */


### PR DESCRIPTION
The API is marked as experimental, as we can change the way it works if we find a more performant way to save the logger.