### PR TITLE
feat(webmcp): support canceling tool execution

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1529,6 +1529,13 @@ Options for [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
 </td></tr>
 <tr><td>
 
+<span id="webmcptoolexecuteoptions">[WebMCPToolExecuteOptions](./puppeteer.webmcptoolexecuteoptions.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 <span id="webmcptoolsaddedevent">[WebMCPToolsAddedEvent](./puppeteer.webmcptoolsaddedevent.md)</span>
 
 </td><td>

--- a/docs/api/puppeteer.webmcptool.execute.md
+++ b/docs/api/puppeteer.webmcptool.execute.md
@@ -10,7 +10,10 @@ Executes tool with input parameters, matching tool's `inputSchema`.
 
 ```typescript
 class WebMCPTool {
-  execute(input?: object): Promise<WebMCPToolCallResult>;
+  execute(
+    input?: object,
+    options?: WebMCPToolExecuteOptions,
+  ): Promise<WebMCPToolCallResult>;
 }
 ```
 
@@ -36,6 +39,19 @@ input
 </td><td>
 
 object
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[WebMCPToolExecuteOptions](./puppeteer.webmcptoolexecuteoptions.md)
 
 </td><td>
 

--- a/docs/api/puppeteer.webmcptool.md
+++ b/docs/api/puppeteer.webmcptool.md
@@ -171,7 +171,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-<span id="execute">[execute(input)](./puppeteer.webmcptool.execute.md)</span>
+<span id="execute">[execute(input, options)](./puppeteer.webmcptool.execute.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.webmcptoolexecuteoptions.md
+++ b/docs/api/puppeteer.webmcptoolexecuteoptions.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: WebMCPToolExecuteOptions
+---
+
+# WebMCPToolExecuteOptions interface
+
+### Signature
+
+```typescript
+export interface WebMCPToolExecuteOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="signal">signal</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+AbortSignal
+
+</td><td>
+
+A signal object that allows you to cancel the tool execution.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/guides/webmcp.md
+++ b/docs/guides/webmcp.md
@@ -76,6 +76,28 @@ if (tool) {
 }
 ```
 
+### Canceling tool execution
+
+You can cancel an in-progress tool execution by passing an `AbortSignal`:
+
+```ts
+const controller = new AbortController();
+
+// Cancel execution after 2 seconds
+setTimeout(() => {
+  controller.abort();
+}, 2000);
+
+const result = await tool.execute(
+  {query: 'large data processing'},
+  {signal: controller.signal},
+);
+
+if (result.status === 'Canceled') {
+  console.log('Tool execution was canceled.');
+}
+```
+
 ## Handling tool invocations
 
 You can observe when a tool is invoked by the page or the browser and when it responds.
@@ -91,6 +113,8 @@ page.webmcp.on('toolresponded', response => {
   );
   if (response.status === 'Completed') {
     console.log('Output:', response.output);
+  } else if (response.status === 'Canceled') {
+    console.log('Invocation was canceled');
   } else {
     console.log('Error:', response.errorText);
   }

--- a/packages/puppeteer-core/src/cdp/WebMCP.ts
+++ b/packages/puppeteer-core/src/cdp/WebMCP.ts
@@ -105,18 +105,40 @@ export class WebMCPTool extends EventEmitter<{
   /**
    * Executes tool with input parameters, matching tool's `inputSchema`.
    */
-  async execute(input: object = {}): Promise<WebMCPToolCallResult> {
+  async execute(
+    input: object = {},
+    options: WebMCPToolExecuteOptions = {},
+  ): Promise<WebMCPToolCallResult> {
     const {invocationId} = await this.#webmcp.invokeTool(this, input);
     return await new Promise<WebMCPToolCallResult>(resolve => {
+      const onAbort = () => {
+        void this.#webmcp.cancelInvocation(invocationId);
+      };
       const handler = (event: WebMCPToolCallResult) => {
         if (event.id === invocationId) {
+          options.signal?.removeEventListener('abort', onAbort);
           this.#webmcp.off('toolresponded', handler);
           resolve(event);
         }
       };
       this.#webmcp.on('toolresponded', handler);
+      if (options.signal?.aborted) {
+        onAbort();
+      } else {
+        options.signal?.addEventListener('abort', onAbort, {once: true});
+      }
     });
   }
+}
+
+/**
+ * @public
+ */
+export interface WebMCPToolExecuteOptions {
+  /**
+   * A signal object that allows you to cancel the tool execution.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -364,6 +386,19 @@ export class WebMCP extends EventEmitter<{
       toolName: tool.name,
       input,
     });
+  }
+
+  /**
+   * @internal
+   */
+  async cancelInvocation(invocationId: string): Promise<void> {
+    return await this.#client
+      .send('WebMCP.cancelInvocation', {
+        invocationId,
+      })
+      .catch(err => {
+        this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+      });
   }
 
   /**

--- a/test/src/cdp/webmcp.test.ts
+++ b/test/src/cdp/webmcp.test.ts
@@ -650,6 +650,122 @@ describe('Page.webmcp', function () {
     expect(response.exception).toBeUndefined();
   });
 
+  it('should cancel tool execution', async () => {
+    const {page, httpsServer} = state;
+    await page.goto(httpsServer.EMPTY_PAGE);
+
+    expect(page.webmcp).toBeDefined();
+
+    const toolAddedPromise = new Promise<any>(resolve => {
+      page.webmcp.on('toolsadded', resolve);
+    });
+
+    // Register an imperative WebMCP tool with a delayed response.
+    await page.evaluate(async () => {
+      await document.modelContext?.registerTool({
+        name: 'test-tool-1',
+        description: 'A test tool 1',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            text: {type: 'string', description: 'Some text'},
+          },
+          required: ['text'],
+        },
+        execute: () => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve('done');
+            }, 5000);
+          });
+        },
+      });
+    });
+
+    await toolAddedPromise;
+
+    const [tool] = page.webmcp.tools();
+
+    const toolCalled = new Promise<WebMCPToolCall>(resolve => {
+      page.webmcp.once('toolinvoked', resolve);
+    });
+
+    const controller = new AbortController();
+    const executePromise = tool!.execute(
+      {text: 'world'},
+      {signal: controller.signal},
+    );
+
+    const call = await toolCalled;
+    controller.abort();
+
+    const response = await executePromise;
+
+    expect(response.id).toBe(call.id);
+    expect(response.call).toBe(call);
+    expect(response.status).toBe('Canceled');
+    expect(response.output).toBeUndefined();
+    expect(response.errorText).toBe('');
+    expect(response.exception).toBeUndefined();
+  });
+
+  it('should cancel tool execution with already aborted signal', async () => {
+    const {page, httpsServer} = state;
+    await page.goto(httpsServer.EMPTY_PAGE);
+
+    expect(page.webmcp).toBeDefined();
+
+    const toolAddedPromise = new Promise<any>(resolve => {
+      page.webmcp.on('toolsadded', resolve);
+    });
+
+    // Register an imperative WebMCP tool with a delayed response.
+    await page.evaluate(async () => {
+      await document.modelContext?.registerTool({
+        name: 'test-tool-1',
+        description: 'A test tool 1',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            text: {type: 'string', description: 'Some text'},
+          },
+          required: ['text'],
+        },
+        execute: () => {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve('done');
+            }, 5000);
+          });
+        },
+      });
+    });
+
+    await toolAddedPromise;
+
+    const [tool] = page.webmcp.tools();
+
+    const toolCalled = new Promise<WebMCPToolCall>(resolve => {
+      page.webmcp.once('toolinvoked', resolve);
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+    const response = await tool!.execute(
+      {text: 'world'},
+      {signal: controller.signal},
+    );
+
+    const call = await toolCalled;
+
+    expect(response.id).toBe(call.id);
+    expect(response.call).toBe(call);
+    expect(response.status).toBe('Canceled');
+    expect(response.output).toBeUndefined();
+    expect(response.errorText).toBe('');
+    expect(response.exception).toBeUndefined();
+  });
+
   it('should emit issue event from WebMCP form missing tooldescription', async () => {
     const {page, httpsServer} = state;
     await page.goto(httpsServer.EMPTY_PAGE);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Support WebMCP canceling tool execution.

**Did you add tests for your changes?**

Added tests for cancellation during execution and with already aborted signals.

**If relevant, did you update the documentation?**

Updated docs/guides/webmcp.md with a "Canceling tool execution" section and example.
Generated API docs for WebMCPToolExecuteOptions and WebMCPTool.execute.

**Summary**

Adding cancellation support lets us cleanly abort long-running or obsolete WebMCP tool executions using standard AbortSignal, keeping operations responsive and preventing wasted resources.

**Does this PR introduce a breaking change?**

Nope.

**Other information**

FYI @OrKoN


