### PR TITLE
chore: make lint:expectations work on Windows

### DIFF
--- a/tools/sort-test-expectations.mjs
+++ b/tools/sort-test-expectations.mjs
@@ -7,6 +7,7 @@
 // TODO: this could be an eslint rule probably.
 import fs from 'node:fs';
 import path from 'node:path';
+import {pathToFileURL} from 'node:url';
 
 import prettier from 'prettier';
 
@@ -28,7 +29,7 @@ function testIdMatchesExpectationPattern(title, pattern) {
 }
 
 const prettierConfig = await import(
-  path.join(import.meta.dirname, '..', 'prettier.config.js')
+  pathToFileURL(path.join(import.meta.dirname, '..', 'prettier.config.js')).href
 );
 
 function getSpecificity(item) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix for cross-platform repository tooling.

**Did you add tests for your changes?**

No new tests. Verified `npm run lint:expectations` and `npm run lint` on Windows.

**If relevant, did you update the documentation?**

Not applicable.

**Summary**

`sort-test-expectations.mjs` passed a Windows filesystem path directly to dynamic `import()`, causing Node.js to interpret the drive letter as a URL scheme and throw `ERR_UNSUPPORTED_ESM_URL_SCHEME`.

Convert the path to a file URL with `pathToFileURL()` before importing the Prettier configuration.

**Does this PR introduce a breaking change?**

No.