### PR TITLE
fix: set frame content without document.write

### DIFF
--- a/packages/puppeteer-core/src/cdp/Frame.ts
+++ b/packages/puppeteer-core/src/cdp/Frame.ts
@@ -295,8 +295,9 @@ export class CdpFrame extends Frame {
       timeout = this._frameManager.timeoutSettings.navigationTimeout(),
     } = options;
 
-    // We rely upon the fact that document.open() will reset frame lifecycle with "init"
-    // lifecycle event. @see https://crrev.com/608658
+    // We rely upon the fact that the document is reopened, which resets the
+    // frame lifecycle with an "init" lifecycle event.
+    // @see https://crrev.com/608658
     await this.setFrameContent(html);
 
     const watcher = new LifecycleWatcher(
@@ -313,6 +314,19 @@ export class CdpFrame extends Frame {
     if (error) {
       throw error;
     }
+  }
+
+  /**
+   * @internal
+   */
+  override async setFrameContent(content: string): Promise<void> {
+    // Writing the content from the page would go through document.write, which
+    // makes Chrome treat parser-blocking cross-site scripts in it as an
+    // intervention candidate and may block them outright.
+    await this.#client.send('Page.setDocumentContent', {
+      frameId: this._id,
+      html: content,
+    });
   }
 
   override url(): string {

--- a/test/src/page.test.ts
+++ b/test/src/page.test.ts
@@ -1566,6 +1566,33 @@ describe('Page', function () {
       const result = await page.content();
       expect(result).toBe(`${comment}${expectedOutput}`);
     });
+    it('should not run a cross-origin script through document.write', async () => {
+      const {page, server} = await getTestState();
+
+      await page.goto(server.EMPTY_PAGE);
+      const warnings: string[] = [];
+      page.on('console', message => {
+        if (message.type() === 'warn') {
+          warnings.push(message.text());
+        }
+      });
+
+      await page.setContent(
+        html`<script src="${server.CROSS_PROCESS_PREFIX + '/injectedfile.js'}"></script>`,
+        {waitUntil: 'load'},
+      );
+
+      expect(
+        await page.evaluate(() => {
+          return (globalThis as any).__injected;
+        }),
+      ).toBe(42);
+      expect(
+        warnings.filter(warning => {
+          return warning.includes('document.write');
+        }),
+      ).toHaveLength(0);
+    });
   });
 
   describe('Page.setBypassCSP', function () {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix.

**Did you add tests for your changes?**

Yes — one new test under `Page.setContent`.

**If relevant, did you update the documentation?**

Not relevant; no public API change.

**Summary**

Fixes #12476.

`setContent()` rebuilds the document from inside the page:

```js
document.open();
document.write(html);
document.close();
```

so from Chrome's point of view every parser-blocking cross-site `<script src>` in that HTML was injected by `document.write`. That trips the document.write intervention:

```
A parser-blocking, cross site (i.e. different eTLD+1) script,
http://127.0.0.1:52453/injectedfile.js, is invoked via document.write.
The network request for this script MAY be blocked by the browser in this or a
future page load due to poor network connectivity.
```

It is not only noise in the console — on a connection Chrome rates as slow the request is blocked, so the script silently never runs.

CDP has `Page.setDocumentContent`, which reopens the document from the browser side. Nothing calls `document.write` from script anymore, so the intervention no longer applies, and the document is still reopened — the `init` lifecycle event that `setContent` relies on for `LifecycleWatcher` is unchanged, which is why the existing waitUntil/timeout tests still pass untouched.

**Does this PR introduce a breaking change?**

No.

**Other information**

The new test reuses the test server's two origins (`localhost` for the page, `127.0.0.1` for the script), so it needs no network access. On `main` it fails with two of the warnings above; with this change it passes and the script still executes.

Scope: this overrides `setFrameContent` on the CDP frame only. The WebDriver BiDi path keeps the shared `document.write` implementation, since BiDi has no equivalent command. The intervention warning is also not surfaced to `page.on('console')` over BiDi today, so the new test passes there rather than failing — happy to mark it CDP-only in `TestExpectations.json` if you'd prefer that to be explicit.

`npm run test:chrome:headless`: 1321 passing, 4 unexpected — `emulateTimezone` (my machine's locale) and three `proxy.test` cases, all four of which fail the same way on `main` without this change.

#15286 proposed the same `Page.setDocumentContent` approach and was closed by its author over the CLA. I wrote this independently and added the test and the lifecycle reasoning; glad to step aside if they come back to it.

I used Claude Code while working on this; I reviewed the change and verified it locally.
