### PR TITLE
ci: create full-ci workflow

### DIFF
--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -45,6 +45,7 @@ jobs:
             puppeteer:
               - '.nvmrc'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/full-ci.yml'
               - 'packages/browsers/src/install.ts'
               - 'packages/browsers/src/browser-data/firefox.ts'
               - 'packages/browsers/src/fileUtil.ts'
@@ -63,6 +64,7 @@ jobs:
             website:
               - '.nvmrc'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/full-ci.yml'
               - 'docs/**'
               - 'website/**'
               - 'README.md'
@@ -70,10 +72,12 @@ jobs:
             ng-schematics:
               - '.nvmrc'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/full-ci.yml'
               - 'packages/ng-schematics/**'
               - 'tsconfig.base.json'
             browsers:
               - '.nvmrc'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/full-ci.yml'
               - 'packages/browsers/**'
               - 'tsconfig.base.json'

--- a/.github/workflows/changed-packages.yml
+++ b/.github/workflows/changed-packages.yml
@@ -64,6 +64,7 @@ jobs:
             website:
               - '.nvmrc'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/docs.yml'
               - '.github/workflows/full-ci.yml'
               - 'docs/**'
               - 'website/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ permissions:
   contents: read
 
 on:
+  workflow_call:
   push:
     branches:
       - main
@@ -15,21 +16,17 @@ on:
       - opened
       - reopened
       - synchronize
-
-      # Used for `full-ci`
-      - labeled
     branches:
       - '**'
 
 concurrency:
-  group: ci-${{ github.head_ref || github.run_id }}-${{ github.event.action == 'labeled' && github.event.label.name != 'full-ci' && github.run_id || '' }}
+  group: ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   inspect-code:
     name: '[Required] Inspect code'
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'full-ci' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -73,7 +70,6 @@ jobs:
           rm $diff_file
 
   check-changes:
-    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'full-ci' }}
     uses: ./.github/workflows/changed-packages.yml
     with:
       check-mergeable-state: true
@@ -237,7 +233,7 @@ jobs:
     name: '[Required] Chrome tests'
     needs: [check-changes, chrome-tests]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.chrome-tests.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'puppeteer') }}
         run: 'exit 1'
@@ -316,7 +312,7 @@ jobs:
     name: '[Required] Firefox tests'
     needs: [check-changes, firefox-tests]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.firefox-tests.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'puppeteer') }}
         run: 'exit 1'
@@ -382,7 +378,7 @@ jobs:
     name: '[Required] Installation tests'
     needs: [check-changes, installation-test]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.installation-test.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'puppeteer') }}
         run: 'exit 1'
@@ -424,7 +420,7 @@ jobs:
     name: '[Required] Docker image test'
     needs: [check-changes, docker-tests]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.docker-tests.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'puppeteer') }}
         run: 'exit 1'
@@ -455,7 +451,7 @@ jobs:
     name: '[Required] Puppeteer Unit tests'
     needs: [check-changes, unit-tests]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.unit-tests.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'puppeteer') }}
         run: 'exit 1'
@@ -485,7 +481,7 @@ jobs:
     name: '[Required] Angular Schematics tests'
     needs: [check-changes, ng-schematics-unit]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.ng-schematics-unit.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'ng-schematics') }}
         run: 'exit 1'
@@ -542,7 +538,7 @@ jobs:
     name: '[Required] Angular Schematics smoke tests'
     needs: [check-changes, ng-schematics-smoke-tests]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.ng-schematics-smoke-tests.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'ng-schematics') }}
         run: 'exit 1'
@@ -594,7 +590,7 @@ jobs:
     name: '[Required] Test the browsers packages'
     needs: [check-changes, browsers-tests]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.check-changes.result != 'skipped' }}
     steps:
       - if: ${{ needs.browsers-tests.result != 'success' && contains(fromJSON(needs.check-changes.outputs.changes), 'browsers') }}
         run: 'exit 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,60 +74,6 @@ jobs:
     with:
       check-mergeable-state: true
 
-  deploy-docs:
-    needs: check-changes
-    name: Deploy docs (if needed)
-    if: ${{ contains(fromJSON(needs.check-changes.outputs.changes), 'website') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          cache: npm
-          node-version-file: '.nvmrc'
-      - name: Install dependencies
-        working-directory: ./website
-        run: npm ci
-      - name: Build website
-        working-directory: ./website
-        env:
-          NODE_OPTIONS: --max-old-space-size=6144
-        run: npm run build
-      - name: Deploy to GitHub Pages
-        # Only change on push to main
-        if: ${{ github.event_name != 'pull_request'}}
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build
-          user_name: release-please[bot]
-          user_email: 55107282+release-please[bot]@users.noreply.github.com
-      - name: Test Algolia if Crawler is blocked
-        # Only change on push to main
-        if: ${{ github.event_name != 'pull_request'}}
-        env:
-          CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
-          CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
-          CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
-        run: |
-          RESPONSE=$(curl -H "Content-Type: application/json" -X GET --user "$CRAWLER_USER_ID:$CRAWLER_API_KEY" \
-            "https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID" | grep "\"blocked\":true" || true ); \
-          if [ ! -z "$RESPONSE" ]; then echo "Please go to https://crawler.algolia.com/" && exit 1; fi
-      - name: Trigger Algolia reindexing
-        # Only change on push to main
-        if: ${{ github.event_name != 'pull_request'}}
-        env:
-          CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
-          CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
-          CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
-        run: |
-          curl -H "Content-Type: application/json" -X POST --user "$CRAWLER_USER_ID:$CRAWLER_API_KEY" \
-            "https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID/reindex"
-
   doctest:
     name: Doctest
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,81 @@
+name: Docs
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - '**'
+
+concurrency:
+  group: docs-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  check-changes:
+    uses: ./.github/workflows/changed-packages.yml
+    with:
+      check-mergeable-state: true
+
+  deploy-docs:
+    needs: check-changes
+    name: Deploy docs (if needed)
+    if: ${{ contains(fromJSON(needs.check-changes.outputs.changes), 'website') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: npm
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        working-directory: ./website
+        run: npm ci
+      - name: Build website
+        working-directory: ./website
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: npm run build
+      - name: Deploy to GitHub Pages
+        # Only change on push to main
+        if: ${{ github.event_name != 'pull_request'}}
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build
+          user_name: release-please[bot]
+          user_email: 55107282+release-please[bot]@users.noreply.github.com
+      - name: Test Algolia if Crawler is blocked
+        # Only change on push to main
+        if: ${{ github.event_name != 'pull_request'}}
+        env:
+          CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
+          CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
+          CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
+        run: |
+          RESPONSE=$(curl -H "Content-Type: application/json" -X GET --user "$CRAWLER_USER_ID:$CRAWLER_API_KEY" \
+            "https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID" | grep "\"blocked\":true" || true ); \
+          if [ ! -z "$RESPONSE" ]; then echo "Please go to https://crawler.algolia.com/" && exit 1; fi
+      - name: Trigger Algolia reindexing
+        # Only change on push to main
+        if: ${{ github.event_name != 'pull_request'}}
+        env:
+          CRAWLER_USER_ID: ${{secrets.ALGOLIA_CRAWLER_USER_ID}}
+          CRAWLER_API_KEY: ${{secrets.ALGOLIA_CRAWLER_API_KEY}}
+          CRAWLER_ID: ${{secrets.ALGOLIA_CRAWLER_ID}}
+        run: |
+          curl -H "Content-Type: application/json" -X POST --user "$CRAWLER_USER_ID:$CRAWLER_API_KEY" \
+            "https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID/reindex"

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -1,0 +1,19 @@
+name: Full CI
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+concurrency:
+  group: full-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    if: ${{ github.event.label.name == 'full-ci' }}
+    uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
Dependabot creates multiple labels when creating a PR causing multiple CI runs to be created that would cause some of them to get skipped. This PR moves full-ci to a separate workflow so that the ci workflow is not triggered on labelled events.