### PR TITLE
fix: distinguish an unwritable userDataDir from a running browser

### DIFF
--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -3,7 +3,7 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {existsSync} from 'node:fs';
+import {accessSync, constants, existsSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 
@@ -50,6 +50,21 @@ export interface ResolvedLaunchArgs {
   userDataDir: string;
   executablePath: string;
   args: string[];
+}
+
+/**
+ * Whether the profile directory exists and the current process can write to it.
+ * A missing directory counts as writable: the browser creates it on launch.
+ *
+ * @internal
+ */
+function isWritableDirectory(directory: string): boolean {
+  try {
+    accessSync(directory, constants.W_OK);
+    return true;
+  } catch {
+    return !existsSync(directory);
+  }
 }
 
 /**
@@ -291,6 +306,14 @@ export abstract class BrowserLauncher {
         (process.platform === 'win32' &&
           existsSync(join(launchArgs.userDataDir, 'lockfile')))
       ) {
+        // The browser reports the same ProcessSingleton failure whether another
+        // instance holds the lock or it simply cannot write to the profile
+        // directory, so check for the latter before blaming a running browser.
+        if (!isWritableDirectory(launchArgs.userDataDir)) {
+          throw new Error(
+            `The browser cannot write to ${launchArgs.userDataDir}. Make the \`userDataDir\` writable or use a different one.`,
+          );
+        }
         throw new Error(
           `The browser is already running for ${launchArgs.userDataDir}. Use a different \`userDataDir\` or stop the running browser first.`,
         );

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -987,7 +987,7 @@
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],
     "expectations": ["SKIP"],
-    "comment": "we currently do not detect this siutation for Firefox"
+    "comment": "we currently do not detect this situation for Firefox"
   },
   {
     "testIdPattern": "[webgl.test] webgl Create webgl context should work",

--- a/test/TestExpectations.json
+++ b/test/TestExpectations.json
@@ -976,6 +976,20 @@
     "comment": "TODO: add a comment explaining why this expectation is required (include links to issues)"
   },
   {
+    "testIdPattern": "[userDataDir.test] userDataDir should report a permission error when the userDataDir is not writable",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["chrome-headless-shell"],
+    "expectations": ["SKIP"],
+    "comment": "headless-shell can launch from an unwritable user data dir, so it never reports the ProcessSingleton failure this message is derived from"
+  },
+  {
+    "testIdPattern": "[userDataDir.test] userDataDir should report a permission error when the userDataDir is not writable",
+    "platforms": ["darwin", "linux", "win32"],
+    "parameters": ["firefox"],
+    "expectations": ["SKIP"],
+    "comment": "we currently do not detect this siutation for Firefox"
+  },
+  {
     "testIdPattern": "[webgl.test] webgl Create webgl context should work",
     "platforms": ["darwin", "linux", "win32"],
     "parameters": ["firefox"],

--- a/test/src/cdp/userDataDir.test.ts
+++ b/test/src/cdp/userDataDir.test.ts
@@ -45,4 +45,26 @@ describe('userDataDir', function () {
       }
     });
   }
+
+  it('should report a permission error when the userDataDir is not writable', async function () {
+    // Windows ignores the read-only bit for the directory owner, and root
+    // bypasses the write check entirely, so neither can observe the failure.
+    if (os.platform() === 'win32' || process.getuid?.() === 0) {
+      return this.skip();
+    }
+    const userDataDir = await mkdtemp(TMP_FOLDER);
+    fs.chmodSync(userDataDir, 0o555);
+    try {
+      const {close} = await launch({userDataDir});
+      await close();
+      assert.fail('Not reached');
+    } catch (err) {
+      assert.strictEqual(
+        (err as Error).message.startsWith('The browser cannot write to'),
+        true,
+      );
+    } finally {
+      fs.chmodSync(userDataDir, 0o755);
+    }
+  });
 });


### PR DESCRIPTION
**Fixes #15401**

### Problem

Chromium logs `Failed to create a ProcessSingleton for your profile directory` for more than one underlying cause: another instance holding the profile lock, and a profile directory the browser cannot write to. `BrowserLauncher` classified that log line as the first case unconditionally, so `chmod 555` on a `userDataDir` produced:

> The browser is already running for /tmp/... Use a different `userDataDir` or stop the running browser first.

which sends you looking for a stray browser process instead of at the directory permissions. The reporter hit this with a wrong `chmod` in a Datadog Synthetics worker image.

### Change

Per @OrKoN's suggestion on the issue ("keep the error message but add a dedicated check for the permissions of the user data dir"), the launcher now checks whether the directory is writable before emitting the "already running" message, and reports the permission problem instead when it is not.

A directory that does not exist yet is treated as writable, since the browser creates it on launch, so this does not change behavior for the ordinary first-run case.

I left the Windows `lockfile` heuristic alone. It has its own false-positive mode (a stale lockfile after a crash), but that is a separate bug from this one and fixing it would need a different signal.

### Test plan

Added a case to `test/src/cdp/userDataDir.test.ts` that creates a temp dir, `chmod 555`s it, attempts a launch, and asserts the permission message, restoring the mode afterwards.

It is guarded to skip on two platforms that cannot observe the failure:

- **Windows** ignores the read-only bit for a directory's owner, so `chmod 555` does not make the directory unwritable.
- **root** bypasses the write permission check entirely, so the launch would succeed.

I verified that guard is necessary rather than assuming it: on this Windows machine `fs.accessSync(dir, W_OK)` still succeeds after `chmod 555`, which is exactly why the test skips there.

**What I could not verify locally:** I develop on Windows, so I could not exercise the POSIX path end to end, which means I have not observed the new message come out of a real launch. The logic and the guard are verified; the browser-level assertion needs CI (or a POSIX reviewer) to confirm. Flagging that explicitly rather than implying a green local run.

`npm run build --workspace=puppeteer-core` passes. `eslint` reports no rule violations on either changed file (the only output is `Delete ␍` line-ending noise from a Windows checkout, which `core.autocrlf` normalizes to LF on commit; the recorded diff contains no CR characters).
