### PR TITLE
feat: support followSymlinks option

### DIFF
--- a/docs/api/puppeteer.puppeteernode.md
+++ b/docs/api/puppeteer.puppeteernode.md
@@ -183,6 +183,17 @@ Puppeteer can also be used to control the Chrome browser, but it works best with
 </td></tr>
 <tr><td>
 
+<span id="setfollowsymlinks">[setFollowSymlinks(followSymlinks)](./puppeteer.puppeteernode.setfollowsymlinks.md)</span>
+
+</td><td>
+
+</td><td>
+
+Defines whether Puppeteer should follow symlinks for file operations.
+
+</td></tr>
+<tr><td>
+
 <span id="trimcache">[trimCache()](./puppeteer.puppeteernode.trimcache.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.puppeteernode.setfollowsymlinks.md
+++ b/docs/api/puppeteer.puppeteernode.setfollowsymlinks.md
@@ -1,0 +1,49 @@
+---
+sidebar_label: PuppeteerNode.setFollowSymlinks
+---
+
+# PuppeteerNode.setFollowSymlinks() method
+
+Defines whether Puppeteer should follow symlinks for file operations.
+
+### Signature
+
+```typescript
+class PuppeteerNode {
+  setFollowSymlinks(followSymlinks: boolean): void;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+followSymlinks
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether Puppeteer should follow symlinks.
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+void

--- a/packages/puppeteer-core/src/api/Frame.ts
+++ b/packages/puppeteer-core/src/api/Frame.ts
@@ -938,7 +938,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
     }
 
     if (path) {
-      content = await environment.value.fs.promises.readFile(path, 'utf8');
+      content = await environment.value.readFile(path, 'utf8');
       content += `//# sourceURL=${path.replace(/\n/g, '')}`;
     }
 
@@ -1018,7 +1018,7 @@ export abstract class Frame extends EventEmitter<FrameEvents> {
     }
 
     if (path) {
-      content = await environment.value.fs.promises.readFile(path, 'utf8');
+      content = await environment.value.readFile(path, 'utf8');
       content += '/*# sourceURL=' + path.replace(/\n/g, '') + '*/';
       options.content = content;
     }

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -2508,7 +2508,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
       return;
     }
 
-    await environment.value.fs.promises.writeFile(path, typedArray);
+    await environment.value.writeFile(path, typedArray);
   }
 
   /**
@@ -2620,8 +2620,9 @@ export abstract class Page extends EventEmitter<PageEvents> {
       throw error;
     }
     if (options.path) {
-      const {createWriteStream} = environment.value.fs;
-      const stream = createWriteStream(options.path, 'binary');
+      const stream = environment.value.createWriteStream(options.path, {
+        encoding: 'binary',
+      });
       recorder.pipe(stream);
     }
     return recorder;

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -888,8 +888,7 @@ export class CdpPage extends Page {
   override async captureHeapSnapshot(
     options: HeapSnapshotOptions,
   ): Promise<void> {
-    const {createWriteStream} = environment.value.fs;
-    const stream = createWriteStream(options.path);
+    const stream = environment.value.createWriteStream(options.path);
     const streamPromise = new Promise<void>((resolve, reject) => {
       stream.on('error', reject);
       stream.on('finish', resolve);

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -147,10 +147,7 @@ async function getConnectionTransport(
     );
     const portPath = join(userDataDir, 'DevToolsActivePort');
     try {
-      const fileContent = await environment.value.fs.promises.readFile(
-        portPath,
-        'ascii',
-      );
+      const fileContent = await environment.value.readFile(portPath, 'ascii');
       const [rawPort, rawPath] = fileContent
         .split('\n')
         .map(line => {

--- a/packages/puppeteer-core/src/common/util.ts
+++ b/packages/puppeteer-core/src/common/util.ts
@@ -197,7 +197,7 @@ export async function getReadableAsTypedArray(
   const buffers: Uint8Array[] = [];
   const reader = readable.getReader();
   if (path) {
-    const fileHandle = await environment.value.fs.promises.open(path, 'w+');
+    const fileHandle = await environment.value.openFileForWriting(path);
     try {
       while (true) {
         const {done, value} = await reader.read();

--- a/packages/puppeteer-core/src/environment.ts
+++ b/packages/puppeteer-core/src/environment.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type FS from 'node:fs';
+import type {FileHandle} from 'node:fs/promises';
 import type Path from 'node:path';
+import type {Writable} from 'node:stream';
 import type {debuglog} from 'node:util';
 
 import type {ScreenRecorder} from './node/ScreenRecorder.js';
@@ -16,10 +17,22 @@ import type {ScreenRecorder} from './node/ScreenRecorder.js';
 export const isNode = !!(typeof process !== 'undefined' && process.version);
 
 export interface EnvironmentDependencies {
-  fs: typeof FS;
   path?: typeof Path;
   ScreenRecorder: typeof ScreenRecorder;
   debuglog?: typeof debuglog;
+  followSymlinks: boolean;
+  readFile: {
+    (path: string, encoding: 'utf8' | 'ascii'): Promise<string>;
+    (path: string): Promise<Uint8Array>;
+  };
+  writeFile: (path: string, data: Uint8Array | string) => Promise<void>;
+  openFileForWriting: (path: string) => Promise<FileHandle>;
+  createWriteStream: (
+    path: string,
+    options?: {
+      encoding?: BufferEncoding;
+    },
+  ) => Writable;
 }
 
 /**
@@ -30,13 +43,25 @@ export const environment: {
   value: EnvironmentDependencies;
 } = {
   value: {
-    get fs(): typeof FS {
-      throw new Error('fs is not available in this environment');
-    },
+    followSymlinks: true,
     ScreenRecorder: class {
       constructor() {
         throw new Error('ScreenRecorder is not available in this environment');
       }
     } as unknown as typeof ScreenRecorder,
+    readFile: (() => {
+      throw new Error('readFile is not available in this environment');
+    }) as unknown as EnvironmentDependencies['readFile'],
+    writeFile: () => {
+      throw new Error('writeFile is not available in this environment');
+    },
+    openFileForWriting: () => {
+      throw new Error(
+        'openFileForWriting is not available in this environment',
+      );
+    },
+    createWriteStream: () => {
+      throw new Error('createWriteStream is not available in this environment');
+    },
   },
 };

--- a/packages/puppeteer-core/src/node-env-setup.ts
+++ b/packages/puppeteer-core/src/node-env-setup.ts
@@ -10,9 +10,83 @@ import {debuglog} from 'node:util';
 
 import {environment} from './environment.js';
 
+const WRITE_NOFOLLOW_FLAGS =
+  fs.constants.O_WRONLY |
+  fs.constants.O_CREAT |
+  fs.constants.O_TRUNC |
+  fs.constants.O_NOFOLLOW;
+const WRITE_NOFOLLOW_MODE = 0o600;
+
+async function readFile(
+  path: string,
+  encoding: 'utf8' | 'ascii',
+): Promise<string>;
+async function readFile(path: string): Promise<Uint8Array>;
+async function readFile(
+  path: string,
+  encoding?: 'utf8' | 'ascii',
+): Promise<string | Uint8Array> {
+  if (
+    !environment.value.followSymlinks &&
+    fs.constants.O_NOFOLLOW !== undefined
+  ) {
+    return await fs.promises.readFile(path, {
+      encoding,
+      flag: fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+    });
+  }
+  return await fs.promises.readFile(path, {encoding});
+}
+
 environment.value = {
-  fs,
   path,
   debuglog,
   ScreenRecorder: environment.value.ScreenRecorder,
+  followSymlinks: true,
+  readFile,
+  writeFile: async (filePath, data) => {
+    if (
+      !environment.value.followSymlinks &&
+      fs.constants.O_NOFOLLOW !== undefined
+    ) {
+      await fs.promises.writeFile(filePath, data, {
+        flag: WRITE_NOFOLLOW_FLAGS,
+        mode: WRITE_NOFOLLOW_MODE,
+      });
+    } else {
+      await fs.promises.writeFile(filePath, data);
+    }
+  },
+  openFileForWriting: async filePath => {
+    if (
+      !environment.value.followSymlinks &&
+      fs.constants.O_NOFOLLOW !== undefined
+    ) {
+      return await fs.promises.open(
+        filePath,
+        WRITE_NOFOLLOW_FLAGS,
+        WRITE_NOFOLLOW_MODE,
+      );
+    }
+    return await fs.promises.open(filePath, 'w+');
+  },
+  createWriteStream: (filePath, options) => {
+    const encoding = options?.encoding;
+    if (
+      !environment.value.followSymlinks &&
+      fs.constants.O_NOFOLLOW !== undefined
+    ) {
+      const fd = fs.openSync(
+        filePath,
+        WRITE_NOFOLLOW_FLAGS,
+        WRITE_NOFOLLOW_MODE,
+      );
+      return fs.createWriteStream('', {
+        fd,
+        mode: WRITE_NOFOLLOW_MODE,
+        encoding,
+      });
+    }
+    return fs.createWriteStream(filePath, encoding ? {encoding} : undefined);
+  },
 };

--- a/packages/puppeteer-core/src/node/PuppeteerNode.ts
+++ b/packages/puppeteer-core/src/node/PuppeteerNode.ts
@@ -18,6 +18,7 @@ import type {ConnectOptions} from '../common/ConnectOptions.js';
 import {debug, type Logger} from '../common/Debug.js';
 import {type CommonPuppeteerSettings, Puppeteer} from '../common/Puppeteer.js';
 import type {SupportedBrowser} from '../common/SupportedBrowser.js';
+import {environment} from '../environment.js';
 import {PUPPETEER_REVISIONS} from '../revisions.js';
 
 import type {BrowserLauncher} from './BrowserLauncher.js';
@@ -328,5 +329,14 @@ export class PuppeteerNode extends Puppeteer {
         buildId: installedBrowser.buildId,
       });
     }
+  }
+
+  /**
+   * Defines whether Puppeteer should follow symlinks for file operations.
+   *
+   * @param followSymlinks - Whether Puppeteer should follow symlinks.
+   */
+  setFollowSymlinks(followSymlinks: boolean): void {
+    environment.value.followSymlinks = followSymlinks;
   }
 }

--- a/packages/puppeteer/src/puppeteer.ts
+++ b/packages/puppeteer/src/puppeteer.ts
@@ -40,6 +40,10 @@ export const {
    * @public
    */
   trimCache,
+  /**
+   * @public
+   */
+  setFollowSymlinks,
 } = puppeteer;
 
 export default puppeteer;

--- a/test/src/followSymlinks.test.ts
+++ b/test/src/followSymlinks.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import expect from 'expect';
+import puppeteer from 'puppeteer/internal/puppeteer.js';
+
+import {getTestState, setupTestBrowserHooks} from './mocha-utils.js';
+
+describe('followSymlinks', () => {
+  let tmpDir: string;
+  let scriptFile: string;
+  let scriptSymlink: string;
+  let styleFile: string;
+  let styleSymlink: string;
+  let symlinksSupported = true;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pptr-symlink-'));
+    scriptFile = path.join(tmpDir, 'script.js');
+    scriptSymlink = path.join(tmpDir, 'script-link.js');
+    await fs.promises.writeFile(scriptFile, 'window.__injected = 123;');
+    try {
+      await fs.promises.symlink(scriptFile, scriptSymlink);
+      symlinksSupported = true;
+    } catch {
+      symlinksSupported = false;
+      return;
+    }
+
+    styleFile = path.join(tmpDir, 'style.css');
+    styleSymlink = path.join(tmpDir, 'style-link.css');
+    await fs.promises.writeFile(
+      styleFile,
+      'body { background-color: rgb(0, 255, 0); }',
+    );
+    await fs.promises.symlink(styleFile, styleSymlink);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, {recursive: true, force: true});
+  });
+
+  describe('when followSymlinks is false', () => {
+    setupTestBrowserHooks();
+
+    beforeEach(() => {
+      puppeteer.setFollowSymlinks(false);
+    });
+
+    afterEach(() => {
+      puppeteer.setFollowSymlinks(true);
+    });
+
+    it('should reject addScriptTag with a symlinked path', async function () {
+      if (!symlinksSupported || process.platform === 'win32') {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      let error!: Error;
+      try {
+        await page.addScriptTag({path: scriptSymlink});
+      } catch (err) {
+        error = err as Error;
+      }
+      expect(error).toBeDefined();
+      expect((error as NodeJS.ErrnoException).code).toBe('ELOOP');
+    });
+
+    it('should allow addScriptTag with a regular file path', async () => {
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      await page.addScriptTag({path: scriptFile});
+      const result = await page.evaluate(() => {
+        return (globalThis as unknown as {__injected?: number}).__injected;
+      });
+      expect(result).toBe(123);
+    });
+
+    it('should reject addStyleTag with a symlinked path', async function () {
+      if (!symlinksSupported || process.platform === 'win32') {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      let error!: Error;
+      try {
+        await page.addStyleTag({path: styleSymlink});
+      } catch (err) {
+        error = err as Error;
+      }
+      expect(error).toBeDefined();
+      expect((error as NodeJS.ErrnoException).code).toBe('ELOOP');
+    });
+
+    it('should allow addStyleTag with a regular file path', async () => {
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      await page.addStyleTag({path: styleFile});
+      const result = await page.evaluate(() => {
+        return window
+          .getComputedStyle(document.body)
+          .getPropertyValue('background-color');
+      });
+      expect(result).toBe('rgb(0, 255, 0)');
+    });
+
+    it('should reject screenshot to an existing symlink path', async function () {
+      if (!symlinksSupported || process.platform === 'win32') {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      const targetFile = path.join(tmpDir, 'screenshot.png');
+      const linkFile = path.join(tmpDir, 'screenshot-link.png');
+      await fs.promises.writeFile(targetFile, 'placeholder');
+      await fs.promises.symlink(targetFile, linkFile);
+
+      let error!: Error;
+      try {
+        await page.screenshot({path: linkFile});
+      } catch (err) {
+        error = err as Error;
+      }
+      expect(error).toBeDefined();
+      expect((error as NodeJS.ErrnoException).code).toBe('ELOOP');
+    });
+
+    it('should reject pdf to an existing symlink path', async function () {
+      if (!symlinksSupported || process.platform === 'win32') {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      const targetFile = path.join(tmpDir, 'output.pdf');
+      const linkFile = path.join(tmpDir, 'output-link.pdf');
+      await fs.promises.writeFile(targetFile, 'placeholder');
+      await fs.promises.symlink(targetFile, linkFile);
+
+      let error!: Error;
+      try {
+        await page.pdf({path: linkFile});
+      } catch (err) {
+        error = err as Error;
+      }
+      expect(error).toBeDefined();
+      expect((error as NodeJS.ErrnoException).code).toBe('ELOOP');
+    });
+  });
+
+  describe('when followSymlinks is true (default)', () => {
+    setupTestBrowserHooks();
+
+    it('should allow addScriptTag with a symlinked path', async function () {
+      if (!symlinksSupported) {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      await page.addScriptTag({path: scriptSymlink});
+      const result = await page.evaluate(() => {
+        return (globalThis as unknown as {__injected?: number}).__injected;
+      });
+      expect(result).toBe(123);
+    });
+
+    it('should allow addStyleTag with a symlinked path', async function () {
+      if (!symlinksSupported) {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      await page.addStyleTag({path: styleSymlink});
+      const result = await page.evaluate(() => {
+        return window
+          .getComputedStyle(document.body)
+          .getPropertyValue('background-color');
+      });
+      expect(result).toBe('rgb(0, 255, 0)');
+    });
+
+    it('should allow screenshot to a symlink path', async function () {
+      if (!symlinksSupported) {
+        this.skip();
+      }
+      const {page, server} = await getTestState();
+      await page.goto(server.EMPTY_PAGE);
+
+      const targetFile = path.join(tmpDir, 'screenshot-target.png');
+      const linkFile = path.join(tmpDir, 'screenshot-default-link.png');
+      await fs.promises.writeFile(targetFile, 'placeholder');
+      await fs.promises.symlink(targetFile, linkFile);
+
+      await page.screenshot({path: linkFile});
+      const content = await fs.promises.readFile(targetFile);
+      expect(content.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
followSymlinks defaults to true to keep existing behavior. Setting `followSymlinks=false` will make Puppeteer to stop following symlinks when writing or reading files. Implemented by adding environment file access functions and enforcing the configuration globally.