### PR TITLE
ci: remove base and ref passing from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,9 +25,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/docs.yml
     with:
-      base: ${{ format('{0}^', github.sha) }}
       deploy: true
-      ref: ${{ github.sha }}
     secrets:
       ALGOLIA_CRAWLER_API_KEY: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
       ALGOLIA_CRAWLER_ID: ${{ secrets.ALGOLIA_CRAWLER_ID }}


### PR DESCRIPTION
It is no longer required since the job locates the latest release automatically.