### PR TITLE
build: run docs versioning on Windows

### DIFF
--- a/website/materialize-docs.ts
+++ b/website/materialize-docs.ts
@@ -188,10 +188,12 @@ async function runDocusaurusVersioning(version: string): Promise<void> {
   const docusaurus = path.join(
     websiteDir,
     'node_modules',
-    '.bin',
-    'docusaurus',
+    '@docusaurus',
+    'core',
+    'bin',
+    'docusaurus.mjs',
   );
-  await execFile(docusaurus, ['docs:version', version], {
+  await execFile(process.execPath, [docusaurus, 'docs:version', version], {
     cwd: websiteDir,
     env: {...process.env, DOCS_PATH: releaseDocsDir},
     maxBuffer: 10 * 1024 * 1024,


### PR DESCRIPTION
**What kind of change does this PR introduce?**  Bug fix.  **Did you add tests for your changes?**  The website build itself exercises the docs materialization path; it now completes on Windows.  **If relevant, did you update the documentation?**  Not applicable.  **Summary**  Run Docusaurus through the current Node executable instead of invoking the extensionless `.bin` shim. This lets `website/npm run build` materialize and build the docs on Windows. Addresses #15437.  **Does this PR introduce a breaking change?**  No.  **Other information**  Validated on Windows with `npm run build` in `website`; the build generated the static site successfully.