### PR TITLE
feat: implement video-stream-based screen recording via page.record()

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -510,6 +510,17 @@ The constructor for this class is marked as internal. Third-party code should no
 </td></tr>
 <tr><td>
 
+<span id="screenrecording">[ScreenRecording](./puppeteer.screenrecording.md)</span>
+
+</td><td>
+
+**Remarks:**
+
+The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `ScreenRecording` class.
+
+</td></tr>
+<tr><td>
+
 <span id="securitydetails">[SecurityDetails](./puppeteer.securitydetails.md)</span>
 
 </td><td>
@@ -1363,6 +1374,15 @@ The OS-integration state of an installed web app, returned by [Browser.getPWASta
 </td></tr>
 <tr><td>
 
+<span id="recordoptions">[RecordOptions](./puppeteer.recordoptions.md)</span>
+
+</td><td>
+
+**_(Experimental)_**
+
+</td></tr>
+<tr><td>
+
 <span id="reloadoptions">[ReloadOptions](./puppeteer.reloadoptions.md)</span>
 
 </td><td>
@@ -1565,6 +1585,13 @@ Options for [Browser.uninstallPWA()](./puppeteer.browser.uninstallpwa.md).
 <tr><td>
 
 <span id="workareainsets">[WorkAreaInsets](./puppeteer.workareainsets.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="writabledestination">[WritableDestination](./puppeteer.writabledestination.md)</span>
 
 </td><td>
 

--- a/docs/api/puppeteer.page.md
+++ b/docs/api/puppeteer.page.md
@@ -1006,6 +1006,19 @@ This method iterates the JavaScript heap and finds all objects with the given pr
 </td></tr>
 <tr><td>
 
+<span id="record">[record(options)](./puppeteer.page.record.md)</span>
+
+</td><td>
+
+</td><td>
+
+**_(Experimental)_** Records this [page](./puppeteer.page.md) using the Chrome DevTools Protocol [Page.startScreenRecording](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreenRecording) API.
+
+Outputs mp4 video stream.
+
+</td></tr>
+<tr><td>
+
 <span id="reload">[reload(options)](./puppeteer.page.reload.md)</span>
 
 </td><td>
@@ -1054,9 +1067,15 @@ Removes script that injected into page by Page.evaluateOnNewDocument.
 
 </td><td>
 
+`deprecated`
+
 </td><td>
 
-**_(Experimental)_** Captures a screencast of this [page](./puppeteer.page.md).
+Captures a screencast of this [page](./puppeteer.page.md). Works in Chrome 153+.
+
+**Deprecated:**
+
+Use [Page.record()](./puppeteer.page.record.md) instead.
 
 **Remarks:**
 

--- a/docs/api/puppeteer.page.record.md
+++ b/docs/api/puppeteer.page.record.md
@@ -1,0 +1,78 @@
+---
+sidebar_label: Page.record
+---
+
+# Page.record() method
+
+Records this [page](./puppeteer.page.md) using the Chrome DevTools Protocol [Page.startScreenRecording](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreenRecording) API.
+
+Outputs mp4 video stream.
+
+### Signature
+
+```typescript
+class Page {
+  record(options?: Readonly<RecordOptions>): Promise<ScreenRecording>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+options
+
+</td><td>
+
+Readonly&lt;[RecordOptions](./puppeteer.recordoptions.md)&gt;
+
+</td><td>
+
+_(Optional)_ Configures recording behavior.
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;[ScreenRecording](./puppeteer.screenrecording.md)&gt;
+
+## Example
+
+Recording a [page](./puppeteer.page.md):
+
+```ts
+import puppeteer from 'puppeteer';
+
+// Launch a browser
+const browser = await puppeteer.launch();
+
+// Create a new page
+const page = await browser.newPage();
+
+// Go to your site.
+await page.goto('https://www.example.com');
+
+// Start recording.
+const recorder = await page.record({path: 'recording.mp4'});
+
+// Do something.
+
+// Stop recording.
+await recorder.stop();
+
+await browser.close();
+```

--- a/docs/api/puppeteer.page.screencast.md
+++ b/docs/api/puppeteer.page.screencast.md
@@ -4,7 +4,11 @@ sidebar_label: Page.screencast
 
 # Page.screencast() method
 
-Captures a screencast of this [page](./puppeteer.page.md).
+> Warning: This API is now obsolete.
+>
+> Use [Page.record()](./puppeteer.page.record.md) instead.
+
+Captures a screencast of this [page](./puppeteer.page.md). Works in Chrome 153+.
 
 ### Signature
 

--- a/docs/api/puppeteer.recordoptions.md
+++ b/docs/api/puppeteer.recordoptions.md
@@ -1,0 +1,173 @@
+---
+sidebar_label: RecordOptions
+---
+
+# RecordOptions interface
+
+### Signature
+
+```typescript
+export interface RecordOptions
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="audio">audio</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether to record audio.
+
+</td><td>
+
+`false`
+
+</td></tr>
+<tr><td>
+
+<span id="fps">fps</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Frame rate in frames per second (alias for frameRate).
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="framerate">frameRate</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Maximum frame rate in frames per second.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="maxheight">maxHeight</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Maximum frame height in pixels.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="maxwidth">maxWidth</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+number
+
+</td><td>
+
+Maximum frame width in pixels.
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="overwrite">overwrite</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Specifies whether to overwrite output file, or exit immediately if it already exists.
+
+</td><td>
+
+`true`
+
+</td></tr>
+<tr><td>
+
+<span id="path">path</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+string
+
+</td><td>
+
+File path to save the recording to.
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.screenrecording._asyncdisposesymbol_.md
+++ b/docs/api/puppeteer.screenrecording._asyncdisposesymbol_.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: ScreenRecording.[asyncDisposeSymbol]
+---
+
+# ScreenRecording.\[asyncDisposeSymbol\]() method
+
+### Signature
+
+```typescript
+class ScreenRecording {
+  [asyncDisposeSymbol](): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.screenrecording.md
+++ b/docs/api/puppeteer.screenrecording.md
@@ -1,0 +1,74 @@
+---
+sidebar_label: ScreenRecording
+---
+
+# ScreenRecording class
+
+### Signature
+
+```typescript
+export declare class ScreenRecording extends ReadableStream<Uint8Array>
+```
+
+**Extends:** ReadableStream&lt;Uint8Array&gt;
+
+## Remarks
+
+The constructor for this class is marked as internal. Third-party code should not call the constructor directly or create subclasses that extend the `ScreenRecording` class.
+
+## Methods
+
+<table><thead><tr><th>
+
+Method
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="_asyncdisposesymbol_">[\[asyncDisposeSymbol\]()](./puppeteer.screenrecording._asyncdisposesymbol_.md)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="pipe">[pipe(destination)](./puppeteer.screenrecording.pipe.md)</span>
+
+</td><td>
+
+</td><td>
+
+Pipes the recorded stream to a destination stream.
+
+</td></tr>
+<tr><td>
+
+<span id="pipe">[pipe(destination)](./puppeteer.screenrecording.pipe.md#overload-2)</span>
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="stop">[stop()](./puppeteer.screenrecording.stop.md)</span>
+
+</td><td>
+
+</td><td>
+
+Stops the screen recording.
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.screenrecording.md
+++ b/docs/api/puppeteer.screenrecording.md
@@ -7,7 +7,7 @@ sidebar_label: ScreenRecording
 ### Signature
 
 ```typescript
-export declare class ScreenRecording extends ReadableStream<Uint8Array>
+export declare abstract class ScreenRecording extends ReadableStream<Uint8Array>
 ```
 
 **Extends:** ReadableStream&lt;Uint8Array&gt;

--- a/docs/api/puppeteer.screenrecording.pipe.md
+++ b/docs/api/puppeteer.screenrecording.pipe.md
@@ -1,0 +1,91 @@
+---
+sidebar_label: ScreenRecording.pipe
+---
+
+# ScreenRecording.pipe() method
+
+<h2 id="overload-1">pipe(): Promise&lt;void&gt;</h2>
+
+Pipes the recorded stream to a destination stream.
+
+### Signature
+
+```typescript
+class ScreenRecording {
+  pipe<T extends WritableStream<Uint8Array>>(destination: T): Promise<void>;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+destination
+
+</td><td>
+
+T
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+Promise&lt;void&gt;
+
+<h2 id="overload-2">pipe(): T</h2>
+
+### Signature
+
+```typescript
+class ScreenRecording {
+  pipe<T extends WritableDestination>(destination: T): T;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+destination
+
+</td><td>
+
+T
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+T

--- a/docs/api/puppeteer.screenrecording.stop.md
+++ b/docs/api/puppeteer.screenrecording.stop.md
@@ -10,7 +10,7 @@ Stops the screen recording.
 
 ```typescript
 class ScreenRecording {
-  stop(): Promise<void>;
+  abstract stop(): Promise<void>;
 }
 ```
 

--- a/docs/api/puppeteer.screenrecording.stop.md
+++ b/docs/api/puppeteer.screenrecording.stop.md
@@ -1,0 +1,19 @@
+---
+sidebar_label: ScreenRecording.stop
+---
+
+# ScreenRecording.stop() method
+
+Stops the screen recording.
+
+### Signature
+
+```typescript
+class ScreenRecording {
+  stop(): Promise<void>;
+}
+```
+
+**Returns:**
+
+Promise&lt;void&gt;

--- a/docs/api/puppeteer.writabledestination.end.md
+++ b/docs/api/puppeteer.writabledestination.end.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: WritableDestination.end
+---
+
+# WritableDestination.end() method
+
+### Signature
+
+```typescript
+interface WritableDestination {
+  end(): unknown;
+}
+```
+
+**Returns:**
+
+unknown

--- a/docs/api/puppeteer.writabledestination.md
+++ b/docs/api/puppeteer.writabledestination.md
@@ -1,0 +1,121 @@
+---
+sidebar_label: WritableDestination
+---
+
+# WritableDestination interface
+
+### Signature
+
+```typescript
+export interface WritableDestination
+```
+
+## Properties
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th><th>
+
+Default
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="closed">closed</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="destroyed">destroyed</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="writablefinished">writableFinished</span>
+
+</td><td>
+
+`optional`
+
+</td><td>
+
+boolean
+
+</td><td>
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+## Methods
+
+<table><thead><tr><th>
+
+Method
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+<span id="end">[end()](./puppeteer.writabledestination.end.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="once">[once(event, cb)](./puppeteer.writabledestination.once.md)</span>
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+<span id="write">[write(chunk)](./puppeteer.writabledestination.write.md)</span>
+
+</td><td>
+
+</td></tr>
+</tbody></table>

--- a/docs/api/puppeteer.writabledestination.once.md
+++ b/docs/api/puppeteer.writabledestination.once.md
@@ -1,0 +1,56 @@
+---
+sidebar_label: WritableDestination.once
+---
+
+# WritableDestination.once() method
+
+### Signature
+
+```typescript
+interface WritableDestination {
+  once?(event: string, cb: (arg?: unknown) => void): unknown;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+event
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+cb
+
+</td><td>
+
+(arg?: unknown) =&gt; void
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+unknown

--- a/docs/api/puppeteer.writabledestination.write.md
+++ b/docs/api/puppeteer.writabledestination.write.md
@@ -1,0 +1,45 @@
+---
+sidebar_label: WritableDestination.write
+---
+
+# WritableDestination.write() method
+
+### Signature
+
+```typescript
+interface WritableDestination {
+  write(chunk: Uint8Array): boolean;
+}
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+chunk
+
+</td><td>
+
+Uint8Array
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+boolean

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -33,7 +33,6 @@ import type {HTTPResponse} from '../api/HTTPResponse.js';
 import type {Accessibility} from '../cdp/Accessibility.js';
 import type {Coverage} from '../cdp/Coverage.js';
 import type {NetworkConditions} from '../cdp/NetworkManager.js';
-import {ScreenRecording} from '../cdp/ScreenRecording.js';
 import type {Tracing} from '../cdp/Tracing.js';
 import type {WebMCP} from '../cdp/WebMCP.js';
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
@@ -120,6 +119,7 @@ import {
   type AwaitedLocator,
 } from './locators/locators.js';
 import type {Realm} from './Realm.js';
+import type {ScreenRecording} from './ScreenRecording.js';
 import type {Target} from './Target.js';
 import type {WebWorker} from './WebWorker.js';
 
@@ -2680,6 +2680,13 @@ export abstract class Page extends EventEmitter<PageEvents> {
   }
 
   /**
+   * @internal
+   */
+  protected abstract createScreenRecording(
+    options: Readonly<RecordOptions>,
+  ): ScreenRecording;
+
+  /**
    * Records this {@link Page | page} using the Chrome DevTools Protocol
    * {@link https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreenRecording | Page.startScreenRecording}
    * API.
@@ -2746,7 +2753,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
         })
       : undefined;
 
-    const recording = new ScreenRecording(this, options, this.logger);
+    const recording = this.createScreenRecording(options);
 
     try {
       await recording._start();

--- a/packages/puppeteer-core/src/api/Page.ts
+++ b/packages/puppeteer-core/src/api/Page.ts
@@ -33,6 +33,7 @@ import type {HTTPResponse} from '../api/HTTPResponse.js';
 import type {Accessibility} from '../cdp/Accessibility.js';
 import type {Coverage} from '../cdp/Coverage.js';
 import type {NetworkConditions} from '../cdp/NetworkManager.js';
+import {ScreenRecording} from '../cdp/ScreenRecording.js';
 import type {Tracing} from '../cdp/Tracing.js';
 import type {WebMCP} from '../cdp/WebMCP.js';
 import type {ConsoleMessage} from '../common/ConsoleMessage.js';
@@ -461,6 +462,46 @@ export interface ScreencastOptions {
    * @defaultValue `'ffmpeg'`
    */
   ffmpegPath?: string;
+}
+
+/**
+ * @public
+ * @experimental
+ */
+export interface RecordOptions {
+  /**
+   * File path to save the recording to.
+   */
+  path?: string;
+  /**
+   * Specifies whether to overwrite output file,
+   * or exit immediately if it already exists.
+   *
+   * @defaultValue `true`
+   */
+  overwrite?: boolean;
+  /**
+   * Whether to record audio.
+   *
+   * @defaultValue `false`
+   */
+  audio?: boolean;
+  /**
+   * Maximum frame width in pixels.
+   */
+  maxWidth?: number;
+  /**
+   * Maximum frame height in pixels.
+   */
+  maxHeight?: number;
+  /**
+   * Maximum frame rate in frames per second.
+   */
+  frameRate?: number;
+  /**
+   * Frame rate in frames per second (alias for frameRate).
+   */
+  fps?: number;
 }
 
 /**
@@ -2512,7 +2553,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
   }
 
   /**
-   * Captures a screencast of this {@link Page | page}.
+   * Captures a screencast of this {@link Page | page}. Works in Chrome 153+.
    *
    * @example
    * Recording a {@link Page | page}:
@@ -2542,7 +2583,7 @@ export abstract class Page extends EventEmitter<PageEvents> {
    *
    * @param options - Configures screencast behavior.
    *
-   * @experimental
+   * @deprecated Use {@link Page.record} instead.
    *
    * @remarks
    *
@@ -2636,6 +2677,89 @@ export abstract class Page extends EventEmitter<PageEvents> {
       recorder.pipe(stream);
     }
     return recorder;
+  }
+
+  /**
+   * Records this {@link Page | page} using the Chrome DevTools Protocol
+   * {@link https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreenRecording | Page.startScreenRecording}
+   * API.
+   *
+   * Outputs mp4 video stream.
+   *
+   * @example
+   * Recording a {@link Page | page}:
+   *
+   * ```ts
+   * import puppeteer from 'puppeteer';
+   *
+   * // Launch a browser
+   * const browser = await puppeteer.launch();
+   *
+   * // Create a new page
+   * const page = await browser.newPage();
+   *
+   * // Go to your site.
+   * await page.goto('https://www.example.com');
+   *
+   * // Start recording.
+   * const recorder = await page.record({path: 'recording.mp4'});
+   *
+   * // Do something.
+   *
+   * // Stop recording.
+   * await recorder.stop();
+   *
+   * await browser.close();
+   * ```
+   *
+   * @param options - Configures recording behavior.
+   *
+   * @experimental
+   */
+  async record(
+    options: Readonly<RecordOptions> = {},
+  ): Promise<ScreenRecording> {
+    if (options.maxWidth !== undefined && options.maxWidth <= 0) {
+      throw new Error('`maxWidth` must be greater than 0.');
+    }
+    if (options.maxHeight !== undefined && options.maxHeight <= 0) {
+      throw new Error('`maxHeight` must be greater than 0.');
+    }
+    if (options.frameRate !== undefined && options.frameRate <= 0) {
+      throw new Error('`frameRate` must be greater than 0.');
+    }
+    if (options.fps !== undefined && options.fps <= 0) {
+      throw new Error('`fps` must be greater than 0.');
+    }
+
+    if (options.path && environment.value.path) {
+      await environment.value.mkdir(
+        environment.value.path.dirname(options.path),
+        {recursive: options.overwrite ?? true},
+      );
+    }
+
+    const stream = options.path
+      ? environment.value.createWriteStream(options.path, {
+          encoding: 'binary',
+          overwrite: options.overwrite,
+        })
+      : undefined;
+
+    const recording = new ScreenRecording(this, options, this.logger);
+
+    try {
+      await recording._start();
+    } catch (error) {
+      void recording.stop();
+      throw error;
+    }
+
+    if (stream) {
+      recording.pipe(stream);
+    }
+
+    return recording;
   }
 
   #screencastSessionCount = 0;

--- a/packages/puppeteer-core/src/api/ScreenRecording.ts
+++ b/packages/puppeteer-core/src/api/ScreenRecording.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {Logger} from '../common/Debug.js';
+import {asyncDisposeSymbol} from '../util/disposable.js';
+
+import type {Page, RecordOptions} from './Page.js';
+
+/**
+ * @public
+ */
+export interface WritableDestination {
+  write(chunk: Uint8Array): boolean;
+  end(): unknown;
+  writableFinished?: boolean;
+  closed?: boolean;
+  destroyed?: boolean;
+  once?(event: string, cb: (arg?: unknown) => void): unknown;
+}
+
+/**
+ * @public
+ */
+export abstract class ScreenRecording extends ReadableStream<Uint8Array> {
+  /**
+   * @internal
+   */
+  protected page: Page;
+  /**
+   * @internal
+   */
+  protected options: RecordOptions;
+  /**
+   * @internal
+   */
+  protected logger: Logger;
+  /**
+   * @internal
+   */
+  protected controller!: ReadableStreamDefaultController<Uint8Array>;
+  /**
+   * @internal
+   */
+  protected destinations = new Set<WritableDestination>();
+  /**
+   * @internal
+   */
+  protected stopped = false;
+
+  /**
+   * @internal
+   */
+  constructor(page: Page, options: RecordOptions = {}, logger: Logger) {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    super({
+      start(c) {
+        controller = c;
+      },
+    });
+    this.controller = controller;
+
+    this.page = page;
+    this.options = options;
+    this.logger = logger;
+  }
+
+  /**
+   * @internal
+   */
+  abstract _start(): Promise<void>;
+
+  /**
+   * Pipes the recorded stream to a destination stream.
+   *
+   * @public
+   */
+  pipe<T extends WritableStream<Uint8Array>>(destination: T): Promise<void>;
+  pipe<T extends WritableDestination>(destination: T): T;
+  pipe(
+    destination: WritableStream<Uint8Array> | WritableDestination,
+  ): Promise<void> | WritableDestination {
+    if (
+      'getWriter' in destination &&
+      typeof destination.getWriter === 'function'
+    ) {
+      return this.pipeTo(destination as WritableStream<Uint8Array>);
+    }
+    const dest = destination as WritableDestination;
+    this.destinations.add(dest);
+    dest.once?.('unpipe', () => {
+      this.destinations.delete(dest);
+    });
+    dest.once?.('error', () => {
+      this.destinations.delete(dest);
+    });
+    dest.once?.('close', () => {
+      this.destinations.delete(dest);
+    });
+    dest.once?.('finish', () => {
+      this.destinations.delete(dest);
+    });
+    return dest;
+  }
+
+  /**
+   * Stops the screen recording.
+   *
+   * @public
+   */
+  abstract stop(): Promise<void>;
+
+  /**
+   * @internal
+   */
+  protected async closeDestinations(): Promise<void> {
+    try {
+      this.controller.close();
+    } catch {
+      // Controller might already be closed.
+    }
+    for (const dest of this.destinations) {
+      dest.end();
+    }
+    const destinationPromises = Array.from(this.destinations).map(dest => {
+      return new Promise(resolve => {
+        if (dest.writableFinished || dest.closed || dest.destroyed) {
+          resolve(undefined);
+        } else {
+          dest.once?.('finish', resolve);
+          dest.once?.('close', resolve);
+          dest.once?.('error', resolve);
+        }
+      });
+    });
+
+    await Promise.all(destinationPromises);
+  }
+
+  async [asyncDisposeSymbol](): Promise<void> {
+    await this.stop();
+  }
+}

--- a/packages/puppeteer-core/src/api/api.ts
+++ b/packages/puppeteer-core/src/api/api.ts
@@ -21,6 +21,7 @@ export type * from './Issue.js';
 export * from './JSHandle.js';
 export * from './Page.js';
 export * from './Realm.js';
+export * from './ScreenRecording.js';
 export * from './Target.js';
 export * from './WebWorker.js';
 export * from './locators/locators.js';

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -56,7 +56,6 @@ import type {PDFOptions} from '../common/PDFOptions.js';
 import type {Awaitable} from '../common/types.js';
 import {evaluationString, parsePDFOptions, timeout} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
-import {environment} from '../environment.js';
 import type {Realm} from '../puppeteer-core.js';
 import {assert} from '../util/assert.js';
 import {bubble} from '../util/decorators.js';
@@ -1037,50 +1036,13 @@ export class BidiPage extends Page {
     throw new UnsupportedOperation();
   }
 
-  override async record(
-    options: Readonly<RecordOptions> = {},
-  ): Promise<BidiScreenRecording> {
-    if (options.maxWidth !== undefined && options.maxWidth <= 0) {
-      throw new Error('`maxWidth` must be greater than 0.');
-    }
-    if (options.maxHeight !== undefined && options.maxHeight <= 0) {
-      throw new Error('`maxHeight` must be greater than 0.');
-    }
-    if (options.frameRate !== undefined && options.frameRate <= 0) {
-      throw new Error('`frameRate` must be greater than 0.');
-    }
-    if (options.fps !== undefined && options.fps <= 0) {
-      throw new Error('`fps` must be greater than 0.');
-    }
-
-    if (options.path && environment.value.path) {
-      await environment.value.mkdir(
-        environment.value.path.dirname(options.path),
-        {recursive: options.overwrite ?? true},
-      );
-    }
-
-    const stream = options.path
-      ? environment.value.createWriteStream(options.path, {
-          encoding: 'binary',
-          overwrite: options.overwrite,
-        })
-      : undefined;
-
-    const recording = new BidiScreenRecording(this, options, this.logger);
-
-    try {
-      await recording._start();
-    } catch (error) {
-      void recording.stop();
-      throw error;
-    }
-
-    if (stream) {
-      recording.pipe(stream);
-    }
-
-    return recording;
+  /**
+   * @internal
+   */
+  override createScreenRecording(
+    options: Readonly<RecordOptions>,
+  ): BidiScreenRecording {
+    return new BidiScreenRecording(this, options, this.logger);
   }
 }
 

--- a/packages/puppeteer-core/src/bidi/Page.ts
+++ b/packages/puppeteer-core/src/bidi/Page.ts
@@ -22,6 +22,7 @@ import type {
   HeapSnapshotOptions,
   MediaFeature,
   PageEvents,
+  RecordOptions,
   ReloadOptions,
   WaitTimeoutOptions,
 } from '../api/Page.js';
@@ -55,6 +56,7 @@ import type {PDFOptions} from '../common/PDFOptions.js';
 import type {Awaitable} from '../common/types.js';
 import {evaluationString, parsePDFOptions, timeout} from '../common/util.js';
 import type {Viewport} from '../common/Viewport.js';
+import {environment} from '../environment.js';
 import type {Realm} from '../puppeteer-core.js';
 import {assert} from '../util/assert.js';
 import {bubble} from '../util/decorators.js';
@@ -70,6 +72,7 @@ import {BidiFrame} from './Frame.js';
 import type {BidiHTTPResponse} from './HTTPResponse.js';
 import {BidiKeyboard, BidiMouse, BidiTouchscreen} from './Input.js';
 import type {BidiJSHandle} from './JSHandle.js';
+import {BidiScreenRecording} from './ScreenRecording.js';
 import {rewriteNavigationError} from './util.js';
 import type {BidiWebWorker} from './WebWorker.js';
 
@@ -1032,6 +1035,52 @@ export class BidiPage extends Page {
 
   override extensionRealms(): Realm[] {
     throw new UnsupportedOperation();
+  }
+
+  override async record(
+    options: Readonly<RecordOptions> = {},
+  ): Promise<BidiScreenRecording> {
+    if (options.maxWidth !== undefined && options.maxWidth <= 0) {
+      throw new Error('`maxWidth` must be greater than 0.');
+    }
+    if (options.maxHeight !== undefined && options.maxHeight <= 0) {
+      throw new Error('`maxHeight` must be greater than 0.');
+    }
+    if (options.frameRate !== undefined && options.frameRate <= 0) {
+      throw new Error('`frameRate` must be greater than 0.');
+    }
+    if (options.fps !== undefined && options.fps <= 0) {
+      throw new Error('`fps` must be greater than 0.');
+    }
+
+    if (options.path && environment.value.path) {
+      await environment.value.mkdir(
+        environment.value.path.dirname(options.path),
+        {recursive: options.overwrite ?? true},
+      );
+    }
+
+    const stream = options.path
+      ? environment.value.createWriteStream(options.path, {
+          encoding: 'binary',
+          overwrite: options.overwrite,
+        })
+      : undefined;
+
+    const recording = new BidiScreenRecording(this, options, this.logger);
+
+    try {
+      await recording._start();
+    } catch (error) {
+      void recording.stop();
+      throw error;
+    }
+
+    if (stream) {
+      recording.pipe(stream);
+    }
+
+    return recording;
   }
 }
 

--- a/packages/puppeteer-core/src/bidi/ScreenRecording.test.ts
+++ b/packages/puppeteer-core/src/bidi/ScreenRecording.test.ts
@@ -5,7 +5,7 @@
  */
 
 import {PassThrough, Writable} from 'node:stream';
-import {describe, it} from 'node:test';
+import {afterEach, beforeEach, describe, it} from 'node:test';
 
 import expect from 'expect';
 
@@ -14,6 +14,7 @@ import {environment} from '../environment.js';
 import {asyncDisposeSymbol} from '../util/disposable.js';
 
 import {BidiPage} from './Page.js';
+import {BidiScreenRecording} from './ScreenRecording.js';
 
 class MockBrowsingContext extends EventEmitter<any> {
   commands: Array<{method: string; params?: unknown}> = [];
@@ -59,7 +60,9 @@ class MockBidiPage extends BidiPage {
         children: [],
         on() {},
       } as any,
-      undefined as any,
+      (() => {
+        return undefined;
+      }) as any,
     );
     this.mockContext = context;
   }
@@ -72,89 +75,93 @@ class MockBidiPage extends BidiPage {
       },
     };
   }
+
+  override createScreenRecording(options: any): any {
+    return new BidiScreenRecording(this as any, options, this.logger);
+  }
 }
 
 describe('BidiScreenRecording', () => {
+  let originalReadFile: typeof environment.value.readFile;
+
+  beforeEach(() => {
+    originalReadFile = environment.value.readFile;
+  });
+
+  afterEach(() => {
+    environment.value.readFile = originalReadFile;
+  });
+
   it('should start screen recording and read file on stop', async () => {
     const context = new MockBrowsingContext();
     const page = new MockBidiPage(context);
 
-    const originalReadFile = environment.value.readFile;
     environment.value.readFile = (async () => {
       return Buffer.from('video-data');
     }) as any;
 
-    try {
-      const recording = await page.record({
+    const recording = await page.record({
+      audio: true,
+      maxWidth: 1920,
+      maxHeight: 1080,
+      frameRate: 60,
+    });
+
+    expect(context.commands[0]).toEqual({
+      method: 'browsingContext.startScreencast',
+      params: {
         audio: true,
-        maxWidth: 1920,
-        maxHeight: 1080,
-        frameRate: 60,
-      });
-
-      expect(context.commands[0]).toEqual({
-        method: 'browsingContext.startScreencast',
-        params: {
-          audio: true,
-          video: {
-            width: 1920,
-            height: 1080,
-            frameRate: 60,
-          },
+        video: {
+          width: 1920,
+          height: 1080,
+          frameRate: 60,
         },
-      });
+      },
+    });
 
-      const chunks: Buffer[] = [];
-      const dest = new Writable({
-        write(chunk, _encoding, callback) {
-          chunks.push(Buffer.from(chunk));
-          callback();
-        },
-      });
+    const chunks: Buffer[] = [];
+    const dest = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    });
 
-      recording.pipe(dest);
-      await recording.stop();
+    recording.pipe(dest);
+    await recording.stop();
 
-      expect(Buffer.concat(chunks).toString()).toBe('video-data');
-      expect(context.commands).toContainEqual({
-        method: 'browsingContext.stopScreencast',
-        params: {screencast: 'screencast-1'},
-      });
-    } finally {
-      environment.value.readFile = originalReadFile;
-    }
+    expect(Buffer.concat(chunks).toString()).toBe('video-data');
+    expect(context.commands).toContainEqual({
+      method: 'browsingContext.stopScreencast',
+      params: {screencast: 'screencast-1'},
+    });
   });
 
   it('should support fps as alias for frameRate', async () => {
     const context = new MockBrowsingContext();
     const page = new MockBidiPage(context);
 
-    const originalReadFile = environment.value.readFile;
     environment.value.readFile = (async () => {
       return Buffer.from('');
     }) as any;
 
-    try {
-      const recording = await page.record({
-        fps: 24,
-      });
+    const recording = await page.record({
+      fps: 24,
+    });
 
-      expect(context.commands[0]).toEqual({
-        method: 'browsingContext.startScreencast',
-        params: {
-          audio: undefined,
-          video: {
-            width: undefined,
-            height: undefined,
-            frameRate: 24,
-          },
+    expect(context.commands[0]).toEqual({
+      method: 'browsingContext.startScreencast',
+      params: {
+        audio: undefined,
+        video: {
+          width: undefined,
+          height: undefined,
+          frameRate: 24,
         },
-      });
+      },
+    });
 
-      await recording.stop();
-    } finally {
-      environment.value.readFile = originalReadFile;
-    }
+    await recording.stop();
   });
 
   it('should validate options', async () => {
@@ -192,139 +199,114 @@ describe('BidiScreenRecording', () => {
     context.startResponse = {screencast: 'screencast-start', path: ''};
     context.stopResponse = {path: '/tmp/from-stop.mp4'};
 
-    const originalReadFile = environment.value.readFile;
     let readPath = '';
     environment.value.readFile = (async (path: string) => {
       readPath = path;
       return Buffer.from('hello');
     }) as any;
 
-    try {
-      const page = new MockBidiPage(context);
-      const recording = await page.record();
+    const page = new MockBidiPage(context);
+    const recording = await page.record();
 
-      const chunks: Buffer[] = [];
-      const dest = new PassThrough();
-      dest.on('data', chunk => {
-        chunks.push(Buffer.from(chunk));
-      });
+    const chunks: Buffer[] = [];
+    const dest = new PassThrough();
+    dest.on('data', chunk => {
+      chunks.push(Buffer.from(chunk));
+    });
 
-      recording.pipe(dest);
-      await recording.stop();
+    recording.pipe(dest);
+    await recording.stop();
 
-      expect(readPath).toBe('/tmp/from-stop.mp4');
-      expect(Buffer.concat(chunks).toString()).toBe('hello');
-      expect(context.commands).toContainEqual({
-        method: 'browsingContext.stopScreencast',
-        params: {screencast: 'screencast-start'},
-      });
-    } finally {
-      environment.value.readFile = originalReadFile;
-    }
+    expect(readPath).toBe('/tmp/from-stop.mp4');
+    expect(Buffer.concat(chunks).toString()).toBe('hello');
+    expect(context.commands).toContainEqual({
+      method: 'browsingContext.stopScreencast',
+      params: {screencast: 'screencast-start'},
+    });
   });
 
   it('should support async iteration', async () => {
     const context = new MockBrowsingContext();
     const page = new MockBidiPage(context);
 
-    const originalReadFile = environment.value.readFile;
     environment.value.readFile = (async () => {
       return Buffer.from('chunkA');
     }) as any;
 
-    try {
-      const recording = await page.record();
+    const recording = await page.record();
 
-      const stopPromise = recording.stop();
+    const stopPromise = recording.stop();
 
-      const received: Uint8Array[] = [];
-      for await (const chunk of recording) {
-        received.push(chunk);
-      }
-      await stopPromise;
-
-      expect(Buffer.concat(received).toString()).toBe('chunkA');
-    } finally {
-      environment.value.readFile = originalReadFile;
+    const received: Uint8Array[] = [];
+    for await (const chunk of recording) {
+      received.push(chunk);
     }
+    await stopPromise;
+
+    expect(Buffer.concat(received).toString()).toBe('chunkA');
   });
 
   it('should support pipeTo with WritableStream', async () => {
     const context = new MockBrowsingContext();
     const page = new MockBidiPage(context);
 
-    const originalReadFile = environment.value.readFile;
     environment.value.readFile = (async () => {
       return Buffer.from('web-stream-data');
     }) as any;
 
-    try {
-      const recording = await page.record();
+    const recording = await page.record();
 
-      const chunks: Uint8Array[] = [];
-      const writableStream = new WritableStream<Uint8Array>({
-        write(chunk) {
-          chunks.push(chunk);
-        },
-      });
+    const chunks: Uint8Array[] = [];
+    const writableStream = new WritableStream<Uint8Array>({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    });
 
-      const pipePromise = recording.pipe(writableStream);
-      await recording.stop();
-      await pipePromise;
+    const pipePromise = recording.pipe(writableStream);
+    await recording.stop();
+    await pipePromise;
 
-      expect(Buffer.concat(chunks).toString()).toBe('web-stream-data');
-    } finally {
-      environment.value.readFile = originalReadFile;
-    }
+    expect(Buffer.concat(chunks).toString()).toBe('web-stream-data');
   });
 
   it('should stop on browsing context closed', async () => {
     const context = new MockBrowsingContext();
     const page = new MockBidiPage(context);
 
-    const originalReadFile = environment.value.readFile;
     environment.value.readFile = (async () => {
       return Buffer.from('');
     }) as any;
 
-    try {
-      const recording = await page.record();
+    const recording = await page.record();
 
-      context.emit('closed', undefined);
-      // Calling stop again should be a no-op
-      await recording.stop();
+    context.emit('closed', undefined);
+    // Calling stop again should be a no-op
+    await recording.stop();
 
-      expect(
-        context.commands.filter(c => {
-          return c.method === 'browsingContext.stopScreencast';
-        }).length,
-      ).toBe(1);
-    } finally {
-      environment.value.readFile = originalReadFile;
-    }
+    expect(
+      context.commands.filter(c => {
+        return c.method === 'browsingContext.stopScreencast';
+      }).length,
+    ).toBe(1);
   });
 
   it('should support asyncDisposeSymbol', async () => {
     const context = new MockBrowsingContext();
     const page = new MockBidiPage(context);
 
-    const originalReadFile = environment.value.readFile;
     environment.value.readFile = (async () => {
       return Buffer.from('');
     }) as any;
 
-    try {
-      const recording = await page.record();
+    const recording = await page.record();
 
-      await recording[asyncDisposeSymbol]();
+    await recording[asyncDisposeSymbol]();
 
-      expect(
-        context.commands.filter(c => {
-          return c.method === 'browsingContext.stopScreencast';
-        }).length,
-      ).toBe(1);
-    } finally {
-      environment.value.readFile = originalReadFile;
-    }
+    expect(
+      context.commands.filter(c => {
+        return c.method === 'browsingContext.stopScreencast';
+      }).length,
+    ).toBe(1);
   });
 });

--- a/packages/puppeteer-core/src/bidi/ScreenRecording.test.ts
+++ b/packages/puppeteer-core/src/bidi/ScreenRecording.test.ts
@@ -1,0 +1,330 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {PassThrough, Writable} from 'node:stream';
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {EventEmitter} from '../common/EventEmitter.js';
+import {environment} from '../environment.js';
+import {asyncDisposeSymbol} from '../util/disposable.js';
+
+import {BidiPage} from './Page.js';
+
+class MockBrowsingContext extends EventEmitter<any> {
+  commands: Array<{method: string; params?: unknown}> = [];
+  startResponse: {screencast: string; path: string} = {
+    screencast: 'screencast-1',
+    path: '/tmp/screencast.mp4',
+  };
+  stopResponse: {path: string; error?: string} = {
+    path: '/tmp/screencast.mp4',
+  };
+
+  async startScreencast(params: any): Promise<any> {
+    this.commands.push({method: 'browsingContext.startScreencast', params});
+    return this.startResponse;
+  }
+
+  async stopScreencast(screencast: string): Promise<any> {
+    this.commands.push({
+      method: 'browsingContext.stopScreencast',
+      params: {screencast},
+    });
+    return this.stopResponse;
+  }
+}
+
+// @ts-expect-error mock implementation
+class MockBidiPage extends BidiPage {
+  mockContext: MockBrowsingContext;
+
+  constructor(context: MockBrowsingContext) {
+    super(
+      {
+        browser: () => {
+          return {cdpSupported: false};
+        },
+      } as any,
+      {
+        id: 'mock-id',
+        defaultRealm: new EventEmitter(),
+        createWindowRealm: () => {
+          return new EventEmitter();
+        },
+        children: [],
+        on() {},
+      } as any,
+      undefined as any,
+    );
+    this.mockContext = context;
+  }
+
+  override mainFrame(): any {
+    return {
+      browsingContext: this.mockContext,
+      client: {
+        once() {},
+      },
+    };
+  }
+}
+
+describe('BidiScreenRecording', () => {
+  it('should start screen recording and read file on stop', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    const originalReadFile = environment.value.readFile;
+    environment.value.readFile = (async () => {
+      return Buffer.from('video-data');
+    }) as any;
+
+    try {
+      const recording = await page.record({
+        audio: true,
+        maxWidth: 1920,
+        maxHeight: 1080,
+        frameRate: 60,
+      });
+
+      expect(context.commands[0]).toEqual({
+        method: 'browsingContext.startScreencast',
+        params: {
+          audio: true,
+          video: {
+            width: 1920,
+            height: 1080,
+            frameRate: 60,
+          },
+        },
+      });
+
+      const chunks: Buffer[] = [];
+      const dest = new Writable({
+        write(chunk, _encoding, callback) {
+          chunks.push(Buffer.from(chunk));
+          callback();
+        },
+      });
+
+      recording.pipe(dest);
+      await recording.stop();
+
+      expect(Buffer.concat(chunks).toString()).toBe('video-data');
+      expect(context.commands).toContainEqual({
+        method: 'browsingContext.stopScreencast',
+        params: {screencast: 'screencast-1'},
+      });
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+
+  it('should support fps as alias for frameRate', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    const originalReadFile = environment.value.readFile;
+    environment.value.readFile = (async () => {
+      return Buffer.from('');
+    }) as any;
+
+    try {
+      const recording = await page.record({
+        fps: 24,
+      });
+
+      expect(context.commands[0]).toEqual({
+        method: 'browsingContext.startScreencast',
+        params: {
+          audio: undefined,
+          video: {
+            width: undefined,
+            height: undefined,
+            frameRate: 24,
+          },
+        },
+      });
+
+      await recording.stop();
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+
+  it('should validate options', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    await expect(page.record({maxWidth: 0})).rejects.toThrow(
+      '`maxWidth` must be greater than 0.',
+    );
+    await expect(page.record({maxWidth: -10})).rejects.toThrow(
+      '`maxWidth` must be greater than 0.',
+    );
+    await expect(page.record({maxHeight: 0})).rejects.toThrow(
+      '`maxHeight` must be greater than 0.',
+    );
+    await expect(page.record({maxHeight: -10})).rejects.toThrow(
+      '`maxHeight` must be greater than 0.',
+    );
+    await expect(page.record({frameRate: 0})).rejects.toThrow(
+      '`frameRate` must be greater than 0.',
+    );
+    await expect(page.record({frameRate: -5})).rejects.toThrow(
+      '`frameRate` must be greater than 0.',
+    );
+    await expect(page.record({fps: 0})).rejects.toThrow(
+      '`fps` must be greater than 0.',
+    );
+    await expect(page.record({fps: -5})).rejects.toThrow(
+      '`fps` must be greater than 0.',
+    );
+  });
+
+  it('should support path returned from stopScreencast', async () => {
+    const context = new MockBrowsingContext();
+    context.startResponse = {screencast: 'screencast-start', path: ''};
+    context.stopResponse = {path: '/tmp/from-stop.mp4'};
+
+    const originalReadFile = environment.value.readFile;
+    let readPath = '';
+    environment.value.readFile = (async (path: string) => {
+      readPath = path;
+      return Buffer.from('hello');
+    }) as any;
+
+    try {
+      const page = new MockBidiPage(context);
+      const recording = await page.record();
+
+      const chunks: Buffer[] = [];
+      const dest = new PassThrough();
+      dest.on('data', chunk => {
+        chunks.push(Buffer.from(chunk));
+      });
+
+      recording.pipe(dest);
+      await recording.stop();
+
+      expect(readPath).toBe('/tmp/from-stop.mp4');
+      expect(Buffer.concat(chunks).toString()).toBe('hello');
+      expect(context.commands).toContainEqual({
+        method: 'browsingContext.stopScreencast',
+        params: {screencast: 'screencast-start'},
+      });
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+
+  it('should support async iteration', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    const originalReadFile = environment.value.readFile;
+    environment.value.readFile = (async () => {
+      return Buffer.from('chunkA');
+    }) as any;
+
+    try {
+      const recording = await page.record();
+
+      const stopPromise = recording.stop();
+
+      const received: Uint8Array[] = [];
+      for await (const chunk of recording) {
+        received.push(chunk);
+      }
+      await stopPromise;
+
+      expect(Buffer.concat(received).toString()).toBe('chunkA');
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+
+  it('should support pipeTo with WritableStream', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    const originalReadFile = environment.value.readFile;
+    environment.value.readFile = (async () => {
+      return Buffer.from('web-stream-data');
+    }) as any;
+
+    try {
+      const recording = await page.record();
+
+      const chunks: Uint8Array[] = [];
+      const writableStream = new WritableStream<Uint8Array>({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+      });
+
+      const pipePromise = recording.pipe(writableStream);
+      await recording.stop();
+      await pipePromise;
+
+      expect(Buffer.concat(chunks).toString()).toBe('web-stream-data');
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+
+  it('should stop on browsing context closed', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    const originalReadFile = environment.value.readFile;
+    environment.value.readFile = (async () => {
+      return Buffer.from('');
+    }) as any;
+
+    try {
+      const recording = await page.record();
+
+      context.emit('closed', undefined);
+      // Calling stop again should be a no-op
+      await recording.stop();
+
+      expect(
+        context.commands.filter(c => {
+          return c.method === 'browsingContext.stopScreencast';
+        }).length,
+      ).toBe(1);
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+
+  it('should support asyncDisposeSymbol', async () => {
+    const context = new MockBrowsingContext();
+    const page = new MockBidiPage(context);
+
+    const originalReadFile = environment.value.readFile;
+    environment.value.readFile = (async () => {
+      return Buffer.from('');
+    }) as any;
+
+    try {
+      const recording = await page.record();
+
+      await recording[asyncDisposeSymbol]();
+
+      expect(
+        context.commands.filter(c => {
+          return c.method === 'browsingContext.stopScreencast';
+        }).length,
+      ).toBe(1);
+    } finally {
+      environment.value.readFile = originalReadFile;
+    }
+  });
+});

--- a/packages/puppeteer-core/src/bidi/ScreenRecording.ts
+++ b/packages/puppeteer-core/src/bidi/ScreenRecording.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {RecordOptions} from '../api/Page.js';
+import {ScreenRecording} from '../cdp/ScreenRecording.js';
+import {DEBUG_PREFIXES, type Logger} from '../common/Debug.js';
+import {environment} from '../environment.js';
+import {guarded} from '../util/decorators.js';
+
+import type {BidiPage} from './Page.js';
+
+/**
+ * @internal
+ */
+export class BidiScreenRecording extends ScreenRecording {
+  declare protected page: BidiPage;
+  #screencastId?: string;
+  #path?: string;
+
+  /**
+   * @internal
+   */
+  constructor(page: BidiPage, options: RecordOptions = {}, logger?: Logger) {
+    super(page, options, logger);
+
+    const browsingContext = this.page.mainFrame().browsingContext;
+    browsingContext?.once?.('closed', () => {
+      void this.stop().catch(err => {
+        this.logger?.(DEBUG_PREFIXES.error)?.(err);
+      });
+    });
+  }
+
+  /**
+   * @internal
+   */
+  override async _start(): Promise<void> {
+    const frameRate = this.options.frameRate ?? this.options.fps;
+    const video =
+      this.options.maxWidth !== undefined ||
+      this.options.maxHeight !== undefined ||
+      frameRate !== undefined
+        ? {
+            width: this.options.maxWidth,
+            height: this.options.maxHeight,
+            frameRate,
+          }
+        : undefined;
+
+    const result = await this.page.mainFrame().browsingContext.startScreencast({
+      audio: this.options.audio,
+      video,
+    });
+    this.#screencastId = result.screencast;
+    this.#path = result.path;
+  }
+
+  /**
+   * Stops the screen recording.
+   *
+   * @public
+   */
+  @guarded()
+  override async stop(): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+
+    try {
+      if (this.#screencastId) {
+        const result = await this.page
+          .mainFrame()
+          .browsingContext.stopScreencast(this.#screencastId)
+          .catch(err => {
+            this.logger?.(DEBUG_PREFIXES.error)?.(err);
+            return undefined;
+          });
+
+        if (result?.error) {
+          this.logger?.(DEBUG_PREFIXES.error)?.(new Error(result.error));
+        }
+
+        const filePath = result?.path ?? this.#path;
+        if (filePath) {
+          try {
+            const buffer = await environment.value.readFile(filePath);
+            this.controller.enqueue(buffer);
+            for (const dest of this.destinations) {
+              dest.write(buffer);
+            }
+          } catch (err) {
+            this.logger?.(DEBUG_PREFIXES.error)?.(err);
+          }
+        }
+      }
+    } finally {
+      try {
+        this.controller.close();
+      } catch {
+        // Controller might already be closed.
+      }
+      for (const dest of this.destinations) {
+        dest.end();
+      }
+      const destinationPromises = Array.from(this.destinations).map(dest => {
+        return new Promise(resolve => {
+          if (dest.writableFinished || dest.closed || dest.destroyed) {
+            resolve(undefined);
+          } else {
+            dest.once?.('finish', resolve);
+            dest.once?.('close', resolve);
+            dest.once?.('error', resolve);
+          }
+        });
+      });
+
+      await Promise.all(destinationPromises);
+    }
+  }
+}

--- a/packages/puppeteer-core/src/bidi/ScreenRecording.ts
+++ b/packages/puppeteer-core/src/bidi/ScreenRecording.ts
@@ -5,7 +5,7 @@
  */
 
 import type {RecordOptions} from '../api/Page.js';
-import {ScreenRecording} from '../cdp/ScreenRecording.js';
+import {ScreenRecording} from '../api/ScreenRecording.js';
 import {DEBUG_PREFIXES, type Logger} from '../common/Debug.js';
 import {environment} from '../environment.js';
 import {guarded} from '../util/decorators.js';
@@ -23,13 +23,13 @@ export class BidiScreenRecording extends ScreenRecording {
   /**
    * @internal
    */
-  constructor(page: BidiPage, options: RecordOptions = {}, logger?: Logger) {
+  constructor(page: BidiPage, options: RecordOptions = {}, logger: Logger) {
     super(page, options, logger);
 
     const browsingContext = this.page.mainFrame().browsingContext;
     browsingContext?.once?.('closed', () => {
       void this.stop().catch(err => {
-        this.logger?.(DEBUG_PREFIXES.error)?.(err);
+        this.logger(DEBUG_PREFIXES.error)?.(err);
       });
     });
   }
@@ -71,54 +71,36 @@ export class BidiScreenRecording extends ScreenRecording {
     this.stopped = true;
 
     try {
-      if (this.#screencastId) {
-        const result = await this.page
-          .mainFrame()
-          .browsingContext.stopScreencast(this.#screencastId)
-          .catch(err => {
-            this.logger?.(DEBUG_PREFIXES.error)?.(err);
-            return undefined;
-          });
+      if (!this.#screencastId) {
+        return;
+      }
 
-        if (result?.error) {
-          this.logger?.(DEBUG_PREFIXES.error)?.(new Error(result.error));
-        }
+      const result = await this.page
+        .mainFrame()
+        .browsingContext.stopScreencast(this.#screencastId)
+        .catch(err => {
+          this.logger(DEBUG_PREFIXES.error)?.(err);
+          return undefined;
+        });
 
-        const filePath = result?.path ?? this.#path;
-        if (filePath) {
-          try {
-            const buffer = await environment.value.readFile(filePath);
-            this.controller.enqueue(buffer);
-            for (const dest of this.destinations) {
-              dest.write(buffer);
-            }
-          } catch (err) {
-            this.logger?.(DEBUG_PREFIXES.error)?.(err);
+      if (result?.error) {
+        this.logger(DEBUG_PREFIXES.error)?.(result.error);
+      }
+
+      const filePath = result?.path ?? this.#path;
+      if (filePath) {
+        try {
+          const buffer = await environment.value.readFile(filePath);
+          this.controller.enqueue(buffer);
+          for (const dest of this.destinations) {
+            dest.write(buffer);
           }
+        } catch (err) {
+          this.logger(DEBUG_PREFIXES.error)?.(err);
         }
       }
     } finally {
-      try {
-        this.controller.close();
-      } catch {
-        // Controller might already be closed.
-      }
-      for (const dest of this.destinations) {
-        dest.end();
-      }
-      const destinationPromises = Array.from(this.destinations).map(dest => {
-        return new Promise(resolve => {
-          if (dest.writableFinished || dest.closed || dest.destroyed) {
-            resolve(undefined);
-          } else {
-            dest.once?.('finish', resolve);
-            dest.once?.('close', resolve);
-            dest.once?.('error', resolve);
-          }
-        });
-      });
-
-      await Promise.all(destinationPromises);
+      await this.closeDestinations();
     }
   }
 }

--- a/packages/puppeteer-core/src/bidi/bidi.ts
+++ b/packages/puppeteer-core/src/bidi/bidi.ts
@@ -16,3 +16,4 @@ export * from './Input.js';
 export * from './JSHandle.js';
 export * from './Page.js';
 export * from './Realm.js';
+export * from './ScreenRecording.js';

--- a/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
+++ b/packages/puppeteer-core/src/bidi/core/BrowsingContext.ts
@@ -75,6 +75,14 @@ export type SetViewportOptions = Omit<
 /**
  * @internal
  */
+export type StartScreencastOptions = Omit<
+  Bidi.BrowsingContext.StartScreencastParameters,
+  'context'
+>;
+
+/**
+ * @internal
+ */
 export type GetCookiesOptions = Omit<
   Bidi.Storage.GetCookiesParameters,
   'partition'
@@ -388,6 +396,39 @@ export class BrowsingContext extends EventEmitter<{
       ...options,
     });
     return data;
+  }
+
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
+  async startScreencast(
+    options: StartScreencastOptions = {},
+  ): Promise<Bidi.BrowsingContext.StartScreencastResult> {
+    const {result} = await this.#session.send(
+      'browsingContext.startScreencast',
+      {
+        context: this.id,
+        ...options,
+      },
+    );
+    return result;
+  }
+
+  @throwIfDisposed<BrowsingContext>(context => {
+    // SAFETY: Disposal implies this exists.
+    return context.#reason!;
+  })
+  async stopScreencast(
+    screencast: Bidi.BrowsingContext.Screencast,
+  ): Promise<Bidi.BrowsingContext.StopScreencastResult> {
+    const {result} = await this.#session.send(
+      'browsingContext.stopScreencast',
+      {
+        screencast,
+      },
+    );
+    return result;
   }
 
   @throwIfDisposed<BrowsingContext>(context => {

--- a/packages/puppeteer-core/src/cdp/Page.ts
+++ b/packages/puppeteer-core/src/cdp/Page.ts
@@ -20,6 +20,7 @@ import type {JSHandle} from '../api/JSHandle.js';
 import type {
   Credentials,
   HeapSnapshotOptions,
+  RecordOptions,
   ReloadOptions,
 } from '../api/Page.js';
 import {
@@ -81,6 +82,7 @@ import type {IsolatedWorld} from './IsolatedWorld.js';
 import {MAIN_WORLD} from './IsolatedWorlds.js';
 import {releaseObject} from './JSHandle.js';
 import type {NetworkConditions} from './NetworkManager.js';
+import {CdpScreenRecording} from './ScreenRecording.js';
 import type {CdpTarget} from './Target.js';
 import {TargetManagerEvent} from './TargetManageEvents.js';
 import type {TargetManager} from './TargetManager.js';
@@ -1360,6 +1362,15 @@ export class CdpPage extends Page {
 
   override extensionRealms(): Realm[] {
     return this.mainFrame().extensionRealms();
+  }
+
+  /**
+   * @internal
+   */
+  override createScreenRecording(
+    options: Readonly<RecordOptions>,
+  ): CdpScreenRecording {
+    return new CdpScreenRecording(this, options, this.logger);
   }
 }
 

--- a/packages/puppeteer-core/src/cdp/ScreenRecording.test.ts
+++ b/packages/puppeteer-core/src/cdp/ScreenRecording.test.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {PassThrough, Writable} from 'node:stream';
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {CDPSession, CDPSessionEvent} from '../api/CDPSession.js';
+import {Page} from '../api/Page.js';
+import type {Connection} from '../cdp/Connection.js';
+import {asyncDisposeSymbol} from '../util/disposable.js';
+
+class MockCDPSession extends CDPSession {
+  commands: Array<{method: string; params?: unknown}> = [];
+  readChunks: Array<{data: string; base64Encoded?: boolean; eof: boolean}> = [];
+  startResponse: {stream?: string} = {};
+  stopResponse: {stream?: string} = {};
+
+  override id(): string {
+    return 'mock-id';
+  }
+
+  override connection(): Connection | undefined {
+    return undefined;
+  }
+
+  override get detached(): boolean {
+    return false;
+  }
+
+  // @ts-expect-error mock implementation
+  override async send(method: string, params?: unknown): Promise<unknown> {
+    this.commands.push({method, params});
+    switch (method) {
+      case 'Page.startScreenRecording':
+        return this.startResponse;
+      case 'Page.stopScreenRecording':
+        return this.stopResponse;
+      case 'IO.read':
+        return (
+          this.readChunks.shift() ?? {data: '', base64Encoded: false, eof: true}
+        );
+      case 'IO.close':
+        return {};
+      default:
+        return {};
+    }
+  }
+
+  override async detach(): Promise<void> {}
+}
+
+// @ts-expect-error no need to implement all methods
+class MockPage extends Page {
+  mockClient: MockCDPSession;
+
+  constructor(client: MockCDPSession) {
+    super(() => {
+      return undefined;
+    });
+    this.mockClient = client;
+  }
+
+  override mainFrame(): any {
+    return {
+      client: this.mockClient,
+    };
+  }
+}
+
+describe('ScreenRecording', () => {
+  it('should start screen recording and read all chunks on stop', async () => {
+    const client = new MockCDPSession();
+    client.stopResponse = {stream: 'stream-1'};
+    client.readChunks = [
+      {
+        data: Buffer.from('chunk1').toString('base64'),
+        base64Encoded: true,
+        eof: false,
+      },
+      {
+        data: Buffer.from('chunk2').toString('base64'),
+        base64Encoded: true,
+        eof: true,
+      },
+    ];
+
+    const page = new MockPage(client);
+    const recording = await page.record({
+      audio: true,
+      maxWidth: 1920,
+      maxHeight: 1080,
+      frameRate: 60,
+    });
+
+    expect(client.commands[0]).toEqual({
+      method: 'Page.startScreenRecording',
+      params: {
+        audio: true,
+        maxWidth: 1920,
+        maxHeight: 1080,
+        frameRate: 60,
+      },
+    });
+
+    const chunks: Buffer[] = [];
+    const dest = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    });
+
+    recording.pipe(dest);
+    await recording.stop();
+
+    expect(Buffer.concat(chunks).toString()).toBe('chunk1chunk2');
+    expect(client.commands).toContainEqual({
+      method: 'Page.stopScreenRecording',
+      params: undefined,
+    });
+    expect(client.commands).toContainEqual({
+      method: 'IO.close',
+      params: {handle: 'stream-1'},
+    });
+  });
+
+  it('should support fps as alias for frameRate', async () => {
+    const client = new MockCDPSession();
+    const page = new MockPage(client);
+    const recording = await page.record({
+      fps: 24,
+    });
+
+    expect(client.commands[0]).toEqual({
+      method: 'Page.startScreenRecording',
+      params: {
+        audio: undefined,
+        maxWidth: undefined,
+        maxHeight: undefined,
+        frameRate: 24,
+      },
+    });
+
+    await recording.stop();
+  });
+
+  it('should validate options', async () => {
+    const client = new MockCDPSession();
+    const page = new MockPage(client);
+
+    await expect(page.record({maxWidth: 0})).rejects.toThrow(
+      '`maxWidth` must be greater than 0.',
+    );
+    await expect(page.record({maxWidth: -10})).rejects.toThrow(
+      '`maxWidth` must be greater than 0.',
+    );
+    await expect(page.record({maxHeight: 0})).rejects.toThrow(
+      '`maxHeight` must be greater than 0.',
+    );
+    await expect(page.record({maxHeight: -10})).rejects.toThrow(
+      '`maxHeight` must be greater than 0.',
+    );
+    await expect(page.record({frameRate: 0})).rejects.toThrow(
+      '`frameRate` must be greater than 0.',
+    );
+    await expect(page.record({frameRate: -5})).rejects.toThrow(
+      '`frameRate` must be greater than 0.',
+    );
+    await expect(page.record({fps: 0})).rejects.toThrow(
+      '`fps` must be greater than 0.',
+    );
+    await expect(page.record({fps: -5})).rejects.toThrow(
+      '`fps` must be greater than 0.',
+    );
+  });
+
+  it('should support stream handle returned from startScreenRecording', async () => {
+    const client = new MockCDPSession();
+    client.startResponse = {stream: 'stream-start'};
+    client.stopResponse = {};
+    client.readChunks = [
+      {
+        data: Buffer.from('hello').toString('base64'),
+        base64Encoded: true,
+        eof: true,
+      },
+    ];
+
+    const page = new MockPage(client);
+    const recording = await page.record();
+
+    const chunks: Buffer[] = [];
+    const dest = new PassThrough();
+    dest.on('data', chunk => {
+      chunks.push(Buffer.from(chunk));
+    });
+
+    recording.pipe(dest);
+    await recording.stop();
+
+    expect(Buffer.concat(chunks).toString()).toBe('hello');
+    expect(client.commands).toContainEqual({
+      method: 'IO.close',
+      params: {handle: 'stream-start'},
+    });
+  });
+
+  it('should support async iteration', async () => {
+    const client = new MockCDPSession();
+    client.stopResponse = {stream: 'stream-iter'};
+    client.readChunks = [
+      {
+        data: Buffer.from('chunkA').toString('base64'),
+        base64Encoded: true,
+        eof: false,
+      },
+      {
+        data: Buffer.from('chunkB').toString('base64'),
+        base64Encoded: true,
+        eof: true,
+      },
+    ];
+
+    const page = new MockPage(client);
+    const recording = await page.record();
+
+    const stopPromise = recording.stop();
+
+    const received: Uint8Array[] = [];
+    for await (const chunk of recording) {
+      received.push(chunk);
+    }
+    await stopPromise;
+
+    expect(Buffer.concat(received).toString()).toBe('chunkAchunkB');
+  });
+
+  it('should support pipeTo with WritableStream', async () => {
+    const client = new MockCDPSession();
+    client.stopResponse = {stream: 'stream-web'};
+    client.readChunks = [
+      {
+        data: Buffer.from('web-stream-data').toString('base64'),
+        base64Encoded: true,
+        eof: true,
+      },
+    ];
+
+    const page = new MockPage(client);
+    const recording = await page.record();
+
+    const chunks: Uint8Array[] = [];
+    const writableStream = new WritableStream<Uint8Array>({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    });
+
+    const pipePromise = recording.pipe(writableStream);
+    await recording.stop();
+    await pipePromise;
+
+    expect(Buffer.concat(chunks).toString()).toBe('web-stream-data');
+  });
+
+  it('should stop on client disconnection', async () => {
+    const client = new MockCDPSession();
+    const page = new MockPage(client);
+    const recording = await page.record();
+
+    client.emit(CDPSessionEvent.Disconnected, undefined);
+    // Calling stop again should be a no-op
+    await recording.stop();
+
+    expect(
+      client.commands.filter(c => {
+        return c.method === 'Page.stopScreenRecording';
+      }).length,
+    ).toBe(1);
+  });
+
+  it('should support asyncDisposeSymbol', async () => {
+    const client = new MockCDPSession();
+    const page = new MockPage(client);
+    const recording = await page.record();
+
+    await recording[asyncDisposeSymbol]();
+
+    expect(
+      client.commands.filter(c => {
+        return c.method === 'Page.stopScreenRecording';
+      }).length,
+    ).toBe(1);
+  });
+});

--- a/packages/puppeteer-core/src/cdp/ScreenRecording.test.ts
+++ b/packages/puppeteer-core/src/cdp/ScreenRecording.test.ts
@@ -14,10 +14,12 @@ import {Page} from '../api/Page.js';
 import type {Connection} from '../cdp/Connection.js';
 import {asyncDisposeSymbol} from '../util/disposable.js';
 
+import {CdpScreenRecording} from './ScreenRecording.js';
+
 class MockCDPSession extends CDPSession {
   commands: Array<{method: string; params?: unknown}> = [];
   readChunks: Array<{data: string; base64Encoded?: boolean; eof: boolean}> = [];
-  startResponse: {stream?: string} = {};
+  startResponse: {stream?: string} = {stream: 'stream-1'};
   stopResponse: {stream?: string} = {};
 
   override id(): string {
@@ -70,12 +72,16 @@ class MockPage extends Page {
       client: this.mockClient,
     };
   }
+
+  override createScreenRecording(options: any): any {
+    return new CdpScreenRecording(this as any, options, this.logger);
+  }
 }
 
 describe('ScreenRecording', () => {
   it('should start screen recording and read all chunks on stop', async () => {
     const client = new MockCDPSession();
-    client.stopResponse = {stream: 'stream-1'};
+    client.startResponse = {stream: 'stream-1'};
     client.readChunks = [
       {
         data: Buffer.from('chunk1').toString('base64'),
@@ -212,7 +218,7 @@ describe('ScreenRecording', () => {
 
   it('should support async iteration', async () => {
     const client = new MockCDPSession();
-    client.stopResponse = {stream: 'stream-iter'};
+    client.startResponse = {stream: 'stream-iter'};
     client.readChunks = [
       {
         data: Buffer.from('chunkA').toString('base64'),
@@ -242,7 +248,7 @@ describe('ScreenRecording', () => {
 
   it('should support pipeTo with WritableStream', async () => {
     const client = new MockCDPSession();
-    client.stopResponse = {stream: 'stream-web'};
+    client.startResponse = {stream: 'stream-web'};
     client.readChunks = [
       {
         data: Buffer.from('web-stream-data').toString('base64'),

--- a/packages/puppeteer-core/src/cdp/ScreenRecording.ts
+++ b/packages/puppeteer-core/src/cdp/ScreenRecording.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {CDPSessionEvent} from '../api/CDPSession.js';
+import type {Page, RecordOptions} from '../api/Page.js';
+import {DEBUG_PREFIXES, type Logger} from '../common/Debug.js';
+import {guarded} from '../util/decorators.js';
+import {asyncDisposeSymbol} from '../util/disposable.js';
+import {stringToTypedArray} from '../util/encoding.js';
+
+/**
+ * @public
+ */
+export interface WritableDestination {
+  write(chunk: Uint8Array): boolean;
+  end(): unknown;
+  writableFinished?: boolean;
+  closed?: boolean;
+  destroyed?: boolean;
+  once?(event: string, cb: (arg?: unknown) => void): unknown;
+}
+
+/**
+ * @public
+ */
+export class ScreenRecording extends ReadableStream<Uint8Array> {
+  #page: Page;
+  #options: RecordOptions;
+  #logger?: Logger;
+  #streamHandle?: string;
+  #controller!: ReadableStreamDefaultController<Uint8Array>;
+  #destinations = new Set<WritableDestination>();
+  #stopped = false;
+
+  /**
+   * @internal
+   */
+  constructor(page: Page, options: RecordOptions = {}, logger?: Logger) {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    super({
+      start(c) {
+        controller = c;
+      },
+    });
+    this.#controller = controller;
+
+    this.#page = page;
+    this.#options = options;
+    this.#logger = logger;
+
+    const {client} = this.#page.mainFrame();
+    client.once(CDPSessionEvent.Disconnected, () => {
+      void this.stop().catch(err => {
+        this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+      });
+    });
+  }
+
+  /**
+   * @internal
+   */
+  async _start(): Promise<void> {
+    const {client} = this.#page.mainFrame();
+    const frameRate = this.#options.frameRate ?? this.#options.fps;
+    // @ts-expect-error Page.startScreenRecording is not yet in devtools-protocol
+    const result = (await client.send('Page.startScreenRecording', {
+      audio: this.#options.audio,
+      maxWidth: this.#options.maxWidth,
+      maxHeight: this.#options.maxHeight,
+      frameRate,
+    })) as {stream?: string} | undefined;
+    if (result && typeof result.stream === 'string') {
+      this.#streamHandle = result.stream;
+    }
+  }
+
+  /**
+   * Pipes the recorded stream to a destination stream.
+   *
+   * @public
+   */
+  pipe<T extends WritableStream<Uint8Array>>(destination: T): Promise<void>;
+  pipe<T extends WritableDestination>(destination: T): T;
+  pipe(
+    destination: WritableStream<Uint8Array> | WritableDestination,
+  ): Promise<void> | WritableDestination {
+    if (
+      'getWriter' in destination &&
+      typeof destination.getWriter === 'function'
+    ) {
+      return this.pipeTo(destination as WritableStream<Uint8Array>);
+    }
+    const dest = destination as WritableDestination;
+    this.#destinations.add(dest);
+    dest.once?.('unpipe', () => {
+      this.#destinations.delete(dest);
+    });
+    dest.once?.('error', () => {
+      this.#destinations.delete(dest);
+    });
+    dest.once?.('close', () => {
+      this.#destinations.delete(dest);
+    });
+    dest.once?.('finish', () => {
+      this.#destinations.delete(dest);
+    });
+    return dest;
+  }
+
+  /**
+   * Stops the screen recording.
+   *
+   * @public
+   */
+  @guarded()
+  async stop(): Promise<void> {
+    if (this.#stopped) {
+      return;
+    }
+    this.#stopped = true;
+
+    try {
+      const {client} = this.#page.mainFrame();
+      const result = (await client
+        // @ts-expect-error Page.stopScreenRecording is not yet in devtools-protocol
+        .send('Page.stopScreenRecording')
+        .catch(err => {
+          this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+          return undefined;
+        })) as {stream?: string} | undefined;
+
+      const handle = result?.stream ?? this.#streamHandle;
+
+      if (handle) {
+        let eof = false;
+        while (!eof) {
+          const {
+            data,
+            base64Encoded,
+            eof: isEof,
+          } = await client.send('IO.read', {handle});
+          eof = isEof;
+          if (data) {
+            const buffer = stringToTypedArray(data, base64Encoded ?? false);
+            this.#controller.enqueue(buffer);
+            for (const dest of this.#destinations) {
+              dest.write(buffer);
+            }
+          }
+        }
+        await client.send('IO.close', {handle}).catch(err => {
+          this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+        });
+      }
+    } finally {
+      try {
+        this.#controller.close();
+      } catch {
+        // Controller might already be closed.
+      }
+      for (const dest of this.#destinations) {
+        dest.end();
+      }
+      const destinationPromises = Array.from(this.#destinations).map(dest => {
+        return new Promise(resolve => {
+          if (dest.writableFinished || dest.closed || dest.destroyed) {
+            resolve(undefined);
+          } else {
+            dest.once?.('finish', resolve);
+            dest.once?.('close', resolve);
+            dest.once?.('error', resolve);
+          }
+        });
+      });
+
+      await Promise.all(destinationPromises);
+    }
+  }
+
+  async [asyncDisposeSymbol](): Promise<void> {
+    await this.stop();
+  }
+}

--- a/packages/puppeteer-core/src/cdp/ScreenRecording.ts
+++ b/packages/puppeteer-core/src/cdp/ScreenRecording.ts
@@ -27,13 +27,31 @@ export interface WritableDestination {
  * @public
  */
 export class ScreenRecording extends ReadableStream<Uint8Array> {
-  #page: Page;
-  #options: RecordOptions;
-  #logger?: Logger;
+  /**
+   * @internal
+   */
+  protected page: Page;
+  /**
+   * @internal
+   */
+  protected options: RecordOptions;
+  /**
+   * @internal
+   */
+  protected logger?: Logger;
   #streamHandle?: string;
-  #controller!: ReadableStreamDefaultController<Uint8Array>;
-  #destinations = new Set<WritableDestination>();
-  #stopped = false;
+  /**
+   * @internal
+   */
+  protected controller!: ReadableStreamDefaultController<Uint8Array>;
+  /**
+   * @internal
+   */
+  protected destinations = new Set<WritableDestination>();
+  /**
+   * @internal
+   */
+  protected stopped = false;
 
   /**
    * @internal
@@ -45,16 +63,16 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
         controller = c;
       },
     });
-    this.#controller = controller;
+    this.controller = controller;
 
-    this.#page = page;
-    this.#options = options;
-    this.#logger = logger;
+    this.page = page;
+    this.options = options;
+    this.logger = logger;
 
-    const {client} = this.#page.mainFrame();
-    client.once(CDPSessionEvent.Disconnected, () => {
+    const {client} = this.page.mainFrame();
+    client?.once?.(CDPSessionEvent.Disconnected, () => {
       void this.stop().catch(err => {
-        this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+        this.logger?.(DEBUG_PREFIXES.error)?.(err);
       });
     });
   }
@@ -63,13 +81,13 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
    * @internal
    */
   async _start(): Promise<void> {
-    const {client} = this.#page.mainFrame();
-    const frameRate = this.#options.frameRate ?? this.#options.fps;
+    const {client} = this.page.mainFrame();
+    const frameRate = this.options.frameRate ?? this.options.fps;
     // @ts-expect-error Page.startScreenRecording is not yet in devtools-protocol
     const result = (await client.send('Page.startScreenRecording', {
-      audio: this.#options.audio,
-      maxWidth: this.#options.maxWidth,
-      maxHeight: this.#options.maxHeight,
+      audio: this.options.audio,
+      maxWidth: this.options.maxWidth,
+      maxHeight: this.options.maxHeight,
       frameRate,
     })) as {stream?: string} | undefined;
     if (result && typeof result.stream === 'string') {
@@ -94,18 +112,18 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
       return this.pipeTo(destination as WritableStream<Uint8Array>);
     }
     const dest = destination as WritableDestination;
-    this.#destinations.add(dest);
+    this.destinations.add(dest);
     dest.once?.('unpipe', () => {
-      this.#destinations.delete(dest);
+      this.destinations.delete(dest);
     });
     dest.once?.('error', () => {
-      this.#destinations.delete(dest);
+      this.destinations.delete(dest);
     });
     dest.once?.('close', () => {
-      this.#destinations.delete(dest);
+      this.destinations.delete(dest);
     });
     dest.once?.('finish', () => {
-      this.#destinations.delete(dest);
+      this.destinations.delete(dest);
     });
     return dest;
   }
@@ -117,18 +135,18 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
    */
   @guarded()
   async stop(): Promise<void> {
-    if (this.#stopped) {
+    if (this.stopped) {
       return;
     }
-    this.#stopped = true;
+    this.stopped = true;
 
     try {
-      const {client} = this.#page.mainFrame();
+      const {client} = this.page.mainFrame();
       const result = (await client
         // @ts-expect-error Page.stopScreenRecording is not yet in devtools-protocol
         .send('Page.stopScreenRecording')
         .catch(err => {
-          this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+          this.logger?.(DEBUG_PREFIXES.error)?.(err);
           return undefined;
         })) as {stream?: string} | undefined;
 
@@ -145,26 +163,26 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
           eof = isEof;
           if (data) {
             const buffer = stringToTypedArray(data, base64Encoded ?? false);
-            this.#controller.enqueue(buffer);
-            for (const dest of this.#destinations) {
+            this.controller.enqueue(buffer);
+            for (const dest of this.destinations) {
               dest.write(buffer);
             }
           }
         }
         await client.send('IO.close', {handle}).catch(err => {
-          this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+          this.logger?.(DEBUG_PREFIXES.error)?.(err);
         });
       }
     } finally {
       try {
-        this.#controller.close();
+        this.controller.close();
       } catch {
         // Controller might already be closed.
       }
-      for (const dest of this.#destinations) {
+      for (const dest of this.destinations) {
         dest.end();
       }
-      const destinationPromises = Array.from(this.#destinations).map(dest => {
+      const destinationPromises = Array.from(this.destinations).map(dest => {
         return new Promise(resolve => {
           if (dest.writableFinished || dest.closed || dest.destroyed) {
             resolve(undefined);

--- a/packages/puppeteer-core/src/cdp/ScreenRecording.ts
+++ b/packages/puppeteer-core/src/cdp/ScreenRecording.ts
@@ -5,74 +5,31 @@
  */
 
 import {CDPSessionEvent} from '../api/CDPSession.js';
-import type {Page, RecordOptions} from '../api/Page.js';
+import type {RecordOptions} from '../api/Page.js';
+import {ScreenRecording} from '../api/ScreenRecording.js';
 import {DEBUG_PREFIXES, type Logger} from '../common/Debug.js';
 import {guarded} from '../util/decorators.js';
-import {asyncDisposeSymbol} from '../util/disposable.js';
 import {stringToTypedArray} from '../util/encoding.js';
 
-/**
- * @public
- */
-export interface WritableDestination {
-  write(chunk: Uint8Array): boolean;
-  end(): unknown;
-  writableFinished?: boolean;
-  closed?: boolean;
-  destroyed?: boolean;
-  once?(event: string, cb: (arg?: unknown) => void): unknown;
-}
+import type {CdpPage} from './Page.js';
 
 /**
- * @public
+ * @internal
  */
-export class ScreenRecording extends ReadableStream<Uint8Array> {
-  /**
-   * @internal
-   */
-  protected page: Page;
-  /**
-   * @internal
-   */
-  protected options: RecordOptions;
-  /**
-   * @internal
-   */
-  protected logger?: Logger;
+export class CdpScreenRecording extends ScreenRecording {
+  declare protected page: CdpPage;
   #streamHandle?: string;
-  /**
-   * @internal
-   */
-  protected controller!: ReadableStreamDefaultController<Uint8Array>;
-  /**
-   * @internal
-   */
-  protected destinations = new Set<WritableDestination>();
-  /**
-   * @internal
-   */
-  protected stopped = false;
 
   /**
    * @internal
    */
-  constructor(page: Page, options: RecordOptions = {}, logger?: Logger) {
-    let controller!: ReadableStreamDefaultController<Uint8Array>;
-    super({
-      start(c) {
-        controller = c;
-      },
-    });
-    this.controller = controller;
-
-    this.page = page;
-    this.options = options;
-    this.logger = logger;
+  constructor(page: CdpPage, options: RecordOptions = {}, logger: Logger) {
+    super(page, options, logger);
 
     const {client} = this.page.mainFrame();
     client?.once?.(CDPSessionEvent.Disconnected, () => {
       void this.stop().catch(err => {
-        this.logger?.(DEBUG_PREFIXES.error)?.(err);
+        this.logger(DEBUG_PREFIXES.error)?.(err);
       });
     });
   }
@@ -80,7 +37,7 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
   /**
    * @internal
    */
-  async _start(): Promise<void> {
+  override async _start(): Promise<void> {
     const {client} = this.page.mainFrame();
     const frameRate = this.options.frameRate ?? this.options.fps;
     // @ts-expect-error Page.startScreenRecording is not yet in devtools-protocol
@@ -89,43 +46,8 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
       maxWidth: this.options.maxWidth,
       maxHeight: this.options.maxHeight,
       frameRate,
-    })) as {stream?: string} | undefined;
-    if (result && typeof result.stream === 'string') {
-      this.#streamHandle = result.stream;
-    }
-  }
-
-  /**
-   * Pipes the recorded stream to a destination stream.
-   *
-   * @public
-   */
-  pipe<T extends WritableStream<Uint8Array>>(destination: T): Promise<void>;
-  pipe<T extends WritableDestination>(destination: T): T;
-  pipe(
-    destination: WritableStream<Uint8Array> | WritableDestination,
-  ): Promise<void> | WritableDestination {
-    if (
-      'getWriter' in destination &&
-      typeof destination.getWriter === 'function'
-    ) {
-      return this.pipeTo(destination as WritableStream<Uint8Array>);
-    }
-    const dest = destination as WritableDestination;
-    this.destinations.add(dest);
-    dest.once?.('unpipe', () => {
-      this.destinations.delete(dest);
-    });
-    dest.once?.('error', () => {
-      this.destinations.delete(dest);
-    });
-    dest.once?.('close', () => {
-      this.destinations.delete(dest);
-    });
-    dest.once?.('finish', () => {
-      this.destinations.delete(dest);
-    });
-    return dest;
+    })) as {stream: string};
+    this.#streamHandle = result.stream;
   }
 
   /**
@@ -134,7 +56,7 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
    * @public
    */
   @guarded()
-  async stop(): Promise<void> {
+  override async stop(): Promise<void> {
     if (this.stopped) {
       return;
     }
@@ -142,63 +64,38 @@ export class ScreenRecording extends ReadableStream<Uint8Array> {
 
     try {
       const {client} = this.page.mainFrame();
-      const result = (await client
+      await client
         // @ts-expect-error Page.stopScreenRecording is not yet in devtools-protocol
         .send('Page.stopScreenRecording')
         .catch(err => {
-          this.logger?.(DEBUG_PREFIXES.error)?.(err);
-          return undefined;
-        })) as {stream?: string} | undefined;
+          this.logger(DEBUG_PREFIXES.error)?.(err);
+        });
 
-      const handle = result?.stream ?? this.#streamHandle;
+      if (!this.#streamHandle) {
+        throw new Error('Screen recording stream handle is missing.');
+      }
 
-      if (handle) {
-        let eof = false;
-        while (!eof) {
-          const {
-            data,
-            base64Encoded,
-            eof: isEof,
-          } = await client.send('IO.read', {handle});
-          eof = isEof;
-          if (data) {
-            const buffer = stringToTypedArray(data, base64Encoded ?? false);
-            this.controller.enqueue(buffer);
-            for (const dest of this.destinations) {
-              dest.write(buffer);
-            }
+      let eof = false;
+      while (!eof) {
+        const {
+          data,
+          base64Encoded,
+          eof: isEof,
+        } = await client.send('IO.read', {handle: this.#streamHandle});
+        eof = isEof;
+        if (data) {
+          const buffer = stringToTypedArray(data, base64Encoded ?? false);
+          this.controller.enqueue(buffer);
+          for (const dest of this.destinations) {
+            dest.write(buffer);
           }
         }
-        await client.send('IO.close', {handle}).catch(err => {
-          this.logger?.(DEBUG_PREFIXES.error)?.(err);
-        });
       }
-    } finally {
-      try {
-        this.controller.close();
-      } catch {
-        // Controller might already be closed.
-      }
-      for (const dest of this.destinations) {
-        dest.end();
-      }
-      const destinationPromises = Array.from(this.destinations).map(dest => {
-        return new Promise(resolve => {
-          if (dest.writableFinished || dest.closed || dest.destroyed) {
-            resolve(undefined);
-          } else {
-            dest.once?.('finish', resolve);
-            dest.once?.('close', resolve);
-            dest.once?.('error', resolve);
-          }
-        });
+      await client.send('IO.close', {handle: this.#streamHandle}).catch(err => {
+        this.logger(DEBUG_PREFIXES.error)?.(err);
       });
-
-      await Promise.all(destinationPromises);
+    } finally {
+      await this.closeDestinations();
     }
-  }
-
-  async [asyncDisposeSymbol](): Promise<void> {
-    await this.stop();
   }
 }

--- a/packages/puppeteer-core/src/cdp/cdp.ts
+++ b/packages/puppeteer-core/src/cdp/cdp.ts
@@ -35,6 +35,7 @@ export * from './NetworkEventManager.js';
 export * from './NetworkManager.js';
 export * from './Page.js';
 export * from './PredefinedNetworkConditions.js';
+export * from './ScreenRecording.js';
 export * from './Target.js';
 export * from './TargetManager.js';
 export * from './TargetManageEvents.js';

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -182,6 +182,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[page.test] Page Page.record *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome"],
+    "expectations": ["FAIL"],
+    "comment": "Screen recording is not supported until Chrome 153"
+  },
+  {
+    "testIdPattern": "[page.test] Page Page.record *",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["FAIL"],
+    "comment": "https://bugzilla.mozilla.org/show_bug.cgi?id=2066782"
+  },
+  {
     "testIdPattern": "[pipe.test] *",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/src/page.test.ts
+++ b/test/src/page.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   attachFrame,
   detachFrame,
+  getUniqueVideoFilePlaceholder,
   html,
   htmlRaw,
   isFavicon,
@@ -2689,6 +2690,26 @@ describe('Page', function () {
 
       expect(innerSize.width).toBe(contentWidth);
       expect(innerSize.height).toBe(contentHeight);
+    });
+  });
+
+  describe('Page.record', function () {
+    it('should record page', async () => {
+      using file = getUniqueVideoFilePlaceholder();
+
+      const {page} = await getTestState();
+
+      const recording = await page.record({
+        path: file.filename,
+      });
+
+      await page.goto('data:text/html,<input>');
+      using input = await page.locator('input').waitHandle();
+      await input.type('ab', {delay: 100});
+
+      await recording.stop();
+
+      expect(fs.statSync(file.filename).size).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
This is available starting from M153 and with M154 carrying improvements. Covers CDP and WebDriver BiDi. Since WebDriver BiDi API is filed based the file is converted to a stream after the recording for compatibility.

The new API deprecates the previous ffmpeg-based API and does not require any dependencies.