### PR TITLE
feat(tracing): support bufferSize option in tracing.start

### DIFF
--- a/docs/api/puppeteer.tracingoptions.md
+++ b/docs/api/puppeteer.tracingoptions.md
@@ -35,6 +35,25 @@ Default
 </th></tr></thead>
 <tbody><tr><td>
 
+<span id="buffersize">bufferSize</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Size of the trace buffer in kilobytes. If not specified or zero is passed, the default value of 200 MB (200,000 KB) is used by Chromium.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="categories">categories</span>
 
 </td><td>
@@ -47,7 +66,13 @@ string\[\]
 
 </td><td>
 
+The tracing categories to include/exclude.
+
+To exclude a category, prefix it with `-` (e.g., `-toplevel`).
+
 </td><td>
+
+Default categories listed in the implementation.
 
 </td></tr>
 <tr><td>
@@ -63,6 +88,8 @@ string\[\]
 string
 
 </td><td>
+
+The file path to write the trace to. If no path is specified, the trace will not be written to disk, but can still be retrieved as a `Uint8Array` from `tracing.stop()`.
 
 </td><td>
 
@@ -81,7 +108,11 @@ boolean
 
 </td><td>
 
+Whether to capture screenshots in the trace.
+
 </td><td>
+
+`false`
 
 </td></tr>
 </tbody></table>

--- a/packages/puppeteer-core/src/cdp/Tracing.ts
+++ b/packages/puppeteer-core/src/cdp/Tracing.ts
@@ -17,9 +17,32 @@ import {isErrorLike} from '../util/ErrorLike.js';
  * @public
  */
 export interface TracingOptions {
+  /**
+   * The file path to write the trace to.
+   * If no path is specified, the trace will not be written to disk, but can
+   * still be retrieved as a `Uint8Array` from `tracing.stop()`.
+   */
   path?: string;
+  /**
+   * Whether to capture screenshots in the trace.
+   *
+   * @defaultValue `false`
+   */
   screenshots?: boolean;
+  /**
+   * The tracing categories to include/exclude.
+   *
+   * To exclude a category, prefix it with `-` (e.g., `-toplevel`).
+   *
+   * @defaultValue Default categories listed in the implementation.
+   */
   categories?: string[];
+  /**
+   * Size of the trace buffer in kilobytes.
+   * If not specified or zero is passed, the default value of 200 MB
+   * (200,000 KB) is used by Chromium.
+   */
+  bufferSize?: number;
 }
 
 /**
@@ -85,7 +108,12 @@ export class Tracing {
       'disabled-by-default-devtools.timeline.stack',
       'disabled-by-default-v8.cpu_profiler',
     ];
-    const {path, screenshots = false, categories = defaultCategories} = options;
+    const {
+      path,
+      screenshots = false,
+      categories = defaultCategories,
+      bufferSize,
+    } = options;
 
     if (screenshots) {
       categories.push('disabled-by-default-devtools.screenshot');
@@ -109,6 +137,7 @@ export class Tracing {
       traceConfig: {
         excludedCategories,
         includedCategories,
+        traceBufferSizeInKb: bufferSize,
       },
     });
   }

--- a/test/src/tracing.test.ts
+++ b/test/src/tracing.test.ts
@@ -8,6 +8,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import expect from 'expect';
+import type {CdpPage} from 'puppeteer-core/internal/cdp/Page.js';
+import sinon from 'sinon';
 
 import {setupSeparateTestBrowserHooks} from './mocha-utils.js';
 
@@ -96,6 +98,31 @@ describe('Tracing', function () {
     await page.goto(server.PREFIX + '/grid.html');
     const trace = await page.tracing.stop();
     expect(trace).toBeTruthy();
+  });
+
+  it('should support bufferSize option', async () => {
+    const {page, server} = state;
+    const client = (page as CdpPage)._client();
+    const sendSpy = sinon.spy(client, 'send');
+
+    await page.tracing.start({
+      path: outputFile,
+      bufferSize: 10,
+    });
+    await page.goto(server.PREFIX + '/grid.html');
+    await page.tracing.stop();
+
+    const tracingStartCall = sendSpy.getCalls().find(call => {
+      return call.args[0] === 'Tracing.start';
+    });
+    expect(tracingStartCall).toBeDefined();
+    expect(tracingStartCall?.args[1]).toEqual(
+      expect.objectContaining({
+        traceConfig: expect.objectContaining({
+          traceBufferSizeInKb: 10,
+        }),
+      }),
+    );
   });
 
   it('should support a typedArray without a path', async () => {


### PR DESCRIPTION
Add support for the `bufferSize` option in `TracingOptions`, which maps to `traceBufferSizeInKb` in the DevTools Protocol `Tracing.start` configuration. This enables users to customize the tracing buffer size limit.