### PR TITLE
feat: emit console and network events on Browser and BrowserContext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27825,9 +27825,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -27929,9 +27926,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -27946,9 +27940,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -27963,9 +27954,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -27980,9 +27968,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -27997,9 +27982,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28014,9 +27996,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28031,9 +28010,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28048,9 +28024,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28065,9 +28038,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28082,9 +28052,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28099,9 +28066,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28116,9 +28080,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -28133,9 +28094,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/puppeteer-core/src/api/Browser.ts
+++ b/packages/puppeteer-core/src/api/Browser.ts
@@ -34,7 +34,12 @@ import {asyncDisposeSymbol, disposeSymbol} from '../util/disposable.js';
 import type {BrowserContext} from './BrowserContext.js';
 import type {Extension} from './Extension.js';
 import type {Page} from './Page.js';
+import {PageEvent} from './Page.js';
 import type {Target} from './Target.js';
+import type {ConsoleMessage} from '../common/ConsoleMessage.js';
+import type {HTTPRequest} from './HTTPRequest.js';
+import type {HTTPResponse} from './HTTPResponse.js';
+
 /**
  * @public
  */
@@ -218,6 +223,30 @@ export interface BrowserEvents extends Record<EventType, unknown> {
    * @internal
    */
   [BrowserEvent.TargetDiscovered]: Protocol.Target.TargetInfo;
+  /**
+   * Emitted when a console message is logged.
+   */
+  [PageEvent.Console]: ConsoleMessage;
+  /**
+   * Emitted when a page issues a request.
+   */
+  [PageEvent.Request]: HTTPRequest;
+  /**
+   * Emitted when a response is received.
+   */
+  [PageEvent.Response]: HTTPResponse;
+  /**
+   * Emitted when a request fails.
+   */
+  [PageEvent.RequestFailed]: HTTPRequest;
+  /**
+   * Emitted when a request finishes.
+   */
+  [PageEvent.RequestFinished]: HTTPRequest;
+  /**
+   * Emitted when a request is served from cache.
+   */
+  [PageEvent.RequestServedFromCache]: HTTPRequest;
 }
 
 /**
@@ -477,6 +506,46 @@ export interface PWAState {
  */
 export abstract class Browser extends EventEmitter<BrowserEvents> {
   #logger: Logger;
+
+  /**
+   * @internal
+   */
+  _deferredEvents: Array<{
+    emitter: EventEmitter<any>;
+    type: any;
+    event: any;
+  }> = [];
+
+  /**
+   * @internal
+   */
+  _isBuffering = false;
+
+  /**
+   * @internal
+   */
+  _startBuffering(): void {
+    this._isBuffering = true;
+  }
+
+  /**
+   * @internal
+   */
+  _stopBufferingAndReplay(): void {
+    this._isBuffering = false;
+    const events = this._deferredEvents;
+    this._deferredEvents = [];
+    for (const {emitter, type, event} of events) {
+      emitter.emit(type, event);
+    }
+  }
+
+  /**
+   * @internal
+   */
+  _deferEvent(emitter: EventEmitter<any>, type: any, event: any): void {
+    this._deferredEvents.push({emitter, type, event});
+  }
 
   /**
    * @internal

--- a/packages/puppeteer-core/src/api/BrowserContext.ts
+++ b/packages/puppeteer-core/src/api/BrowserContext.ts
@@ -30,7 +30,11 @@ import type {
   WaitForTargetOptions,
 } from './Browser.js';
 import type {Page} from './Page.js';
+import {PageEvent} from './Page.js';
 import type {Target} from './Target.js';
+import type {ConsoleMessage} from '../common/ConsoleMessage.js';
+import type {HTTPRequest} from './HTTPRequest.js';
+import type {HTTPResponse} from './HTTPResponse.js';
 
 /**
  * @public
@@ -65,6 +69,30 @@ export interface BrowserContextEvents extends Record<EventType, unknown> {
   [BrowserContextEvent.TargetChanged]: Target;
   [BrowserContextEvent.TargetCreated]: Target;
   [BrowserContextEvent.TargetDestroyed]: Target;
+  /**
+   * Emitted when a console message is logged.
+   */
+  [PageEvent.Console]: ConsoleMessage;
+  /**
+   * Emitted when a page issues a request.
+   */
+  [PageEvent.Request]: HTTPRequest;
+  /**
+   * Emitted when a response is received.
+   */
+  [PageEvent.Response]: HTTPResponse;
+  /**
+   * Emitted when a request fails.
+   */
+  [PageEvent.RequestFailed]: HTTPRequest;
+  /**
+   * Emitted when a request finishes.
+   */
+  [PageEvent.RequestFinished]: HTTPRequest;
+  /**
+   * Emitted when a request is served from cache.
+   */
+  [PageEvent.RequestServedFromCache]: HTTPRequest;
 }
 
 /**

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -826,6 +826,69 @@ export abstract class Page extends EventEmitter<PageEvents> {
   }
 
   /**
+   * @internal
+   */
+  override emit<Key extends keyof PageEvents>(
+    type: Key,
+    event: PageEvents[Key],
+  ): boolean {
+    const emitted = super.emit(type, event);
+    if (
+      type === PageEvent.Console ||
+      type === PageEvent.Request ||
+      type === PageEvent.Response ||
+      type === PageEvent.RequestFailed ||
+      type === PageEvent.RequestFinished ||
+      type === PageEvent.RequestServedFromCache
+    ) {
+      try {
+        const browser = this.browser();
+        if (browser) {
+          if (browser._isBuffering) {
+            browser._deferEvent(this.browserContext(), type as any, event);
+            browser._deferEvent(browser, type as any, event);
+          } else {
+            this.browserContext().emit(type as any, event);
+            browser.emit(type as any, event);
+          }
+        }
+      } catch {
+        // Safe check during early construction
+      }
+    }
+    return emitted;
+  }
+
+  /**
+   * @internal
+   */
+  override listenerCount(type: keyof PageEvents): number {
+    let count = super.listenerCount(type);
+    if (
+      type === PageEvent.Console ||
+      type === PageEvent.Request ||
+      type === PageEvent.Response ||
+      type === PageEvent.RequestFailed ||
+      type === PageEvent.RequestFinished ||
+      type === PageEvent.RequestServedFromCache
+    ) {
+      try {
+        const browser = this.browser();
+        if (browser) {
+          count += this.browserContext().listenerCount(type as any);
+          count += browser.listenerCount(type as any);
+          if (browser._isBuffering) {
+            count += 1;
+          }
+        }
+      } catch {
+        // Safe check during early construction
+      }
+    }
+    return count;
+  }
+
+  /**
    * `true` if the service worker are being bypassed, `false` otherwise.
    */
   abstract isServiceWorkerBypassed(): boolean;

--- a/packages/puppeteer-core/src/bidi/Browser.ts
+++ b/packages/puppeteer-core/src/bidi/Browser.ts
@@ -142,7 +142,11 @@ export class BidiBrowser extends Browser {
     );
 
     const browser = new BidiBrowser(session.browser, opts, opts.logger);
+    browser._startBuffering();
     browser.#initialize();
+    setTimeout(() => {
+      browser._stopBufferingAndReplay();
+    }, 0);
     return browser;
   }
 

--- a/packages/puppeteer-core/src/cdp/Browser.ts
+++ b/packages/puppeteer-core/src/cdp/Browser.ts
@@ -35,7 +35,7 @@ import {CDPSessionEvent} from '../api/CDPSession.js';
 import type {Extension} from '../api/Extension.js';
 import type {Page} from '../api/Page.js';
 import type {Target} from '../api/Target.js';
-import type {Logger} from '../common/Debug.js';
+import {DEBUG_PREFIXES, type Logger} from '../common/Debug.js';
 import type {DownloadBehavior} from '../common/DownloadBehavior.js';
 import {EventEmitter} from '../common/EventEmitter.js';
 import type {Viewport} from '../common/Viewport.js';
@@ -204,6 +204,7 @@ export class CdpBrowser extends BrowserBase {
   };
 
   async _attach(downloadBehavior: DownloadBehavior | undefined): Promise<void> {
+    this._startBuffering();
     const connectionEmitter = this.#subscriptions.use(
       new EventEmitter(this.#connection),
     );
@@ -231,6 +232,9 @@ export class CdpBrowser extends BrowserBase {
       this.#onTargetDiscovered,
     );
     await this.#targetManager.initialize();
+    setTimeout(() => {
+      this._stopBufferingAndReplay();
+    }, 0);
   }
 
   _detach(): void {
@@ -378,6 +382,15 @@ export class CdpBrowser extends BrowserBase {
     ) {
       this.emit(BrowserEvent.TargetCreated, target);
       target.browserContext().emit(BrowserContextEvent.TargetCreated, target);
+      if (
+        target.type() === 'page' ||
+        target.type() === 'background_page' ||
+        target.type() === 'webview'
+      ) {
+        void target.page().catch(err => {
+          this.logger?.(DEBUG_PREFIXES.error)?.(err);
+        });
+      }
     }
   };
 

--- a/test/src/connect.test.ts
+++ b/test/src/connect.test.ts
@@ -67,4 +67,76 @@ describe('Puppeteer.connect', function () {
       'Failed to fetch browser webSocket URL from',
     );
   });
+
+  it('should emit and buffer console and network events on Browser and BrowserContext', async () => {
+    const {close, puppeteer, browser: originalBrowser} = await launch({});
+    try {
+      const browserWSEndpoint = originalBrowser.wsEndpoint();
+      const page = await originalBrowser.newPage();
+
+      // Trigger a console message and request BEFORE connecting remoteBrowser
+      await page.evaluate(() => {
+        console.log('early-hello');
+      });
+
+      // Connect remote browser
+      const browserEvents: any[] = [];
+      const contextEvents: any[] = [];
+
+      const remoteBrowser = await puppeteer.connect({
+        browserWSEndpoint,
+        protocol: originalBrowser.protocol,
+      });
+
+      remoteBrowser.on('console', msg => {
+        browserEvents.push({type: 'console', text: msg.text()});
+      });
+      remoteBrowser.on('request', req => {
+        browserEvents.push({type: 'request', url: req.url()});
+      });
+
+      const defaultContext = remoteBrowser.defaultBrowserContext();
+      defaultContext.on('console', msg => {
+        contextEvents.push({type: 'console', text: msg.text()});
+      });
+      defaultContext.on('request', req => {
+        contextEvents.push({type: 'request', url: req.url()});
+      });
+
+      // Wait a macroTask for replay to fire
+      await new Promise(resolve => {
+        setTimeout(resolve, 50);
+      });
+
+      // Now verify that the buffered console message was replayed and received
+      const earlyConsoleBrowser = browserEvents.find(e => {
+        return e.type === 'console' && e.text === 'early-hello';
+      });
+      const earlyConsoleContext = contextEvents.find(e => {
+        return e.type === 'console' && e.text === 'early-hello';
+      });
+      expect(earlyConsoleBrowser).toBeDefined();
+      expect(earlyConsoleContext).toBeDefined();
+
+      // Also trigger a live console message and request
+      const page2 = await remoteBrowser.newPage();
+      const liveEventPromise = Promise.all([
+        new Promise<void>(resolve => {
+          remoteBrowser.on('console', msg => {
+            if (msg.text() === 'live-hello') {
+              resolve();
+            }
+          });
+        }),
+        page2.evaluate(() => {
+          console.log('live-hello');
+        }),
+      ]);
+      await liveEventPromise;
+
+      await remoteBrowser.disconnect();
+    } finally {
+      await close();
+    }
+  });
 });


### PR DESCRIPTION
Emits console and network events at Browser/BrowserContext level and buffers/replays them during puppeteer.connect. Fixes https://github.com/puppeteer/puppeteer/issues/15270