### PR TITLE
test(ng-schematics): use selected runner in smoke tests

### DIFF
--- a/packages/ng-schematics/src/builders/puppeteer/index.ts
+++ b/packages/ng-schematics/src/builders/puppeteer/index.ts
@@ -212,9 +212,19 @@ async function executeE2ETest(
 
     message('\n Running tests 🧪 ... \n', context);
     const testRunnerCommand = getCommandForRunner(options.testRunner);
-    await executeCommand(context, testRunnerCommand, {
+    const env: NodeJS.ProcessEnv = {
       baseUrl: result.baseUrl,
-    });
+    };
+    if (options.testRunner === TestRunner.Jest) {
+      // Jest requires VM modules to load Puppeteer's ESM-only package.
+      env['NODE_OPTIONS'] = [
+        process.env['NODE_OPTIONS'],
+        '--experimental-vm-modules',
+      ]
+        .filter(Boolean)
+        .join(' ');
+    }
+    await executeCommand(context, testRunnerCommand, env);
 
     message('\n 🚀 Test ran successfully! 🚀 ', context, 'success');
     return {success: true};

--- a/packages/ng-schematics/src/schematics/utils/packages.ts
+++ b/packages/ng-schematics/src/schematics/utils/packages.ts
@@ -109,7 +109,7 @@ export function getDependenciesFromOptions(
 
   switch (options.testRunner) {
     case TestRunner.Jasmine:
-      dependencies.push('jasmine');
+      dependencies.push('jasmine', '@types/jasmine');
       break;
     case TestRunner.Jest:
       dependencies.push('jest', '@types/jest');

--- a/packages/ng-schematics/test/src/ng-add.test.ts
+++ b/packages/ng-schematics/test/src/ng-add.test.ts
@@ -63,6 +63,7 @@ void describe('@puppeteer/ng-schematics: ng-add', () => {
 
       expect(tree.files).toContain('/e2e/jasmine.json');
       expect(devDependencies).toContain('jasmine');
+      expect(devDependencies).toContain('@types/jasmine');
       expect(options['testRunner']).toBe('jasmine');
     });
     void it('should create Jest files and update "package.json"', async () => {
@@ -171,6 +172,7 @@ void describe('@puppeteer/ng-schematics: ng-add', () => {
 
       expect(tree.files).toContain(getMultiApplicationFile('e2e/jasmine.json'));
       expect(devDependencies).toContain('jasmine');
+      expect(devDependencies).toContain('@types/jasmine');
       expect(options['testRunner']).toBe('jasmine');
     });
     void it('should create Jest files and update "package.json"', async () => {

--- a/packages/ng-schematics/tools/projects.mjs
+++ b/packages/ng-schematics/tools/projects.mjs
@@ -54,7 +54,10 @@ class AngularProject {
   type = '';
 
   constructor(runner, name) {
-    this.#runner = runner ?? 'node';
+    if (!runner) {
+      throw new Error('A test runner must be specified.');
+    }
+    this.#runner = runner;
     this.#name = name ?? randomUUID();
   }
 

--- a/packages/ng-schematics/tools/smoke.mjs
+++ b/packages/ng-schematics/tools/smoke.mjs
@@ -100,8 +100,8 @@ if (!args.runner) {
     );
   }
 } else {
-  const single = new AngularProjectSingle(args.testRunner, args.name);
-  const multi = new AngularProjectMulti(args.testRunner, args.name);
+  const single = new AngularProjectSingle(args.runner, args.name);
+  const multi = new AngularProjectMulti(args.runner, args.name);
 
   // Create Angular projects
   await Promise.all([single.create(), multi.create()]);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.

**Did you add tests for your changes?**

No.

**If relevant, did you update the documentation?**

Not applicable.

**Summary**

The smoke test passed `args.testRunner` instead of the selected `args.runner`, causing every matrix job to fall back to Node.js. This passes the selected runner to both project variants and rejects missing runners instead of silently falling back.
