### PR TITLE
test: adding resize test after fullscreen window

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -781,6 +781,13 @@
     "comment": "Not supported by WebDriver BiDi"
   },
   {
+    "testIdPattern": "[page.test] Page Page.resize should resize the browser window to fit page content when fullscreen",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["webDriverBiDi"],
+    "expectations": ["FAIL"],
+    "comment": "Not supported by WebDriver BiDi"
+  },
+  {
     "testIdPattern": "[page.test] Page Page.setBypassCSP *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox", "webDriverBiDi"],
@@ -2014,6 +2021,13 @@
     "parameters": ["cdp", "chrome", "chrome-headless-shell"],
     "expectations": ["SKIP"],
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+  },
+  {
+    "testIdPattern": "[page.test] Page Page.resize should resize the browser window to fit page content when fullscreen",
+    "platforms": ["darwin"],
+    "parameters": ["cdp", "chrome", "headless"],
+    "expectations": ["FAIL", "PASS"],
+    "comment": "After chrome 152 this test is broken. a bug to headless chrome was open here: b/549573183"
   },
   {
     "testIdPattern": "[requestinterception.test] request interception Page.setRequestInterception should be abortable",

--- a/test/src/page.test.ts
+++ b/test/src/page.test.ts
@@ -2599,8 +2599,12 @@ describe('Page', function () {
   });
 
   describe('Page.resize', function () {
+    const state = setupSeparateTestBrowserHooks({
+      args: ['--screen-info={3840x2160}'],
+    });
+
     it('should resize the browser window to fit page content', async () => {
-      const {context} = await getTestState();
+      const {context} = state;
 
       const page = await context.newPage();
 
@@ -2620,6 +2624,42 @@ describe('Page', function () {
       const innerSize = await page.evaluate(() => {
         return {width: window.innerWidth, height: window.innerHeight};
       });
+      expect(innerSize.width).toBe(contentWidth);
+      expect(innerSize.height).toBe(contentHeight);
+    });
+
+    it('should resize the browser window to fit page content when fullscreen', async () => {
+      const {browser, context} = state;
+
+      const page = await context.newPage();
+      // Default view port restricts window to 800x600, so remove it.
+      await page.setViewport(null);
+      const windowId = await page.windowId();
+      await browser.setWindowBounds(windowId, {windowState: 'fullscreen'});
+
+      const windowState = await browser.getWindowBounds(windowId);
+      assert.strictEqual(windowState.windowState, 'fullscreen');
+
+      await browser.setWindowBounds(windowId, {windowState: 'normal'});
+      await browser.setWindowBounds(windowId, {windowState: 'normal'});
+
+      const contentWidth = 500;
+      const contentHeight = 400;
+      const resized = page.evaluate(() => {
+        return new Promise(resolve => {
+          window.onresize = resolve;
+        });
+      });
+      await page.resize({contentWidth, contentHeight});
+      await resized;
+
+      const innerSize = await page.evaluate(() => {
+        return {
+          width: window.innerWidth,
+          height: window.innerHeight,
+        };
+      });
+
       expect(innerSize.width).toBe(contentWidth);
       expect(innerSize.height).toBe(contentHeight);
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds a test
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
**If relevant, did you update the documentation?**
Not relevant
**Summary**
After the update to chrome 152 the resize doesn't behave correctly on mac when exiting the fullscreen window when the dimension of the headless windows allow 4K. This adds a test to track this failing behaviour.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
