### PR TITLE
chore: avoid Unix-only tail in protocol check

### DIFF
--- a/packages/puppeteer-core/tools/ensure-correct-devtools-protocol-package.mts
+++ b/packages/puppeteer-core/tools/ensure-correct-devtools-protocol-package.mts
@@ -59,16 +59,14 @@ async function main() {
 
   console.log(`Revisions for ${chromeVersion}: ${chromeRevision}`);
 
+  const command = `npm view "devtools-protocol@<=0.0.${chromeRevision}" version --json`;
   console.log(
     'Checking npm for devtools-protocol revisions:\n',
-    `'npm view "devtools-protocol@<=0.0.${chromeRevision}" version --json'`,
+    `'${command}'`,
     '\n',
   );
 
-  const output = execSync(
-    `npm view "devtools-protocol@<=0.0.${chromeRevision}" version --json`,
-    {encoding: 'utf8'},
-  );
+  const output = execSync(command, {encoding: 'utf8'});
 
   const versions = JSON.parse(output) as string | string[];
   const bestRevisionFromNpm = (

--- a/packages/puppeteer-core/tools/ensure-correct-devtools-protocol-package.mts
+++ b/packages/puppeteer-core/tools/ensure-correct-devtools-protocol-package.mts
@@ -59,19 +59,21 @@ async function main() {
 
   console.log(`Revisions for ${chromeVersion}: ${chromeRevision}`);
 
-  const command = `npm view "devtools-protocol@<=0.0.${chromeRevision}" version | tail -1`;
-
   console.log(
     'Checking npm for devtools-protocol revisions:\n',
-    `'${command}'`,
+    `'npm view "devtools-protocol@<=0.0.${chromeRevision}" version --json'`,
     '\n',
   );
 
-  const output = execSync(command, {
-    encoding: 'utf8',
-  });
+  const output = execSync(
+    `npm view "devtools-protocol@<=0.0.${chromeRevision}" version --json`,
+    {encoding: 'utf8'},
+  );
 
-  const bestRevisionFromNpm = output.split(' ')[1]!.replace(/'|\n/g, '');
+  const versions = JSON.parse(output) as string | string[];
+  const bestRevisionFromNpm = (
+    Array.isArray(versions) ? versions.at(-1) : versions
+  )!.trim();
 
   if (currentProtocolPackageInstalledVersion !== bestRevisionFromNpm) {
     console.log(`ERROR: bad devtools-protocol revision detected:


### PR DESCRIPTION
**What kind of change does this PR introduce?**  Bug fix.  **Did you add tests for your changes?**  The existing dependency-version check now runs cross-platform; validation exercises it on Windows with the current pinned revision.  **If relevant, did you update the documentation?**  Not applicable.  **Summary**  Replace the Unix-only `tail` pipeline with npm's JSON output and select the newest matching protocol version in Node. This lets `npm run check --workspace puppeteer-core` run from the supported Windows shell. Addresses #15436.  **Does this PR introduce a breaking change?**  No.  **Other information**  Validated on Windows with `npm run check --workspace puppeteer-core` and Prettier.