### PR TITLE
test: explain the CDP-only mouse expectations

### DIFF
--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -611,14 +611,14 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp"],
     "expectations": ["FAIL"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "The test exercises the WebDriver BiDi behavior: BidiMouse keeps no button state and forwards a repeated down() to the browser, while CdpMouse deliberately throws on a duplicate down(). Kept for CDP compatibility, see https://github.com/puppeteer/puppeteer/issues/15379"
   },
   {
     "testIdPattern": "[mouse.test] Mouse should reset properly",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["cdp"],
     "expectations": ["SKIP"],
-    "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
+    "comment": "The test asserts the WebDriver BiDi release order: pressed buttons are released in the reverse order they were pressed, so the page sees the right button's mouseup and auxclick first, and the pointer is left where it is. CdpMouse releases in a fixed Left, Middle, Right, Forward, Back order and moves the pointer back to (0, 0) as documented for Mouse.reset(), see https://github.com/puppeteer/puppeteer/issues/15379"
   },
   {
     "testIdPattern": "[mouse.test] Mouse should select the text with mouse",

--- a/test/src/mouse.test.ts
+++ b/test/src/mouse.test.ts
@@ -284,6 +284,9 @@ describe('Mouse', function () {
 
     expect(await page.evaluate('result')).toEqual({x: 30, y: 40});
   });
+  // Exercises the WebDriver BiDi behavior: BidiMouse keeps no button state and
+  // forwards the repeated down() to the browser. CdpMouse deliberately throws
+  // instead, so this is expected to fail on CDP (see TestExpectations.json).
   it('should not throw if buttons are pressed twice', async () => {
     const {page, server} = await getTestState();
 
@@ -383,6 +386,10 @@ describe('Mouse', function () {
     });
   });
 
+  // Exercises the WebDriver BiDi release order: the pressed buttons are
+  // released in the reverse order they were pressed and the pointer stays where
+  // it is. CdpMouse releases in a fixed order and moves the pointer back to
+  // (0, 0), so this is skipped on CDP (see TestExpectations.json).
   it('should reset properly', async () => {
     const {page, server, isChrome} = await getTestState();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test/documentation change. This PR started as a change to `CdpMouse` (no throw on a duplicate
`down()`, release in reverse press order) and was rescoped after @OrKoN's feedback on #15379:
the CDP behaviour stays as is for compatibility, and instead the two CDP-only entries in
`test/TestExpectations.json` that still carried the placeholder
`"TODO: add a comment explaining why this expectation is required"` now explain what they pin:

- `[mouse.test] Mouse should not throw if buttons are pressed twice` (FAIL on CDP) —
  `BidiMouse` keeps no button state and forwards the repeated `down()`, `CdpMouse` throws on
  a duplicate `down()` by design.
- `[mouse.test] Mouse should reset properly` (SKIP on CDP) — the test asserts WebDriver's
  release order (reverse of the press order, pointer left in place), while `CdpMouse`
  releases in a fixed order and moves the pointer back to `(0, 0)` as `Mouse.reset()` documents.

Both tests also get a short comment saying they exercise the WebDriver BiDi behaviour.

**Did you add tests for your changes?**

No, only comments; no expectations change. `npm run lint` and prettier are clean.

I used Claude Code while working on this; I reviewed the change myself.

Issues: #15379
