### PR TITLE
fix(network): do not emit duplicate request on Fetch.requestPaused restart

### DIFF
--- a/packages/puppeteer-core/src/api/HTTPRequest.ts
+++ b/packages/puppeteer-core/src/api/HTTPRequest.ts
@@ -432,10 +432,10 @@ export abstract class HTTPRequest {
       return;
     }
 
+    this.interception.requestOverrides = overrides;
     if (priority === undefined) {
       return await this._continue(overrides);
     }
-    this.interception.requestOverrides = overrides;
     if (
       this.interception.resolutionState.priority === undefined ||
       priority > this.interception.resolutionState.priority

--- a/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.test.ts
@@ -576,7 +576,84 @@ describe('NetworkManager', () => {
       networkId: '11ACE9783588040D644B905E8B55285B',
     });
 
-    expect(requests).toHaveLength(2);
+    expect(requests).toHaveLength(1);
+  });
+  it(`should emit requestfinished for a stylesheet font request that Chrome restarts (github.com/puppeteer/puppeteer/issues/11641)`, async () => {
+    const mockCDPSession = new MockCDPSession();
+    const manager = createNetworkManager();
+    await manager.addClient(mockCDPSession);
+    await manager.setRequestInterception(true);
+
+    const finished: HTTPRequest[] = [];
+    manager.on(NetworkManagerEvent.Request, async (request: HTTPRequest) => {
+      await request.continue();
+    });
+    manager.on(NetworkManagerEvent.RequestFinished, (request: HTTPRequest) => {
+      finished.push(request);
+    });
+
+    const fontRequest = {
+      url: 'https://example.com/fonts/font.woff2',
+      method: 'GET',
+      headers: {},
+      initialPriority: 'VeryHigh',
+      referrerPolicy: 'strict-origin-when-cross-origin',
+    } as const;
+    mockCDPSession.emit('Network.requestWillBeSent', {
+      requestId: '3C6E9E2A5D1B4F3F5E8C0B1A2D3E4F50',
+      loaderId: '11ACE9783588040D644B905E8B55285B',
+      documentURL: 'https://example.com/',
+      request: {...fontRequest, mixedContentType: 'none', isSameSite: true},
+      timestamp: 224604.980827,
+      wallTime: 1637955746.786191,
+      initiator: {type: 'parser', url: 'https://example.com/style.css'},
+      redirectHasExtraInfo: false,
+      type: 'Font',
+      frameId: '84AC261A351B86932B775B76D1DD79F8',
+      hasUserGesture: false,
+    });
+    // Chrome restarts the font fetch and pauses it again under a new
+    // interception id (crbug.com/1196004).
+    for (const requestId of ['interception-job-1.0', 'interception-job-2.0']) {
+      mockCDPSession.emit('Fetch.requestPaused', {
+        requestId,
+        request: fontRequest,
+        frameId: '84AC261A351B86932B775B76D1DD79F8',
+        resourceType: 'Font',
+        networkId: '3C6E9E2A5D1B4F3F5E8C0B1A2D3E4F50',
+      });
+    }
+    mockCDPSession.emit('Network.responseReceived', {
+      requestId: '3C6E9E2A5D1B4F3F5E8C0B1A2D3E4F50',
+      loaderId: '11ACE9783588040D644B905E8B55285B',
+      timestamp: 224605.0,
+      type: 'Font',
+      response: {
+        url: fontRequest.url,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        mimeType: 'font/woff2',
+        charset: '',
+        connectionReused: false,
+        connectionId: 1,
+        encodedDataLength: 100,
+        securityState: 'secure',
+      },
+      hasExtraInfo: false,
+      frameId: '84AC261A351B86932B775B76D1DD79F8',
+    });
+    mockCDPSession.emit('Network.loadingFinished', {
+      requestId: '3C6E9E2A5D1B4F3F5E8C0B1A2D3E4F50',
+      timestamp: 224605.1,
+      encodedDataLength: 100,
+    });
+
+    expect(
+      finished.map(r => {
+        return r.url();
+      }),
+    ).toEqual([fontRequest.url]);
   });
   it(`should handle Network.responseReceivedExtraInfo event after Network.responseReceived event (github.com/puppeteer/puppeteer/issues/8234)`, async () => {
     const mockCDPSession = new MockCDPSession();

--- a/packages/puppeteer-core/src/cdp/NetworkManager.ts
+++ b/packages/puppeteer-core/src/cdp/NetworkManager.ts
@@ -473,27 +473,54 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
       return;
     }
 
-    const requestWillBeSentEvent = (() => {
-      const requestWillBeSentEvent =
-        this.#networkEventManager.getRequestWillBeSent(networkRequestId);
-
-      // redirect requests have the same `requestId`,
+    const requestWillBeSentEvent =
+      this.#networkEventManager.getRequestWillBeSent(networkRequestId);
+    if (!requestWillBeSentEvent) {
+      // Chrome may restart a request and send a second Fetch.requestPaused
+      // for a request Puppeteer already emitted (crbug.com/1196004). Repoint
+      // that request instead of emitting a duplicate that never finishes.
+      const request = this.#networkEventManager.getRequest(networkRequestId);
       if (
-        requestWillBeSentEvent &&
-        (requestWillBeSentEvent.request.url !== event.request.url ||
-          requestWillBeSentEvent.request.method !== event.request.method)
+        request &&
+        request.url() === event.request.url &&
+        request.method() === event.request.method
       ) {
-        this.#networkEventManager.forgetRequestWillBeSent(networkRequestId);
+        this.#onRequestRestarted(request, fetchRequestId);
         return;
       }
-      return requestWillBeSentEvent;
-    })();
-
-    if (requestWillBeSentEvent) {
-      this.#patchRequestEventHeaders(requestWillBeSentEvent, event);
-      this.#onRequest(client, requestWillBeSentEvent, fetchRequestId);
-    } else {
       this.#networkEventManager.storeRequestPaused(networkRequestId, event);
+      return;
+    }
+
+    // Redirect requests have the same `requestId`. Wait for the redirect's
+    // own Network.requestWillBeSent.
+    if (
+      requestWillBeSentEvent.request.url !== event.request.url ||
+      requestWillBeSentEvent.request.method !== event.request.method
+    ) {
+      this.#networkEventManager.forgetRequestWillBeSent(networkRequestId);
+      this.#networkEventManager.storeRequestPaused(networkRequestId, event);
+      return;
+    }
+
+    this.#patchRequestEventHeaders(requestWillBeSentEvent, event);
+    this.#onRequest(client, requestWillBeSentEvent, fetchRequestId);
+  }
+
+  #onRequestRestarted(
+    request: CdpHTTPRequest,
+    fetchRequestId: FetchRequestId,
+  ): void {
+    request._interceptionId = fetchRequestId;
+    if (
+      this.#userRequestInterceptionEnabled &&
+      request.isInterceptResolutionHandled()
+    ) {
+      // The user already resolved the interception; the restarted job needs
+      // the same resolution or the request hangs.
+      void request._continue(request.continueRequestOverrides()).catch(err => {
+        this.#logger?.(DEBUG_PREFIXES.error)?.(err);
+      });
     }
   }
 
@@ -603,6 +630,7 @@ export class NetworkManager extends EventEmitter<NetworkManagerEvents> {
 
     request._fromMemoryCache = fromMemoryCache;
     this.#networkEventManager.storeRequest(event.requestId, request);
+    this.#networkEventManager.forgetRequestWillBeSent(event.requestId);
     this.emit(NetworkManagerEvent.Request, request);
     void request.finalizeInterceptions();
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

Yes. Also updated the "double pause" test case above it that shows the bug. It feeds one `requestWillBeSent` followed by two `Fetch.requestPaused` events for the same network id, and asserted that Puppeteer emits two request events.

**If relevant, did you update the documentation?**

Not needed

**Summary**

When Chrome restarts a request it sends a second `Fetch.requestPaused` with a new interception id for the same `Network.requestWillBeSent` (crbug.com/1196004). This is common for fonts declared in stylesheets. Puppeteer emitted a second `request` for it, and since the two shared a network id the first never received `requestfinished` or `requestfailed`.

Repoint the existing request at the new interception id instead. If the user already resolved the interception, replay it with the original continue overrides so the restarted job does not hang.

Issues: #7060, #11641

**Does this PR introduce a breaking change?**

No
