### PR TITLE
build: use portable npm output in browser revision update

### DIFF
--- a/tools/update_browser_revision.mjs
+++ b/tools/update_browser_revision.mjs
@@ -153,13 +153,15 @@ async function updateDevToolsProtocolVersion(browserVersion) {
   }
 
   const currentProtocol = packageJson.dependencies['devtools-protocol'];
-  const command = `npm view "devtools-protocol@<=0.0.${revision}" version | tail -1`;
-
-  const bestNewProtocol = execSync(command, {
-    encoding: 'utf8',
-  })
-    .split(' ')[1]
-    .replace(/'|\n/g, '');
+  const command = `npm view "devtools-protocol@<=0.0.${revision}" version --json`;
+  const versions = JSON.parse(
+    execSync(command, {
+      encoding: 'utf8',
+    }),
+  );
+  const bestNewProtocol = (
+    Array.isArray(versions) ? versions.at(-1) : versions
+  ).trim();
 
   await replaceInFile(
     './packages/puppeteer-core/package.json',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: make the browser revision update tool work from Windows shells.

**Did you add tests for your changes?**

No new test file. The change is a small release-tool parsing fix; validation covers the JSON response shape and the tool source assertions.

**If relevant, did you update the documentation?**

No documentation changes are needed.

**Summary**

`tools/update_browser_revision.mjs` used the Unix-only `tail -1` pipeline to select a `devtools-protocol` version. npm already supports JSON output, so this change parses that output in Node and selects the newest match, while also handling npm's scalar response when only one version matches. No browser revision update was run while preparing this PR.

**Does this PR introduce a breaking change?**

No.

**Other information**

Validation on Windows PowerShell:
- `npm run build:tools`
- targeted Prettier check with the repository's Windows line-ending form
- targeted ESLint and `node --check tools/update_browser_revision.mjs`
- live `npm view ... version --json` query and source assertions
