### PR TITLE
fix: launch browsers in detached mode on Windows to fix flakiness

### DIFF
--- a/packages/browsers/src/launch.ts
+++ b/packages/browsers/src/launch.ts
@@ -318,11 +318,10 @@ export class Process {
     opts.handleSIGINT ??= true;
     opts.handleSIGTERM ??= true;
     opts.handleSIGHUP ??= true;
-    // On non-windows platforms, `detached: true` makes child process a
-    // leader of a new process group, making it possible to kill child
-    // process tree with `.kill(-pid)` command. @see
-    // https://nodejs.org/api/child_process.html#child_process_options_detached
-    opts.detached ??= process.platform !== 'win32';
+    // `detached: true` makes child process a leader of a new process group,
+    // making it possible to isolate process trees and prevent console signal propagation.
+    // @see https://nodejs.org/api/child_process.html#child_process_options_detached
+    opts.detached ??= true;
     const stdio = this.#configureStdio({
       pipe: opts.pipe,
     });
@@ -351,6 +350,7 @@ export class Process {
       this.#args,
       {
         detached: opts.detached,
+        windowsHide: true,
         env,
         stdio,
       },

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -156,6 +156,11 @@ export abstract class BrowserLauncher {
     });
 
     if (!existsSync(launchArgs.executablePath)) {
+      if (launchArgs.isTempUserDataDir) {
+        await this.cleanUserDataDir(launchArgs.userDataDir, {
+          isTemp: true,
+        });
+      }
       throw new Error(
         `Browser was not found at the configured executablePath (${launchArgs.executablePath})`,
       );

--- a/packages/puppeteer-core/src/node/ChromeLauncher.ts
+++ b/packages/puppeteer-core/src/node/ChromeLauncher.ts
@@ -160,7 +160,6 @@ export class ChromeLauncher extends BrowserLauncher {
         await rm(path);
       } catch (error) {
         this.logger(DEBUG_PREFIXES.error)?.(error);
-        throw error;
       }
     }
   }

--- a/packages/puppeteer-core/src/node/FirefoxLauncher.ts
+++ b/packages/puppeteer-core/src/node/FirefoxLauncher.ts
@@ -142,7 +142,6 @@ export class FirefoxLauncher extends BrowserLauncher {
         await rm(userDataDir);
       } catch (error) {
         this.logger(DEBUG_PREFIXES.error)?.(error);
-        throw error;
       }
     } else {
       try {

--- a/packages/puppeteer-core/src/node/util/fs.ts
+++ b/packages/puppeteer-core/src/node/util/fs.ts
@@ -9,7 +9,8 @@ import fs from 'node:fs';
 const rmOptions = {
   force: true,
   recursive: true,
-  maxRetries: 5,
+  maxRetries: 10,
+  retryDelay: 100,
 };
 
 /**

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -955,6 +955,13 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[touchscreen.test] Touchscreen Touchscreen.prototype.touchMove should work with three touches",
+    "platforms": ["darwin"],
+    "parameters": ["chrome"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "Started to flake on MacOS"
+  },
+  {
     "testIdPattern": "[tracing.test] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -351,10 +351,10 @@ async function main() {
           ? `Run failed: ${unexpected} unexpected result(s).`
           : `Run failed.`,
       );
-    } else {
-      console.log('Run succeeded.');
+      process.exit(1);
     }
-    process.exit(fail ? 1 : 0);
+    console.log('Run succeeded.');
+    process.exit(0);
   }
 }
 

--- a/tools/mocha-runner/src/mocha-runner.ts
+++ b/tools/mocha-runner/src/mocha-runner.ts
@@ -11,6 +11,7 @@ import {randomUUID} from 'node:crypto';
 import fs, {globSync} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
@@ -235,26 +236,33 @@ async function main() {
         args.push(...specs);
       }
 
+      const mochaBinary = fileURLToPath(
+        import.meta.resolve('mocha/bin/mocha.js'),
+      );
       const mochaCommand = [
         ...(useCoverage
-          ? ['c8', '--check-coverage', '--lines', '90', 'npx']
+          ? ['c8', '--check-coverage', '--lines', '90', process.execPath]
           : []),
-        'mocha',
+        mochaBinary,
         ...mochaArgs.map(String),
         ...args,
       ];
 
-      const handle = spawn('npx', mochaCommand, {
-        shell: true,
+      const handle = spawn(process.execPath, mochaCommand, {
         cwd: process.cwd(),
         stdio: 'inherit',
         env,
+        windowsHide: true,
       });
+      let exitCode: number | null = 0;
+      let exitSignal: NodeJS.Signals | null = null;
       await new Promise<void>((resolve, reject) => {
         handle.on('error', err => {
           reject(err);
         });
-        handle.on('close', () => {
+        handle.on('close', (code, signal) => {
+          exitCode = code;
+          exitSignal = signal;
           resolve();
         });
       });
@@ -263,9 +271,17 @@ async function main() {
           try {
             return readJSON(tmpFilename) as MochaResults;
           } catch (cause) {
-            throw new Error('Test results are not found', {
-              cause,
-            });
+            const terminationReason = exitSignal
+              ? `terminated with signal ${exitSignal}`
+              : exitCode !== 0
+                ? `exited with code ${exitCode}`
+                : 'did not produce results';
+            throw new Error(
+              `Test results are not found because Mocha process ${terminationReason}`,
+              {
+                cause,
+              },
+            );
           }
         })();
         console.log('Finished', JSON.stringify(parameters));
@@ -329,11 +345,15 @@ async function main() {
       );
     }
     const unexpected = added.length + removed.length + updated.length;
-    console.log(
-      fail && Boolean(unexpected)
-        ? `Run failed: ${unexpected} unexpected result(s).`
-        : `Run succeeded.`,
-    );
+    if (fail) {
+      console.log(
+        unexpected > 0
+          ? `Run failed: ${unexpected} unexpected result(s).`
+          : `Run failed.`,
+      );
+    } else {
+      console.log('Run succeeded.');
+    }
     process.exit(fail ? 1 : 0);
   }
 }


### PR DESCRIPTION
- remove errors that can be uncaught
- increase rm retries with an explicit delay
- handle test runner's exit codes better