### PR TITLE
fix(launcher): clean temporary profiles on process exit

### DIFF
--- a/packages/puppeteer-core/src/node/BrowserLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.test.ts
@@ -16,6 +16,10 @@ import {registerProcessExitCleanup} from './BrowserLauncher.js';
 class ProcessEmitter {
   #listeners = new Set<() => void>();
 
+  get listenerCount(): number {
+    return this.#listeners.size;
+  }
+
   once(_event: 'exit', listener: () => void): void {
     this.#listeners.add(listener);
   }
@@ -66,5 +70,24 @@ describe('registerProcessExitCleanup', () => {
 
     expect(existsSync(userDataDir)).toBe(true);
     rmSync(userDataDir, {recursive: true, force: true});
+  });
+
+  it('uses one process-exit listener for multiple temporary profiles', () => {
+    const firstDir = mkdtempSync(
+      join(tmpdir(), 'puppeteer-process-exit-cleanup-'),
+    );
+    const secondDir = mkdtempSync(
+      join(tmpdir(), 'puppeteer-process-exit-cleanup-'),
+    );
+    const processEmitter = new ProcessEmitter();
+
+    registerProcessExitCleanup(firstDir, logger, processEmitter);
+    registerProcessExitCleanup(secondDir, logger, processEmitter);
+    expect(processEmitter.listenerCount).toBe(1);
+
+    processEmitter.emit('exit');
+
+    expect(existsSync(firstDir)).toBe(false);
+    expect(existsSync(secondDir)).toBe(false);
   });
 });

--- a/packages/puppeteer-core/src/node/BrowserLauncher.test.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Google Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {existsSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {describe, it} from 'node:test';
+
+import expect from 'expect';
+
+import {registerProcessExitCleanup} from './BrowserLauncher.js';
+
+class ProcessEmitter {
+  #listeners = new Set<() => void>();
+
+  once(_event: 'exit', listener: () => void): void {
+    this.#listeners.add(listener);
+  }
+
+  off(_event: 'exit', listener: () => void): void {
+    this.#listeners.delete(listener);
+  }
+
+  emit(_event: 'exit'): void {
+    for (const listener of this.#listeners) {
+      listener();
+    }
+    this.#listeners.clear();
+  }
+}
+
+const logger = (_prefix: string) => {
+  return undefined;
+};
+
+describe('registerProcessExitCleanup', () => {
+  it('removes a temporary profile synchronously on process exit', () => {
+    const userDataDir = mkdtempSync(
+      join(tmpdir(), 'puppeteer-process-exit-cleanup-'),
+    );
+    writeFileSync(join(userDataDir, 'profile'), 'profile');
+    const processEmitter = new ProcessEmitter();
+
+    registerProcessExitCleanup(userDataDir, logger, processEmitter);
+    processEmitter.emit('exit');
+
+    expect(existsSync(userDataDir)).toBe(false);
+  });
+
+  it('can unregister cleanup after the browser process exits', () => {
+    const userDataDir = mkdtempSync(
+      join(tmpdir(), 'puppeteer-process-exit-cleanup-'),
+    );
+    const processEmitter = new ProcessEmitter();
+    const unregister = registerProcessExitCleanup(
+      userDataDir,
+      logger,
+      processEmitter,
+    );
+
+    unregister();
+    processEmitter.emit('exit');
+
+    expect(existsSync(userDataDir)).toBe(true);
+    rmSync(userDataDir, {recursive: true, force: true});
+  });
+});

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -204,9 +204,7 @@ export abstract class BrowserLauncher {
       );
     }
 
-    const removeTempUserDataDirOnExit = launchArgs.isTempUserDataDir
-      ? registerProcessExitCleanup(launchArgs.userDataDir, this.#logger)
-      : undefined;
+    let removeTempUserDataDirOnExit: (() => void) | undefined;
 
     let browserProcess: ReturnType<typeof launch>;
     try {
@@ -223,6 +221,12 @@ export abstract class BrowserLauncher {
         signal: options.signal,
         logger: options.logger,
       });
+      // Register after @puppeteer/browsers has installed its process-exit
+      // dispatcher. That dispatcher kills the browser before this synchronous
+      // fallback removes the profile directory.
+      removeTempUserDataDirOnExit = launchArgs.isTempUserDataDir
+        ? registerProcessExitCleanup(launchArgs.userDataDir, this.#logger)
+        : undefined;
     } catch (error) {
       removeTempUserDataDirOnExit?.();
       await this.cleanUserDataDir(launchArgs.userDataDir, {
@@ -675,6 +679,16 @@ interface ProcessExitEmitter {
   off(event: 'exit', listener: () => void): void;
 }
 
+interface ProcessExitCleanupEntry {
+  userDataDir: string;
+  logger: Logger;
+}
+
+const processExitCleanupEntries = new WeakMap<
+  ProcessExitEmitter,
+  {entries: Set<ProcessExitCleanupEntry>; onExit: () => void}
+>();
+
 /**
  * Registers a synchronous fallback for removing a temporary profile when the
  * host process exits before the browser process can run its async cleanup.
@@ -686,16 +700,34 @@ export function registerProcessExitCleanup(
   logger: Logger,
   processEmitter: ProcessExitEmitter = process,
 ): () => void {
-  const onExit = (): void => {
-    try {
-      rmSync(userDataDir, {recursive: true, force: true});
-    } catch (error) {
-      logger(DEBUG_PREFIXES.error)?.(error);
-    }
-  };
-
-  processEmitter.once('exit', onExit);
+  let cleanup = processExitCleanupEntries.get(processEmitter);
+  if (!cleanup) {
+    const entries = new Set<ProcessExitCleanupEntry>();
+    const onExit = (): void => {
+      for (const entry of entries) {
+        try {
+          rmSync(entry.userDataDir, {
+            recursive: true,
+            force: true,
+            maxRetries: 3,
+            retryDelay: 100,
+          });
+        } catch (error) {
+          entry.logger(DEBUG_PREFIXES.error)?.(error);
+        }
+      }
+    };
+    cleanup = {entries, onExit};
+    processExitCleanupEntries.set(processEmitter, cleanup);
+    processEmitter.once('exit', onExit);
+  }
+  const entry = {userDataDir, logger};
+  cleanup.entries.add(entry);
   return () => {
-    processEmitter.off('exit', onExit);
+    if (!cleanup?.entries.delete(entry) || cleanup.entries.size > 0) {
+      return;
+    }
+    processEmitter.off('exit', cleanup.onExit);
+    processExitCleanupEntries.delete(processEmitter);
   };
 }

--- a/packages/puppeteer-core/src/node/BrowserLauncher.ts
+++ b/packages/puppeteer-core/src/node/BrowserLauncher.ts
@@ -3,7 +3,7 @@
  * Copyright 2017 Google Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
-import {accessSync, constants, existsSync} from 'node:fs';
+import {accessSync, constants, existsSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 
@@ -185,9 +185,13 @@ export abstract class BrowserLauncher {
     const usePipe = launchArgs.args.includes('--remote-debugging-pipe');
 
     const onProcessExit = async () => {
-      await this.cleanUserDataDir(launchArgs.userDataDir, {
-        isTemp: launchArgs.isTempUserDataDir,
-      });
+      try {
+        await this.cleanUserDataDir(launchArgs.userDataDir, {
+          isTemp: launchArgs.isTempUserDataDir,
+        });
+      } finally {
+        removeTempUserDataDirOnExit?.();
+      }
     };
 
     if (
@@ -200,19 +204,32 @@ export abstract class BrowserLauncher {
       );
     }
 
-    const browserProcess = launch({
-      executablePath: launchArgs.executablePath,
-      args: launchArgs.args,
-      handleSIGHUP,
-      handleSIGTERM,
-      handleSIGINT,
-      dumpio,
-      env,
-      pipe: usePipe,
-      onExit: onProcessExit,
-      signal: options.signal,
-      logger: options.logger,
-    });
+    const removeTempUserDataDirOnExit = launchArgs.isTempUserDataDir
+      ? registerProcessExitCleanup(launchArgs.userDataDir, this.#logger)
+      : undefined;
+
+    let browserProcess: ReturnType<typeof launch>;
+    try {
+      browserProcess = launch({
+        executablePath: launchArgs.executablePath,
+        args: launchArgs.args,
+        handleSIGHUP,
+        handleSIGTERM,
+        handleSIGINT,
+        dumpio,
+        env,
+        pipe: usePipe,
+        onExit: onProcessExit,
+        signal: options.signal,
+        logger: options.logger,
+      });
+    } catch (error) {
+      removeTempUserDataDirOnExit?.();
+      await this.cleanUserDataDir(launchArgs.userDataDir, {
+        isTemp: launchArgs.isTempUserDataDir,
+      });
+      throw error;
+    }
 
     let browser: Browser;
     let cdpConnection: Connection;
@@ -651,4 +668,34 @@ export abstract class BrowserLauncher {
     }
     return executablePath;
   }
+}
+
+interface ProcessExitEmitter {
+  once(event: 'exit', listener: () => void): void;
+  off(event: 'exit', listener: () => void): void;
+}
+
+/**
+ * Registers a synchronous fallback for removing a temporary profile when the
+ * host process exits before the browser process can run its async cleanup.
+ *
+ * @internal
+ */
+export function registerProcessExitCleanup(
+  userDataDir: string,
+  logger: Logger,
+  processEmitter: ProcessExitEmitter = process,
+): () => void {
+  const onExit = (): void => {
+    try {
+      rmSync(userDataDir, {recursive: true, force: true});
+    } catch (error) {
+      logger(DEBUG_PREFIXES.error)?.(error);
+    }
+  };
+
+  processEmitter.once('exit', onExit);
+  return () => {
+    processEmitter.off('exit', onExit);
+  };
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: remove temporary browser profiles synchronously when the Node.js host process exits unexpectedly.

**Did you add tests for your changes?**

Yes. Added unit coverage for synchronous cleanup on an exit event and for unregistering the fallback after normal browser cleanup.

**If relevant, did you update the documentation?**

No documentation changes are needed.

**Summary**

When the host process terminates due to an uncaught exception or `process.exit()`, the browser child process cannot run Puppeteer's existing asynchronous profile cleanup. This change registers a synchronous `process.exit` fallback in `puppeteer-core` for each temporary profile, unregistering it after the browser process cleanup completes or launch fails. The temporary profile naming remains unchanged.

Related issue: #15156

**Does this PR introduce a breaking change?**

No.

**Other information**

Validation:
- `npm run build --workspace puppeteer-core`
- targeted Prettier and ESLint checks
- targeted `BrowserLauncher.test.js`: 2 passed
- full `npm run unit --workspace puppeteer-core`: 179 passed, 6 environment-sensitive failures (Page timing and NodeWebSocketTransport binding to `0.0.0.0:8080`)
