### PR TITLE
fix(connect): preserve browserURL path prefixes

### DIFF
--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -51,6 +51,35 @@ describe('BrowserConnector', () => {
         ],
       ).toBe('Bearer test-token');
     });
+
+    it('should preserve the browserURL path prefix', async () => {
+      const capturedRequests: string[] = [];
+
+      mock.method(
+        globalThis,
+        'fetch',
+        async (url: string | URL | Request) => {
+          capturedRequests.push(String(url));
+          return new Response(
+            JSON.stringify({
+              webSocketDebuggerUrl: 'ws://localhost:1234/devtools/browser/1',
+            }),
+            {status: 200, headers: {'Content-Type': 'application/json'}},
+          );
+        },
+      );
+
+      await _connectToBrowser({
+        browserURL: 'http://localhost:1234/t/session/?token=secret',
+        logger: () => {
+          return undefined;
+        },
+      }).catch(() => {});
+
+      expect(capturedRequests).toEqual([
+        'http://localhost:1234/t/session/json/version?token=secret',
+      ]);
+    });
   });
 
   describe('_connectToBrowser', () => {

--- a/packages/puppeteer-core/src/common/BrowserConnector.test.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.test.ts
@@ -8,12 +8,18 @@ import {describe, it, mock, afterEach} from 'node:test';
 
 import expect from 'expect';
 
-import {_connectToBrowser} from './BrowserConnector.js';
+import {_connectToBrowser, getWSEndpointURL} from './BrowserConnector.js';
 
 describe('BrowserConnector', () => {
   describe('getWSEndpoint via browserURL', () => {
     afterEach(() => {
       mock.restoreAll();
+    });
+
+    it('rewrites browser URLs to the version endpoint', () => {
+      expect(
+        getWSEndpointURL('http://localhost:1234/t/session/?token=secret#ignored'),
+      ).toBe('http://localhost:1234/t/session/json/version?token=secret');
     });
 
     it('should forward headers to the /json/version HTTP request', async () => {

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -198,13 +198,10 @@ async function getWSEndpoint(
   browserURL: string,
   headers?: Record<string, string>,
 ): Promise<string> {
-  const endpointURL = new URL(browserURL);
-  endpointURL.pathname =
-    endpointURL.pathname.replace(/\/?$/, '') + '/json/version';
-  endpointURL.hash = '';
+  const endpointURL = getWSEndpointURL(browserURL);
 
   try {
-    const result = await globalThis.fetch(endpointURL.toString(), {
+    const result = await globalThis.fetch(endpointURL, {
       method: 'GET',
       headers,
     });
@@ -221,4 +218,12 @@ async function getWSEndpoint(
     }
     throw error;
   }
+}
+
+export function getWSEndpointURL(browserURL: string): string {
+  const endpointURL = new URL(browserURL);
+  endpointURL.pathname =
+    endpointURL.pathname.replace(/\/?$/, '') + '/json/version';
+  endpointURL.hash = '';
+  return endpointURL.toString();
 }

--- a/packages/puppeteer-core/src/common/BrowserConnector.ts
+++ b/packages/puppeteer-core/src/common/BrowserConnector.ts
@@ -198,7 +198,10 @@ async function getWSEndpoint(
   browserURL: string,
   headers?: Record<string, string>,
 ): Promise<string> {
-  const endpointURL = new URL('/json/version', browserURL);
+  const endpointURL = new URL(browserURL);
+  endpointURL.pathname =
+    endpointURL.pathname.replace(/\/?$/, '') + '/json/version';
+  endpointURL.hash = '';
 
   try {
     const result = await globalThis.fetch(endpointURL.toString(), {


### PR DESCRIPTION
**What kind of change does this PR introduce?**  Bug fix.  **Did you add tests for your changes?**  Yes. Added unit coverage for a path-prefixed `browserURL`, including a trailing slash and query string.  **If relevant, did you update the documentation?**  Not applicable.  **Summary**  `getWSEndpoint` now appends `/json/version` to the existing `browserURL` pathname, preserving reverse-proxy and tunnel path prefixes. Addresses #15250.  **Does this PR introduce a breaking change?**  No.  **Other information**  Validated with `npm run build`, `npm run unit --workspace puppeteer-core`, the focused `BrowserConnector` unit test, ESLint, Prettier, expectations lint, and repository lint. The repository check remains unable to run on Windows because its existing dependency-version script invokes the Unix-only `tail` command.