### PR TITLE
test: cover Browser.connected state after disconnect

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1029,7 +1029,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
     "expectations": ["FAIL", "PASS"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "Firefox WebDriver BiDi does not yet provide a stable remote connection lifecycle for this test."
   },
   {
     "testIdPattern": "[browser.test] Browser specs Browser.connected should set the browser connected state",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -1025,6 +1025,20 @@
     "comment": "CDP-specific"
   },
   {
+    "testIdPattern": "[browser.test] Browser specs Browser.connected should set the browser connected state",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox", "webDriverBiDi"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[browser.test] Browser specs Browser.connected should set the browser connected state",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome", "pipe"],
+    "expectations": ["SKIP"],
+    "comment": "We can't connect to a browser started with pipe:true"
+  },
+  {
     "testIdPattern": "[browser.test] Browser specs Browser.process should not return child_process for remote browser",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],

--- a/test/src/browser.test.ts
+++ b/test/src/browser.test.ts
@@ -93,6 +93,23 @@ describe('Browser specs', function () {
     });
   });
 
+  describe('Browser.connected', () => {
+    it('should set the browser connected state', async () => {
+      const {browser, puppeteer} = await getTestState({
+        skipContextCreation: true,
+      });
+
+      const browserWSEndpoint = browser.wsEndpoint();
+      using newBrowser = await puppeteer.connect({
+        browserWSEndpoint,
+        protocol: browser.protocol,
+      });
+      expect(newBrowser.connected).toBe(true);
+      await newBrowser.disconnect();
+      expect(newBrowser.connected).toBe(false);
+    });
+  });
+
   describe('Browser.screens', function () {
     it('should return default screen info', async () => {
       const {browser, isHeadless} = await getTestState();


### PR DESCRIPTION
## Summary

Add regression coverage for the Browser.connected lifecycle after the isConnected API removal.

## Validation

- npm run build:tools
- targeted Browser.connected Chrome, Firefox, and pipe suites
- npm run lint:expectations
- Prettier and git diff --check