### PR TITLE
docs: clarify JavaScript coverage across navigations

### DIFF
--- a/docs/api/puppeteer.jscoverageoptions.md
+++ b/docs/api/puppeteer.jscoverageoptions.md
@@ -89,6 +89,8 @@ boolean
 
 Whether to reset coverage on every navigation.
 
+Setting this to `false` does not guarantee that coverage survives a navigation. Chrome may discard the previous page's JavaScript execution environment, including its coverage data, when navigating. To preserve coverage, call [Coverage.stopJSCoverage()](./puppeteer.coverage.stopjscoverage.md) before navigating away, then start a new collection for the next page and merge the reports.
+
 </td><td>
 
 </td></tr>

--- a/packages/puppeteer-core/src/cdp/Coverage.ts
+++ b/packages/puppeteer-core/src/cdp/Coverage.ts
@@ -51,6 +51,12 @@ export interface JSCoverageEntry extends CoverageEntry {
 export interface JSCoverageOptions {
   /**
    * Whether to reset coverage on every navigation.
+   *
+   * Setting this to `false` does not guarantee that coverage survives a
+   * navigation. Chrome may discard the previous page's JavaScript execution
+   * environment, including its coverage data, when navigating.
+   * To preserve coverage, call {@link Coverage.stopJSCoverage} before navigating
+   * away, then start a new collection for the next page and merge the reports.
    */
   resetOnNavigation?: boolean;
   /**


### PR DESCRIPTION
﻿**What kind of change does this PR introduce?**

Documentation clarification.

**Did you add tests for your changes?**

No runtime behavior changes. `npm run docs`, ESLint for `Coverage.ts`, and `git diff --check` pass. The generated option description contains the warning and resolves the `Coverage.stopJSCoverage()` link. Browser tests were not run.

**If relevant, did you update the documentation?**

Updated the source TSDoc and regenerated the API page with `npm run docs`.

**Summary**

Refs #15005. The `resetOnNavigation` description can suggest that setting it to `false` guarantees coverage survives navigation. As discussed in that issue, Chrome can discard the previous execution environment and its coverage data.

Document the limitation alongside the option and recommend collecting coverage before leaving each page, then merging the reports. This does not change the option or claim to fix the underlying browser limitation.

**Does this PR introduce a breaking change?**

No.

**Other information**

Docs generation reports two existing unresolved `PermissionDescriptor` references unrelated to this change. Validation ran on Windows with Node 22.21.1.

